### PR TITLE
Revert the temporary fix for `download-ci-llvm`

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -687,7 +687,7 @@ commands:
         default: false
     steps:
       - ferrocene-git-shallow-clone:
-          depth: 20
+          depth: 2
       - when:
           condition: << parameters.llvm-subset >>
           steps:

--- a/src/stage0.json
+++ b/src/stage0.json
@@ -3,7 +3,7 @@
     "dist_server": "https://static.rust-lang.org",
     "artifacts_server": "s3://ferrocene-ci-artifacts/ferrocene/dist",
     "artifacts_with_llvm_assertions_server": "s3://ferrocene-ci-artifacts/ferrocene/dist",
-    "git_merge_commit_email": "bors@rust-lang.org",
+    "git_merge_commit_email": "87868125+bors-ferrocene\\[bot\\]@users.noreply.github.com",
     "nightly_branch": "main"
   },
   "__comments": [


### PR DESCRIPTION
The temporary commit is not needed anymore, as there is now a merge by `ferrocene-bors` as the latest commit on `main`.