### PR TITLE
Fix minor typos in library description

### DIFF
--- a/ferrocene/doc/index/index.html
+++ b/ferrocene/doc/index/index.html
@@ -50,7 +50,7 @@
                     Libraries distributed with Ferrocene are not pre-certified
                     for safety-critical use. Certification of the parts used is
                     currently the obligation of the user, for which Ferrous
-                    Systems provide support. This limitation is expected go
+                    Systems provides support. This limitation is expected to go
                     away in future releases.
                 </p>
                 <div class="docs">


### PR DESCRIPTION
Minor fix without changing meaning, adds missing words.