### PR TITLE
Allow releases of commits not present in this repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ on:
       allow-duplicate:
         description: Allow duplicate releases
         type: boolean
+      verbatim-ref:
+        description: Do not resolve ref, keep it verbatim
+        type: boolean
 
 
 permissions:

--- a/ferrocene/ci/scripts/calculate-release-job-matrix.py
+++ b/ferrocene/ci/scripts/calculate-release-job-matrix.py
@@ -200,7 +200,10 @@ def run():
         commits = commits_in_release_branches(ctx)
         releases = filter_automated_channels(commits_to_releases(ctx, commits))
     elif ctx.event_name == "workflow_dispatch":
-        commit = resolve_ref(ctx, ctx.event_data["inputs"]["ref"])
+        if ctx.event_data["inputs"]["verbatim-ref"] == "true":
+            commit = ctx.event_data["inputs"]["ref"]
+        else:
+            commit = resolve_ref(ctx, ctx.event_data["inputs"]["ref"])
         releases = commits_to_releases(ctx, [commit])
     else:
         raise RuntimeError(f"unsupported event name: {event_name}")


### PR DESCRIPTION
Right now, the source code of Ferrocene 23.06.0 still lives in a private repository, while the release process runs in ferrocene/ferrocene. Until we open source 23.06.1, we need a way to publish releases for 23.06.0.

The release tooling is able to publish releases for 23.06.0 from the public repository (if the full commit hash is provided), but the resolution of the git ref into a commit hash would fail.

This adds a new option to skip resolving the git ref when starting a manual release.