### PR TITLE
Fix the release scheduler failing when no rolling releases are present

### DIFF
--- a/ferrocene/ci/scripts/calculate-release-job-matrix.py
+++ b/ferrocene/ci/scripts/calculate-release-job-matrix.py
@@ -109,7 +109,10 @@ def filter_automated_channels(releases):
             )
 
     rolling_releases.sort(key=lambda vr: vr[0])
-    yield rolling_releases.pop()[1]
+    # When starting from a squashed repo with no release branches yielding the
+    # latest rolling release would crash the script.
+    if rolling_releases:
+        yield rolling_releases.pop()[1]
     for discarded in rolling_releases:
         print(
             f"note: version {discarded[1].metadata.rust_version} is not the latest "


### PR DESCRIPTION
Before this commit, if no rolling releases were present (due to the lack of a `release/1.NN` branch with `stable` in `src/ci/channel`), the script calculating the releases to publish would crash. This happened after the squashing of all the history.

The problem can be seen in https://github.com/ferrocene/ferrocene/actions/runs/6399720087/job/17372224848, and it appeared only after the squash (as we didn't squash the release branches yet).