### PR TITLE
Fix failure to create pull requests in pull-subtrees

### DIFF
--- a/ferrocene/tools/pull-subtrees/pull.py
+++ b/ferrocene/tools/pull-subtrees/pull.py
@@ -204,6 +204,7 @@ def update_subtree(repo_root, subtree):
             )
 
         print(f"updating subtree {subtree.path}")
+        commit_before = resolve_commit("HEAD")
         run(
             [
                 "git",
@@ -217,6 +218,13 @@ def update_subtree(repo_root, subtree):
             ],
             cwd=repo_root,
         )
+
+        # Mark the update as not being executed (returning None) when no commit
+        # was created by the subtree pull. Otherwise the PR automation will try
+        # creating a PR without diff, which will be rejected by GitHub.
+        if resolve_commit("HEAD") == commit_before:
+            print("warning: tried to update subtree, but no change was committed")
+            return
     else:
         print(f"creating subtree {subtree.path}")
         (repo_root / subtree.path.parent).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
When no previous commit created by the automation was found, and the subtree pull didn't result in any change, the automation would fail as it'd try to create a GitHub PR without any diff. This changes the automation to detect whether a subtree pull was actually committed.