### PR TITLE
Typo fix: Tesults -> Results

### DIFF
--- a/ferrocene/doc/qualification-report/src/tests.rst
+++ b/ferrocene/doc/qualification-report/src/tests.rst
@@ -1,7 +1,7 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-Tests Tesults
+Tests Results
 =============
 
 Ferrocene for ARMv8-A bare metal and x86-64 Linux


### PR DESCRIPTION
There is a minor typo in the qualification report.

Found by https://www.reddit.com/user/hgomersall/