### PR TITLE
Bump download-ci-llvm-stamp

### DIFF
--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -7,4 +7,4 @@ Last change is for: https://github.com/rust-lang/rust/pull/113996
 
 (white space intentional to avoid merge conflicts)
 
-Last Ferrocene change is for: https://github.com/ferrocene/ferrocene/pull/1014
+Last Ferrocene change is for: https://github.com/ferrocene/ferrocene/pull/30


### PR DESCRIPTION
Due to the squash, bootstrap isn't able to determine the commit that last updated LLVM. This bump should fix it.