### PR TITLE
Test and fix CI for the 1.74 branch

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -687,7 +687,7 @@ commands:
         default: false
     steps:
       - ferrocene-git-shallow-clone:
-          depth: 2
+          depth: 20
       - when:
           condition: << parameters.llvm-subset >>
           steps:

--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -7,4 +7,4 @@ Last change is for: https://github.com/rust-lang/rust/pull/113996
 
 (white space intentional to avoid merge conflicts)
 
-Last Ferrocene change is for: https://github.com/ferrocene/ferrocene/pull/1014
+Last Ferrocene change is for: https://github.com/ferrocene/ferrocene/pull/31

--- a/src/stage0.json
+++ b/src/stage0.json
@@ -3,7 +3,7 @@
     "dist_server": "https://static.rust-lang.org",
     "artifacts_server": "s3://ferrocene-ci-artifacts/ferrocene/dist",
     "artifacts_with_llvm_assertions_server": "s3://ferrocene-ci-artifacts/ferrocene/dist",
-    "git_merge_commit_email": "87868125+bors-ferrocene\\[bot\\]@users.noreply.github.com",
+    "git_merge_commit_email": "bors@rust-lang.org",
     "nightly_branch": "main"
   },
   "__comments": [


### PR DESCRIPTION
I just squashed the 1.74 branch in `release/1.74`, this is the equivalent of #1 and #30 for it.