### PR TITLE
Automate dependency updates with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+version: 2
+updates:
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "5:00"
+    groups:
+      monorepo-dependencies:
+        patterns: "*"
+    labels:
+      - "automation"
+      - "backport:never"
+    versioning-strategy: "lockfile-only"
+
+  - package-ecosystem: "cargo"
+    directory: "/src/bootstrap/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "5:00"
+    groups:
+      bootstrap-dependencies:
+        patterns: "*"
+    labels:
+      - "automation"
+      - "backport:never"
+    versioning-strategy: "lockfile-only"


### PR DESCRIPTION
This PR configures dependabot to update the dependencies in the monorepo automatically, both for the majority of crates and for bootstrap. This is configured to open a weekly PR on Monday morning, and to group all updates in a single PR.