### PR TITLE
Make experimental targets table consistent

### DIFF
--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -67,25 +67,25 @@ should not be used in production.
 
    * - Target
      - Triple
-     - Host compiler
+     - Kind
      - Standard library
      - Notes
 
    * - ARMv7e-M (Thumb) bare metal
      - ``thumbv7em-none-eabi``
-     - \-
+     - Cross-compilation
      - Bare-metal
      - \-
 
    * - ARMv7e-M (Thumb, floats) bare metal
      - ``thumbv7em-none-eabihf``
-     - \-
+     - Cross-compilation
      - Bare-metal
      - \-
 
    * - WASM bare metal
      - ``wasm32-unknown-unknown``
-     - \-
+     - Cross-compilation
      - Full
      - The full standard library is available, but unsupported functions in ``std`` will panic.
 


### PR DESCRIPTION
Just noticed while browsing around that the experimental targets table in the user manual was not consistent with the supported targets table. This PR changes it to add the "kind" column.

![image](https://github.com/ferrocene/ferrocene/assets/2299951/a896f557-6817-46ef-bcb2-ebb7d46986b0)
