### PR TITLE
Fix errors in the dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "5:00"
+      time: "05:00"
     groups:
       monorepo-dependencies:
-        patterns: "*"
+        patterns:
+          - "*"
     labels:
       - "automation"
       - "backport:never"
@@ -23,10 +24,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "5:00"
+      time: "05:00"
     groups:
       bootstrap-dependencies:
-        patterns: "*"
+        patterns:
+          - "*"
     labels:
       - "automation"
       - "backport:never"


### PR DESCRIPTION
Apparently there is no validation done ahead of merging a PR, thrilling. Errors are described in https://github.com/ferrocene/ferrocene/runs/17814290458.