### PR TITLE
Fix traceability matrix not including any tests

### DIFF
--- a/ferrocene/tools/traceability-matrix/src/test_outcomes.rs
+++ b/ferrocene/tools/traceability-matrix/src/test_outcomes.rs
@@ -160,7 +160,7 @@ mod tests {
                                             "kind": "test_suite",
                                             "metadata": {
                                                 "target": "aarch64-unknown-linux-gnu",
-                                                "kind": "cargo_package",
+                                                "kind": "compiletest",
                                             },
                                             "tests": [
                                                 {


### PR DESCRIPTION
Before this PR, the traceability matrix code to load test outcomes filtered which suites to load by checking whether any of the parent steps were of the `bootstrap::test::Compiletest` type.

A recent upstream refactor shuffled things around and moved that type to `bootstrap::core::build_steps::test::Compiletest`. The type rename caused the code to think those tests were not run by compiletest, which resulted in them being ignored.

The check wasn't actually needed anymore. It was needed before upstream introduced the v1 metrics format, which didn't have any structured metadata on what kind of test suite was invoked. This is not a concern in v1 build metrics though, as they include the test suite kind in the `TestSuiteMetadata` struct.

Thus, this PR changes the logic to check the structured metadata to learn whether a test was invoked by compiletest, rather than guessing based on the step type.