### PR TITLE
remove backlinks from automated PRs

### DIFF
--- a/ferrocene/tools/common/pr_links.py
+++ b/ferrocene/tools/common/pr_links.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+# Utility to generate references to PRs in issue bodies. We cannot simply use a
+# GitHub reference (like #12345), as that'd generate backlinks in the target
+# PR, which is unnecessary noise. We thus fetch the PR title and construct the
+# link manually, taking care of avoiding to generate backlinks.
+
+import os
+import requests
+import sys
+
+
+# Backlinks are not inserted if www. is prefixed to the domain, even though in
+# the end it redirects to the www-less domain.
+DOMAIN_WITHOUT_BACKLINKS = "www.github.com"
+
+
+class PRLinker:
+    def __init__(self):
+        self.client = requests.Session()
+        if "GITHUB_TOKEN" in os.environ:
+            self.client.headers["Authorization"] = f"token {os.environ['GITHUB_TOKEN']}"
+            self.has_token = True
+        else:
+            self.has_token = False
+
+    def link(self, repo, number):
+        if type(number) == str and "#" in number:
+            number = int(number.rsplit("#", 1)[1])
+
+        details = self._get(f"https://api.github.com/repos/{repo}/issues/{number}")
+        return f"`{number}`: [{details['title']}](https://{DOMAIN_WITHOUT_BACKLINKS}/{repo}/issues/{number})"
+
+    def _get(self, url):
+        resp = self.client.get(url)
+        if resp.status_code == 429:
+            print("error: failed to retrieve PR names: rate limited", file=sys.stderr)
+            if not self.has_token:
+                print(
+                    "The rate limit for unauthenticated requests is low, set a GitHub token"
+                    "in $GITHUB_TOKEN to increase it.",
+                    file=sys.stderr,
+                )
+        resp.raise_for_status()
+        return resp.json()

--- a/ferrocene/tools/pull-subtrees/pull.py
+++ b/ferrocene/tools/pull-subtrees/pull.py
@@ -28,6 +28,7 @@ import yaml
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "common"))
 
 from automated_prs import AutomatedPR, AutomationResult
+from pr_links import PRLinker
 
 
 @dataclass
@@ -164,6 +165,8 @@ def generate_merged_pull_requests_list(subtree, previous_commit, latest_commit):
         ]
     )
 
+    linker = PRLinker()
+
     result = ""
     for line in messages.split("\0"):
         if not line:
@@ -176,12 +179,12 @@ def generate_merged_pull_requests_list(subtree, previous_commit, latest_commit):
                     continue
                 if not number.isdigit():
                     continue
-                result += f"* {subtree.repo}#{number}\n"
+                result += f"* {linker.link(subtree.repo, number)}\n"
         elif (pr := remove_prefix(line, "Auto merge of #")) != line:
             number, _ = pr.split(" - ", 1)
             if not number.isdigit():
                 continue
-            result += f"* {subtree.repo}#{number}\n"
+            result += f"* {linker.link(subtree.repo, number)}\n"
 
     return result
 

--- a/ferrocene/tools/pull-upstream/generate_pr_body.py
+++ b/ferrocene/tools/pull-upstream/generate_pr_body.py
@@ -6,11 +6,15 @@
 # changes from upstream. It's automatically invoked by automation.py, and can
 # be invoked manually if the pull is performed manually (on merge conflicts).
 
-import subprocess
 from dataclasses import dataclass
 from typing import Optional
+import os
+import subprocess
 import sys
 
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "common"))
+
+from pr_links import PRLinker
 
 UPSTREAM_REPO = "rust-lang/rust"
 
@@ -37,6 +41,7 @@ def render_changes(origin, base_branch, new_branch):
     automatic pull as a bullet list of merged pull requests. This also renders
     pull requests merged as part of a rollup.
     """
+    linker = PRLinker()
 
     # Ensure we have all the commits we need, otherwise the log command
     # below could fail.
@@ -89,7 +94,7 @@ def render_changes(origin, base_branch, new_branch):
         pr = extract_pr_from_message("Auto", commit.message)
         if pr is None:
             continue
-        changes += f"* {pr}\n"
+        changes += f"* {linker.link(UPSTREAM_REPO, pr)}\n"
 
         if commit.merge in commits:
             rollup_cursor = commit.merge
@@ -100,7 +105,7 @@ def render_changes(origin, base_branch, new_branch):
                 rollup_pr = extract_pr_from_message("Rollup", rollup_commit.message)
                 if rollup_pr is None:
                     break
-                changes += f"  * {rollup_pr}\n"
+                changes += f"  * {linker.link(UPSTREAM_REPO, rollup_pr)}\n"
 
     return changes
 


### PR DESCRIPTION
Before this PR, every pull request mentioned in an automated pull from upstream or a subtree would include a link to the pulled PR in the form of `repo#number`. GitHub then used that to include a link to the PR, and automatically insert the PR title.

Unfortunately, doing so also resulted in a "backlink" event being included in the target PR. That is indeed annoying, and caused a fair amount of spam in `rust-lang/rust`. We asked GitHub Support, but there isn't an officially supported way to prevent those backlinks from being generated.

To solve the problem, this PR implements custom code to generate the links in automated PRs, crucially using `www.github.com` rather than `github.com` as the domain name. It turns out that adding www to the domain prevents backlinks from being created, which is perfect for us. This updates both pulls from upstream, and pulls from subtrees. Example rendered version:

| Before | After |
| --- | --- |
| ![image](https://github.com/ferrocene/ferrocene/assets/2299951/293004ad-1a1e-41c4-923a-fee5bac15946) | ![image](https://github.com/ferrocene/ferrocene/assets/2299951/dafe9166-29e5-4332-a87e-38e7e6ceee79) |


