### PR TITLE
Prevent `ferrocene/ci/configure.sh` from being invoked locally

### DIFF
--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -16,6 +16,20 @@ add() {
     done
 }
 
+if [[ -z "${CI+x}" ]]; then
+    echo "error: this doesn't look like it's being executed in CI."
+    echo
+    echo "The purpose of this script is to configure the build system for CI"
+    echo "use, and it's not recommended for local development. If you are"
+    echo "developing Ferrocene, please check the the Internal Procedures"
+    echo "documentation on how to set up a local environment."
+    echo
+    echo "If you're trying to simulate CI to debug an issue locally, set the"
+    echo '$CI' "environment variable when invoking this script to suppress"
+    echo "this error message."
+    exit 1
+fi
+
 ##################################################################
 #                                                                #
 #   Configuration items not affecting the resulting toolchain.   #

--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -21,8 +21,9 @@ if [[ -z "${CI+x}" ]]; then
     echo
     echo "The purpose of this script is to configure the build system for CI"
     echo "use, and it's not recommended for local development. If you are"
-    echo "developing Ferrocene, please check the the Internal Procedures"
-    echo "documentation on how to set up a local environment."
+    echo "developing Ferrocene, please check the the Internal Procedures:"
+    echo
+    echo "    https://public-docs.ferrocene.dev/main/qualification/internal-procedures/setup-local-env.html"
     echo
     echo "If you're trying to simulate CI to debug an issue locally, set the"
     echo '$CI' "environment variable when invoking this script to suppress"

--- a/ferrocene/doc/internal-procedures/src/setup-local-env.rst
+++ b/ferrocene/doc/internal-procedures/src/setup-local-env.rst
@@ -103,7 +103,7 @@ content in it:
 .. code-block:: text
 
    profile = "compiler"
-   changelog-seen = 2
+   change-id = 115898
 
    [ferrocene]
    aws-profile = "ferrocene-ci"


### PR DESCRIPTION
Using the configure script to setup a local development environment is usually not a good idea, as that is meant to be used as part of our CI, and some of its settings hamper local development (for example, it rebuilds everything as soon as a new git commit is made).

To guide developers in not using the script, running it outside CI will now error out, pointing people to the internal procedures doc. There is an escape hatch if someone really needs it, which is pointed out in the error message.

This also updates the suggested `config.toml` with the new change tracking introduced upstream.