### PR TITLE
Add infra to include the technical report in the built docs

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -886,3 +886,7 @@ change-id = 117435
 # - Avoids an error that occurs if signatures are present,
 #   but you don't have access to the private signature files
 #ignore-document-signatures = false
+
+# Download URL for the qualification technical report. If omitted, the
+# technical report will not be included in the documentation.
+#technical-report-url = <none> (url)

--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -254,6 +254,12 @@ add --set ferrocene.tarball-signing-kms-key-arn="arn:aws:kms:us-east-1:886866542
 # This will not work for non-employees of Ferrous Systems
 add --set ferrocene.oxidos-src="s3://ferrocene-ci-mirrors/manual/oxidos/oxidos-source-2023-09-21.tar.xz"
 
+# Include the technical report from the assessor in the documentation.
+#
+# If this is not provided, the report will not be included in the generated
+# documentation. This should only be set in stable, qualified releases.
+#add --set ferrocene.technical-report-url="s3://ferrocene-ci-mirrors/manual/tuv-technical-reports/YYYY-MM-DD-ferrocene-YY.MM.N-technical-report.pdf"
+
 ###############################################
 #                                             #
 #  Write the configuration to `config.toml`   #

--- a/ferrocene/doc/index/index-assets/index.css
+++ b/ferrocene/doc/index/index-assets/index.css
@@ -89,6 +89,12 @@ div.docs a {
     color: var(--text-fg);
 }
 
+/* By default hide items with a subset. They will be shown thanks to
+ * subset-spcific CSS files */
+div.docs a[data-subset] {
+    display: none;
+}
+
 div.docs a h3 {
     margin: 0;
     font-size: 1.1em;

--- a/ferrocene/doc/index/index-assets/subset-filters/signatures.css
+++ b/ferrocene/doc/index/index-assets/subset-filters/signatures.css
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: MIT OR Apache-2.0 */
+/* SPDX-FileCopyrightText: The Ferrocene Developers */
+
+div.docs a[data-subset="signatures"] {
+    display: block;
+}

--- a/ferrocene/doc/index/index-assets/subset-filters/signatures.css.ferrocene-subset
+++ b/ferrocene/doc/index/index-assets/subset-filters/signatures.css.ferrocene-subset
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+signatures

--- a/ferrocene/doc/index/index.html
+++ b/ferrocene/doc/index/index.html
@@ -103,6 +103,10 @@
                         <h3>Internal Procedures</h3>
                         <p>Engineering level procedures for installing the develoment environment, using the existing infrastructure, and working with the Ferrocene toolchain.</p>
                     </a>
+                    <a href="qualification/technical-report.pdf" data-subset="signatures">
+                        <h3>Technical Report</h3>
+                        <p>Technical report of the qualification, written by the assessors.</p>
+                    </a>
                 </div>
             </section>
             <section>

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -831,6 +831,7 @@ impl<'a> Builder<'a> {
                 crate::ferrocene::doc::QualificationReport,
                 crate::ferrocene::doc::SafetyManual,
                 crate::ferrocene::doc::TraceabilityMatrix,
+                crate::ferrocene::doc::TechnicalReport,
                 // QMS Documents
                 crate::ferrocene::doc::InternalProcedures,
                 doc::Bootstrap,

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -306,6 +306,7 @@ pub struct Config {
     pub ferrocene_tarball_signing_kms_key_arn: Option<String>,
     pub ferrocene_document_signatures_s3_bucket: String,
     pub ferrocene_ignore_document_signatures: bool,
+    pub ferrocene_technical_report_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1088,6 +1089,7 @@ define_config! {
         tarball_signing_kms_key_arn: Option<String> = "tarball-signing-kms-key-arn",
         document_signatures_s3_bucket: Option<String> = "document-signatures-s3-bucket",
         ignore_document_signatures: Option<bool> = "ignore-document-signatures",
+        technical_report_url: Option<String> = "technical-report-url",
     }
 }
 
@@ -1681,6 +1683,7 @@ impl Config {
                 .unwrap_or_else(|| "ferrocene-document-signatures".into());
             config.ferrocene_ignore_document_signatures =
                 f.ignore_document_signatures.unwrap_or(false);
+            config.ferrocene_technical_report_url = f.technical_report_url;
         }
 
         if config.llvm_from_ci {

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -553,6 +553,61 @@ impl Step for TraceabilityMatrix {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub(crate) struct TechnicalReport {
+    target: TargetSelection,
+}
+
+impl Step for TechnicalReport {
+    type Output = ();
+    const DEFAULT: bool = true;
+
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+        let builder = run.builder;
+        run.alias("ferrocene-technical-report").default_condition(
+            builder.config.docs && builder.config.ferrocene_technical_report_url.is_some(),
+        )
+    }
+
+    fn make_run(run: RunConfig<'_>) {
+        run.builder.ensure(TechnicalReport { target: run.target });
+    }
+
+    fn run(self, builder: &Builder<'_>) -> Self::Output {
+        let url = builder
+            .config
+            .ferrocene_technical_report_url
+            .as_deref()
+            .expect("ferrocene.technical-report-url is not configured");
+        let cache_path = builder
+            .out
+            .join("cache")
+            .join("ferrocene")
+            .join(url.rsplit_once('/').map(|(_, name)| name).unwrap_or(url));
+        let output_dir = builder.doc_out(self.target).join("qualification");
+
+        if builder.config.dry_run() {
+            return;
+        }
+
+        if !cache_path.exists() {
+            if let Some(parent) = cache_path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            builder.config.download_file(url, &cache_path, "");
+        }
+
+        let mut output_file = output_dir.join("technical-report.pdf");
+
+        builder.create_dir(&output_dir);
+        builder.copy(&cache_path, &output_file);
+
+        // Include the technical report file only in the signatures subset.
+        output_file.as_mut_os_string().push(".ferrocene-subset");
+        builder.create(&output_file, "signatures");
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub(crate) struct Index {
     target: TargetSelection,
 }


### PR DESCRIPTION
This PR adds the infrastructure needed to include the technical report from TÜV into the generated documentation, by setting a key in `config.toml` pointing to the file in S3. Right now that is not configured in CI, as it's supposed to be used only on stable releases.

Two changes to the rest of Ferrocene were needed to make this work:

* There is now a way to hide some elements from the index based on the subsets the customer has access to. This is accomplished by hiding all elements with a `data-subset` HTML attribute by default, and having per-subset CSS files that show the subset's elements.
* There is now a way to include individual files in a subset by creating a file called `$name.ferrocene-subset`. The file behaves like a `ferrocene-subset` file inside a directory, but it only applies to that file rather than the whole directory.