### PR TITLE
Draft: Use LLD instead of LD for our three targets

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -589,6 +589,12 @@ impl LinkSelfContainedDefault {
             _ => "crt-objects-fallback",
         }
     }
+
+    /// Creates a `LinkSelfContained` enabling the self-contained linker for target specs (the
+    /// equivalent of `-Clink-self-contained=+linker` on the CLI).
+    pub fn with_linker() -> LinkSelfContainedDefault {
+        LinkSelfContainedDefault::WithComponents(LinkSelfContainedComponents::LINKER)
+    }
 }
 
 bitflags::bitflags! {

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_none.rs
@@ -6,13 +6,14 @@
 //
 // For example, `-C target-cpu=cortex-a53`.
 
-use crate::spec::{PanicStrategy, RelocModel, SanitizerSet, Target, TargetOptions};
+use crate::spec::{
+    Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, SanitizerSet, Target, TargetOptions,
+};
 
 pub fn target() -> Target {
     let opts = TargetOptions {
-        // FERROCENE: use the default linker rather than rust-lld
-        //linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
-        //linker: Some("rust-lld".into()),
+        linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
+        linker: Some("rust-lld".into()),
         features: "+v8a,+strict-align,+neon,+fp-armv8".into(),
         supported_sanitizers: SanitizerSet::KCFI | SanitizerSet::KERNELADDRESS,
         relocation_model: RelocModel::Static,

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnu.rs
@@ -5,6 +5,18 @@ pub fn target() -> Target {
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
     base.max_atomic_width = Some(64);
+    // Ferrocene elects to use lld as the linker on this target.
+    // Upstream still uses ld.
+    //
+    // Setting Lld::Yes causes `-fuse-ld=lld` to be added to the linker args
+    // (and by linker I mean `cc` as the linker as we use Cc::Yes)
+    base.linker_flavor = LinkerFlavor::Gnu(Cc::Yes, Lld::Yes);
+    // This setting causes `-B path/to/gcc-ld` to be added to the linker args.
+    // This means that that the `ld.lld` wrapper for `rust-lld` appears in the
+    // path that `cc` uses to find `ld.lld` (also the path used for `cpp` and
+    // `cc1`, but we don't supply those so it goes back to the defaults for
+    // those tools).
+    base.link_self_contained = crate::spec::LinkSelfContainedDefault::with_linker();
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::X86;
     base.static_position_independent_executables = true;


### PR DESCRIPTION
1) Switch x86_64-linux-gnu to use lld.

   Using the bundled `rust-lld` as the linker (via its `ld.lld` wrapper) means all users always use the same linker. This helps with the qualification efforts, rather than users using random versions of `ld`.

   However, we still drive `rust-lld` (or actually `ld.lld`) via the system C compiler, because the C compiler knows where the system libraries live, and Rust does not.

2) Switch the aarch64-unknown-none target to use rust-lld.

   Using the bundled `rust-lld` as the linker (via its `ld.lld` wrapper) means all users always use the same linker. This helps with the qualification efforts, rather than users using random versions of `ld`.

   We don't go via the system C compiler on `aarch64-unknown-none` because we do not need system C libraries. We do go via the system C compiler on `aarch64-unknown-ferrocenecoretest` because that needs `libstd` to build the test runner.

