### PR TITLE
remove redundant call

### DIFF
--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -219,7 +219,6 @@ impl<'a> Subsetter<'a> {
             .lines()
             .map(|line| line.trim())
             .filter(|line| !line.starts_with('#'))
-            .map(|line| line.trim())
             .filter(|line| !line.is_empty());
 
         let Some(subset) = lines.next() else {


### PR DESCRIPTION
`trim` is already called 2 lines prior