### PR TITLE
Fix PR message not being generated during some upstream pulls

### DIFF
--- a/.github/workflows/automation-pull-upstream.yml
+++ b/.github/workflows/automation-pull-upstream.yml
@@ -67,6 +67,9 @@ jobs:
         if: matrix.branch != 'master'
         id: create_branch
 
+      - name: Clone a subset of the LLVM submodule rather than the whole thing
+        run: ferrocene/ci/scripts/clone-llvm-subset.sh
+
       - name: Run the pull-upstream automation
         run: python3 ferrocene/tools/pull-upstream/automation.py ${{ matrix.branch }} ${{ steps.create_branch.outputs.name || 'main' }}
         env:

--- a/ferrocene/tools/pull-upstream/generate_pr_body.py
+++ b/ferrocene/tools/pull-upstream/generate_pr_body.py
@@ -84,6 +84,18 @@ def render_changes(origin, base_branch, new_branch):
     if last is None:
         return "**Nothing**"
 
+    # When merge conflicts are fixes with separate commits, the latest commit
+    # on the branch will not be the merge commit from upstream. In those cases
+    # we need to walk back through the commit graph until we find it.
+    while commits[last].merge is None:
+        print(f"skipping commit {last} as it's not a merge commit", file=sys.stderr)
+        last = commits[last].parent
+        # When there are no merge commits in the branch, we will reach a point
+        # where the parent commit is not in the subset of commits retrieved
+        # from the git invocation above. Gracefully handle that.
+        if last not in commits:
+            return "**Nothing**"
+
     # Parse the commit graph and generate the list of changes
     changes = ""
     cursor = commits[last].merge

--- a/ferrocene/tools/pull-upstream/generate_pr_body.py
+++ b/ferrocene/tools/pull-upstream/generate_pr_body.py
@@ -84,7 +84,7 @@ def render_changes(origin, base_branch, new_branch):
     if last is None:
         return "**Nothing**"
 
-    # When merge conflicts are fixes with separate commits, the latest commit
+    # When merge conflicts are fixed with separate commits, the latest commit
     # on the branch will not be the merge commit from upstream. In those cases
     # we need to walk back through the commit graph until we find it.
     while commits[last].merge is None:


### PR DESCRIPTION
There was a long standing bug in the script used to generate upstream pulls' PR bodies: if followup commits were present on the branch, the script would not output anything. Up until today this only happened if the script was ran locally after committing extra changes, but since #112 the automation itself can generate followup commits.

This PR fixes the bug by walking back the commit graph until a merge commit is found, rather than the current behavior of always using the last commit even if it's not a merge commit.

This PR also speeds up the execution of the automation in CI, as most of the time right now is spent cloning LLVM. The CI script to download a shallow clone of a subset of it is now used instead.