### PR TITLE
Actually run tests for `generate-tarball`

### DIFF
--- a/src/bootstrap/src/ferrocene/test.rs
+++ b/src/bootstrap/src/ferrocene/test.rs
@@ -159,6 +159,6 @@ impl Step for GenerateTarball {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(CheckDocumentSignatures { target: run.target });
+        run.builder.ensure(Self { target: run.target });
     }
 }


### PR DESCRIPTION
While preparing the open sourcing of Ferrocene 23.06, I stumbled upon ferrocene/ferrocene-prehistory#1454. As part of the fix, that PR accidentally switched the step executed when requesting the `generated-tarball` tests. This PR fixes that.