### PR TITLE
Update target docs.

### DIFF
--- a/ferrocene/doc/safety-manual/src/options.rst
+++ b/ferrocene/doc/safety-manual/src/options.rst
@@ -4,6 +4,9 @@
 Tool Options
 ============
 
+Ferrocene Options
+-----------------
+
 Ferrocene is qualified exclusively for the following command line options:
 
 - Users shall pass command line option ``--edition 2021`` to each invocation of
@@ -42,3 +45,67 @@ chapter, they must verify that the feature exists and is compatible with their
 target, that their safety context is compatible with the use of the CLI option or
 feature, and develop appropriate verification activities and tests to ensure
 the correct functionality of the generated code.
+
+Linker Options
+--------------
+
+Ferrocene is qualified using the ``rust-lld`` linker supplied with
+Ferrocene. The linker can either be driven directly by Ferrocene, or via a
+system C compiler acting as a *linker driver*, depending on whether the target
+requires access to system-specific C libraries to correctly link an executable
+or shared library.
+
+The :doc:`Compilation Targets <user-manual:targets/index>` section of the User
+Manual specifies for each target whether the linker is used directly, or via a
+system C compiler as a *linker-driver*.
+
+Where a C compiler is acting as a *linker driver*, the C compiler is given a
+path to a binary called ``ld.lld`` to use as its linker. The ``ld.lld`` binary
+is a small wrapper around ``rust-lld`` which puts ``rust-lld`` into a *GNU ld
+compatible mode* and otherwise passes on any arguments given straight through to
+``rust-lld``.
+
+Regardless of whether a C compiler is used as a *linker-driver* or not, only the
+following arguments may be presented to the ``rust-lld`` linker for the linking
+of Ferrocene executables and shared libraries:
+
+- Input objects for linking
+
+- The *Output object name* option, ``-o <path>``
+
+- The *Library Path* option, ``-L <path>``
+
+- The *Discard All* option ``-X`` or ``--discard-all``
+
+- The *Keyword* option, ``-z <keyword>``
+
+- The *Link* option, ``-l <somelibrary>`` or ``--library-path <somelibrary>``
+
+- The *Emulation* option, ``-m <mode>``
+
+- The *Little Endian* option, ``-EL``
+
+- The *PIC Executable* option, ``--pie`` or ``--pic-executable``
+
+- The *Non-PIC Executable* option, ``--no-pie``
+
+- The *Dynamic Linker* option, ``-I <path>`` or ``--dynamic-linker <path>``
+
+- The *SysRoot* option, ``--sysroot``
+
+- The *Build ID* option, ``--build-id``
+
+- The *Exception Frame Header* option, ``--eh-frame-header``
+
+- The *Hash Style* option, ``--hash-style <style>``
+
+- The *As Needed* options, ``--as-needed`` and ``--no-as-needed``
+
+- The *Push and Pop* options, ``--push-state`` and ``--pop-state``
+
+- The *Arm Cortex-A53 Errata fix* option, ``--fix-cortex-a53-843419``
+
+Where alternative forms of the above options, for example using a single dash
+(``-``) instead of two dashes (``--``), or using the ``--option=value`` form
+instead of ``--option value`` form, are treated as equivalent by the linker they
+are also acceptable.

--- a/ferrocene/doc/safety-manual/src/procedures.rst
+++ b/ferrocene/doc/safety-manual/src/procedures.rst
@@ -24,7 +24,7 @@ The Ferrocene provides a checker called ``ferrocene-self-test`` (see
 for verifying the installation of the toolchain in a non-certification context.
 
 This tool is not qualified. Consequently, in certification context, the
-following manual checks must be perfomred as per the :doc:`User Exported
+following manual checks must be performed as per the :doc:`User Exported
 Constraints <safety-manual:constraints>`:
 
 - the tarballs were extracted correctly, and permissions were preserved

--- a/ferrocene/doc/user-manual/src/self-test/error-codes.rst
+++ b/ferrocene/doc/user-manual/src/self-test/error-codes.rst
@@ -111,44 +111,6 @@ This error occurs when a Ferrocene toolset library is not accessible.
 
 Ensure that file ownership and system permissions are correctly set.
 
-FST_011: Linker not found
--------------------------
-
-This error occurs when a linker has not been installed.
-
-**Suggested fixes**
-
-Ensure that a linker is installed.
-
-FST_012: Linker version fetch failed
-------------------------------------
-
-This error occurs when the invocation of the linker failed.
-
-**Suggested fixes**
-
-Ensure that a linker is installed.
-
-FST_013: Linker version parse failed
-------------------------------------
-
-This error occurs when the linker is not a valid binary.
-
-**Suggested fixes**
-
-Ensure that another binary with the same name has not been installed in the
-linker installation directory.
-
-FST_014: Unsupported linker version
------------------------------------
-
-This error occurs when the version of the linker is not supported by the
-qualified Ferrocene toolset.
-
-**Suggested fixes**
-
-Use a linker that is supported by the qualified Ferrocene toolset.
-
 FST_015: Bundled linker missing
 -------------------------------
 
@@ -240,3 +202,23 @@ Ensure that the Ferrocene sysroot is not tampered with while the self-test
 tool is running.
 
 Ensure that the Ferrocene toolset has been properly installed.
+
+FLS_023: Suitable C Compiler not found
+--------------------------------------
+
+This error occurs when the Ferrocene self-test tool is unable to find a C
+compiler which meets the requirements for a specific target.
+
+**Suggested fixes**
+
+Install a suitable C compiler for that target, such as GCC or clang.
+
+FLS_024: Linker Arguments error
+-------------------------------
+
+This error occurs when the Ferrocene self-test tool is unable to find a C
+compiler which emits only valid linker arguments to the linker.
+
+**Suggested fixes**
+
+Install a suitable C compiler for that target, such as GCC or clang.

--- a/ferrocene/doc/user-manual/src/self-test/error-codes.rst
+++ b/ferrocene/doc/user-manual/src/self-test/error-codes.rst
@@ -123,7 +123,7 @@ Ensure that the Ferrocene toolset has been properly installed.
 FLS_016: Path not in UTF-8
 --------------------------
 
-This error occurs when the Ferrocene self-test tool attemts to access a
+This error occurs when the Ferrocene self-test tool attempts to access a
 path that is not in UTF-8.
 
 **Suggested fixes**

--- a/ferrocene/doc/user-manual/src/targets/aarch64-unknown-none.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-unknown-none.rst
@@ -12,7 +12,7 @@ bare-metal ARMv8-A processors operating in Aarch64 mode.
 Prerequisites
 -------------
 
-This target uses the LLVM ``rust-lld`` linker and is qualfied for use with the
+This target uses the LLVM ``rust-lld`` linker and is qualified for use with the
 version of ``rust-lld`` bundled with Ferrocene.
 
 Required compiler flags

--- a/ferrocene/doc/user-manual/src/targets/aarch64-unknown-none.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-unknown-none.rst
@@ -12,8 +12,7 @@ bare-metal ARMv8-A processors operating in Aarch64 mode.
 Prerequisites
 -------------
 
-This target uses the LLVM ``rust-lld`` linker and is qualified for use with the
-version of ``rust-lld`` bundled with Ferrocene.
+This target has no pre-requisites.
 
 Required compiler flags
 -----------------------
@@ -22,6 +21,3 @@ To use the target, the following additional flags must be provided to
 ``rustc``:
 
 * ``--target=aarch64-unknown-none``
-
-Mitigations in the linker for Arm Cortex-A53 Errata 843419 are automatically
-enabled.

--- a/ferrocene/doc/user-manual/src/targets/aarch64-unknown-none.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-unknown-none.rst
@@ -7,25 +7,13 @@ ARMv8-A bare metal
 ==================
 
 The ``aarch64-unknown-none`` Ferrocene target provides support for
-bare-metal ARMv8-A.
+bare-metal ARMv8-A processors operating in Aarch64 mode.
 
 Prerequisites
 -------------
 
-This target requires the ``aarch64-linux-gnu-gcc`` compiler, and is qualified
-for use with version 7.5.x, as shipped by Ubuntu 18.04 LTS.
-
-On Ubuntu 18.04 LTS you can install it with:
-
-.. code-block::
-
-   $ sudo apt install gcc-aarch64-linux-gnu
-
-Once installed, you can check the version is correct by running:
-
-.. code-block::
-
-   $ aarch64-linux-gnu-gcc --version
+This target uses the LLVM ``rust-lld`` linker and is qualfied for use with the
+version of ``rust-lld`` bundled with Ferrocene.
 
 Required compiler flags
 -----------------------
@@ -34,7 +22,6 @@ To use the target, the following additional flags must be provided to
 ``rustc``:
 
 * ``--target=aarch64-unknown-none``
-* ``-Clinker=aarch64-linux-gnu-gcc``
-* ``-Clinker-flavor=gcc``
-* ``-Clink-arg=-ffreestanding``
-* ``-Clink-arg=-nostdlib``
+
+Mitigations in the linker for Arm Cortex-A53 Errata 843419 are automatically
+enabled.

--- a/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
@@ -12,7 +12,7 @@ or higher on x86_64 using glibc 2.17 or higher.
 Prerequisites
 -------------
 
-This target uses the LLVM ``ld.lld`` linker and is qualfied for use with the
+This target uses the LLVM ``ld.lld`` linker and is qualified for use with the
 version of ``ld.lld`` bundled with Ferrocene. To locate the system C libraries
 required to link a functional Linux binary, this target drives the ``ld.lld``
 linker using your system's C compiler as a linker-driver.

--- a/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
@@ -18,10 +18,15 @@ linker using your system's C compiler as a linker-driver.
 
 You must have a C compiler which:
 
-* Supports ``-fuse-ld=ld.lld`` option to select ``ld.lld`` as the linker
-* Supports ``-B`` option to modify the tool search path so it can find Ferrocene's
+- Supports ``-fuse-ld=ld.lld`` option to select ``ld.lld`` as the linker
+
+- Supports ``-B`` option to modify the tool search path so it can find Ferrocene's
   copy of ``ld.lld``
-* Does not load plugins into the linker (e.g. the GCC LTO plugin)
+
+- Does not load plugins into the linker (e.g. the GCC LTO plugin)
+
+- Supplies to ``ld.lld`` only those linker arguments specified in the
+  :doc:`Safety Manual <safety-manual:options>`
 
 On Ubuntu 18.04 LTS you can install a suitable C compiler with:
 
@@ -35,11 +40,13 @@ Required compiler flags
 To use the target, the following additional flags must be provided to
 ``rustc``:
 
-* ``--target=x86_64-unknown-linux-gnu``
-* ``-C linker=<your-c-compiler>``
-   * e.g. ``-C linker=/usr/bin/gcc``
+- ``--target=x86_64-unknown-linux-gnu``
+
+- ``-C linker=<your-c-compiler>``
+
+  - e.g. ``-C linker=/usr/bin/gcc``
 
 If your C compiler loads the GCC LTO plugins by default, you will also need to
 switch off GCC LTO with:
 
-* ``-Clink-arg=-fno-lto``
+- ``-Clink-arg=-fno-lto``

--- a/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
@@ -6,62 +6,28 @@
 x86_64 Linux (glibc)
 ====================
 
-The ``x86_64-unknown-linux-gnu`` Ferrocene target provides support for Linux 3.2
-or higher on x86_64 using glibc 2.17 or higher.
+The ``x86_64-unknown-linux-gnu`` Ferrocene target provides support for Linux on
+x86_64 using glibc 2.27 or higher.
 
 Prerequisites
 -------------
 
-This target uses the LLVM ``ld.lld`` linker and is qualified for use with the
-version of ``ld.lld`` bundled with Ferrocene. To locate the system C libraries
+This target uses the LLVM ``ld.lld`` linker but to locate the system C libraries
 required to link a functional Linux binary, this target drives the ``ld.lld``
 linker using your system's C compiler as a linker-driver.
 
-The ``ld.lld`` binary is a small wrapper around the LLVM ``rust-lld`` linker;
-it's job is to provide an additional argument to put ``rust-lld`` into a GNU
-``ld`` compatible mode.
+You must have a C compiler which:
 
-You must run the Ferrocene Self Test (`ferrocene-self-test`) to determine
-whether you have a system C compiler that supports using the Ferrocene
-``ld.lld`` linker in place of your system's default linker (usually GNU ``ld``).
-This means a C compiler which supports both the ``-fuse-ld=lld`` and ``-B/path``
-options. Your C compiler must also be configured to not cause the GCC LTO
-plugins (or any other plugins) to be loaded into the linker.
+* Supports ``-fuse-ld=ld.lld`` option to select ``ld.lld`` as the linker
+* Supports ``-B`` option to modify the tool search path so it can find Ferrocene's
+  copy of ``ld.lld``
+* Does not load plugins into the linker (e.g. the GCC LTO plugin)
+
+On Ubuntu 18.04 LTS you can install a suitable C compiler with:
 
 .. code-block::
 
-   $ /path/to/ferrocene/bin/ferrocene-self-test
-
-Ferrocene Self Test will try `cc`, `gcc` and then `clang` in that order whilst
-searching for a suitable C compiler to act as a linker-driver. It will then
-determine whether any plugins were loaded into the linker, and attempt to
-identify a command-line option which will disable those plugins.
-
-Finally it will report which, if any, compiler flags are required each target.
-
-.. code-block::
-
-   $ /path/to/ferrocene/bin/ferrocene-self-test
-       Info: using sysroot /path/to/ferrocene
-    Success: binary rustc is valid
-    Success: binary rustdoc is valid
-    Skipped: optional binary cargo (not present)
-    Success: target installed correctly: x86_64-unknown-linux-gnu
-    Success: target installed correctly: aarch64-unknown-none
-    Success: bundled linker detected
-    Success: bundled linker-wrapper detected
-    Success: Found C compiler `cc` for target `x86_64-unknown-linux-gnu`
-    Skipped: Target `aarch64-unknown-none` does not require a C compiler
-    Success: compiled sample program `addition.rs` for target x86_64-unknown-linux-gnu
-    Success: compiled sample program `subtraction.rs` for target x86_64-unknown-linux-gnu
-    Success: compiled sample program `subtraction-sys.rs` for target x86_64-unknown-linux-gnu
-    Success: compiled sample program `assertion.rs` for target x86_64-unknown-linux-gnu
-    Success: compiled sample program `addition.rs` for target aarch64-unknown-linux-gnu
-       Info: Target 'x86_64-unknown-linux-gnu' requires special linker flags:
-       Info: 	-Clinker=cc
-       Info: 	-Clink-arg=-fno-lto
-       Info: Target 'aarch64-unknown-none' requires no special linker flags
-    Success: Ferrocene self-check completed!
+   $ sudo apt install gcc
 
 Required compiler flags
 -----------------------
@@ -70,6 +36,10 @@ To use the target, the following additional flags must be provided to
 ``rustc``:
 
 * ``--target=x86_64-unknown-linux-gnu``
+* ``-C linker=<your-c-compiler>``
+   * e.g. ``-C linker=/usr/bin/gcc``
 
-In addition, you must also supply to ``rustc`` any additional flags identified
-by ``ferrocene-self-test``.
+If your C compiler loads the GCC LTO plugins by default, you will also need to
+switch off GCC LTO with:
+
+* ``-Clink-arg=-fno-lto``

--- a/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
@@ -6,26 +6,62 @@
 x86_64 Linux (glibc)
 ====================
 
-The ``x86_64-unknown-linux-gnu`` Ferrocene target provides support for
-Linux on x86_64 using glibc.
+The ``x86_64-unknown-linux-gnu`` Ferrocene target provides support for Linux 3.2
+or higher on x86_64 using glibc 2.17 or higher.
 
 Prerequisites
 -------------
 
-This target requires the ``x86_64-linux-gnu-gcc`` compiler, and is qualified
-for use with version 7.5.x, as shipped by Ubuntu 18.04 LTS.
+This target uses the LLVM ``ld.lld`` linker and is qualfied for use with the
+version of ``ld.lld`` bundled with Ferrocene. To locate the system C libraries
+required to link a functional Linux binary, this target drives the ``ld.lld``
+linker using your system's C compiler as a linker-driver.
 
-On Ubuntu 18.04 LTS you can install it with:
+The ``ld.lld`` binary is a small wrapper around the LLVM ``rust-lld`` linker;
+it's job is to provide an additional argument to put ``rust-lld`` into a GNU
+``ld`` compatible mode.
+
+You must run the Ferrocene Self Test (`ferrocene-self-test`) to determine
+whether you have a system C compiler that supports using the Ferrocene
+``ld.lld`` linker in place of your system's default linker (usually GNU ``ld``).
+This means a C compiler which supports both the ``-fuse-ld=lld`` and ``-B/path``
+options. Your C compiler must also be configured to not cause the GCC LTO
+plugins (or any other plugins) to be loaded into the linker.
 
 .. code-block::
 
-   $ sudo apt install gcc
+   $ /path/to/ferrocene/bin/ferrocene-self-test
 
-Once installed, you can ensure the version is correct by running:
+Ferrocene Self Test will try `cc`, `gcc` and then `clang` in that order whilst
+searching for a suitable C compiler to act as a linker-driver. It will then
+determine whether any plugins were loaded into the linker, and attempt to
+identify a command-line option which will disable those plugins.
+
+Finally it will report which, if any, compiler flags are required each target.
 
 .. code-block::
 
-   $ x86_64-linux-gnu-gcc --version
+   $ /path/to/ferrocene/bin/ferrocene-self-test
+       Info: using sysroot /path/to/ferrocene
+    Success: binary rustc is valid
+    Success: binary rustdoc is valid
+    Skipped: optional binary cargo (not present)
+    Success: target installed correctly: x86_64-unknown-linux-gnu
+    Success: target installed correctly: aarch64-unknown-none
+    Success: bundled linker detected
+    Success: bundled linker-wrapper detected
+    Success: Found C compiler `cc` for target `x86_64-unknown-linux-gnu`
+    Skipped: Target `aarch64-unknown-none` does not require a C compiler
+    Success: compiled sample program `addition.rs` for target x86_64-unknown-linux-gnu
+    Success: compiled sample program `subtraction.rs` for target x86_64-unknown-linux-gnu
+    Success: compiled sample program `subtraction-sys.rs` for target x86_64-unknown-linux-gnu
+    Success: compiled sample program `assertion.rs` for target x86_64-unknown-linux-gnu
+    Success: compiled sample program `addition.rs` for target aarch64-unknown-linux-gnu
+       Info: Target 'x86_64-unknown-linux-gnu' requires special linker flags:
+       Info: 	-Clinker=cc
+       Info: 	-Clink-arg=-fno-lto
+       Info: Target 'aarch64-unknown-none' requires no special linker flags
+    Success: Ferrocene self-check completed!
 
 Required compiler flags
 -----------------------
@@ -34,5 +70,6 @@ To use the target, the following additional flags must be provided to
 ``rustc``:
 
 * ``--target=x86_64-unknown-linux-gnu``
-* ``-Clinker=x86_64-linux-gnu-gcc``
-* ``-Clinker-flavor=gcc``
+
+In addition, you must also supply to ``rustc`` any additional flags identified
+by ``ferrocene-self-test``.


### PR DESCRIPTION
Updates the docs for `aarch64-unknown-none` and `x86_64-unknown-linux-gnu` to reflect our new choices around which linker we use (see #10)