### PR TITLE
Test and fix CI for the 1.68 branch (23.06)

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -670,7 +670,7 @@ commands:
         default: false
     steps:
       - ferrocene-git-shallow-clone:
-          depth: 2
+          depth: 20
       - when:
           condition: << parameters.llvm-subset >>
           steps:

--- a/src/stage0.json
+++ b/src/stage0.json
@@ -3,7 +3,7 @@
     "dist_server": "https://static.rust-lang.org",
     "artifacts_server": "s3://ferrocene-ci-artifacts/ferrocene/dist",
     "artifacts_with_llvm_assertions_server": "s3://ferrocene-ci-artifacts/ferrocene/dist",
-    "git_merge_commit_email": "87868125+bors-ferrocene\\[bot\\]@users.noreply.github.com",
+    "git_merge_commit_email": "bors@rust-lang.org",
     "nightly_branch": "main"
   },
   "__comments": [


### PR DESCRIPTION
This PR is the equivalent of #36 for the 1.68 branch, which contains the source code of Ferrocene 23.06.x.