### PR TITLE
Ferrocene Self Test: Check C compiler passes extra args.

### DIFF
--- a/ferrocene/doc/safety-manual/src/options.rst
+++ b/ferrocene/doc/safety-manual/src/options.rst
@@ -65,6 +65,22 @@ is a small wrapper around ``rust-lld`` which puts ``rust-lld`` into a *GNU ld
 compatible mode* and otherwise passes on any arguments given straight through to
 ``rust-lld``.
 
+Any C compiler acting as a *linker driver*, must:
+
+- Pass to the underlying linker any arguments which do not start with a `-`
+  character and which end with a recognised file extension for Object Code
+  (typically ``.o``) or a Static Library containing Object Code (typically
+  ``.a``).
+
+- Accept arguments of the form ``-Wl,<linker-arg>``, passing ``<linker-arg>`` to
+  the underlying linker as an argument.
+
+- Accept the ``-fuse-ld=lld`` argument, which must cause the C compiler to use
+  ``lld`` as the linker instead of its default linker.
+
+- Accept the ``-B <path>`` argument, which must cause the C compiler search
+  the path ``<path>`` for the ``lld`` linker binary.
+
 Regardless of whether a C compiler is used as a *linker-driver* or not, only the
 following arguments may be presented to the ``rust-lld`` linker for the linking
 of Ferrocene executables and shared libraries:
@@ -107,5 +123,6 @@ of Ferrocene executables and shared libraries:
 
 Alternative forms of the above options are acceptable:
 
-- Using a single dash (``-``) instead of two dashes (``--``),
+- Using a single dash (``-``) instead of two dashes (``--``)
+
 - Using the ``--option=value`` form instead of ``--option value`` form

--- a/ferrocene/tools/self-test/sample-programs/assertion.rs
+++ b/ferrocene/tools/self-test/sample-programs/assertion.rs
@@ -9,6 +9,8 @@ use subtraction_sys::sub;
 
 pub fn main() {
     assert_eq!(2, add(sub(2, 1), 1));
+    #[cfg(not(selftest_no_std))]
+    print!("123456789");
 }
 
 #[cfg(selftest_no_std)]

--- a/ferrocene/tools/self-test/src/error.rs
+++ b/ferrocene/tools/self-test/src/error.rs
@@ -6,6 +6,16 @@ use std::fmt::Display;
 use std::path::PathBuf;
 use std::process::Output;
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum LinkerArgsErrorKind {
+    UnknownArgument,
+    DisallowedPlugin,
+    NoArgsFile,
+    InvalidArgsFile,
+    EmptyArgsFile,
+    MissingArg,
+}
+
 #[derive(Debug)]
 pub(crate) enum Error {
     NoSysroot,
@@ -28,7 +38,7 @@ pub(crate) enum Error {
     MissingCompilationArtifact { name: String, after_compiling: String },
     UnexpectedCompilationArtifact { name: String, after_compiling: String },
     SuitableCCompilerNotFound { target: String },
-    LinkerArgsError { target: String },
+    LinkerArgsError { target: String, kind: LinkerArgsErrorKind },
 }
 
 impl Error {
@@ -166,8 +176,8 @@ impl Display for Error {
             Error::SuitableCCompilerNotFound { target } => {
                 write!(f, "unable to find LLD-compatible C compiler for `{target}`")
             }
-            Error::LinkerArgsError { target } => {
-                write!(f, "Unable to analyse linker arguments for `{target}`")
+            Error::LinkerArgsError { target, kind } => {
+                write!(f, "Unable to analyse linker arguments for `{target}` (kind={kind:?})")
             }
         }
     }

--- a/ferrocene/tools/self-test/src/error.rs
+++ b/ferrocene/tools/self-test/src/error.rs
@@ -39,6 +39,8 @@ pub(crate) enum Error {
     UnexpectedCompilationArtifact { name: String, after_compiling: String },
     SuitableCCompilerNotFound { target: String },
     LinkerArgsError { target: String, kind: LinkerArgsErrorKind },
+    RunningSampleProgramFailed { name: String, error: std::io::Error },
+    SampleProgramOutputWrong { name: String, expected: Vec<u8>, found: Vec<u8> },
 }
 
 impl Error {
@@ -65,6 +67,8 @@ impl Error {
             Error::UnexpectedCompilationArtifact { .. } => 22,
             Error::SuitableCCompilerNotFound { .. } => 23,
             Error::LinkerArgsError { .. } => 24,
+            Error::RunningSampleProgramFailed { .. } => 25,
+            Error::SampleProgramOutputWrong { .. } => 26,
         }
     }
 }
@@ -93,6 +97,8 @@ impl std::error::Error for Error {
             Error::UnexpectedCompilationArtifact { .. } => None,
             Error::SuitableCCompilerNotFound { .. } => None,
             Error::LinkerArgsError { .. } => None,
+            Error::RunningSampleProgramFailed { error, .. } => Some(error),
+            Error::SampleProgramOutputWrong { .. } => None,
         }
     }
 }
@@ -178,6 +184,15 @@ impl Display for Error {
             }
             Error::LinkerArgsError { target, kind } => {
                 write!(f, "Unable to analyse linker arguments for `{target}` (kind={kind:?})")
+            }
+            Error::RunningSampleProgramFailed { name, .. } => {
+                write!(f, "unable to execute sample program {name}")
+            }
+            Error::SampleProgramOutputWrong { name, expected, found } => {
+                write!(
+                    f,
+                    "sample program {name} should have produced {expected:?}, actually produced {found:?}"
+                )
             }
         }
     }


### PR DESCRIPTION
We now give the C compiler a `-Wl,--foobar` argument, and test that the linker receives `--foobar` as an argument (but using a long random string instead of `foobar`).