### PR TITLE
Re-enable OxidOS in CI

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -163,6 +163,18 @@ jobs:
           # code into the tarball we ship to customers.
           llvm-subset: false
 
+  wasm-dist-oxidos:
+    executor: docker-ubuntu-18
+    resource_class: large # 4-core
+    environment:
+      FERROCENE_HOST: x86_64-unknown-linux-gnu
+      FERROCENE_TARGETS: wasm32-unknown-unknown
+      SCRIPT: |
+        ./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist:oxidos)
+    steps:
+      - ferrocene-job-dist:
+          restore-from-job: x86_64-linux-build
+
   x86_64-linux-generic-test-container:
     executor: docker-ubuntu-18
     parameters:
@@ -465,6 +477,10 @@ workflows:
           requires:
             - x86_64-linux-build
 
+      - wasm-dist-oxidos:
+          requires:
+            - x86_64-linux-build
+
       - x86_64-linux-self-test:
           requires:
             - x86_64-linux-dist
@@ -476,6 +492,8 @@ workflows:
             - x86_64-linux-dist-src
             - x86_64-linux-traceability-matrix
             - x86_64-linux-self-test
+            - wasm-dist-oxidos
+
 
   # Record the branch commit for all the jobs bors merges commit into.
   record-branch-commit:

--- a/ferrocene/packages.toml
+++ b/ferrocene/packages.toml
@@ -56,6 +56,13 @@ targets = ["aarch64-unknown-none", "aarch64-unknown-linux-gnu", "thumbv7em-none-
 name = "rust-std"
 subset = "default"
 
+[groups.oxidos]
+targets = ["wasm32-unknown-unknown"]
+
+[[groups.oxidos.packages]]
+name = "oxidos"
+subset = "oxidos"
+
 [groups.any-platform]
 targets = ["*"]
 

--- a/src/bootstrap/src/ferrocene/partners/oxidos.rs
+++ b/src/bootstrap/src/ferrocene/partners/oxidos.rs
@@ -39,6 +39,10 @@ const OXIDOS_ALLOW_UNSTABLE_FEATURES: &[&str] = &[
     "core_intrinsics",
     "asm_experimental_arch",
 ];
+const OXIDOS_ALLOW_LINTS: &[&str] = &[
+    // Allow internal features to be used. This is needed due to the core_intrinsics feature.
+    "internal_features",
+];
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
 pub(crate) struct DistOxidOs {
@@ -129,6 +133,10 @@ impl Step for BuildOxidOS {
 
         cargo.current_dir(&source);
         cargo.rustflag(&format!("-Zallow-features={}", OXIDOS_ALLOW_UNSTABLE_FEATURES.join(",")));
+
+        for lint in OXIDOS_ALLOW_LINTS {
+            cargo.rustflag(&format!("-A{lint}"));
+        }
 
         for krate in OXIDOS_CRATES {
             cargo.args(["-p", *krate]);

--- a/src/bootstrap/src/ferrocene/partners/oxidos.rs
+++ b/src/bootstrap/src/ferrocene/partners/oxidos.rs
@@ -143,13 +143,16 @@ impl Step for BuildOxidOS {
         }
 
         for (cfg_name, cfg_values) in OXIDOS_CHECK_CFG {
-            let mut flag = format!("--check-cfg=values({cfg_name}");
-            for cfg_value in *cfg_values {
-                flag.push_str(",\"");
+            let mut flag = format!("--check-cfg=cfg({cfg_name},values(");
+            for (i, cfg_value) in cfg_values.iter().enumerate() {
+                if i != 0 {
+                    flag.push(',');
+                }
+                flag.push('"');
                 flag.push_str(cfg_value);
                 flag.push('"');
             }
-            flag.push(')');
+            flag.push_str("))");
             cargo.rustflag(&flag);
         }
 


### PR DESCRIPTION
#157 disabled building OxidOS in CI due to the `core_intrinsics` unstable feature being marked as internal by upstream. This PR re-enables it, and changes bootstrap to allow internal features when building OxidOS.