### PR TITLE
Revert temporary commit in 1.68

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -670,7 +670,7 @@ commands:
         default: false
     steps:
       - ferrocene-git-shallow-clone:
-          depth: 20
+          depth: 2
       - when:
           condition: << parameters.llvm-subset >>
           steps:

--- a/src/stage0.json
+++ b/src/stage0.json
@@ -3,7 +3,7 @@
     "dist_server": "https://static.rust-lang.org",
     "artifacts_server": "s3://ferrocene-ci-artifacts/ferrocene/dist",
     "artifacts_with_llvm_assertions_server": "s3://ferrocene-ci-artifacts/ferrocene/dist",
-    "git_merge_commit_email": "bors@rust-lang.org",
+    "git_merge_commit_email": "87868125+bors-ferrocene\\[bot\\]@users.noreply.github.com",
     "nightly_branch": "main"
   },
   "__comments": [


### PR DESCRIPTION
This PR reverts the temporary commit used to make the initial CI job for 1.68 pass in the new repo.