### PR TITLE
Code Coverage Support for Core Library

### DIFF
--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -779,7 +779,7 @@ impl<'a, 'tcx> CrateLoader<'a, 'tcx> {
         self.inject_dependency_if(cnum, "a panic runtime", &|data| data.needs_panic_runtime());
     }
 
-    fn inject_profiler_runtime(&mut self, krate: &ast::Crate) {
+    fn inject_profiler_runtime(&mut self) {
         if self.sess.opts.unstable_opts.no_profiler_runtime
             || !(self.sess.instrument_coverage()
                 || self.sess.opts.unstable_opts.profile
@@ -791,9 +791,9 @@ impl<'a, 'tcx> CrateLoader<'a, 'tcx> {
         info!("loading profiler");
 
         let name = Symbol::intern(&self.sess.opts.unstable_opts.profiler_runtime);
-        if name == sym::profiler_builtins && attr::contains_name(&krate.attrs, sym::no_core) {
-            self.sess.emit_err(errors::ProfilerBuiltinsNeedsCore);
-        }
+        // if name == sym::profiler_builtins && attr::contains_name(&krate.attrs, sym::no_core) {
+        //     self.sess.emit_err(errors::ProfilerBuiltinsNeedsCore);
+        // }
 
         let Some(cnum) = self.resolve_crate(name, DUMMY_SP, CrateDepKind::Implicit) else {
             return;
@@ -991,7 +991,7 @@ impl<'a, 'tcx> CrateLoader<'a, 'tcx> {
 
     pub fn postprocess(&mut self, krate: &ast::Crate) {
         self.inject_forced_externs();
-        self.inject_profiler_runtime(krate);
+        self.inject_profiler_runtime();
         self.inject_allocator_crate(krate);
         self.inject_panic_runtime(krate);
 

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -791,9 +791,6 @@ impl<'a, 'tcx> CrateLoader<'a, 'tcx> {
         info!("loading profiler");
 
         let name = Symbol::intern(&self.sess.opts.unstable_opts.profiler_runtime);
-        // if name == sym::profiler_builtins && attr::contains_name(&krate.attrs, sym::no_core) {
-        //     self.sess.emit_err(errors::ProfilerBuiltinsNeedsCore);
-        // }
 
         let Some(cnum) = self.resolve_crate(name, DUMMY_SP, CrateDepKind::Implicit) else {
             return;

--- a/library/profiler_builtins/Cargo.toml
+++ b/library/profiler_builtins/Cargo.toml
@@ -8,9 +8,13 @@ test = false
 bench = false
 doc = false
 
+[features]
+default = ["core"]
+core = ["dep:core", "dep:compiler_builtins"]
+
 [dependencies]
-core = { path = "../core" }
-compiler_builtins = { version = "0.1.0", features = ['rustc-dep-of-std'] }
+core = { path = "../core", optional = true }
+compiler_builtins = { version = "0.1.0", features = ['rustc-dep-of-std'], optional = true}
 
 [build-dependencies]
 cc = "1.0.69"

--- a/library/profiler_builtins/src/lib.rs
+++ b/library/profiler_builtins/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(feature = "core", no_std)]
 #![cfg_attr(not(feature = "core"), feature(no_core), no_core)]
-
 #![feature(profiler_runtime)]
 #![profiler_runtime]
 #![unstable(

--- a/library/profiler_builtins/src/lib.rs
+++ b/library/profiler_builtins/src/lib.rs
@@ -1,4 +1,6 @@
-#![no_std]
+#![cfg_attr(feature = "core", no_std)]
+#![cfg_attr(not(feature = "core"), feature(no_core), no_core)]
+
 #![feature(profiler_runtime)]
 #![profiler_runtime]
 #![unstable(

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -26,6 +26,7 @@ use crate::core::builder::crate_description;
 use crate::core::builder::Cargo;
 use crate::core::builder::{Builder, Kind, PathSet, RunConfig, ShouldRun, Step, TaskPath};
 use crate::core::config::{DebuginfoLevel, LlvmLibunwind, RustcLto, TargetSelection};
+use crate::ferrocene::code_coverage::ProfilerBuiltinsNoCore;
 use crate::utils::cache::{Interned, INTERNER};
 use crate::utils::helpers::{
     exe, get_clang_cl_resource_dir, is_debug_info, is_dylib, output, symlink_dir, t, up_to_date,
@@ -210,6 +211,13 @@ impl Step for Std {
         std_cargo(builder, target, compiler.stage, &mut cargo);
         for krate in &*self.crates {
             cargo.arg("-p").arg(krate);
+        }
+
+        if builder.config.ferrocene_code_coverage && compiler.stage == 1 {
+            let instrument_coverage_flags = builder.ensure(ProfilerBuiltinsNoCore);
+            for flag in instrument_coverage_flags.flags() {
+                cargo.rustflag(&flag);
+            }
         }
 
         // See src/bootstrap/synthetic_targets.rs

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2506,12 +2506,9 @@ impl Step for Crate {
         let target = self.target;
         let mode = self.mode;
 
-        let profiler_builtins_no_core_path = if builder.config.ferrocene_code_coverage {
-            Some(builder.ensure(ProfilerBuiltinsNoCore))
-        } else {
-            None
-        };
-
+        if builder.config.ferrocene_code_coverage && builder.doc_tests != DocTests::No {
+            panic!("Cannot generate coverage for doc tests");
+        }
         // See [field@compile::Std::force_recompile].
         builder.ensure(compile::Std::force_recompile(compiler, target));
         builder.ensure(RemoteCopyLibs { compiler, target });
@@ -2524,16 +2521,15 @@ impl Step for Crate {
 
         let mut cargo =
             builder.cargo(compiler, mode, SourceType::InTree, target, builder.kind.as_str());
-        
-            
-            match mode {
-                Mode::Std => {
-                    compile::std_cargo(builder, target, compiler.stage, &mut cargo);
-                    // `std_cargo` actually does the wrong thing: it passes `--sysroot build/host/stage2`,
-                    // but we want to use the force-recompile std we just built in `build/host/stage2-test-sysroot`.
-                    // Override it.
-                    if builder.download_rustc() && compiler.stage > 0 {
-                        let sysroot = builder
+
+        match mode {
+            Mode::Std => {
+                compile::std_cargo(builder, target, compiler.stage, &mut cargo);
+                // `std_cargo` actually does the wrong thing: it passes `--sysroot build/host/stage2`,
+                // but we want to use the force-recompile std we just built in `build/host/stage2-test-sysroot`.
+                // Override it.
+                if builder.download_rustc() && compiler.stage > 0 {
+                    let sysroot = builder
                         .out
                         .join(compiler.host.triple)
                         .join(format!("stage{}-test-sysroot", compiler.stage));
@@ -2546,18 +2542,12 @@ impl Step for Crate {
             _ => panic!("can only test libraries"),
         };
 
-
         if builder.config.ferrocene_code_coverage {
-            let profiler_builtins_no_core_path = profiler_builtins_no_core_path.unwrap();
-            cargo.rustflag("-Cinstrument-coverage");
-            cargo.rustflag("--extern");
-            cargo.rustflag(&format!("profiler_builtins={}", profiler_builtins_no_core_path.to_str().unwrap()));
-            cargo.rustflag("-L");
-            cargo.rustflag(profiler_builtins_no_core_path.parent().unwrap().to_str().unwrap());
-
-            // dbg!(&cargo);
+            let instrument_coverage_flags = builder.ensure(ProfilerBuiltinsNoCore);
+            for flag in instrument_coverage_flags.flags() {
+                cargo.rustflag(&flag);
+            }
         }
-        
         run_cargo_test(
             cargo,
             if target.contains("ferrocenecoretest") { &["--test-threads", "1"] } else { &[] },

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2506,9 +2506,6 @@ impl Step for Crate {
         let target = self.target;
         let mode = self.mode;
 
-        if !builder.config.dry_run() {
-            dbg!(&self.crates);
-        }
         if builder.config.ferrocene_code_coverage && builder.doc_tests != DocTests::No {
             panic!("Cannot generate coverage for doc tests");
         }

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2551,7 +2551,10 @@ impl Step for Crate {
             let profiler_builtins_no_core_path = profiler_builtins_no_core_path.unwrap();
             cargo.rustflag("-Cinstrument-coverage");
             cargo.rustflag("--extern");
-            cargo.rustflag(&format!("profiler_builtins={}", profiler_builtins_no_core_path.to_string_lossy()));
+            cargo.rustflag(&format!("profiler_builtins={}", profiler_builtins_no_core_path.to_str().unwrap()));
+            cargo.rustflag("-L");
+            cargo.rustflag(profiler_builtins_no_core_path.parent().unwrap().to_str().unwrap());
+
             // dbg!(&cargo);
         }
         

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1458,7 +1458,11 @@ impl<'a> Builder<'a> {
                 setting
             }
             None => {
-                if mode == Mode::Std {
+                // The legacy symbol mangling is used in the standard library to prevent it from
+                // showing up in user code yet (see https://github.com/rust-lang/rust/pull/90054).
+                // We only do so when we're not checking code coverage though, as code coverage
+                // requires the v0 symbol mangling.
+                if mode == Mode::Std && !self.config.ferrocene_code_coverage {
                     // The standard library defaults to the legacy scheme
                     false
                 } else {

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -732,6 +732,7 @@ impl<'a> Builder<'a> {
                 crate::ferrocene::test::SelfTest,
                 crate::ferrocene::test::CheckDocumentSignatures,
                 crate::ferrocene::test::GenerateTarball,
+                crate::ferrocene::code_coverage::ProfilerBuiltinsNoCore,
                 crate::core::build_steps::toolstate::ToolStateCheck,
                 test::ExpandYamlAnchors,
                 test::Tidy,

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1281,13 +1281,11 @@ impl Config {
         // We still support running outside the repository if we find we aren't in a git directory.
         cmd.arg("rev-parse").arg("--show-toplevel");
         // Discard stderr because we expect this to fail when building from a tarball.
-        let output = cmd.stderr(std::process::Stdio::null()).output().ok().and_then(|output| {
-            if output.status.success() {
-                Some(output)
-            } else {
-                None
-            }
-        });
+        let output = cmd
+            .stderr(std::process::Stdio::null())
+            .output()
+            .ok()
+            .and_then(|output| if output.status.success() { Some(output) } else { None });
         if let Some(output) = output {
             let git_root = String::from_utf8(output.stdout).unwrap();
             // We need to canonicalize this path to make sure it uses backslashes instead of forward slashes.

--- a/src/bootstrap/src/core/config/flags.rs
+++ b/src/bootstrap/src/core/config/flags.rs
@@ -380,6 +380,9 @@ pub enum Subcommand {
         /// enable this to generate a Rustfix coverage file, which is saved in
         /// `/<build_base>/rustfix_missing_coverage.txt`
         rustfix_coverage: bool,
+        /// generate coverage for tests
+        #[arg(long)]
+        coverage: bool
     },
     /// Build and run some benchmarks
     Bench {

--- a/src/bootstrap/src/core/config/flags.rs
+++ b/src/bootstrap/src/core/config/flags.rs
@@ -382,7 +382,7 @@ pub enum Subcommand {
         rustfix_coverage: bool,
         /// generate coverage for tests
         #[arg(long)]
-        coverage: bool
+        coverage: bool,
     },
     /// Build and run some benchmarks
     Bench {

--- a/src/bootstrap/src/ferrocene/code_coverage.rs
+++ b/src/bootstrap/src/ferrocene/code_coverage.rs
@@ -1,24 +1,33 @@
+use std::path::Path;
+
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
-use crate::Command;
-use crate::BootstrapCommand;
-use crate::Mode;
 use crate::core::build_steps::tool::SourceType;
-use std::path::{Path, PathBuf};
+use crate::BootstrapCommand;
+use crate::Command;
+use crate::Mode;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) struct ProfilerBuiltinsNoCore;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub(crate) struct ProfilerBuiltins;
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct InstrumentationCoverageFlags {
+    rustflags: Vec<String>,
+}
+
+impl InstrumentationCoverageFlags {
+    pub fn flags(&self) -> &[String] {
+        &self.rustflags
+    }
+}
 
 impl Step for ProfilerBuiltinsNoCore {
-    type Output = PathBuf;
+    type Output = InstrumentationCoverageFlags;
     const ONLY_HOSTS: bool = true;
     const DEFAULT: bool = true;
 
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         builder.info("Building profiler_builtins with no_core");
-        
+
         let target = builder.config.build;
         let compiler = builder.compiler(1, target);
 
@@ -26,19 +35,18 @@ impl Step for ProfilerBuiltinsNoCore {
         // [ProfilerBuiltinNoCore step] Builds profiler_builtins with no core -> profiler_builtins_no_core.rlib
         // [Core Tests step] Compile tests of core with -Cinsturment-coverage -> link against profiler_builtins_no_core.rlib
 
-        
         let mut cargo = builder.cargo(compiler, Mode::Std, SourceType::InTree, target, "build");
-        
+
         cargo.current_dir(Path::new("library/profiler_builtins"));
-        
+
         let profiler_builtins_no_core_dir = "profiler_builtins_no_core";
         let target_dir =
-        builder.cargo_out(compiler, Mode::Std, target).join(profiler_builtins_no_core_dir);
+            builder.cargo_out(compiler, Mode::Std, target).join(profiler_builtins_no_core_dir);
 
         cargo.arg("--target-dir");
         cargo.arg(&*target_dir.to_string_lossy());
         cargo.arg("--no-default-features");
-        
+
         let mut cmd: Command = cargo.into();
         builder.run_cmd(BootstrapCommand::from(&mut cmd).fail_fast());
 
@@ -50,7 +58,17 @@ impl Step for ProfilerBuiltinsNoCore {
         if !builder.config.dry_run() {
             assert!(lib_path.exists() && lib_path.is_file());
         }
-        lib_path
+        let mut instrument_coverage_flags = InstrumentationCoverageFlags { rustflags: Vec::new() };
+
+        instrument_coverage_flags.rustflags.push("-Cinstrument-coverage".into());
+        instrument_coverage_flags.rustflags.push("--extern".into());
+        instrument_coverage_flags
+            .rustflags
+            .push(format!("profiler_builtins={}", lib_path.to_str().unwrap()));
+        instrument_coverage_flags.rustflags.push("-L".into());
+        instrument_coverage_flags.rustflags.push(lib_dir.to_str().unwrap().to_string());
+
+        instrument_coverage_flags
     }
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {

--- a/src/bootstrap/src/ferrocene/code_coverage.rs
+++ b/src/bootstrap/src/ferrocene/code_coverage.rs
@@ -1,0 +1,49 @@
+use crate::builder::{Builder, RunConfig, ShouldRun, Step};
+
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct ProfilerBuiltinsNoCore;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct ProfilerBuiltins;
+
+impl Step for ProfilerBuiltinsNoCore {
+    type Output = ();
+    const ONLY_HOSTS: bool = true;
+    const DEFAULT: bool = true;
+
+    fn run(self, builder: &Builder<'_>) -> Self::Output {
+        builder.info("Building profiler_builtins with no_core");
+        dbg!("Building profiler_builtins here");
+        
+        // let compiler = builder.compiler(0, self.target);
+        // let cargo = tool::prepare_tool_cargo(
+        //     builder,
+        //     compiler,
+        //     Mode::ToolBootstrap,
+        //     self.target,
+        //     "test",
+        //     "ferrocene/tools/generate-tarball",
+        //     SourceType::InTree,
+        //     &[],
+        // );
+        // crate::core::build_steps::test::run_cargo_test(
+        //     cargo,
+        //     &[],
+        //     &[],
+        //     "generate-tarball",
+        //     "generate-tarball",
+        //     compiler,
+        //     self.target,
+        //     builder,
+        // );
+    }
+
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+        run.never()
+    }
+
+    fn make_run(run: RunConfig<'_>) {
+        run.builder.ensure(Self {});
+    }
+}

--- a/src/bootstrap/src/ferrocene/code_coverage.rs
+++ b/src/bootstrap/src/ferrocene/code_coverage.rs
@@ -1,5 +1,9 @@
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
-
+use crate::Command;
+use crate::BootstrapCommand;
+use crate::Mode;
+use crate::core::build_steps::tool::SourceType;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) struct ProfilerBuiltinsNoCore;
@@ -8,35 +12,45 @@ pub(crate) struct ProfilerBuiltinsNoCore;
 pub(crate) struct ProfilerBuiltins;
 
 impl Step for ProfilerBuiltinsNoCore {
-    type Output = ();
+    type Output = PathBuf;
     const ONLY_HOSTS: bool = true;
     const DEFAULT: bool = true;
 
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         builder.info("Building profiler_builtins with no_core");
-        dbg!("Building profiler_builtins here");
         
-        // let compiler = builder.compiler(0, self.target);
-        // let cargo = tool::prepare_tool_cargo(
-        //     builder,
-        //     compiler,
-        //     Mode::ToolBootstrap,
-        //     self.target,
-        //     "test",
-        //     "ferrocene/tools/generate-tarball",
-        //     SourceType::InTree,
-        //     &[],
-        // );
-        // crate::core::build_steps::test::run_cargo_test(
-        //     cargo,
-        //     &[],
-        //     &[],
-        //     "generate-tarball",
-        //     "generate-tarball",
-        //     compiler,
-        //     self.target,
-        //     builder,
-        // );
+        let target = builder.config.build;
+        let compiler = builder.compiler(1, target);
+
+        // x.py test --coverage
+        // [ProfilerBuiltinNoCore step] Builds profiler_builtins with no core -> profiler_builtins_no_core.rlib
+        // [Core Tests step] Compile tests of core with -Cinsturment-coverage -> link against profiler_builtins_no_core.rlib
+
+        
+        let mut cargo = builder.cargo(compiler, Mode::Std, SourceType::InTree, target, "build");
+        
+        cargo.current_dir(Path::new("library/profiler_builtins"));
+        
+        let profiler_builtins_no_core_dir = "profiler_builtins_no_core";
+        let target_dir =
+        builder.cargo_out(compiler, Mode::Std, target).join(profiler_builtins_no_core_dir);
+
+        cargo.arg("--target-dir");
+        cargo.arg(&*target_dir.to_string_lossy());
+        cargo.arg("--no-default-features");
+        
+        let mut cmd: Command = cargo.into();
+        builder.run_cmd(BootstrapCommand::from(&mut cmd).fail_fast());
+
+        let cargo_dir = if builder.config.rust_optimize.is_release() { "release" } else { "debug" };
+
+        let lib_dir = target_dir.join(&*target.triple).join(cargo_dir);
+        let lib_path = lib_dir.join("libprofiler_builtins.rlib");
+
+        if !builder.config.dry_run() {
+            assert!(lib_path.exists() && lib_path.is_file());
+        }
+        lib_path
     }
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {

--- a/src/bootstrap/src/ferrocene/mod.rs
+++ b/src/bootstrap/src/ferrocene/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod run;
 pub(crate) mod sign;
 pub(crate) mod test;
 pub(crate) mod tool;
+pub(crate) mod code_coverage;
 
 use crate::builder::Builder;
 use crate::core::config::{Config, TargetSelection};

--- a/src/bootstrap/src/ferrocene/mod.rs
+++ b/src/bootstrap/src/ferrocene/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: The Ferrocene Developers
 
+pub(crate) mod code_coverage;
 pub(crate) mod dist;
 pub(crate) mod doc;
 pub(crate) mod partners;
@@ -8,7 +9,6 @@ pub(crate) mod run;
 pub(crate) mod sign;
 pub(crate) mod test;
 pub(crate) mod tool;
-pub(crate) mod code_coverage;
 
 use crate::builder::Builder;
 use crate::core::config::{Config, TargetSelection};

--- a/src/bootstrap/src/tests/builder.rs
+++ b/src/bootstrap/src/tests/builder.rs
@@ -708,22 +708,13 @@ mod dist {
             extra_checks: None,
             coverage: true,
         };
-
-        let cargo_dir = if config.rust_optimize.is_release() { "release" } else { "debug" };
         
         let build = Build::new(config);
         let mut builder = Builder::new(&build);
 
         builder.run_step_descriptions(&Builder::get_step_descriptions(Kind::Test), &[]);
+       let step_result = second(builder.cache.all::<ProfilerBuiltinsNoCore>());
 
-
-        let target = TargetSelection::from_user("A");
-        let profiler_builtins_no_core_dir = Path::new("profiler_builtins_no_core");
-        let target_path = profiler_builtins_no_core_dir.join(&*target.triple);
-        let lib_dir = target_path.join(cargo_dir);
-        let lib_path = lib_dir.join("libprofiler_builtins.rlib");
-
-        dbg!(&lib_path);
-        assert!(second(builder.cache.all::<ProfilerBuiltinsNoCore>())[0].ends_with(lib_path));
+       assert_eq!(step_result.len(), 1);
     }
 }

--- a/src/bootstrap/src/tests/builder.rs
+++ b/src/bootstrap/src/tests/builder.rs
@@ -708,7 +708,6 @@ mod dist {
             extra_checks: None,
             coverage: true,
         };
-        
         let build = Build::new(config);
         let mut builder = Builder::new(&build);
 

--- a/src/bootstrap/src/tests/builder.rs
+++ b/src/bootstrap/src/tests/builder.rs
@@ -709,11 +709,21 @@ mod dist {
             coverage: true,
         };
 
+        let cargo_dir = if config.rust_optimize.is_release() { "release" } else { "debug" };
+        
         let build = Build::new(config);
         let mut builder = Builder::new(&build);
 
         builder.run_step_descriptions(&Builder::get_step_descriptions(Kind::Test), &[]);
-        // let a = TargetSelection::from_user("A");
-        assert_eq!(second(builder.cache.all::<ProfilerBuiltinsNoCore>()), &[()]);
+
+
+        let target = TargetSelection::from_user("A");
+        let profiler_builtins_no_core_dir = Path::new("profiler_builtins_no_core");
+        let target_path = profiler_builtins_no_core_dir.join(&*target.triple);
+        let lib_dir = target_path.join(cargo_dir);
+        let lib_path = lib_dir.join("libprofiler_builtins.rlib");
+
+        dbg!(&lib_path);
+        assert!(second(builder.cache.all::<ProfilerBuiltinsNoCore>())[0].ends_with(lib_path));
     }
 }

--- a/src/etc/completions/x.py.fish
+++ b/src/etc/completions/x.py.fish
@@ -297,6 +297,7 @@ complete -c x.py -n "__fish_seen_subcommand_from test" -l bless -d 'whether to a
 complete -c x.py -n "__fish_seen_subcommand_from test" -l force-rerun -d 'rerun tests even if the inputs are unchanged'
 complete -c x.py -n "__fish_seen_subcommand_from test" -l only-modified -d 'only run tests that result has been changed'
 complete -c x.py -n "__fish_seen_subcommand_from test" -l rustfix-coverage -d 'enable this to generate a Rustfix coverage file, which is saved in `/<build_base>/rustfix_missing_coverage.txt`'
+complete -c x.py -n "__fish_seen_subcommand_from test" -l coverage -d 'generate coverage for tests'
 complete -c x.py -n "__fish_seen_subcommand_from test" -s v -l verbose -d 'use verbose output (-vv for very verbose)'
 complete -c x.py -n "__fish_seen_subcommand_from test" -s i -l incremental -d 'use incremental compilation'
 complete -c x.py -n "__fish_seen_subcommand_from test" -l include-default-paths -d 'include default paths in addition to the provided ones'

--- a/src/etc/completions/x.py.ps1
+++ b/src/etc/completions/x.py.ps1
@@ -370,6 +370,7 @@ Register-ArgumentCompleter -Native -CommandName 'x.py' -ScriptBlock {
             [CompletionResult]::new('--force-rerun', 'force-rerun', [CompletionResultType]::ParameterName, 'rerun tests even if the inputs are unchanged')
             [CompletionResult]::new('--only-modified', 'only-modified', [CompletionResultType]::ParameterName, 'only run tests that result has been changed')
             [CompletionResult]::new('--rustfix-coverage', 'rustfix-coverage', [CompletionResultType]::ParameterName, 'enable this to generate a Rustfix coverage file, which is saved in `/<build_base>/rustfix_missing_coverage.txt`')
+            [CompletionResult]::new('--coverage', 'coverage', [CompletionResultType]::ParameterName, 'generate coverage for tests')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'use verbose output (-vv for very verbose)')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'use verbose output (-vv for very verbose)')
             [CompletionResult]::new('-i', 'i', [CompletionResultType]::ParameterName, 'use incremental compilation')

--- a/src/etc/completions/x.py.sh
+++ b/src/etc/completions/x.py.sh
@@ -1738,7 +1738,7 @@ _x.py() {
             return 0
             ;;
         x.py__test)
-            opts="-v -i -j -h --no-fail-fast --skip --test-args --rustc-args --no-doc --doc --bless --extra-checks --force-rerun --only-modified --compare-mode --pass --run --rustfix-coverage --verbose --incremental --config --build-dir --build --host --target --exclude --include-default-paths --rustc-error-format --on-fail --dry-run --dump-bootstrap-shims --stage --keep-stage --keep-stage-std --src --jobs --warnings --error-format --json-output --color --bypass-bootstrap-lock --llvm-skip-rebuild --rust-profile-generate --rust-profile-use --llvm-profile-use --llvm-profile-generate --enable-bolt-settings --skip-stage0-validation --reproducible-artifact --set --help [PATHS]... [ARGS]..."
+            opts="-v -i -j -h --no-fail-fast --skip --test-args --rustc-args --no-doc --doc --bless --extra-checks --force-rerun --only-modified --compare-mode --pass --run --rustfix-coverage --coverage --verbose --incremental --config --build-dir --build --host --target --exclude --include-default-paths --rustc-error-format --on-fail --dry-run --dump-bootstrap-shims --stage --keep-stage --keep-stage-std --src --jobs --warnings --error-format --json-output --color --bypass-bootstrap-lock --llvm-skip-rebuild --rust-profile-generate --rust-profile-use --llvm-profile-use --llvm-profile-generate --enable-bolt-settings --skip-stage0-validation --reproducible-artifact --set --help [PATHS]... [ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/src/etc/completions/x.py.zsh
+++ b/src/etc/completions/x.py.zsh
@@ -371,6 +371,7 @@ _arguments "${_arguments_options[@]}" \
 '--force-rerun[rerun tests even if the inputs are unchanged]' \
 '--only-modified[only run tests that result has been changed]' \
 '--rustfix-coverage[enable this to generate a Rustfix coverage file, which is saved in \`/<build_base>/rustfix_missing_coverage.txt\`]' \
+'--coverage[generate coverage for tests]' \
 '*-v[use verbose output (-vv for very verbose)]' \
 '*--verbose[use verbose output (-vv for very verbose)]' \
 '-i[use incremental compilation]' \


### PR DESCRIPTION
This PR adds code coverage support for the `core` library using rustc's existing support for instrumentation using the [`-Cinstrument-coverage`](https://doc.rust-lang.org/rustc/instrument-coverage.html) flag.

## Usage 

To generate the coverage data run the command:
`./x.py test --coverage library/core --no-doc`

1. Currently coverage doesn't work with doc tests, hence the `--no-doc` flag has to be passed.
2. The `.profraw` files are created in the `build/coverage` directory.

## The Problem
When the `-Cinstrument-coverage` flag is set during compilation, llvm's profiler runtime is injected into the binary. This runtime is provided by the `profiler_builtins` crate and this crate is linked by making it an implicit dependency of the current crate being compiled.

This creates a problem when we want to instrument the `core` library, as the `profiler_builtins` crate has a dependency on core and hence can't be built it, creating a cyclic dependency.

> Note: `profiler_builtins` doesn't need to be dependent on core, the dependency is there to define a specific build order.

## Proposed Solution

Our approach is to make the dependency on `core` library optional in `profiler_builtins`. This allows to build and use a different version of the `profiler_builtins` crate, without the `core` dependency when instrumenting the `core` library. 

## Notes

1. Removing `core` dependency in `profiler_builtins` has certain limitations as discussed in [this PR](https://github.com/rust-lang/rust/pull/101009).

2. Another approach to resolve the cylic dependency is to remove the `profiler_builtins` crate entirely and build the profiler runtime as a separate build step similar to sanitizers. Though this works it has certain issues as discussed in [this PR](https://github.com/rust-lang/rust/pull/118305).

## Implementation Details

1. The dependency on core is made optional and is enabled by default by setting a feature flag called `core` in `profiler_builtins`.

2. In bootstrap, a custom step has been added to build `profiler_builtins` separately under a different name with `--no-default-features` and hence without a dependency on `core`.

4.  When gathering code coverage  we link against this custom built `profiler_builtins`.

@pietroalbini @tw-amit @gnana-ganesh-tw