### PR TITLE
Generate the internal `ferrocene-docs-doctrees` tarball

### DIFF
--- a/ferrocene/doc/specification/exts/ferrocene_spec/paragraph_ids.py
+++ b/ferrocene/doc/specification/exts/ferrocene_spec/paragraph_ids.py
@@ -67,6 +67,9 @@ def build_finished(app, exception):
     if exception is not None:
         return
 
+    if app.builder.name != "html":
+        return
+
     with sphinx.util.progress_message("dumping paragraph ids"):
         write_paragraph_ids(app)
 

--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/document_id.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/document_id.py
@@ -106,7 +106,8 @@ def write_document_id(app):
 def build_finished(app, exception):
     if exception is not None:
         return
-    write_document_id(app)
+    if app.builder.name == "html":
+        write_document_id(app)
 
 
 def setup(app):

--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/signature_page.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/signature_page.py
@@ -113,6 +113,9 @@ def build_finished(app, exception):
     if exception is not None:
         return
 
+    if app.builder.name != "html":
+        return
+
     with sphinx.util.progress_message("copying signature files"):
         os.makedirs(f"{app.outdir}/signature", exist_ok=True)
         signature = SignatureStatus(app)

--- a/ferrocene/doc/user-manual/exts/ferrocene_user_manual/traceability_ids.py
+++ b/ferrocene/doc/user-manual/exts/ferrocene_user_manual/traceability_ids.py
@@ -44,6 +44,9 @@ def build_finished(app, exception):
     if exception is not None:
         return
 
+    if app.builder.name != "html":
+        return
+
     with sphinx.util.progress_message("dumping traceability ids"):
         write_traceability_ids(app)
 

--- a/ferrocene/packages.toml
+++ b/ferrocene/packages.toml
@@ -87,3 +87,10 @@ docs-in = "share/doc/ferrocene/html"
 name = "ferrocene-docs-signatures"
 subset = "signatures"
 docs-in = "share/doc/ferrocene/html"
+
+[[groups.any-platform.packages]]
+name = "ferrocene-docs-doctrees"
+# The contents of this package are not confidential, but it's something end
+# users should never need, and displaying it in the list of downloadable
+# packages would only cause confusion.
+subset = "internal"

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -881,6 +881,7 @@ impl<'a> Builder<'a> {
                 dist::BuildManifest,
                 dist::ReproducibleArtifacts,
                 crate::ferrocene::dist::Docs,
+                crate::ferrocene::dist::DocsDoctrees,
                 crate::ferrocene::dist::SourceTarball,
                 crate::ferrocene::dist::SelfTest,
                 crate::ferrocene::dist::TestOutcomes,

--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -3,6 +3,7 @@
 
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::core::config::TargetSelection;
+use crate::ferrocene::doc::ensure_all_xml_doctrees;
 use crate::utils::tarball::{GeneratedTarball, Tarball};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -37,6 +38,37 @@ impl Step for Docs {
         subsetter.add_directory(&doc_out, &doc_out);
 
         subsetter.into_tarballs().map(|tarball| tarball.generate()).collect()
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct DocsDoctrees {
+    target: TargetSelection,
+}
+
+impl Step for DocsDoctrees {
+    type Output = GeneratedTarball;
+    const DEFAULT: bool = true;
+    const ONLY_HOSTS: bool = true;
+
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+        let default = run.builder.config.docs;
+        run.alias("ferrocene-docs-doctrees").default_condition(default)
+    }
+
+    fn make_run(run: RunConfig<'_>) {
+        run.builder.ensure(Self { target: run.target });
+    }
+
+    fn run(self, builder: &Builder<'_>) -> Self::Output {
+        let paths = ensure_all_xml_doctrees(builder, self.target);
+
+        let tarball = Tarball::new_targetless(builder, "ferrocene-docs-doctrees");
+        for (name, path) in paths {
+            tarball.add_dir(path, format!("share/doc/ferrocene/xml-doctrees/{name}"));
+        }
+
+        tarball.generate()
     }
 }
 

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -170,7 +170,10 @@ impl<P: Step> Step for SphinxBook<P> {
             }
         }
 
-        builder.ensure(BreadcrumbsAssets { target: self.target, dest: Some(out.join("_static")) });
+        if let SphinxMode::Html = self.mode {
+            builder
+                .ensure(BreadcrumbsAssets { target: self.target, dest: Some(out.join("_static")) });
+        }
         let venv = builder.ensure(SphinxVirtualEnv { target: self.target });
 
         let path_to_root = std::iter::repeat("..")

--- a/src/bootstrap/src/ferrocene/run.rs
+++ b/src/bootstrap/src/ferrocene/run.rs
@@ -4,7 +4,7 @@
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::core::build_steps::tool::Tool;
 use crate::core::config::{FerroceneTraceabilityMatrixMode, TargetSelection};
-use crate::ferrocene::doc::{Specification, UserManual};
+use crate::ferrocene::doc::{Specification, SphinxMode, UserManual};
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -30,9 +30,16 @@ impl Step for TraceabilityMatrix {
         let test_annotations_base =
             builder.out.join(self.target.triple).join("ferrocene").join("test-annotations");
 
-        let specification =
-            builder.ensure(Specification { target: self.target, fresh_build: false });
-        let user_manual = builder.ensure(UserManual { target: self.target, fresh_build: false });
+        let specification = builder.ensure(Specification {
+            mode: SphinxMode::Html,
+            target: self.target,
+            fresh_build: false,
+        });
+        let user_manual = builder.ensure(UserManual {
+            mode: SphinxMode::Html,
+            target: self.target,
+            fresh_build: false,
+        });
 
         let compiletest = builder.tool_exe(Tool::Compiletest);
         for (suite, mode) in &[("tests/ui", "ui"), ("tests/run-make", "run-make")] {

--- a/src/bootstrap/src/ferrocene/sign.rs
+++ b/src/bootstrap/src/ferrocene/sign.rs
@@ -8,7 +8,7 @@
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::core::build_steps::tool::Tool;
 use crate::core::config::TargetSelection;
-use crate::ferrocene::doc::WithSource;
+use crate::ferrocene::doc::{SphinxMode, WithSource};
 use crate::t;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -93,6 +93,7 @@ macro_rules! documents {
                     builder.ensure(SignDocument {
                         target: self.target,
                         document: crate::ferrocene::doc::$name {
+                            mode: SphinxMode::Html,
                             target: self.target,
                             // Ensure there are no leftover artifacts from a previous incremental
                             // build when generating the signature.
@@ -113,6 +114,7 @@ macro_rules! documents {
                 let source_dir = builder.src.join(crate::ferrocene::doc::$name::SOURCE);
                 if condition(&source_dir) {
                     let output_dir = builder.ensure(crate::ferrocene::doc::$name {
+                        mode: SphinxMode::Html,
                         target,
                         fresh_build: false,
                     });


### PR DESCRIPTION
This PR adds a new dist step that generates an *internal* `ferrocene-docs-doctrees` tarball, which contains the XML serialization of Sphinx's AST (the docutils doctrees). There is no use for the tarball right now, but a thing I'd like to build in the near future is a tool to generate a semantic diff of the documentation between two versions (so that we can easily give a changelog to TÜV), and that requires having the doctrees of old versions.

The tarball is internal not because it contains sensitive info (it's a different representation of the same info after all), but because showing it in the download pages to users would be super confusing.

This also changes some Sphinx extensions to output their files only when building HTML.

This PR is best reviewed commit-by-commit.