### PR TITLE
Enable the new `rust.use-lld=self-contained`

### DIFF
--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -230,6 +230,11 @@ add --set target.wasm32-unknown-unknown.profiler=false
 # If this configuration is missing or changed, LLD will not be included.
 add --enable-lld
 
+# Use our own LLD to build and link rustc itself.
+#
+# If this configuration is missing or changed, other linkers will be used.
+add --set rust.use-lld=self-contained
+
 # Set the release channel for this branch. The channel is read from the
 # `src/ci/channel` file to easily allow tools and automation to know and update
 # the current channel.

--- a/ferrocene/ci/docker-images/ubuntu-18/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-18/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update \
         moreutils \
         zstd \
         sudo \
+        lld \
         # Needed to support the QEMU copied over from Ubuntu 22.04 (see above).
         # Replace this with qemu-user-static once we're not on Ubuntu 18.04.
         binfmt-support \

--- a/ferrocene/ci/docker-images/ubuntu-23/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-23/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update \
         moreutils \
         cmake \
         python-is-python3 \
+        lld \
         # Needed by the `commit-checks` CI job:
         llvm-17-tools \
         llvm-17-dev \


### PR DESCRIPTION
This flag will instruct bootstrap to use our own LLD when linking rustc itself, rather than using the system linker. Introduced in https://github.com/rust-lang/rust/pull/116278.