### PR TITLE
Create central table of human-readable target names

### DIFF
--- a/ferrocene/doc/qualification-report/src/tests.rst
+++ b/ferrocene/doc/qualification-report/src/tests.rst
@@ -4,8 +4,8 @@
 Tests Results
 =============
 
-Ferrocene for ARMv8-A bare metal and x86-64 Linux
--------------------------------------------------
+Ferrocene for :target:`aarch64-unknown-none` and :target:`x86_64-unknown-linux-gnu`
+-----------------------------------------------------------------------------------
 
 Test Environment
 ^^^^^^^^^^^^^^^^
@@ -17,11 +17,11 @@ For this qualification, testing is restricted to the following environments:
    :stub-columns: 1
 
    * - Host
-     - x86_64 Linux
-     - x86_64 Linux
+     - :target:`x86_64-unknown-linux-gnu`
+     - :target:`x86_64-unknown-linux-gnu`
    * - Target
-     - ARMv8-A bare metal (aarch64)
-     - x86_64 Linux
+     - :target:`aarch64-unknown-none`
+     - :target:`x86_64-unknown-linux-gnu`
    * - Supported languages
      - Rust
      - Rust
@@ -37,9 +37,9 @@ For this qualification, testing is restricted to the following environments:
 Bare metal testing
 ******************
 
-The ARMv8-A bare metal Ferrocene target is meant to be used in an environment
-without any operating system. Consequently, it does not include APIs relying on
-one (as part of the ``std`` crate).
+The :target:`aarch64-unknown-none` Ferrocene target is meant to be used in an
+environment without any operating system. Consequently, it does not include
+APIs relying on one (as part of the ``std`` crate).
 
 Rust's test suites require those APIs to be available in order to invoke the
 tests themselves and to report the execution results. To solve the issue, a new
@@ -173,9 +173,10 @@ compiletest test suite.
 Known Problems
 ^^^^^^^^^^^^^^
 
-KPs identified through the lifecycle of Ferrocene for ARMv8-A bare metal and
-x86-64 Linux are tracked in the :doc:`safety-manual:known-problems`. This
-document is made available to customers for consulting.
+KPs identified through the lifecycle of Ferrocene for
+:target:`aarch64-unknown-none` and :target:`x86_64-unknown-linux-gnu` are
+tracked in the :doc:`safety-manual:known-problems`. This document is made
+available to customers for consulting.
 
 Ignored Tests
 ^^^^^^^^^^^^^

--- a/ferrocene/doc/safety-manual/src/environment.rst
+++ b/ferrocene/doc/safety-manual/src/environment.rst
@@ -11,9 +11,9 @@ This qualification is restricted to the following environment:
    :stub-columns: 1
 
    * - Host
-     - x86_64 Linux
+     - :target:`x86_64-unknown-linux-gnu`
    * - Target
-     - ARMv8-A bare metal (aarch64)
+     - :target:`aarch64-unknown-none`
    * - Target specific libraries
      - libcore and liballoc
    * - Supported languages

--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/__init__.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: The Ferrocene Developers
 
-from . import substitutions, document_id, domain, signature_page
+from . import substitutions, document_id, domain, signature_page, target
 import string
 
 
@@ -10,10 +10,12 @@ def setup(app):
     document_id.setup(app)
     domain.setup(app)
     signature_page.setup(app)
+    target.setup(app)
 
     app.connect("config-inited", validate_config)
     app.add_config_value("ferrocene_id", None, "env", [str])
     app.add_config_value("ferrocene_substitutions_path", None, "env", [str])
+    app.add_config_value("ferrocene_target_names_path", None, "env", [str])
     app.add_config_value("ferrocene_signature", None, "env", [str])
     app.add_config_value("ferrocene_private_signature_files_dir", None, "env", [str])
     app.add_config_value("ferrocene_version", None, "env", [str])
@@ -27,7 +29,11 @@ def setup(app):
 
 
 def validate_config(app, config):
-    for required in ["ferrocene_id", "ferrocene_substitutions_path"]:
+    for required in [
+        "ferrocene_id",
+        "ferrocene_substitutions_path",
+        "ferrocene_target_names_path",
+    ]:
         if config[required] is None:
             raise ValueError(f"Missing required {required} configuration")
 

--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/target.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/target.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+from docutils import nodes
+from sphinx.util.docutils import SphinxRole
+import sphinx
+import tomli
+
+
+class TargetRole(SphinxRole):
+    def run(self):
+        target = self.text.strip()
+        if target in self.env.ferrocene_target_names:
+            return [nodes.Text(self.env.ferrocene_target_names[target])], []
+        else:
+            config = self.config["ferrocene_target_names_path"]
+            logger = sphinx.util.logging.getLogger(__name__)
+            logger.warning(
+                f"missing target {target} in {config}", location=self.get_location()
+            )
+            return [nodes.problematic("", self.text)], []
+
+
+def load_target_names(app, env, _docnames):
+    with open(app.config["ferrocene_target_names_path"], "rb") as f:
+        target_names = tomli.load(f)
+    env.ferrocene_target_names = target_names
+
+
+def setup(app):
+    app.connect("env-before-read-docs", load_target_names)
+    app.add_role("target", TargetRole())

--- a/ferrocene/doc/sphinx-shared-resources/themes/ferrocene/static/ferrocene.css
+++ b/ferrocene/doc/sphinx-shared-resources/themes/ferrocene/static/ferrocene.css
@@ -73,6 +73,8 @@
     --code-block-bg: #f7f7f7;
     --focus-border: #68a4e8;
     --table-border: #dbdbdb;
+    --problematic-fg: #fff;
+    --problematic-bg: #f00;
 
     --body-bg: #fff;
     --header-fg: #194e80;
@@ -661,6 +663,15 @@ blockquote {
 
 blockquote code {
     font-style: normal;
+}
+
+/*********************
+ *   Inline errors   *
+ *********************/
+
+.problematic {
+    color: var(--problematic-fg);
+    background: var(--problematic-bg);
 }
 
 /**************************************************

--- a/ferrocene/doc/target-names.toml
+++ b/ferrocene/doc/target-names.toml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+# This file defines the human-readable names for the targets supported by
+# Ferrocene, to provide consistency across documents on how we refer to them.
+#
+# In the documents, as long as the ferrocene_qualification extension is added,
+# you can refer to them with :target:`triple`.
+
+aarch64-unknown-none     = "ARMv8-A bare metal"
+thumbv7em-none-eabi      = "ARMv7e-M bare metal (thumb)"
+thumbv7em-none-eabihf    = "ARMv7e-M bare metal (thumb, floats)"
+wasm32-unknown-unknown   = "WASM bare metal"
+x86_64-unknown-linux-gnu = "x86_64 Linux (glibc)"

--- a/ferrocene/doc/user-manual/src/targets/aarch64-unknown-none.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-unknown-none.rst
@@ -3,8 +3,8 @@
 
 .. _aarch64-unknown-none:
 
-ARMv8-A bare metal
-==================
+:target:`aarch64-unknown-none`
+==============================
 
 The ``aarch64-unknown-none`` Ferrocene target provides support for
 bare-metal ARMv8-A processors operating in Aarch64 mode.

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -71,19 +71,19 @@ should not be used in production.
      - Standard library
      - Notes
 
-   * - ARMv7e-M (Thumb) bare metal
+   * - :target:`thumbv7em-none-eabi`
      - ``thumbv7em-none-eabi``
      - Cross-compilation
      - Bare-metal
      - \-
 
-   * - ARMv7e-M (Thumb, floats) bare metal
+   * - :target:`thumbv7em-none-eabihf`
      - ``thumbv7em-none-eabihf``
      - Cross-compilation
      - Bare-metal
      - \-
 
-   * - WASM bare metal
+   * - :target:`wasm32-unknown-unknown`
      - ``wasm32-unknown-unknown``
      - Cross-compilation
      - Full

--- a/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
@@ -3,8 +3,8 @@
 
 .. _x86_64-unknown-linux-gnu:
 
-x86_64 Linux (glibc)
-====================
+:target:`x86_64-unknown-linux-gnu`
+==================================
 
 The ``x86_64-unknown-linux-gnu`` Ferrocene target provides support for Linux on
 x86_64 using glibc 2.27 or higher.

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -145,6 +145,7 @@ impl<P: Step> Step for SphinxBook<P> {
             builder.src.join("ferrocene").join("doc").join("sphinx-shared-resources");
         let substitutions =
             builder.src.join("ferrocene").join("doc").join("sphinx-substitutions.toml");
+        let target_names = builder.src.join("ferrocene").join("doc").join("target-names.toml");
         let breadcrumbs = builder.src.join("ferrocene").join("doc").join("breadcrumbs");
 
         // In some cases we have to perform a fresh build to guarantee deterministic output (for
@@ -200,6 +201,9 @@ impl<P: Step> Step for SphinxBook<P> {
             // Provide the correct substitutions:
             .arg("-D")
             .arg(path_define("ferrocene_substitutions_path", &relative_path(&src, &substitutions)))
+            // Provide the correct target names:
+            .arg("-D")
+            .arg(path_define("ferrocene_target_names_path", &relative_path(&src, &target_names)))
             // Toolchain versions
             .arg("-D")
             .arg(format!(


### PR DESCRIPTION
This PR adds a new role to the `ferrocene_qualification` extension: `:target:`. The role converts the target triple into the human-readable name based on the new `ferrocene/doc/target-names.toml`. The purpose of this is twofold:

* It increases consistency across the documents, as we have a single place where they are defined.
* It helps with a WIP PR I'm working on to split the [test results](https://public-docs.ferrocene.dev/main/qualification/report/tests.html) page into per-target pages, as it means the rest of the automation can fetch the human-readable target name programmatically.