### PR TITLE
Update traceability matrix

### DIFF
--- a/tests/ui/ferrocene/compiler-arguments/llvm-args/protect-from-escaped-allocas-true.rs
+++ b/tests/ui/ferrocene/compiler-arguments/llvm-args/protect-from-escaped-allocas-true.rs
@@ -1,0 +1,6 @@
+// check-pass
+// compile-flags: -C llvm-args=-protect-from-escaped-allocas=true
+
+fn main() {}
+
+// ferrocene-annotations: um_rustc_C_llvm_args_protect_from_escaped_allocastrue

--- a/tests/ui/for-loop-while/label_break_value.rs
+++ b/tests/ui/for-loop-while/label_break_value.rs
@@ -200,3 +200,6 @@ pub fn main() {
 //
 // ferrocene-annotations: fls_zjoamsr3dbqk
 // Diverging Expressions
+//
+// ferrocene-annotations: fls_0ybsr1heo7wv
+// Named Blocks

--- a/tests/ui/label/label_break_value_continue.rs
+++ b/tests/ui/label/label_break_value_continue.rs
@@ -27,3 +27,6 @@ pub fn main() {}
 
 // ferrocene-annotations: fls_sjwrlwvpulp
 // Continue Expressions
+//
+// ferrocene-annotations: fls_0ybsr1heo7wv
+// Named Blocks

--- a/tests/ui/label/label_break_value_unlabeled_break.rs
+++ b/tests/ui/label/label_break_value_unlabeled_break.rs
@@ -17,3 +17,6 @@ fn unlabeled_break_crossing() {
 }
 
 pub fn main() {}
+
+// ferrocene-annotations: fls_0ybsr1heo7wv
+// Named Blocks

--- a/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-and-name.rs
+++ b/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-and-name.rs
@@ -14,3 +14,6 @@ fn main() {}
 
 // ferrocene-annotations: fls_p44fky7fifc
 // Attribute link_name
+//
+// ferrocene-annotations: fls_obik2w9gvhln
+// Attribute link_ordinal

--- a/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-invalid-format.rs
+++ b/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-invalid-format.rs
@@ -9,3 +9,6 @@ extern "C" {
 }
 
 fn main() {}
+
+// ferrocene-annotations: fls_obik2w9gvhln
+// Attribute link_ordinal

--- a/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-missing-argument.rs
+++ b/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-missing-argument.rs
@@ -9,3 +9,6 @@ extern "C" {
 }
 
 fn main() {}
+
+// ferrocene-annotations: fls_obik2w9gvhln
+// Attribute link_ordinal

--- a/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-multiple.rs
+++ b/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-multiple.rs
@@ -10,3 +10,6 @@ extern "C" {
 }
 
 fn main() {}
+
+// ferrocene-annotations: fls_obik2w9gvhln
+// Attribute link_ordinal

--- a/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-not-foreign-fn.rs
+++ b/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-not-foreign-fn.rs
@@ -20,3 +20,6 @@ extern {
 }
 
 fn main() {}
+
+// ferrocene-annotations: fls_obik2w9gvhln
+// Attribute link_ordinal

--- a/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-too-large.rs
+++ b/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-too-large.rs
@@ -9,3 +9,6 @@ extern "C" {
 }
 
 fn main() {}
+
+// ferrocene-annotations: fls_obik2w9gvhln
+// Attribute link_ordinal

--- a/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-too-many-arguments.rs
+++ b/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-too-many-arguments.rs
@@ -9,3 +9,6 @@ extern "C" {
 }
 
 fn main() {}
+
+// ferrocene-annotations: fls_obik2w9gvhln
+// Attribute link_ordinal

--- a/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-unsupported-link-kind.rs
+++ b/tests/ui/rfcs/rfc-2627-raw-dylib/link-ordinal-unsupported-link-kind.rs
@@ -13,3 +13,6 @@ extern "C" {
 }
 
 fn main() {}
+
+// ferrocene-annotations: fls_obik2w9gvhln
+// Attribute link_ordinal


### PR DESCRIPTION
Update the traceability matrix to have 100% everywhere again.

# Todo
- [x] 6.4.2 Named Blocks 
- [x] 13.2.6.7 Attribute link_ordinal 
- [x] UM: Command-Line Interface
- [ ] ~~(?) FLS: Macros~~ --> @pietroalbini said: "heh that's annoying; because it's not really possible to test proc macros on bare metal targets; leave them as-is for now"
    - warning: "untested targets: aarch64-unknown-ferrocenecoretest"
    - [ ] 20.2.1 Function-like Macros 
    - [ ] 20.2.3 Attribute Macros 