### PR TITLE
Specify that other dev tools are not qualified

### DIFF
--- a/ferrocene/doc/evaluation-plan/src/qualification-scope.rst
+++ b/ferrocene/doc/evaluation-plan/src/qualification-scope.rst
@@ -21,5 +21,3 @@ distributed for convenience only. This includes but is not limited to:
 * `cargo`
 * `rustdoc`
 * `rust-gdb`
-
-It is the end-user responsibility to review the output of these tools.

--- a/ferrocene/doc/evaluation-plan/src/qualification-scope.rst
+++ b/ferrocene/doc/evaluation-plan/src/qualification-scope.rst
@@ -14,3 +14,12 @@ Ferrocene qualification *for compiler use only*. The use of these libraries
 by end-use code is outside the scope of the current Ferrocene
 qualification. It is the end-user responsibility to qualify these libraries if
 they are used in their code.
+
+The other development tools besides `rustc` are not qualified and are
+distributed for convenience only. This includes but is not limited to:
+
+* `cargo`
+* `rustdoc`
+* `rust-gdb`
+
+It is the end-user responsibility to review the output of these tools.


### PR DESCRIPTION
I've only mentioned the, imo, most important tools.

There are also following other tools, but I don't think we need to mention them:
* rust-gdbui
* rust-lldb
* rust-analyzer-proc-macro-srv
* llvm-tools
   * llc
   * llvm-ar
   * llvm-cov
   * llvm-dis
   * llvm-nm
   * llvm-objcopy
   * llvm-objdump
   * llvm-profdata
   * llvm-readobj
   * llvm-size
   * llvm-strip
   * opt

Fixes https://ferroussystems.clickup.com/t/8693phbdq