### PR TITLE
Add `./x doc --fresh --debug-sphinx` flags

### DIFF
--- a/ferrocene/doc/internal-procedures/src/doc-procedures.rst
+++ b/ferrocene/doc/internal-procedures/src/doc-procedures.rst
@@ -64,6 +64,34 @@ flag:
 
    ./x doc ferrocene/doc/$foo --open
 
+If you are making frequent changes to the contents of a document, the
+``--serve`` flag will continuously watch for changes in the file system and
+rebuild content as needed. It also starts a local web server with automatic
+reloading of the changes in the browser:
+
+.. code-block:: text
+
+   ./x doc ferrocene/doc/$foo --serve
+
+When you are working on Sphinx extensions, the ``--debug-sphinx`` flag will
+change the configuration to aid debugging, by running only one builder job at
+the time and showing exception tracebacks:
+
+.. code-block:: text
+
+   ./x doc ferrocene/doc/$foo --debug-sphinx
+
+.. note::
+
+   Sphinx features automatic dependency tracking and should rebuild only the
+   files you actually changed. Dependency tracking doesn't work when the
+   implementation of extensions is changed: in those cases you will want to
+   pass the ``--fresh`` flag, which does a fresh build ignoring caches:
+
+   .. code-block:: text
+
+      ./x doc ferrocene/doc/$foo --fresh
+
 Defining and linking to IDs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -249,7 +249,13 @@ mod defaults {
     fn doc_default() {
         let mut config = configure("doc", &["A"], &["A"]);
         config.compiler_docs = true;
-        config.cmd = Subcommand::Doc { open: false, json: false, serve: false };
+        config.cmd = Subcommand::Doc {
+            open: false,
+            json: false,
+            fresh: false,
+            debug_sphinx: false,
+            serve: false,
+        };
         let mut cache = run_build(&[], config);
         let a = TargetSelection::from_user("A");
 
@@ -604,7 +610,13 @@ mod dist {
     fn doc_ci() {
         let mut config = configure(&["A"], &["A"]);
         config.compiler_docs = true;
-        config.cmd = Subcommand::Doc { open: false, json: false, serve: false };
+        config.cmd = Subcommand::Doc {
+            open: false,
+            json: false,
+            fresh: false,
+            debug_sphinx: false,
+            serve: false,
+        };
         let build = Build::new(config);
         let mut builder = Builder::new(&build);
         builder.run_step_descriptions(&Builder::get_step_descriptions(Kind::Doc), &[]);

--- a/src/bootstrap/src/core/config/flags.rs
+++ b/src/bootstrap/src/core/config/flags.rs
@@ -316,6 +316,9 @@ pub enum Subcommand {
         /// start a live-relodaing web server
         serve: bool,
         #[arg(long)]
+        /// ignore caches when building the documentation
+        fresh: bool,
+        #[arg(long)]
         /// render the documentation in JSON format in addition to the usual HTML format
         json: bool,
     },
@@ -580,6 +583,13 @@ impl Subcommand {
     pub fn serve(&self) -> bool {
         match *self {
             Subcommand::Doc { serve, .. } => serve,
+            _ => false,
+        }
+    }
+
+    pub fn fresh(&self) -> bool {
+        match *self {
+            Subcommand::Doc { fresh, .. } => fresh,
             _ => false,
         }
     }

--- a/src/bootstrap/src/core/config/flags.rs
+++ b/src/bootstrap/src/core/config/flags.rs
@@ -319,6 +319,9 @@ pub enum Subcommand {
         /// ignore caches when building the documentation
         fresh: bool,
         #[arg(long)]
+        /// allow easier debugging of Sphinx extensions
+        debug_sphinx: bool,
+        #[arg(long)]
         /// render the documentation in JSON format in addition to the usual HTML format
         json: bool,
     },
@@ -590,6 +593,13 @@ impl Subcommand {
     pub fn fresh(&self) -> bool {
         match *self {
             Subcommand::Doc { fresh, .. } => fresh,
+            _ => false,
+        }
+    }
+
+    pub fn debug_sphinx(&self) -> bool {
+        match *self {
+            Subcommand::Doc { debug_sphinx, .. } => debug_sphinx,
             _ => false,
         }
     }

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -164,7 +164,7 @@ impl<P: Step> Step for SphinxBook<P> {
         // In some cases we have to perform a fresh build to guarantee deterministic output (for
         // example to generate signatures). We want to purge the old build artifacts only when
         // necessary, to avoid thrashing incremental builds.
-        if self.fresh_build {
+        if self.fresh_build || builder.config.cmd.fresh() {
             for path in [&out, &doctrees] {
                 if path.exists() {
                     builder.remove_dir(path);

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -197,8 +197,6 @@ impl<P: Step> Step for SphinxBook<P> {
         cmd.current_dir(&src)
             .arg(relative_path(&src, &src))
             .arg(relative_path(&src, &out))
-            // Build in parallel
-            .args(&["-j", "auto"])
             // Store doctrees outside the output directory:
             .arg("-d")
             .arg(relative_path(&src, &doctrees))
@@ -247,6 +245,18 @@ impl<P: Step> Step for SphinxBook<P> {
             ))
             // Load extensions from the shared resources as well:
             .env("PYTHONPATH", relative_path(&src, &shared_resources.join("exts")));
+
+        if builder.config.cmd.debug_sphinx() {
+            cmd
+                // Only run one parallel job, as Sphinx occasionally cannot show the error message
+                // with the parallel backend.
+                .args(["-j", "1"])
+                // Show full traceback on exceptions.
+                .arg("-T");
+        } else {
+            // Build in parallel
+            cmd.args(["-j", "auto"]);
+        }
 
         match self.mode {
             SphinxMode::Html => {

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -135,9 +135,13 @@ impl<P: Step> Step for SphinxBook<P> {
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         let src = builder.src.join(&self.src).join("src");
         let out = match self.mode {
-            SphinxMode::Html | SphinxMode::OnlyObjectsInv => {
-                builder.out.join(self.target.triple).join("doc").join(&self.dest)
-            }
+            SphinxMode::Html => builder.out.join(self.target.triple).join("doc").join(&self.dest),
+            SphinxMode::OnlyObjectsInv => builder
+                .out
+                .join(self.target.triple)
+                .join("ferrocene")
+                .join("objectsinv-out")
+                .join(&self.dest),
             SphinxMode::XmlDoctrees => builder
                 .out
                 .join(self.target.triple)
@@ -394,9 +398,13 @@ fn add_intersphinx_arguments<P: Step>(
         // the mappings even during gathering. Since not all objects.inv will be available during
         // gathering, all of them are replaced with an empty objects.inv file during gathering.
         let inv = match book.mode {
-            SphinxMode::Html | SphinxMode::XmlDoctrees => {
-                builder.doc_out(book.target).join(&step.dest).join("objects.inv")
-            }
+            SphinxMode::Html | SphinxMode::XmlDoctrees => builder
+                .out
+                .join(book.target.triple)
+                .join("ferrocene")
+                .join("objectsinv-out")
+                .join(&step.dest)
+                .join("objects.inv"),
             SphinxMode::OnlyObjectsInv => empty_objects_inv.clone(),
         };
 

--- a/src/etc/completions/x.py.fish
+++ b/src/etc/completions/x.py.fish
@@ -251,6 +251,8 @@ complete -c x.py -n "__fish_seen_subcommand_from doc" -l reproducible-artifact -
 complete -c x.py -n "__fish_seen_subcommand_from doc" -l set -d 'override options in config.toml' -r -f
 complete -c x.py -n "__fish_seen_subcommand_from doc" -l open -d 'open the docs in a browser'
 complete -c x.py -n "__fish_seen_subcommand_from doc" -l serve -d 'start a live-relodaing web server'
+complete -c x.py -n "__fish_seen_subcommand_from doc" -l fresh -d 'ignore caches when building the documentation'
+complete -c x.py -n "__fish_seen_subcommand_from doc" -l debug-sphinx -d 'allow easier debugging of Sphinx extensions'
 complete -c x.py -n "__fish_seen_subcommand_from doc" -l json -d 'render the documentation in JSON format in addition to the usual HTML format'
 complete -c x.py -n "__fish_seen_subcommand_from doc" -s v -l verbose -d 'use verbose output (-vv for very verbose)'
 complete -c x.py -n "__fish_seen_subcommand_from doc" -s i -l incremental -d 'use incremental compilation'

--- a/src/etc/completions/x.py.ps1
+++ b/src/etc/completions/x.py.ps1
@@ -317,6 +317,8 @@ Register-ArgumentCompleter -Native -CommandName 'x.py' -ScriptBlock {
             [CompletionResult]::new('--set', 'set', [CompletionResultType]::ParameterName, 'override options in config.toml')
             [CompletionResult]::new('--open', 'open', [CompletionResultType]::ParameterName, 'open the docs in a browser')
             [CompletionResult]::new('--serve', 'serve', [CompletionResultType]::ParameterName, 'start a live-relodaing web server')
+            [CompletionResult]::new('--fresh', 'fresh', [CompletionResultType]::ParameterName, 'ignore caches when building the documentation')
+            [CompletionResult]::new('--debug-sphinx', 'debug-sphinx', [CompletionResultType]::ParameterName, 'allow easier debugging of Sphinx extensions')
             [CompletionResult]::new('--json', 'json', [CompletionResultType]::ParameterName, 'render the documentation in JSON format in addition to the usual HTML format')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'use verbose output (-vv for very verbose)')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'use verbose output (-vv for very verbose)')

--- a/src/etc/completions/x.py.sh
+++ b/src/etc/completions/x.py.sh
@@ -1208,7 +1208,7 @@ _x.py() {
             return 0
             ;;
         x.py__doc)
-            opts="-v -i -j -h --open --serve --json --verbose --incremental --config --build-dir --build --host --target --exclude --skip --include-default-paths --rustc-error-format --on-fail --dry-run --dump-bootstrap-shims --stage --keep-stage --keep-stage-std --src --jobs --warnings --error-format --json-output --color --bypass-bootstrap-lock --llvm-skip-rebuild --rust-profile-generate --rust-profile-use --llvm-profile-use --llvm-profile-generate --enable-bolt-settings --skip-stage0-validation --reproducible-artifact --set --help [PATHS]... [ARGS]..."
+            opts="-v -i -j -h --open --serve --fresh --debug-sphinx --json --verbose --incremental --config --build-dir --build --host --target --exclude --skip --include-default-paths --rustc-error-format --on-fail --dry-run --dump-bootstrap-shims --stage --keep-stage --keep-stage-std --src --jobs --warnings --error-format --json-output --color --bypass-bootstrap-lock --llvm-skip-rebuild --rust-profile-generate --rust-profile-use --llvm-profile-use --llvm-profile-generate --enable-bolt-settings --skip-stage0-validation --reproducible-artifact --set --help [PATHS]... [ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/src/etc/completions/x.py.zsh
+++ b/src/etc/completions/x.py.zsh
@@ -316,6 +316,8 @@ _arguments "${_arguments_options[@]}" \
 '*--set=[override options in config.toml]:section.option=value:( )' \
 '--open[open the docs in a browser]' \
 '--serve[start a live-relodaing web server]' \
+'--fresh[ignore caches when building the documentation]' \
+'--debug-sphinx[allow easier debugging of Sphinx extensions]' \
 '--json[render the documentation in JSON format in addition to the usual HTML format]' \
 '*-v[use verbose output (-vv for very verbose)]' \
 '*--verbose[use verbose output (-vv for very verbose)]' \


### PR DESCRIPTION
This PR adds two flags helpful when working on Sphinx extensions:

* `./x doc --fresh` ignores caches and does a fresh build of the document. I wanted to call the flag `--clean`, but that flag is already taken by bootstrap and rebuild everything including bootstrap itself.
* `./x doc --debug-sphinx` disables parallel building and shows tracebacks on exceptions.

It also documents the flags, plus `--serve` which wasn't documented before.