### PR TITLE
Add test results summary table

### DIFF
--- a/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/__init__.py
+++ b/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/__init__.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: The Ferrocene Developers
 
-from . import outcomes, render_template
+from . import outcomes, render_template, render_summary
 
 def setup(app):
     outcomes.setup(app)
     render_template.setup(app)
+    render_summary.setup(app)
 
     return {
         "version": "0",

--- a/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/render_summary.py
+++ b/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/render_summary.py
@@ -41,10 +41,10 @@ class InjectSummaryTransform(SphinxTransform):
         table.add_row(
             paragraph("Host"),
             paragraph("Target"),
-            paragraph("Results"),
             paragraph("Passed tests"),
             paragraph("Failed tests"),
             paragraph("Ignored tests"),
+            paragraph(""),
             head=True,
         )
         for page in pages:
@@ -68,18 +68,18 @@ class InjectSummaryTransform(SphinxTransform):
             table.add_row(
                 paragraph(self.render_target(node, page.host)),
                 paragraph(self.render_target(node, page.target)),
+                render_sum("passed_tests"),
+                render_sum("failed_tests"),
+                render_sum("ignored_tests"),
                 paragraph(
                     make_refnode(
                         self.app.builder,
                         self.env.docname,
                         page.document,
                         "",
-                        nodes.Text("Detailed test results"),
+                        nodes.Text("Detailed results »"),
                     )
                 ),
-                render_sum("passed_tests"),
-                render_sum("failed_tests"),
-                render_sum("ignored_tests"),
             )
 
         node.replace_self(table.finalize())

--- a/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/render_summary.py
+++ b/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/render_summary.py
@@ -53,7 +53,10 @@ class InjectSummaryTransform(SphinxTransform):
             )
 
             def render_sum(field):
-                return str(sum(getattr(invoc, field) for invoc in platform.invocations))
+                content = sum(getattr(invoc, field) for invoc in platform.invocations)
+                container = paragraph(str(content))
+                container["classes"].append("align-right")
+                return container
 
             table.add_row(
                 paragraph(self.render_target(node, page.host)),
@@ -67,9 +70,9 @@ class InjectSummaryTransform(SphinxTransform):
                         nodes.Text("Detailed test results"),
                     )
                 ),
-                paragraph(render_sum("passed_tests")),
-                paragraph(render_sum("failed_tests")),
-                paragraph(render_sum("ignored_tests")),
+                render_sum("passed_tests"),
+                render_sum("failed_tests"),
+                render_sum("ignored_tests"),
             )
 
         node.replace_self(table.finalize())

--- a/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/render_summary.py
+++ b/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/render_summary.py
@@ -5,6 +5,7 @@ from .render_template import OutcomesPageNode
 from .utils import RenderTable, paragraph
 from dataclasses import dataclass
 from docutils import nodes
+from ferrocene_qualification.target import render_target_name
 from sphinx.directives import SphinxDirective
 from sphinx.environment.collectors import EnvironmentCollector
 from sphinx.transforms import SphinxTransform
@@ -55,8 +56,8 @@ class InjectSummaryTransform(SphinxTransform):
                 return str(sum(getattr(invoc, field) for invoc in platform.invocations))
 
             table.add_row(
-                paragraph(page.host),
-                paragraph(page.target),
+                paragraph(self.render_target(node, page.host)),
+                paragraph(self.render_target(node, page.target)),
                 paragraph(
                     make_refnode(
                         self.app.builder,
@@ -72,6 +73,14 @@ class InjectSummaryTransform(SphinxTransform):
             )
 
         node.replace_self(table.finalize())
+
+    def render_target(self, node, target):
+        return render_target_name(
+            self.env,
+            self.config,
+            target,
+            location=(node.source, node.line),
+        )
 
 
 class OutcomePagesCollector(EnvironmentCollector):

--- a/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/render_summary.py
+++ b/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/render_summary.py
@@ -48,14 +48,21 @@ class InjectSummaryTransform(SphinxTransform):
             head=True,
         )
         for page in pages:
-            platform = self.env.ferrocene_test_outcomes.platform(
-                page.host, page.tested_target
+            platform = (
+                self.env.ferrocene_test_outcomes.platform(page.host, page.tested_target)
+                if self.env.ferrocene_test_outcomes is not None
+                else None
             )
 
             def render_sum(field):
-                content = sum(getattr(invoc, field) for invoc in platform.invocations)
+                if platform is not None:
+                    content = sum(getattr(inv, field) for inv in platform.invocations)
+                    css_class = "align-right"
+                else:
+                    content = "-"
+                    css_class = "align-center"
                 container = paragraph(str(content))
-                container["classes"].append("align-right")
+                container["classes"].append(css_class)
                 return container
 
             table.add_row(

--- a/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/render_summary.py
+++ b/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/render_summary.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+from .render_template import OutcomesPageNode
+from .utils import RenderTable, paragraph
+from dataclasses import dataclass
+from docutils import nodes
+from sphinx.directives import SphinxDirective
+from sphinx.environment.collectors import EnvironmentCollector
+from sphinx.transforms import SphinxTransform
+from sphinx.util.nodes import make_refnode
+
+
+class PendingSummaryNode(nodes.Element):
+    def __init__(self, location):
+        super().__init__()
+        self.source = location[0]
+        self.line = location[1]
+
+
+class SummaryDirective(SphinxDirective):
+    has_content = False
+
+    def run(self):
+        return [PendingSummaryNode(self.get_source_info())]
+
+
+class InjectSummaryTransform(SphinxTransform):
+    default_priority = 500
+
+    def apply(self):
+        for node in self.document.findall(PendingSummaryNode):
+            self.replace_node(node)
+
+    def replace_node(self, node):
+        pages = get_storage(self.env).copy()
+        pages.sort()
+
+        table = RenderTable(7)
+        table.add_row(
+            paragraph("Host"),
+            paragraph("Target"),
+            paragraph("Results"),
+            paragraph("Passed tests"),
+            paragraph("Failed tests"),
+            paragraph("Ignored tests"),
+            head=True,
+        )
+        for page in pages:
+            platform = self.env.ferrocene_test_outcomes.platform(
+                page.host, page.tested_target
+            )
+
+            def render_sum(field):
+                return str(sum(getattr(invoc, field) for invoc in platform.invocations))
+
+            table.add_row(
+                paragraph(page.host),
+                paragraph(page.target),
+                paragraph(
+                    make_refnode(
+                        self.app.builder,
+                        self.env.docname,
+                        page.document,
+                        "",
+                        nodes.Text("Detailed test results"),
+                    )
+                ),
+                paragraph(render_sum("passed_tests")),
+                paragraph(render_sum("failed_tests")),
+                paragraph(render_sum("ignored_tests")),
+            )
+
+        node.replace_self(table.finalize())
+
+
+class OutcomePagesCollector(EnvironmentCollector):
+    def clear_doc(self, app, env, docname):
+        storage = get_storage(env)
+        storage[:] = [page for page in storage if page.document != docname]
+
+    def merge_other(self, app, env, docnames, other):
+        storage = get_storage(env)
+        other_storage = get_storage(other)
+        for page in other_storage:
+            if page.document in docnames:
+                storage.append(page)
+
+    def process_doc(self, app, document):
+        storage = get_storage(app.env)
+        for node in document.findall(OutcomesPageNode):
+            storage.append(
+                OutcomesPage(
+                    document=app.env.docname,
+                    host=node["host"],
+                    target=node["target"],
+                    tested_target=node["tested_target"],
+                )
+            )
+
+
+def get_storage(env):
+    key = "ferrocene_test_outcome_pages"
+    if not hasattr(env, key):
+        setattr(env, key, [])
+    return getattr(env, key)
+
+
+@dataclass(order=True)
+class OutcomesPage:
+    host: str
+    target: str
+    tested_target: str
+    document: str
+
+
+def setup(app):
+    app.add_node(PendingSummaryNode)
+    app.add_directive("render-summary", SummaryDirective)
+    app.add_post_transform(InjectSummaryTransform)
+    app.add_env_collector(OutcomePagesCollector)

--- a/ferrocene/doc/qualification-report/src/statement.rst
+++ b/ferrocene/doc/qualification-report/src/statement.rst
@@ -4,8 +4,8 @@
 Acceptability Statement
 =======================
 
-Ferrocene provides a development environment capable of compiling, binding,
-and linking programs for the target architecture. As per the test results shown
-in this document, Ferrocene |ferrocene_version| has been reviewed
-and is demonstrated compliant with automotive [|iso_ref|] |ferrocene_TCL|/|ferrocene_ASIL|
-and industrial [|iec_ref|] |ferrocene_TQL|.
+Ferrocene provides a development environment capable of compiling, binding, and
+linking programs for the target architecture. As per the test results shown in
+:doc:`tests/index`, Ferrocene |ferrocene_version| has been reviewed and is
+demonstrated compliant with automotive [|iso_ref|]
+|ferrocene_TCL|/|ferrocene_ASIL| and industrial [|iec_ref|] |ferrocene_TQL|.

--- a/ferrocene/doc/qualification-report/src/tests/index.rst
+++ b/ferrocene/doc/qualification-report/src/tests/index.rst
@@ -7,4 +7,4 @@ Test results overview
 Ferrocene has been tested on all the platforms we support as part of the
 qualification. For ease of access, each platform has its own page.
 
-TODO: add table providing summary of each page's test results
+.. render-summary::

--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/target.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/target.py
@@ -10,15 +10,21 @@ import tomli
 class TargetRole(SphinxRole):
     def run(self):
         target = self.text.strip()
-        if target in self.env.ferrocene_target_names:
-            return [nodes.Text(self.env.ferrocene_target_names[target])], []
-        else:
-            config = self.config["ferrocene_target_names_path"]
-            logger = sphinx.util.logging.getLogger(__name__)
-            logger.warning(
-                f"missing target {target} in {config}", location=self.get_location()
+        return [
+            render_target_name(
+                self.env, self.config, target, location=self.get_location()
             )
-            return [nodes.problematic("", self.text)], []
+        ], []
+
+
+def render_target_name(env, config, target, *, location=None):
+    if target in env.ferrocene_target_names:
+        return nodes.Text(env.ferrocene_target_names[target])
+    else:
+        config = config["ferrocene_target_names_path"]
+        logger = sphinx.util.logging.getLogger(__name__)
+        logger.warning(f"missing target {target} in {config}", location=location)
+        return nodes.problematic("", target)
 
 
 def load_target_names(app, env, _docnames):

--- a/ferrocene/doc/sphinx-shared-resources/themes/ferrocene/static/ferrocene.css
+++ b/ferrocene/doc/sphinx-shared-resources/themes/ferrocene/static/ferrocene.css
@@ -175,6 +175,14 @@ a:hover {
     text-decoration: underline;
 }
 
+.align-center {
+    text-align: center;
+}
+
+.align-right {
+    text-align: right;
+}
+
 /****************
  *   Headings   *
  ****************/


### PR DESCRIPTION
This PR adds a summary table in the "test results overview" page that lists how many tests were passed for each target, and links to the more detailed page.

![image](https://github.com/ferrocene/ferrocene/assets/2299951/08525a85-30ff-41a7-8502-baf408e9bf50)
