### PR TITLE
Add `:target-with-triple:` and document it

### DIFF
--- a/ferrocene/doc/internal-procedures/src/doc-procedures.rst
+++ b/ferrocene/doc/internal-procedures/src/doc-procedures.rst
@@ -144,6 +144,33 @@ the substitution name with ``|``:
 
    |doc_title|
 
+Mentioning targets
+~~~~~~~~~~~~~~~~~~
+
+When you need to refer to targets across the documentation, it's better to use
+a human-readable name (like ":target:`aarch64-unknown-none`") than the target
+triple, as the latter is often inconsistent between similar targets and could
+be confusing to customers.
+
+To keep the target names consistent, you can use the ``:target:`` role with the
+target triple as its content, which will be rendered as the human-readable
+name:
+
+.. code-block:: rst
+
+   :target:`x86_64-unknown-linux-gnu`
+
+The ``:target-with-triple:`` role will also add the triple following the
+human-readable name, which is best used when customers then need to copy/paste
+the triple:
+
+.. code-block:: rst
+
+   :target-with-triple:`aarch64-unknown-none`
+
+The human-readable names are stored in ``ferrocene/doc/target-names.toml``, and
+referring to a target not defined in that file will emit a warning.
+
 Signing documents
 -----------------
 

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -54,9 +54,9 @@ For this qualification, testing is restricted to the following environments:
 .. list-table::
 
    * - Host platform:
-     - :target:`{{ host }}`
+     - :target-with-triple:`{{ host }}`
    * - Compilation target:
-     - :target:`{{ target }}`
+     - :target-with-triple:`{{ target }}`
    * - Supported languages:
      - Rust
 

--- a/ferrocene/doc/release-notes/src/24.05.0.rst
+++ b/ferrocene/doc/release-notes/src/24.05.0.rst
@@ -31,9 +31,9 @@ shipped as a preview.
   Note that experimental targets are not qualified for safety critical use. The
   new targets are:
 
-  * :target:`thumbv7em-none-eabi`
-  * :target:`thumbv7em-none-eabihf`
-  * :target:`wasm32-unknown-unknown`
+  * :target-with-triple:`thumbv7em-none-eabi`
+  * :target-with-triple:`thumbv7em-none-eabihf`
+  * :target-with-triple:`wasm32-unknown-unknown`
 
 * The self-testing tool now checks the correct behavior of *linker drivers*,
   according to the new requirements for linkers. Note that the self-testing

--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/target.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/target.py
@@ -8,18 +8,32 @@ import tomli
 
 
 class TargetRole(SphinxRole):
+    def __init__(self, *, include_triple=False):
+        super().__init__()
+        self.include_triple = include_triple
+
     def run(self):
         target = self.text.strip()
         return [
             render_target_name(
-                self.env, self.config, target, location=self.get_location()
+                self.env,
+                self.config,
+                target,
+                include_triple=self.include_triple,
+                location=self.get_location(),
             )
         ], []
 
 
-def render_target_name(env, config, target, *, location=None):
+def render_target_name(env, config, target, *, include_triple=False, location=None):
     if target in env.ferrocene_target_names:
-        return nodes.Text(env.ferrocene_target_names[target])
+        inline = nodes.inline()
+        inline += nodes.Text(env.ferrocene_target_names[target])
+        if include_triple:
+            inline += nodes.Text(" (")
+            inline += nodes.literal("", target)
+            inline += nodes.Text(")")
+        return inline
     else:
         config = config["ferrocene_target_names_path"]
         logger = sphinx.util.logging.getLogger(__name__)
@@ -36,3 +50,4 @@ def load_target_names(app, env, _docnames):
 def setup(app):
     app.connect("env-before-read-docs", load_target_names)
     app.add_role("target", TargetRole())
+    app.add_role("target-with-triple", TargetRole(include_triple=True))

--- a/ferrocene/doc/sphinx-shared-resources/themes/ferrocene/static/ferrocene.css
+++ b/ferrocene/doc/sphinx-shared-resources/themes/ferrocene/static/ferrocene.css
@@ -273,10 +273,12 @@ code {
     padding: 0 0.2em;
     border-radius: 0.2em;
     outline: 0.1em solid var(--inline-code-border);
+    margin: 0 0.1em;
 }
 
 pre code {
     background: transparent;
+    margin: 0;
     padding: 0;
     border-radius: 0;
     outline: none;


### PR DESCRIPTION
This PR adds `:target-with-triple:`, in addition to the existing `:target:` added in #225, as per Jonathan's suggestion. It also adds documentation for both `:target:` and `:target-with-triple:` in the IP.