### PR TITLE
fix segfaulting rustc when `download-ci-llvm = true`

### DIFF
--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -66,6 +66,21 @@ add --enable-cargo-native-static
 # might require libstdc++ to be installed on the user's system.
 add --enable-llvm-static-stdcpp
 
+# Build LLVM as shared libraries
+#
+# `llvm.static-stdcpp` requires dynamic LLVM libraries to work properly. A
+# dynamic library (`.so`) can hold a copy of `libstdc++.a` whereas static
+# libraries (`.a`) will not include a copy of `libstdc++.a`.
+#
+# Building `rustc` against static LLVM libraries will use the local version
+# of `libstdc++.so` to satisfy the dependencies on `std::` symbols that the
+# LLVM libraries have. That can be problematic when `llvm.download-ci-llvm`
+# is enabled and the CI built LLVM as static libraries. CI's LLVM libraries
+# expect the CI's version of `libstdc++.a` but the local build will use the
+# local `libstdc++.so` and that can lead to a library version mismatch which
+# translates to `rustc` segfaulting at runtime.
+add --enable-llvm-link-shared
+
 # Produce XZ-compressed tarballs when building dist artifacts.
 #
 # If this configuration is missing or set to a different value the resulting

--- a/ferrocene/ci/docker-images/ubuntu-18/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-18/Dockerfile
@@ -15,7 +15,7 @@ FROM ubuntu:22.04 AS jammy
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends qemu-user-static
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update \
     # Update all the dependencies
@@ -85,19 +85,6 @@ RUN mkdir /tmp/python \
 COPY reuse-requirements.txt /tmp/reuse-requirements.txt
 RUN python3 -m pip install -r /tmp/reuse-requirements.txt && \
     rm -rf /tmp/reuse-requirements.txt
-
-# Install git 2.25 from source. The version included in Ubuntu 18.04 is too old
-# to perform fast clones of the LLVM monorepo.
-RUN mkdir /tmp/git \
-    && cd /tmp/git \
-    && curl -OL https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.25.5.tar.xz \
-    && echo "164dec6d31843a436c0db2acb79ce49a56f703f587e7c127cf421604d5570bba git-2.25.5.tar.xz" | sha256sum -c \
-    && tar xf git-2.25.5.tar.xz --strip-components=1 \
-    && make configure \
-    && ./configure --prefix=/usr/local \
-    && make -j$(nproc) \
-    && make install \
-    && rm -rf /tmp/git
 
 # Install a recent NodeJS version, as the one shipped in Ubuntu 18.04 is too
 # old to run the rustdoc-js test suite. Note that we cannot install the most

--- a/ferrocene/ci/docker-images/ubuntu-18/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-18/Dockerfile
@@ -78,7 +78,7 @@ RUN mkdir /tmp/python \
     && ./configure \
     && make -j$(nproc) \
     && make install \
-    && rm -rf /tmp/git
+    && rm -rf /tmp/python
 
 # The REUSE tool is used to check the licensing status. It's not available in
 # the Ubuntu archives so we have to install it with pip.

--- a/ferrocene/ci/scripts/persist-between-jobs.sh
+++ b/ferrocene/ci/scripts/persist-between-jobs.sh
@@ -50,7 +50,7 @@ case "$1" in
         # Call `zstd` separately to be able to use all cores available (`-T0`)
         # and the lowest compression level possible, to speed the compression
         # as much as possible.
-        tar c $@ --exclude build/metrics.json | zstd -1 -T0 | aws s3 cp - "$(s3_url "${CIRCLE_JOB}")"
+        tar c --exclude build/metrics.json $@ | zstd -1 -T0 | aws s3 cp - "$(s3_url "${CIRCLE_JOB}")"
         ;;
     restore)
         if [[ "$#" -ne 2 ]]; then

--- a/ferrocene/doc/release-notes/src/next.rst
+++ b/ferrocene/doc/release-notes/src/next.rst
@@ -8,3 +8,8 @@ Next Ferrocene release
 
 This page contains the changes to be introduced in the upcoming Ferrocene
 release.
+
+Changes
+-------
+
+* The ``x86_64-unknown-linux-gnu`` Ferrocene target now requires a glibc version of 2.31 or higher.

--- a/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
@@ -7,7 +7,7 @@
 ==================================
 
 The ``x86_64-unknown-linux-gnu`` Ferrocene target provides support for Linux on
-x86_64 using glibc 2.27 or higher.
+x86_64 using glibc 2.31 or higher.
 
 Prerequisites
 -------------
@@ -28,7 +28,7 @@ You must have a C compiler which:
 - Supplies to ``ld.lld`` only those linker arguments specified in the
   :doc:`Safety Manual <safety-manual:options>`
 
-On Ubuntu 18.04 LTS you can install a suitable C compiler with:
+On Ubuntu 20.04 LTS you can install a suitable C compiler with:
 
 .. code-block::
 


### PR DESCRIPTION
- the segfault occurred in the second / third C++ frame after `rustc` called into LLVM using the `PassWrapper.cpp` glue
- the segfault occurred due a ABI mismatch between those two frames
- both frames corresponded to LLVM C++ functions. (the first frame was the `PassWrapper.cpp` glue)
- one of the frames (functions) came from the LLVM library built in CI; the other frame was codegen'd locally
- when comparing to a rust-lang/rust build, it was found that both frames involved in the segfault were present in the LLVM library built in rust-lang/rust CI. the rust-lang/rust artifact did not result in a segfault
- the differences between the rust-lang/rust and ferrocene build settings are: (a) rust-lang/rust builds llvm as shared library; ferrocene builds them as static libraries. (b) rust-lang/rust uses `clang` and a newer version of `gcc` / `g++`
- building LLVM as shared libraries in ferrocene did not fix the segfault but additionally bumping the `gcc` / `g++` version (by way of using a newer base docker image) did