### PR TITLE
Fix automated pull failing when conflicts are present in bootstrap

### DIFF
--- a/ferrocene/ci/scripts/detect-conflict-markers.py
+++ b/ferrocene/ci/scripts/detect-conflict-markers.py
@@ -11,8 +11,9 @@
 # whenever those are found, this script lists all the conflict markers in the
 # repository, and errors out if some are found.
 
-import subprocess
 from dataclasses import dataclass
+import subprocess
+import argparse
 
 
 START = "<<<<<<< "
@@ -33,10 +34,10 @@ EXCEPTIONS = {
 }
 
 
-def files_with_possible_conflict_markers():
+def files_with_possible_conflict_markers(directory):
     # git grep automatically filters out submodules.
     lines = subprocess.run(
-        ["git", "grep", "-l", "^<<<"],
+        ["git", "grep", "-l", "^<<<", "--", directory],
         check=True,
         stdout=subprocess.PIPE,
         text=True,
@@ -71,9 +72,9 @@ def conflict_markers_in_file(file):
             yield CustomDeleteMarker(file=file)
 
 
-def main():
+def main(directory):
     found_conflicts = False
-    for file in files_with_possible_conflict_markers():
+    for file in files_with_possible_conflict_markers(directory):
         for conflict in conflict_markers_in_file(file):
             print(conflict.repr())
             found_conflicts = True
@@ -102,4 +103,8 @@ class CustomDeleteMarker:
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("directory", default=".", nargs="?")
+    args = parser.parse_args()
+
+    main(args.directory)

--- a/ferrocene/ci/scripts/detect-conflict-markers.py
+++ b/ferrocene/ci/scripts/detect-conflict-markers.py
@@ -38,7 +38,6 @@ def files_with_possible_conflict_markers(directory):
     # git grep automatically filters out submodules.
     lines = subprocess.run(
         ["git", "grep", "-l", "^<<<", "--", directory],
-        check=True,
         stdout=subprocess.PIPE,
         text=True,
     )


### PR DESCRIPTION
#230 changed the automated pull infrastructure to attempt generating new `x.py` completions whenever pulling from upstream, which requires invoking the build system. Of course though this would fail when there are conflicts in the build system itself, and #281 was the first time that happened.

This PR changes the conflict detection script to support looking for conflicts in a subdirectory, and changes the automation to only attempt regenerating completions when no conflicts in bootstrap are detected.