### PR TITLE
Add requirements traceability page

### DIFF
--- a/ferrocene/doc/qualification-report/src/index.rst
+++ b/ferrocene/doc/qualification-report/src/index.rst
@@ -13,6 +13,7 @@ qualification, in accordance to the standards above.
    :numbered:
    :maxdepth: 2
 
+   requirements-traceability
    statement
 
 .. toctree::

--- a/ferrocene/doc/qualification-report/src/requirements-traceability.rst
+++ b/ferrocene/doc/qualification-report/src/requirements-traceability.rst
@@ -1,0 +1,36 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Requirements traceability
+=========================
+
+Our infrastructure automatically tracks the traceability between requirements
+and tests, and the report is available `as part of the documentation package
+<../traceability-matrix.html>`_. The report must show full coverage: when it is
+not possible to test a requirement on a target, an exception will be listed on
+this page.
+
+Note that the reporting tool only considers tests that were actually executed
+as part of the :doc:`test results <tests/index>`. Ignored tests are not
+considered when determining the traceability.
+
+Exceptions
+----------
+
+Some requirements are marked as not covered in the traceability report linked
+above:
+
+.. list-table::
+   :header-rows: 1
+
+   * - ID
+     - Targets
+     - Reasoning
+
+   * - ``fls_2d6bqnpy6tvs``
+     - :target-with-triple:`aarch64-unknown-none`
+     - Procedural macros are only available on host platforms, while this is a cross-compilation target
+
+   * - ``fls_4vjbkm4ceymk``
+     - :target-with-triple:`aarch64-unknown-none`
+     - Procedural macros are only available on host platforms, while this is a cross-compilation target

--- a/ferrocene/doc/qualification-report/src/statement.rst
+++ b/ferrocene/doc/qualification-report/src/statement.rst
@@ -5,7 +5,8 @@ Acceptability Statement
 =======================
 
 Ferrocene provides a development environment capable of compiling, binding, and
-linking programs for the target architecture. As per the test results shown in
+linking programs for the target architecture. As per the traceability in
+:doc:`requirements-traceability` and the test results shown in
 :doc:`tests/index`, Ferrocene |ferrocene_version| has been reviewed and is
 demonstrated compliant with automotive [|iso_ref|]
 |ferrocene_TCL|/|ferrocene_ASIL| and industrial [|iec_ref|] |ferrocene_TQL|.


### PR DESCRIPTION
This adds a page to the QR explaining the traceability matrix, and lists the current exceptions.