### PR TITLE
Bug fixes for `--serve`

### DIFF
--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_toctrees.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_toctrees.py
@@ -110,8 +110,16 @@ class TocTreeCollectorWithAppendices(TocTreeCollector):
 # to disable it. That'll avoid two TocTreeCollectors running in the build.
 def disable_builtin_toctree_collector(app):
     for obj in gc.get_objects():
-        if isinstance(obj, TocTreeCollector):
-            obj.disable(app)
+        if not isinstance(obj, TocTreeCollector):
+            continue
+        # When running sphinx-autobuild, this function might be called multiple
+        # times. When the collector is already disabled `listener_ids` will be
+        # `None`, and thus we don't need to disable it again.
+        #
+        # Note that disabling an already disabled collector will fail.
+        if obj.listener_ids is None:
+            continue
+        obj.disable(app)
 
 
 def setup(app):

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -253,6 +253,16 @@ impl<P: Step> Step for SphinxBook<P> {
             // Load extensions from the shared resources as well:
             .env("PYTHONPATH", relative_path(&src, &shared_resources.join("exts")));
 
+        if builder.config.cmd.fresh() {
+            // The `-E` flag forces Sphinx to ignore any saved environment and build everything
+            // from scratch. This is not strictly required during normal builds or initial builds
+            // with --serve, as code above already clears the directory before invoking Sphinx.
+            //
+            // Without this code, followup builds of --serve would be incremental rather than
+            // fresh, as our code to delete directories only runs once. Passing `-E` fixes that.
+            cmd.arg("-E");
+        }
+
         if self.require_relnotes {
             cmd.arg("-D").arg(path_define(
                 "rust_release_notes",


### PR DESCRIPTION
This PR makes two fixes to the `--serve` command:

* Occasionally rebuilding the documentation would fail due to the `ferrocene_toctrees` extension failing to disable the builtin toctree collector. Now the extension will attempt disabling it only when it's not already disabled.
* `--fresh --serve` would not work as expected, as it'd do an initial fresh build and then incremental builds. Now all followup builds will be fresh too.