### PR TITLE
Allow building all Sphinx docs at once, and error out if `--serve` is misused

### DIFF
--- a/ferrocene/doc/internal-procedures/src/doc-procedures.rst
+++ b/ferrocene/doc/internal-procedures/src/doc-procedures.rst
@@ -50,7 +50,16 @@ paths:
 
    ./x doc ferrocene/doc/$foo ferrocene/doc/$bar ferrocene/doc/$baz
 
-If you want to build all of the available documentation, you can omit the path:
+If you want to build all the documentation generated with Sphinx (for example
+if you need to ensure cross-document links work, or you need to test an
+extension change across all documents) you can run:
+
+.. code-block:: text
+
+   ./x doc ferrocene-all-sphinx
+
+If you want to build all of the available documentation, including the standard
+library docs and documentation from upstream, you can omit the path:
 
 .. code-block:: text
 

--- a/ferrocene/doc/internal-procedures/src/doc-procedures.rst
+++ b/ferrocene/doc/internal-procedures/src/doc-procedures.rst
@@ -82,6 +82,13 @@ reloading of the changes in the browser:
 
    ./x doc ferrocene/doc/$foo --serve
 
+.. caution::
+
+   The ``--serve`` flag is only available for documents built with Sphinx, and
+   it will not do anything for other kinds of documentation (like mdBook or
+   rustdoc). It also only supports serving a *single* Sphinx document: if you
+   attempt to serve more than one at the time it will error out.
+
 When you are working on Sphinx extensions, the ``--debug-sphinx`` flag will
 change the configuration to aid debugging, by running only one builder job at
 the time and showing exception tracebacks:

--- a/ferrocene/doc/internal-procedures/src/doc-procedures.rst
+++ b/ferrocene/doc/internal-procedures/src/doc-procedures.rst
@@ -56,7 +56,7 @@ extension change across all documents) you can run:
 
 .. code-block:: text
 
-   ./x doc ferrocene-all-sphinx
+   ./x doc ferrocene/doc
 
 If you want to build all of the available documentation, including the standard
 library docs and documentation from upstream, you can omit the path:

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -41,7 +41,7 @@ pub struct Builder<'a> {
     cache: Cache,
     stack: RefCell<Vec<Box<dyn Any>>>,
     time_spent_on_dependencies: Cell<Duration>,
-    should_serve_called: atomic::AtomicBool,
+    should_serve_called: atomic::AtomicU64,
     pub paths: Vec<PathBuf>,
 }
 
@@ -975,7 +975,7 @@ impl<'a> Builder<'a> {
             cache: Cache::new(),
             stack: RefCell::new(Vec::new()),
             time_spent_on_dependencies: Cell::new(Duration::new(0, 0)),
-            should_serve_called: atomic::AtomicBool::new(false),
+            should_serve_called: atomic::AtomicU64::new(0),
             paths,
         }
     }
@@ -2328,14 +2328,20 @@ impl<'a> Builder<'a> {
 
     pub(crate) fn should_serve<S: Step>(&self) -> bool {
         // We record whether this method was called to see if it was invoked during the dry run. If
-        // it wasn't and the --serve flag was passed we error out saying this is unsupported.
-        self.should_serve_called.store(true, atomic::Ordering::Relaxed);
+        // it wasn't and the --serve flag was passed we error out saying this is unsupported. If it
+        // was invoked multiple times we also error out since it's not supported to run it for
+        // multiple books at the same time.
+        self.should_serve_called.fetch_add(1, atomic::Ordering::Relaxed);
 
         self.was_invoked_explicitly::<S>(Kind::Doc) && self.config.cmd.serve()
     }
 
     pub(crate) fn is_serve_flag_unsupported(&self) -> bool {
-        self.config.cmd.serve() && !self.should_serve_called.load(atomic::Ordering::Relaxed)
+        self.config.cmd.serve() && self.should_serve_called.load(atomic::Ordering::Relaxed) == 0
+    }
+
+    pub(crate) fn is_serve_flag_called_multiple_times(&self) -> bool {
+        self.config.cmd.serve() && self.should_serve_called.load(atomic::Ordering::Relaxed) > 1
     }
 }
 

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -833,6 +833,7 @@ impl<'a> Builder<'a> {
                 doc::EditionGuide,
                 doc::StyleGuide,
                 doc::Tidy,
+                crate::ferrocene::doc::AllSphinxDocuments,
                 // Basic Documents
                 crate::ferrocene::doc::Index,
                 crate::ferrocene::doc::Specification,

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -560,6 +560,10 @@ macro_rules! sphinx_books {
                         fresh_build: false,
                     });
                 )*
+
+                // Also regenerate the index file, so that the "Ferrocene documentation" link in
+                // the breadcrumbs doesn't break.
+                builder.ensure(Index { target: self.target });
             }
         }
 

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -543,7 +543,7 @@ macro_rules! sphinx_books {
             const DEFAULT: bool = false;
 
             fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-                run.alias("ferrocene-all-sphinx")
+                run.path("ferrocene/doc")
             }
 
             fn make_run(run: RunConfig<'_>) {

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -533,6 +533,36 @@ macro_rules! sphinx_books {
             }
         )*
 
+        #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+        pub(crate) struct AllSphinxDocuments {
+            pub(crate) target: TargetSelection,
+        }
+
+        impl Step for AllSphinxDocuments {
+            type Output = ();
+            const DEFAULT: bool = false;
+
+            fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+                run.alias("ferrocene-all-sphinx")
+            }
+
+            fn make_run(run: RunConfig<'_>) {
+                run.builder.ensure(AllSphinxDocuments {
+                    target: run.target,
+                });
+            }
+
+            fn run(self, builder: &Builder<'_>) {
+                $(
+                    builder.ensure($ty {
+                        mode: SphinxMode::Html,
+                        target: self.target,
+                        fresh_build: false,
+                    });
+                )*
+            }
+        }
+
         fn intersphinx_gather_steps(target: TargetSelection) -> Vec<SphinxBook> {
             let mut steps = Vec::new();
             $({

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -677,6 +677,11 @@ impl Build {
                     eprintln!("error: --serve flag is not supported for the requested path");
                     exit!(1);
                 }
+
+                if builder.is_serve_flag_called_multiple_times() {
+                    eprintln!("error: --serve can only be used when building a single document");
+                    exit!(1);
+                }
             }
 
             self.config.dry_run = DryRun::Disabled;


### PR DESCRIPTION
This PR makes a few quality of life changes to the tooling used to build the documentation:

* There is now a new `./x doc ferrocene/doc`, which builds all the Sphinx documents at once. This is easier than manually listing all documents in the single `./x` invocation, and it's way faster than invoking `./x doc` multiple times[^1]. Bikeshedding welcome on the name, I'm not too happy about it (the only constraint is having the `ferrocene-` prefix).

* Passing `--serve` when multiple documents are requested will now print an error and exit. It was already unsupported to pass `--serve` with multiple documents, as it would only start the server for the first one, but it was a silent and unintuitive.

[^1]: When invoking `./x` to build any document, the build system first gathers the intersphinx artifacts from all the documents, and only then actually builds the requested document(s). Gathering the intersphinx artifacts takes a few seconds. If you build multiple documents in the same invocation, the intersphinx artifacts will be reused, but if you invoke `./x` multiple times they will be regenerated every single time.