### PR TITLE
Two manual backports into 1.76

### DIFF
--- a/ferrocene/doc/evaluation-plan/src/method.rst
+++ b/ferrocene/doc/evaluation-plan/src/method.rst
@@ -11,12 +11,12 @@ of each error will be determined. This is done by evaluating the use cases of
 the tool based on the usage in the activities of safety-critical product
 development that this tool replaces or simplifies.
 
-Through this analysis, the following potential error are identified:
+Through this analysis, the following potential error are identified. Potential errors ...
 
-* Potential errors with the possibility to detect and to mitigate them.
-* Potential errors without the possibility to detect or to mitigate them.
-* Potential errors that do not appear in use cases.
-* Potential errors without an impact for safety.
+* ... with the possibility to detect and to mitigate them.
+* ... without the possibility to detect or to mitigate them.
+* ... that do not appear in use cases.
+* ... without an impact for safety.
 
 Errors, with the possibility of detection and mitigation, are added in
 the :doc:`safety-manual:index` with the following form:

--- a/ferrocene/doc/evaluation-plan/src/method.rst
+++ b/ferrocene/doc/evaluation-plan/src/method.rst
@@ -121,7 +121,7 @@ process by considering the following organization:
 #. Several other meetings allow us to discuss the analysis of each member.
 #. Report is directly updated by members.
 #. An expert reads, the second time, the sessions' report and adds remarks
-   based on his domain knowledge, e.g. "impossible deviation", or adding some
+   based on her domain knowledge, e.g. "impossible deviation", or adding some
    missing deviations.
 #. Finally, an analysis of these results is performed in order to merge similar
    potential errors in an hazard class. This class groups potential errors with

--- a/ferrocene/doc/evaluation-plan/src/method.rst
+++ b/ferrocene/doc/evaluation-plan/src/method.rst
@@ -121,7 +121,7 @@ process by considering the following organization:
 #. Several other meetings allow us to discuss the analysis of each member.
 #. Report is directly updated by members.
 #. An expert reads, the second time, the sessions' report and adds remarks
-   based on her domain knowledge, e.g. "impossible deviation", or adding some
+   based on their domain knowledge, e.g. "impossible deviation", or adding some
    missing deviations.
 #. Finally, an analysis of these results is performed in order to merge similar
    potential errors in an hazard class. This class groups potential errors with

--- a/ferrocene/doc/evaluation-plan/src/method.rst
+++ b/ferrocene/doc/evaluation-plan/src/method.rst
@@ -214,32 +214,32 @@ qualification method:
 
 * For **TCL2**:
 
-.. csv-table:: TCL2 Qualification methods according to ASIL level
-   :name: TCL2 Qualification methods according to ASIL level
-   :header: Method, ASIL A, ASIL B, ASIL C, ASIL D
-   :delim: !
+   .. csv-table:: TCL2 Qualification methods according to ASIL level
+      :name: TCL2 Qualification methods according to ASIL level
+      :header: Method, ASIL A, ASIL B, ASIL C, ASIL D
+      :delim: !
 
-   1a. Increased confidence from use in accordance with 11.4.7! ++ ! ++ ! ++ ! \+
-   1b. Evaluation of the tool development process in accordance with 11.4.8! ++ ! ++ ! ++ ! \+
-   1c. Validation of the software tool in accordance with 11.4.9! \+ ! \+ ! \+ ! ++
-   1d. Development in accordance with a safety standard! \+ ! \+ ! \+ ! \+
+      1a. Increased confidence from use in accordance with 11.4.7! ++ ! ++ ! ++ ! \+
+      1b. Evaluation of the tool development process in accordance with 11.4.8! ++ ! ++ ! ++ ! \+
+      1c. Validation of the software tool in accordance with 11.4.9! \+ ! \+ ! \+ ! ++
+      1d. Development in accordance with a safety standard! \+ ! \+ ! \+ ! \+
 
-.. end of table
+   .. end of table
 
 
 * For **TCL3**:
 
-.. csv-table:: TCL3 Qualification methods according to ASIL level
-   :name: TCL3 Qualification methods according to ASIL level
-   :header: Method, ASIL A, ASIL B, ASIL C, ASIL D
-   :delim: !
+   .. csv-table:: TCL3 Qualification methods according to ASIL level
+      :name: TCL3 Qualification methods according to ASIL level
+      :header: Method, ASIL A, ASIL B, ASIL C, ASIL D
+      :delim: !
 
-   1a. Increased confidence from use in accordance with 11.4.7! ++ ! ++ ! \+ ! \+
-   1b. Evaluation of the tool development process in accordance with 11.4.8! ++ ! ++ ! \+ ! \+
-   1c. Validation of the software tool in accordance with 11.4.9! \+ ! \+ ! ++ ! ++
-   1d. Development in accordance with a safety standard! \+ ! \+ ! ++ ! ++
+      1a. Increased confidence from use in accordance with 11.4.7! ++ ! ++ ! \+ ! \+
+      1b. Evaluation of the tool development process in accordance with 11.4.8! ++ ! ++ ! \+ ! \+
+      1c. Validation of the software tool in accordance with 11.4.9! \+ ! \+ ! ++ ! ++
+      1d. Development in accordance with a safety standard! \+ ! \+ ! ++ ! ++
 
-.. end of table
+   .. end of table
 
 |
 | ++: Highly recommended

--- a/ferrocene/doc/evaluation-plan/src/method.rst
+++ b/ferrocene/doc/evaluation-plan/src/method.rst
@@ -11,12 +11,12 @@ of each error will be determined. This is done by evaluating the use cases of
 the tool based on the usage in the activities of safety-critical product
 development that this tool replaces or simplifies.
 
-Through this analysis, the following potential error are identified. Potential errors ...
+Through this analysis, the following potential error are identified:
 
-* ... with the possibility to detect and to mitigate them.
-* ... without the possibility to detect or to mitigate them.
-* ... that do not appear in use cases.
-* ... without an impact for safety.
+* Potential errors with the possibility to detect and to mitigate them.
+* Potential errors without the possibility to detect or to mitigate them.
+* Potential errors that do not appear in use cases.
+* Potential errors without an impact for safety.
 
 Errors, with the possibility of detection and mitigation, are added in
 the :doc:`safety-manual:index` with the following form:

--- a/ferrocene/doc/evaluation-plan/src/purpose.rst
+++ b/ferrocene/doc/evaluation-plan/src/purpose.rst
@@ -7,7 +7,7 @@ Ferrocene is a software development environment for Rust programming
 language.
 
 .. figure:: figures/toolchain-workflow.svg
-   
+
    Toolchain Workflow
 
 Ferrocene is composed of the following tools:

--- a/ferrocene/doc/evaluation-report/src/method.rst
+++ b/ferrocene/doc/evaluation-report/src/method.rst
@@ -54,7 +54,7 @@ Library Test Suite
 The **library test suite** contains tests that cover library libcore, and on
 supported platforms, libraries liballoc, libstd, and libtest. The tests are a
 mix of unit tests, integration tests, and documentation tests (code snippets
-within the documentation and built and run).
+within the documentation which are built and run).
 
 The library test suite has the following statistics:
 

--- a/ferrocene/doc/evaluation-report/src/purpose.rst
+++ b/ferrocene/doc/evaluation-report/src/purpose.rst
@@ -4,7 +4,7 @@
 Purpose
 =======
 
-Ferrocene is a software development environment for Rust programming 
+Ferrocene is a software development environment for Rust programming
 language.
 
 .. figure:: figures/toolchain-workflow.svg

--- a/ferrocene/doc/evaluation-report/src/tool-analysis.rst
+++ b/ferrocene/doc/evaluation-report/src/tool-analysis.rst
@@ -137,7 +137,7 @@ the following qualification methods:
 * 1c. Validation of the software tool in accordance with 11.4.9
 
 According to the clause 11.4.2 in part 8 of the [|iso_ref|] this choice is
-depending on user's software development life-cycle and her validation strategy,
+depending on user's software development life-cycle and their validation strategy,
 the user has the responsibility to determine whether this level or better one is
 applicable.
 

--- a/ferrocene/doc/evaluation-report/src/tool-analysis.rst
+++ b/ferrocene/doc/evaluation-report/src/tool-analysis.rst
@@ -80,8 +80,8 @@ LLVM
    .. id:: ERR_LLVM_17!:id:`UC1_RLIB`, :id:`UC2_STATICLIB`, :id:`UC3_EXEC`, :id:`UC4_EXEC_RLIB`, :id:`UC5_EXEC_CLIB`!Input parameter has invalid value!Most likely LLVM will crash. Invalid code could also be generated! :id:`AVD_TEST_007`
    .. id:: ERR_LLVM_18!:id:`UC1_RLIB`, :id:`UC2_STATICLIB`, :id:`UC3_EXEC`, :id:`UC4_EXEC_RLIB`, :id:`UC5_EXEC_CLIB`!An object file is invalid!Invalid code generated! :id:`AVD_CHECK_BUILD_SCRIPT_003`
    .. id:: ERR_LLVM_19!:id:`UC1_RLIB`, :id:`UC2_STATICLIB`, :id:`UC3_EXEC`, :id:`UC4_EXEC_RLIB`, :id:`UC5_EXEC_CLIB`!An object file or static library is not correctly translated to machine code!Undefined behavior! :id:`AVD_TEST_007`
-   .. id:: ERR_LLVM_20!:id:`UC1_RLIB`, :id:`UC2_STATICLIB`, :id:`UC3_EXEC`, :id:`UC4_EXEC_RLIB`, :id:`UC5_EXEC_CLIB`!The behavior is incorrect because of concurrent modificaitons!Invalid code generated! :id:`AVD_PARALLEL_BUILD_006`
-   .. id:: ERR_LLVM_21!:id:`UC1_RLIB`, :id:`UC2_STATICLIB`, :id:`UC3_EXEC`, :id:`UC4_EXEC_RLIB`, :id:`UC5_EXEC_CLIB`!An object or static library exposes aditional symbols!Internal functionality might become callable from the outside! :id:`AVD_TEST_007`
+   .. id:: ERR_LLVM_20!:id:`UC1_RLIB`, :id:`UC2_STATICLIB`, :id:`UC3_EXEC`, :id:`UC4_EXEC_RLIB`, :id:`UC5_EXEC_CLIB`!The behavior is incorrect because of concurrent modifications!Invalid code generated! :id:`AVD_PARALLEL_BUILD_006`
+   .. id:: ERR_LLVM_21!:id:`UC1_RLIB`, :id:`UC2_STATICLIB`, :id:`UC3_EXEC`, :id:`UC4_EXEC_RLIB`, :id:`UC5_EXEC_CLIB`!An object or static library exposes additional symbols!Internal functionality might become callable from the outside! :id:`AVD_TEST_007`
    .. id:: ERR_LLVM_22!:id:`UC1_RLIB`, :id:`UC2_STATICLIB`, :id:`UC3_EXEC`, :id:`UC4_EXEC_RLIB`, :id:`UC5_EXEC_CLIB`!Output does not contain expected variables or functions!Invalid code generated! :id:`AVD_CHECK_CLEAN_ENV_002` AND :id:`AVD_CLEAN_004` AND :id:`AVD_TEST_007`
 
 .. end of table

--- a/ferrocene/doc/evaluation-report/src/tool-analysis.rst
+++ b/ferrocene/doc/evaluation-report/src/tool-analysis.rst
@@ -137,7 +137,7 @@ the following qualification methods:
 * 1c. Validation of the software tool in accordance with 11.4.9
 
 According to the clause 11.4.2 in part 8 of the [|iso_ref|] this choice is
-depending on user's software development life-cycle and his validation strategy,
+depending on user's software development life-cycle and her validation strategy,
 the user has the responsibility to determine whether this level or better one is
 applicable.
 

--- a/ferrocene/doc/evaluation-report/src/use-cases.rst
+++ b/ferrocene/doc/evaluation-report/src/use-cases.rst
@@ -193,7 +193,7 @@ library.
 
 4. `rustc` parses the Rust compilation unit.
 
-5. `rustc` analyzes both the Rust compilation unit and the Rust library..
+5. `rustc` analyzes both the Rust compilation unit and the Rust library.
 
 6. `rustc` generates LLVM IR for the Rust compilation unit.
 

--- a/ferrocene/doc/internal-procedures/src/doc-procedures.rst
+++ b/ferrocene/doc/internal-procedures/src/doc-procedures.rst
@@ -109,7 +109,7 @@ dynamically:
 
 * ``doc_short_title``: the acronym of the document (e.g. SM)
 
-You can refer to substitutions across all of our documentation  by surrounding 
+You can refer to substitutions across all of our documentation  by surrounding
 the substitution name with ``|``:
 
 .. code-block:: text
@@ -122,7 +122,7 @@ Signing documents
 All the qualification documents we send to TUV have to be digitally signed by
 the responsible parties, to attest they were reviewed and to prevent accidental
 changes to the documents (which would require TUV to review the documents
-again). 
+again).
 
 The Ferrocene QMS documentation also needs to be digitally signed by
 responsible parties to attest that their contents are up to date and represent

--- a/ferrocene/doc/internal-procedures/src/onboarding.rst
+++ b/ferrocene/doc/internal-procedures/src/onboarding.rst
@@ -21,9 +21,9 @@ This equipment conforms with Ferrocene security requirements.
 Required software and tools
 ---------------------------
 
-The following accounts and tools are necessary to access the Ferrocene 
+The following accounts and tools are necessary to access the Ferrocene
 toolchain, associated management repositories, and other communications means.
-These are necessary to follow the Ferrocene workflow: 
+These are necessary to follow the Ferrocene workflow:
 
 * **Ferrocene Google Drive**
 
@@ -37,7 +37,7 @@ These are necessary to follow the Ferrocene workflow:
       requested
 
 * **Microsoft Teams**
-    * access to necessary sync meetings must be requested 
+    * access to necessary sync meetings must be requested
 
 * **Zulip**
     * access to the Ferrocene channel needs to be requested

--- a/ferrocene/doc/internal-procedures/src/pe-procedures.rst
+++ b/ferrocene/doc/internal-procedures/src/pe-procedures.rst
@@ -26,20 +26,20 @@ PE workflow
 -----------
 
 The workflow outlined below describes the expected interactions between the
-engineer and the ``ferrocene/ferrocene`` GitHub repository. 
+engineer and the ``ferrocene/ferrocene`` GitHub repository.
 
 Create branch
 ~~~~~~~~~~~~~
 Create a personal branch of the ``ferrocene/ferrocene`` repository to work on.
 
-.. Note:: 
+.. Note::
    Once pushed to GitHub, this branch can be shared with other people. These
    branches however, will not be released.
 
 Ensure that you are branching off the ``main`` branch by checking it out before
 creating your own branch.
 ::
-    
+
     git checkout main
 
 Create a new branch based off the ``main`` branch and immediately check it out.
@@ -114,7 +114,7 @@ For initial commit:
    git commit
 
 ``git`` will open an editor where you will need to add the commit message. The
-message should contain the information on the scope and goal for the changes 
+message should contain the information on the scope and goal for the changes
 made.
 
 .. Note::

--- a/ferrocene/doc/internal-procedures/src/setup-local-env.rst
+++ b/ferrocene/doc/internal-procedures/src/setup-local-env.rst
@@ -7,7 +7,7 @@ Setting up a local development environment
 Required software
 -----------------
 
-To develop Ferrocene locally, you’ll need to have the following software 
+To develop Ferrocene locally, you’ll need to have the following software
 installed:
 
 * ``git``, as the version control system used by Ferrocene.
@@ -56,8 +56,8 @@ following snippet to the ``~/.aws/config`` file in your work device:
    sso_role_name = FerroceneDeveloper
    region = us-east-1
 
-.. Note:: 
-   
+.. Note::
+
    If you do not already have the ``~/.aws/config`` file in your local system,
    create a blank one.
 
@@ -76,8 +76,8 @@ by the command). Authenticate with SSO on that page (if prompted) and click
     AWS SSO log in prompt
 
 .. Note::
-   
-   You will need to authenticate with AWS SSO every day. The Ferrocene build 
+
+   You will need to authenticate with AWS SSO every day. The Ferrocene build
    system will remind you to authenticate if you're trying to perform actions
    that require AWS access but you didn't log in that day.
 

--- a/ferrocene/doc/qualification-plan/src/history.rst
+++ b/ferrocene/doc/qualification-plan/src/history.rst
@@ -40,7 +40,7 @@ maintainers governing and developing the project”. The Rust Foundation does no
 make technical, language or governance decisions: it has a support role for the
 project, providing crucial funding, employment of key roles, and legal support.
 
-"Ferrocene", started in 2021 after years of planning, is a qualified Rust compiler 
+"Ferrocene", started in 2021 after years of planning, is a qualified Rust compiler
 with a focus on the ISO 26262 standard for the automotive industry. 
 It is maintained by Ferrous Systems, which also qualifies new versions of 
 the Rust compiler, as required in safety and mission-critical settings. 
@@ -110,9 +110,9 @@ The following diagram shows how the Upstream release trains work:
 Contributing to Upstream
 ------------------------
 
-A developer may contribute to upstream by either requesting a feature be
-developed, reporting a bug, submitting Pull Requests for review and merging into
-the master branch, or by writing documentation.
+A developer may contribute to upstream by either requesting a feature to be
+developed, reporting a bug, submitting a Pull Request for review and merging into
+the master branch, or writing documentation.
 
 The procedures and guidelines for contributing to upstream are outside the scope
 of this document, and can be found at

--- a/ferrocene/doc/qualification-plan/src/history.rst
+++ b/ferrocene/doc/qualification-plan/src/history.rst
@@ -41,9 +41,9 @@ make technical, language or governance decisions: it has a support role for the
 project, providing crucial funding, employment of key roles, and legal support.
 
 "Ferrocene", started in 2021 after years of planning, is a qualified Rust compiler
-with a focus on the ISO 26262 standard for the automotive industry. 
-It is maintained by Ferrous Systems, which also qualifies new versions of 
-the Rust compiler, as required in safety and mission-critical settings. 
+with a focus on the ISO 26262 standard for the automotive industry.
+It is maintained by Ferrous Systems, which also qualifies new versions of
+the Rust compiler, as required in safety and mission-critical settings.
 
 The Rust Project
 ----------------

--- a/ferrocene/doc/qualification-plan/src/infrastructure.rst
+++ b/ferrocene/doc/qualification-plan/src/infrastructure.rst
@@ -21,7 +21,7 @@ feature requests, task management, CI, and wikis.
 
 The sources of the Ferrocene toolchain, including but not limited to the
 compiler, libraries, test suites, documentation, qualification material, helper
-tools, configuration, all reside in a private repository referred to as the
+tools, configuration, all reside in a public repository referred to as the
 "Ferrocene GitHub repository", "``ferrocene/ferrocene``", or "the monorepo".
 
 Hosting the Ferrocene toolchain in a single repository allows the Ferrocene

--- a/ferrocene/doc/qualification-plan/src/infrastructure.rst
+++ b/ferrocene/doc/qualification-plan/src/infrastructure.rst
@@ -44,7 +44,7 @@ low-level to most general and high-level:
 
 * A *job* is a set of *steps* that are either expressed as shell scripts or as
   actions. Steps are executed based on their ordering and dependencies, where
-  data can be shared between steps. 
+  data can be shared between steps.
 
 * A *workflow* is a configurable automated process that runs one or more jobs.
   Workflows are triggered by events, and executed by runners.
@@ -101,7 +101,7 @@ such as the following complex scenario:
     ``drive()`` function - one branch adds a new module invoking the ``drive()``
     function, while the other branch removes the ``drive()`` function and all of
     its callees.
-    
+
     Both branches will pass the full test suite, as the first branch calls an
     existing function and the second branch makes sure all the other functions
     calling ``drive()`` are removed. If a developer were to merge both branches,

--- a/ferrocene/doc/qualification-plan/src/testing.rst
+++ b/ferrocene/doc/qualification-plan/src/testing.rst
@@ -38,7 +38,7 @@ a PR that prompted their creation.
 
 * Pass/Fail criteria
 
-Once the tests are developed, the process continues with the 
+Once the tests are developed, the process continues with the
 :ref:`development:Development Phases` to be merged in the test suite.
 
 Changes to upstream test suites are merged as part of the automated PRs pulling

--- a/ferrocene/doc/qualification-plan/src/validation.rst
+++ b/ferrocene/doc/qualification-plan/src/validation.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: The Ferrocene Developers 
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 Validation Process
 ==================

--- a/ferrocene/doc/qualification-report/src/purpose.rst
+++ b/ferrocene/doc/qualification-report/src/purpose.rst
@@ -4,7 +4,7 @@
 Purpose
 =======
 
-Ferrocene is a software development environment for Rust programming 
+Ferrocene is a software development environment for Rust programming
 language.
 
 .. figure:: figures/toolchain-workflow.svg

--- a/ferrocene/doc/qualification-report/src/references.rst
+++ b/ferrocene/doc/qualification-report/src/references.rst
@@ -19,7 +19,7 @@ Input Documents
 #. :doc:`evaluation-report:index`
 #. :doc:`qualification-plan:index`
 
-.. note:: 
-   The document identifiers and the applicable versions of documents can be 
+.. note::
+   The document identifiers and the applicable versions of documents can be
    found in the :doc:`document-list:index` document; the latest available
    version applies.

--- a/ferrocene/doc/qualification-report/src/tests.rst
+++ b/ferrocene/doc/qualification-report/src/tests.rst
@@ -12,7 +12,7 @@ Test Environment
 
 For this qualification, testing is restricted to the following environments:
 
-.. list-table:: 
+.. list-table::
    :align: left
    :stub-columns: 1
 
@@ -133,7 +133,7 @@ The linkchecker test suite is a pass/fail test suite integrated into the
 Ferrocene CI infrastructure.
 
 The linkchecker test suite is verified as part of
-:ref:`testing:Test Phase 2: Full Testing and Merge`. As indicated in 
+:ref:`testing:Test Phase 2: Full Testing and Merge`. As indicated in
 :doc:`Qualification Plan : Development Process <qualification-plan:development>`
 , a PR is merged into the repository only when it passes full testing.
 
@@ -158,7 +158,7 @@ The tidy test suite is a pass/fail test suite integrated into the Ferrocene
 CI infrastructure.
 
 The tidy test suite is verified as part of
-:ref:`testing:Test Phase 2: Full Testing and Merge`. As indicated in 
+:ref:`testing:Test Phase 2: Full Testing and Merge`. As indicated in
 :doc:`Qualification Plan : Development Process <qualification-plan:development>`
 , a PR is merged into the repository only when it passes full testing.
 

--- a/ferrocene/doc/safety-manual/src/customer-interactions.rst
+++ b/ferrocene/doc/safety-manual/src/customer-interactions.rst
@@ -5,7 +5,7 @@ Customer Interactions
 =====================
 
 Interactions between Customers and the Ferrocene organization are done
-through the following tools: 
+through the following tools:
 
 * **Email**
     * Get contract information
@@ -46,9 +46,9 @@ The following channels are available to customers:
 
 * |channel_name| : Major release of Ferrocene.
 
-.. note:: 
-   For this qualification, only the |channel_name| release has been qualified 
-   for the :doc:`specified environment <safety-manual:environment>`. 
+.. note::
+   For this qualification, only the |channel_name| release has been qualified
+   for the :doc:`specified environment <safety-manual:environment>`.
    Consequently, only |channel_name| should be used in qualified development
    context.
 

--- a/ferrocene/doc/safety-manual/src/customer-interactions.rst
+++ b/ferrocene/doc/safety-manual/src/customer-interactions.rst
@@ -7,7 +7,7 @@ Customer Interactions
 Interactions between Customers and the Ferrocene organization are done
 through the following tools: 
 
-* email
+* **Email**
     * Get contract information
     * Contact our teams for support, questions or enhancement requests
     * Obtain release tarballs
@@ -62,14 +62,14 @@ documentation.
 
 The documentation contains the following information:
 
-* Ferrocene documentation: the necessary documentation to understand
+* **Ferrocene documentation:** the necessary documentation to understand
   Ferrocene, its scope, and safety-related material.
 
-* Dev Log: a list of every new feature implemented in our products.
+* **Dev Log:** a list of every new feature implemented in our products.
 
-* Library AP documentation: description of associated libraries.
+* **Library AP documentation:** description of associated libraries.
 
-* Rust Project's documentation: documentation from the upstream rust project
+* **Rust Project's documentation:** documentation from the upstream rust project
   which provides the basis for understanding and using the Rust language.
 
 Unless specified otherwise, customers have the freedom to copy any of the

--- a/ferrocene/doc/safety-manual/src/customer-interactions.rst
+++ b/ferrocene/doc/safety-manual/src/customer-interactions.rst
@@ -7,16 +7,10 @@ Customer Interactions
 Interactions between Customers and the Ferrocene organization are done
 through the following tools: 
 
-.. list-table::
-   :align: left
-   :stub-columns: 1
-
-   * - email
-     - | - Get contract information;
-       | - Contact our teams for support, questions or enhancement requests;
-       | - Obtain release tarballs
-
-.. end of table
+* email
+    * Get contract information
+    * Contact our teams for support, questions or enhancement requests
+    * Obtain release tarballs
 
 In the following parts, the usage of the customer focused tools are described.
 

--- a/ferrocene/doc/safety-manual/src/degraded-environment.rst
+++ b/ferrocene/doc/safety-manual/src/degraded-environment.rst
@@ -34,8 +34,8 @@ compiler.
 
 .. list-table:: Input Environment Variables
    :align: left
-   
-   * - ``HOST`` 
+
+   * - ``HOST``
    * - ``CARGO``
    * - ``CARGO_ENCODED_RUSTFLAGS``
 
@@ -55,4 +55,4 @@ compiler.
    * - ``CARGO_CFG_TARGET_POINTER_WIDTH``
    * - ``CARGO_CFG_TARGET_VENDOR``
    * - ``CARGO_CFG_UNIX``
-   * - ``CARGO_ENCODED_RUSTFLAGS`` 
+   * - ``CARGO_ENCODED_RUSTFLAGS``

--- a/ferrocene/doc/safety-manual/src/environment.rst
+++ b/ferrocene/doc/safety-manual/src/environment.rst
@@ -6,7 +6,7 @@ Environment
 
 This qualification is restricted to the following environment:
 
-.. list-table:: 
+.. list-table::
    :align: left
    :stub-columns: 1
 

--- a/ferrocene/doc/safety-manual/src/purpose.rst
+++ b/ferrocene/doc/safety-manual/src/purpose.rst
@@ -8,7 +8,7 @@ Ferrocene is a software development environment for Rust programming
 language.
 
 .. figure:: figures/toolchain-workflow.svg
-   
+
    Toolchain Workflow
 
 Ferrocene is composed of the following tools:

--- a/ferrocene/doc/safety-manual/src/unsafety.rst
+++ b/ferrocene/doc/safety-manual/src/unsafety.rst
@@ -97,7 +97,7 @@ When verifying unsafe code, the user at a minimum shall:
 
 * Perform code review of the entire module where the unsafe code resides.
 
-* Perform unit testing on the unsafe code and its clients,
+* Perform unit testing on the unsafe code and its clients.
 
 * Perform integration testing between the unsafe code and its clients.
 

--- a/ferrocene/doc/safety-manual/src/unsafety.rst
+++ b/ferrocene/doc/safety-manual/src/unsafety.rst
@@ -46,7 +46,6 @@ documentation.
     /// even if the resulting reference is not used. The caller has to ensure that
     /// `0 <= mid <= self.len()`.
     ///
-    /// [`split_at_mut`]: slice::split_at_mut
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     . . .
     pub const unsafe fn split_at_mut_unchecked(&mut self, mid: usize) -> (&mut [T], &mut [T]) {
@@ -69,7 +68,6 @@ documentation.
     /// even if the resulting reference is not used. The caller has to ensure that
     /// `0 <= mid <= self.len()`.
     ///
-    /// [`split_at`]: slice::split_at
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     . . .
     pub const fn split_at_mut(&mut self, mid: usize) -> (&mut [T], &mut [T]) {

--- a/ferrocene/doc/specification/exts/ferrocene_spec/paragraph_ids.py
+++ b/ferrocene/doc/specification/exts/ferrocene_spec/paragraph_ids.py
@@ -67,6 +67,9 @@ def build_finished(app, exception):
     if exception is not None:
         return
 
+    if app.builder.name != "html":
+        return
+
     with sphinx.util.progress_message("dumping paragraph ids"):
         write_paragraph_ids(app)
 

--- a/ferrocene/doc/sphinx-shared-resources/README.md
+++ b/ferrocene/doc/sphinx-shared-resources/README.md
@@ -7,6 +7,7 @@ This repository contains the shared Sphinx resources we rely on for our
 Sphinx documentation websites, rather than duplicating them into each site.
 
 🚨 **The contents of this repository are strictly meant for Ferrocene use** 🚨
+
 While this repository is public and released under an open source license,
 breaking changes will regularly happen, we will provide no support and
 third-party pull requests likely won't be accepted.

--- a/ferrocene/doc/sphinx-shared-resources/README.md
+++ b/ferrocene/doc/sphinx-shared-resources/README.md
@@ -6,7 +6,7 @@
 This repository contains the shared Sphinx resources we rely on for our
 Sphinx documentation websites, rather than duplicating them into each site.
 
-🚨 **The contents of this repository are strictly meant for Ferrocene use** 🚨  
+🚨 **The contents of this repository are strictly meant for Ferrocene use** 🚨
 While this repository is public and released under an open source license,
 breaking changes will regularly happen, we will provide no support and
 third-party pull requests likely won't be accepted.

--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/document_id.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/document_id.py
@@ -106,7 +106,8 @@ def write_document_id(app):
 def build_finished(app, exception):
     if exception is not None:
         return
-    write_document_id(app)
+    if app.builder.name == "html":
+        write_document_id(app)
 
 
 def setup(app):

--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/signature_page.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/signature_page.py
@@ -113,6 +113,9 @@ def build_finished(app, exception):
     if exception is not None:
         return
 
+    if app.builder.name != "html":
+        return
+
     with sphinx.util.progress_message("copying signature files"):
         os.makedirs(f"{app.outdir}/signature", exist_ok=True)
         signature = SignatureStatus(app)

--- a/ferrocene/doc/user-manual/exts/ferrocene_user_manual/traceability_ids.py
+++ b/ferrocene/doc/user-manual/exts/ferrocene_user_manual/traceability_ids.py
@@ -44,6 +44,9 @@ def build_finished(app, exception):
     if exception is not None:
         return
 
+    if app.builder.name != "html":
+        return
+
     with sphinx.util.progress_message("dumping traceability ids"):
         write_traceability_ids(app)
 

--- a/ferrocene/doc/user-manual/src/overview.rst
+++ b/ferrocene/doc/user-manual/src/overview.rst
@@ -17,7 +17,7 @@ Structure
 This guide contains the following chapters: 
 
 * *About Ferrocene* describes the requirements and process of installing and
-  running the Ferrocene toolchain. 
+  running the Ferrocene toolchain.
 
 * *Using Ferrocene* describes how to build programs using the Ferrocene
   toolchain. This includes an overview on how to build libraries, executables,
@@ -32,11 +32,11 @@ Further Relevant Documentation
 The Ferrocene documentation package includes:
 
 * The :doc:`specification:index`, which describes the expected behavior of Rust
-  as implemented by the Ferrocene compiler. 
+  as implemented by the Ferrocene compiler.
 
 * The :doc:`safety-manual:index`, which includes usage and constraints
   guidelines of using the Ferrocene toolchain according to functional
-  safety standards. 
+  safety standards.
 
 Further information about the Rust language is available online and maintained
 by the Rust Project. This is a reference only and has not been verified by

--- a/ferrocene/packages.toml
+++ b/ferrocene/packages.toml
@@ -87,3 +87,10 @@ docs-in = "share/doc/ferrocene/html"
 name = "ferrocene-docs-signatures"
 subset = "signatures"
 docs-in = "share/doc/ferrocene/html"
+
+[[groups.any-platform.packages]]
+name = "ferrocene-docs-doctrees"
+# The contents of this package are not confidential, but it's something end
+# users should never need, and displaying it in the list of downloadable
+# packages would only cause confusion.
+subset = "internal"

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -867,6 +867,7 @@ impl<'a> Builder<'a> {
                 dist::BuildManifest,
                 dist::ReproducibleArtifacts,
                 crate::ferrocene::dist::Docs,
+                crate::ferrocene::dist::DocsDoctrees,
                 crate::ferrocene::dist::SourceTarball,
                 crate::ferrocene::dist::SelfTest,
                 crate::ferrocene::dist::TestOutcomes,

--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -6,6 +6,7 @@ use serde_json::json;
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::core::config::TargetSelection;
 use crate::t;
+use crate::ferrocene::doc::ensure_all_xml_doctrees;
 use crate::utils::tarball::{GeneratedTarball, Tarball};
 use std::collections::BTreeMap;
 use std::fs;
@@ -41,6 +42,37 @@ impl Step for Docs {
         subsetter.add_directory(&doc_out, &doc_out);
 
         subsetter.into_tarballs().map(|tarball| tarball.generate()).collect()
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct DocsDoctrees {
+    target: TargetSelection,
+}
+
+impl Step for DocsDoctrees {
+    type Output = GeneratedTarball;
+    const DEFAULT: bool = true;
+    const ONLY_HOSTS: bool = true;
+
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+        let default = run.builder.config.docs;
+        run.alias("ferrocene-docs-doctrees").default_condition(default)
+    }
+
+    fn make_run(run: RunConfig<'_>) {
+        run.builder.ensure(Self { target: run.target });
+    }
+
+    fn run(self, builder: &Builder<'_>) -> Self::Output {
+        let paths = ensure_all_xml_doctrees(builder, self.target);
+
+        let tarball = Tarball::new_targetless(builder, "ferrocene-docs-doctrees");
+        for (name, path) in paths {
+            tarball.add_dir(path, format!("share/doc/ferrocene/xml-doctrees/{name}"));
+        }
+
+        tarball.generate()
     }
 }
 

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -170,7 +170,10 @@ impl<P: Step> Step for SphinxBook<P> {
             }
         }
 
-        builder.ensure(BreadcrumbsAssets { target: self.target, dest: Some(out.join("_static")) });
+        if let SphinxMode::Html = self.mode {
+            builder
+                .ensure(BreadcrumbsAssets { target: self.target, dest: Some(out.join("_static")) });
+        }
         let venv = builder.ensure(SphinxVirtualEnv { target: self.target });
 
         let path_to_root = std::iter::repeat("..")

--- a/src/bootstrap/src/ferrocene/run.rs
+++ b/src/bootstrap/src/ferrocene/run.rs
@@ -4,7 +4,7 @@
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::core::build_steps::tool::Tool;
 use crate::core::config::{FerroceneTraceabilityMatrixMode, TargetSelection};
-use crate::ferrocene::doc::{Specification, UserManual};
+use crate::ferrocene::doc::{Specification, SphinxMode, UserManual};
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -30,9 +30,16 @@ impl Step for TraceabilityMatrix {
         let test_annotations_base =
             builder.out.join(self.target.triple).join("ferrocene").join("test-annotations");
 
-        let specification =
-            builder.ensure(Specification { target: self.target, fresh_build: false });
-        let user_manual = builder.ensure(UserManual { target: self.target, fresh_build: false });
+        let specification = builder.ensure(Specification {
+            mode: SphinxMode::Html,
+            target: self.target,
+            fresh_build: false,
+        });
+        let user_manual = builder.ensure(UserManual {
+            mode: SphinxMode::Html,
+            target: self.target,
+            fresh_build: false,
+        });
 
         let compiletest = builder.tool_exe(Tool::Compiletest);
         for (suite, mode) in &[("tests/ui", "ui"), ("tests/run-make", "run-make")] {

--- a/src/bootstrap/src/ferrocene/sign.rs
+++ b/src/bootstrap/src/ferrocene/sign.rs
@@ -8,7 +8,7 @@
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::core::build_steps::tool::Tool;
 use crate::core::config::TargetSelection;
-use crate::ferrocene::doc::WithSource;
+use crate::ferrocene::doc::{SphinxMode, WithSource};
 use crate::t;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -93,6 +93,7 @@ macro_rules! documents {
                     builder.ensure(SignDocument {
                         target: self.target,
                         document: crate::ferrocene::doc::$name {
+                            mode: SphinxMode::Html,
                             target: self.target,
                             // Ensure there are no leftover artifacts from a previous incremental
                             // build when generating the signature.
@@ -113,6 +114,7 @@ macro_rules! documents {
                 let source_dir = builder.src.join(crate::ferrocene::doc::$name::SOURCE);
                 if condition(&source_dir) {
                     let output_dir = builder.ensure(crate::ferrocene::doc::$name {
+                        mode: SphinxMode::Html,
                         target,
                         fresh_build: false,
                     });


### PR DESCRIPTION
This PR makes a few manual backports to 1.76:

* #212 
  * The conflict was two `use`s in bootstrap conflicting.
* #231
  * No actual conflict, but the automation crashed with the last commit of the PR being an empty commit.