### PR TITLE
re-use the same blurb spread in glossary

### DIFF
--- a/ferrocene/doc/evaluation-plan/src/terms.rst
+++ b/ferrocene/doc/evaluation-plan/src/terms.rst
@@ -1,11 +1,4 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-Terms, Definitions, and Abbreviations
-=====================================
-
-For the purpose of this qualification, the terms, definitions and abbreviated
-terms from the ISO 26262 and IEC 61508 standards apply. Additional terms
-specific to the current qualification are listed below.
-
 .. include:: ../../glossary.rst

--- a/ferrocene/doc/evaluation-report/src/terms.rst
+++ b/ferrocene/doc/evaluation-report/src/terms.rst
@@ -1,11 +1,4 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-Terms, Definitions, and Abbreviations
-=====================================
-
-For the purpose of this qualification, the terms, definitions and abbreviated
-terms from the ISO 26262 and IEC 61508 standards apply. Additional terms
-specific to the current qualification are listed below.
-
 .. include:: ../../glossary.rst

--- a/ferrocene/doc/glossary.rst
+++ b/ferrocene/doc/glossary.rst
@@ -1,6 +1,13 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
+Terms, Definitions, and Abbreviations
+=====================================
+
+For the purpose of this qualification, the terms, definitions and abbreviated
+terms from the ISO 26262 and IEC 61508 standards apply. Additional terms
+specific to the current qualification are listed below.
+
 Definition of Terms
 -------------------
 

--- a/ferrocene/doc/internal-procedures/src/terms.rst
+++ b/ferrocene/doc/internal-procedures/src/terms.rst
@@ -1,11 +1,4 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-Terms, definitions and abbreviations
-====================================
-
-For the purpose of this qualification, the terms, definitions and abbreviated
-terms from the ISO 9001:2015 standards apply. Additional terms specific to the
-current qualification are listed below.
-
 .. include:: ../../glossary.rst

--- a/ferrocene/doc/qualification-plan/src/terms.rst
+++ b/ferrocene/doc/qualification-plan/src/terms.rst
@@ -1,11 +1,4 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-Terms, Definitions, and Abbreviations
-=====================================
-
-For the purpose of this qualification, the terms, definitions and abbreviated
-terms from the ISO 26262 and IEC 61508 standards apply. Additional terms
-specific to the current qualification are listed below.
-
 .. include:: ../../glossary.rst

--- a/ferrocene/doc/qualification-report/src/terms.rst
+++ b/ferrocene/doc/qualification-report/src/terms.rst
@@ -1,11 +1,4 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-Terms, Definitions, and Abbreviations
-=====================================
-
-For the purpose of this qualification, the terms, definitions and abbreviated
-terms from the ISO 26262 and IEC 61508 standards apply. Additional terms
-specific to the current qualification are listed below.
-
 .. include:: ../../glossary.rst

--- a/ferrocene/doc/safety-manual/src/terms.rst
+++ b/ferrocene/doc/safety-manual/src/terms.rst
@@ -1,11 +1,4 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-Terms, Definitions, and Abbreviations
-=====================================
-
-For the purpose of this qualification, the terms, definitions and abbreviated
-terms from the ISO 26262 and IEC 61508 standards apply. Additional terms
-specific to the current qualification are listed below.
-
 .. include:: ../../glossary.rst


### PR DESCRIPTION
noticed that Internal Procedures had a slight difference from the rest, so decided to have this shared to avoid such in future