### PR TITLE
More improvements to the test outcomes pages

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -189,7 +189,7 @@ jobs:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       SCRIPT: |
         # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
-        ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>)
+        ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call
     steps:
       - ferrocene-job-test-container:
           restore-from-job: x86_64-linux-build
@@ -207,7 +207,7 @@ jobs:
       FERROCENE_TARGETS: aarch64-unknown-ferrocenecoretest
       # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
       SCRIPT: |
-        TEST_DEVICE_ADDR=127.0.0.1:12345 ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>)
+        TEST_DEVICE_ADDR=127.0.0.1:12345 ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call
 
     steps:
       - ferrocene-job-test-vm:
@@ -246,7 +246,7 @@ jobs:
       # jobs. Because of that we need to run *just* standard library tests in a
       # virtual machine.
       # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
-      SCRIPT: ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py test:library-std)
+      SCRIPT: ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py test:library-std) --ferrocene-test-one-crate-per-cargo-call
     steps:
       - aws-oidc-auth
       - ferrocene-job-test-vm:

--- a/ferrocene/doc/qualification-plan/src/ci.rst
+++ b/ferrocene/doc/qualification-plan/src/ci.rst
@@ -116,3 +116,32 @@ All test results are compressed into a tarball which is included in the release
 artifacts and stored on AWS S3 alongside the binaries and documentation we ship
 to customers. For qualified releases, those are retained in the S3 bucket
 indefinitely.
+
+.. _bare-metal-testing:
+
+Bare metal testing
+------------------
+
+Some Ferrocene targets are meant to be used in an environment without any
+operating system. Consequently, they don't include APIs relying on one (as part
+of the ``std`` crate), and only include the ``core`` and ``alloc`` crates,
+which are OS-independent.
+
+Unfortunately, Rust's test suites require those APIs (and in general an
+operating system) to be available in order to invoke the tests themselves and
+to report the execution results.
+
+To solve the issue, our approach is to create a new target based on the Rust
+target we need to test: this new "bare metal testing target" has the same
+configuration as the real target, with the only exception being enabling the
+operating system bindings for Linux. This new target won't be shipped to
+customers.
+
+The bare metal testing target allows us to execute the test suite on Linux
+(running on the hardware needed by the real target), side-stepping the
+requiremento to have an operative system.
+
+Since the only difference between the two targets is the implementation of the
+APIs in the ``std`` crate. Since the ``std`` crate is not shipped to customers
+for bare metal targets, we can conclude that the test results of the two
+targets are equivalent.

--- a/ferrocene/doc/qualification-plan/src/ci.rst
+++ b/ferrocene/doc/qualification-plan/src/ci.rst
@@ -142,6 +142,6 @@ The bare metal testing target allows us to execute the test suite on Linux
 requirement to have an operating system.
 
 Since the only difference between the two targets is the implementation of the
-APIs in the ``std`` crate. and that crate is not shipped to customers for bare
+APIs in the ``std`` crate, and that crate is not shipped to customers for bare
 metal targets, we can conclude that the test results of the two targets are
 equivalent.

--- a/ferrocene/doc/qualification-plan/src/ci.rst
+++ b/ferrocene/doc/qualification-plan/src/ci.rst
@@ -139,9 +139,9 @@ customers.
 
 The bare metal testing target allows us to execute the test suite on Linux
 (running on the hardware needed by the real target), side-stepping the
-requiremento to have an operative system.
+requirement to have an operating system.
 
 Since the only difference between the two targets is the implementation of the
-APIs in the ``std`` crate. Since the ``std`` crate is not shipped to customers
-for bare metal targets, we can conclude that the test results of the two
-targets are equivalent.
+APIs in the ``std`` crate. and that crate is not shipped to customers for bare
+metal targets, we can conclude that the test results of the two targets are
+equivalent.

--- a/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/outcomes.py
+++ b/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/outcomes.py
@@ -164,7 +164,8 @@ class FileLoader:
             else:
                 raise RuntimeError(f"unknown test outcome: {test['outcome']}")
 
-        platform.invocations.append(invocation)
+        if invocation.total_tests():
+            platform.invocations.append(invocation)
 
 
 def builder_inited(app):

--- a/ferrocene/doc/qualification-report/src/statement.rst
+++ b/ferrocene/doc/qualification-report/src/statement.rst
@@ -10,3 +10,7 @@ linking programs for the target architecture. As per the traceability in
 :doc:`tests/index`, Ferrocene |ferrocene_version| has been reviewed and is
 demonstrated compliant with automotive [|iso_ref|]
 |ferrocene_TCL|/|ferrocene_ASIL| and industrial [|iec_ref|] |ferrocene_TQL|.
+
+KPs identified through the lifecycle of Ferrocene |ferrocene_version| are
+tracked in the :doc:`safety-manual:known-problems`. This document is made
+available to customers for consulting.

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -30,37 +30,46 @@ As a result, the {{ suite }} test suite reports a **pass** for this
 qualification.
 {% endmacro %}
 
-{% macro invocations_summary(bootstrap_type, only_match_root_node=False) %}
+{% macro cargo_tests_summary(bootstrap_type, only_match_root_node=False) %}
 {% if platform_outcomes is none %}
 {{ no_outcomes_error() }}
 {% else %}
-{% for invocation in platform_outcomes.filter_invocations(bootstrap_type, only_match_root_node=only_match_root_node) %}
+{% set invocations = platform_outcomes.filter_invocations(bootstrap_type, only_match_root_node=only_match_root_node) | list %}
+{% if invocations %}
 .. list-table::
+   :header-rows: 1
 
-   {% if invocation.is_compiletest() %}
-   * - Compiletest suite:
-     - ``{{ invocation.kind.suite }}``
-   {% if invocation.kind.mode is not none %}
-   * - Compiletest mode:
-     - ``{{ invocation.kind.mode }}``
-   {% endif %}
-   {% elif invocation.is_cargo_package() %}
-   * - Tested crates:
-     - {% for crate in invocation.kind.crates %}{% if not loop.first %}, {% endif %}``{{ crate }}``{% endfor %}
-   {% endif %}
-   * - Host compiler:
-     - ``{{ invocation.host }}`` (stage {{ invocation.stage }})
-   * - Target:
-     - ``{{ invocation.target }}``
-   * - Total tests:
-     - {{ invocation.total_tests() }}
-   * - Passed tests:
+   * - Crate name
+     - Passed tests
+     - Ignored tests
+     - Failed tests
+     - Total tests
+
+   {% for invocation in invocations %}
+
+   * - {% if invocation.kind.crates -%}
+           {% for crate in invocation.kind.crates %}{% if not loop.first %}, {% endif %}``{{ crate }}``{% endfor %}
+       {%- else -%}
+           N/A
+       {%- endif %}
+
+       .. rst-class:: align-right
      - {{ invocation.passed_tests }}
-   * - Failed tests:
-     - {{ invocation.failed_tests }}
-   * - Ignored tests:
+
+       .. rst-class:: align-right
      - {{ invocation.ignored_tests }}
-{% endfor %}
+
+       .. rst-class:: align-right
+     - {{ invocation.failed_tests }}
+
+       .. rst-class:: align-right
+     - {{ invocation.total_tests() }}
+   {% endfor %}
+{% else %}
+.. warning::
+
+   No matching test outcomes were found for this suite.
+{% endif %}
 {% endif %}
 {% endmacro %}
 
@@ -196,7 +205,7 @@ Library Test Suite
    root node, otherwise we'd also match other tests invoking Crate down their
    dependency chain.
 
-{{ invocations_summary("bootstrap::core::build_steps::test::Crate", only_match_root_node=True) }}
+{{ cargo_tests_summary("bootstrap::core::build_steps::test::Crate", only_match_root_node=True) }}
 
 .. note::
 
@@ -216,9 +225,9 @@ Compiler Test Suite
 
 **Test suite:** :id:`TS3_CRAT`
 
-{{ invocations_summary("bootstrap::core::build_steps::test::CrateLibrustc") }}
-
-{% if host != target %}
+{% if host == target %}
+{{ cargo_tests_summary("bootstrap::core::build_steps::test::CrateLibrustc") }}
+{% else %}
 {{ only_on_hosts("compiler") }}
 {% endif %}
 
@@ -238,9 +247,10 @@ Build System Test Suite
 
 **Test suite:** :id:`TS6_BSYS`
 
-{{ invocations_summary("bootstrap::core::build_steps::test::Bootstrap") }}
 
-{% if host != target %}
+{% if host == target %}
+{{ cargo_tests_summary("bootstrap::core::build_steps::test::Bootstrap") }}
+{% else %}
 {{ only_on_hosts("build system") }}
 {% endif %}
 

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -105,7 +105,32 @@ Compiletest Test Suite
 
 **Test suite:** :id:`TS1_COMP`
 
-{{ invocations_summary("bootstrap::core::build_steps::test::Compiletest") }}
+The following compiletest suites were executed as part of this test suite:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Compiletest suite
+     - Passed tests
+     - Ignored tests
+     - Failed tests
+     - Total tests
+
+   {% for invocation in platform_outcomes.filter_invocations("bootstrap::core::build_steps::test::Compiletest") %}
+   * - ``{{ invocation.kind.suite }}`` {% if invocation.kind.mode is not none %} (mode: ``{{ invocation.kind.mode }}``){% endif %}
+
+       .. rst-class:: align-right
+     - {{ invocation.passed_tests }}
+
+       .. rst-class:: align-right
+     - {{ invocation.ignored_tests }}
+
+       .. rst-class:: align-right
+     - {{ invocation.failed_tests }}
+
+       .. rst-class:: align-right
+     - {{ invocation.total_tests() }}
+   {% endfor %}
 
 {% if host != target %}
 .. note::

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -10,6 +10,12 @@
    The test outcomes won't be populated until you configure it.
 {% endmacro %}
 
+{% macro no_matching_outcomes_warning() %}
+.. warning::
+
+   No matching test outcomes were found for this suite.
+{% endmacro %}
+
 {% macro only_on_hosts(suite) %}
 .. note::
 
@@ -66,9 +72,7 @@ qualification.
      - {{ invocation.total_tests() }}
    {% endfor %}
 {% else %}
-.. warning::
-
-   No matching test outcomes were found for this suite.
+{{ no_matching_outcomes_warning() }}
 {% endif %}
 {% endif %}
 {% endmacro %}
@@ -115,6 +119,11 @@ Compiletest Test Suite
 
 The following compiletest suites were executed as part of this test suite:
 
+{% if platform_outcomes is none %}
+{{ no_outcomes_error() }}
+{% else %}
+{% set invocations = platform_outcomes.filter_invocations("bootstrap::core::build_steps::test::Compiletest") | list %}
+{% if invocations %}
 .. list-table::
    :header-rows: 1
 
@@ -124,7 +133,7 @@ The following compiletest suites were executed as part of this test suite:
      - Failed tests
      - Total tests
 
-   {% for invocation in platform_outcomes.filter_invocations("bootstrap::core::build_steps::test::Compiletest") %}
+   {% for invocation in invocations %}
    * - ``{{ invocation.kind.suite }}`` {% if invocation.kind.mode is not none %} (mode: ``{{ invocation.kind.mode }}``){% endif %}
 
        .. rst-class:: align-right
@@ -139,6 +148,10 @@ The following compiletest suites were executed as part of this test suite:
        .. rst-class:: align-right
      - {{ invocation.total_tests() }}
    {% endfor %}
+{% else %}
+{{ no_matching_outcomes_warning() }}
+{% endif %}
+{% endif %}
 
 {% if host != target %}
 .. note::

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -98,29 +98,11 @@ This page outlines the testing of Ferrocene |ferrocene_version| (based on Rust
      - :target:`{{ target }}`
      - ``{{ target }}``
 
-{% if bare_metal_test_target %}
-Bare metal testing
-------------------
-
-The :target:`{{ target }}` Ferrocene target is meant to be used in an
-environment without any operating system. Consequently, it does not include
-APIs relying on one (as part of the ``std`` crate).
-
-Rust's test suites require those APIs to be available in order to invoke the
-tests themselves and to report the execution results. To solve the issue, a new
-target, based on the existing Rust ``{{ target }}`` target, was created called
-``{{ bare_metal_test_target }}``.
-
-This target is strictly internal, and will not be released to customers. It has
-the same configuration as the ``{{ target }}`` target, with the only exception
-being enabling the operating system bindings for Linux (the OS used to execute
-the test suite).
-
-Since the only difference between the two targets is the APIs in the ``std``
-crate, which is not present in the ``{{ target }}`` target (and consequently
-not shipped to customers), we can conclude that the test results of
-``{{ bare_metal_test_target }}`` are also valid for ``{{ target }}``.
-{% endif %}
+   {% if bare_metal_test_target %}
+   * - :ref:`Bare metal testing <qualification-plan:bare-metal-testing>` target:
+     - :target:`{{ target }}`
+     - ``{{ bare_metal_test_target }}``
+   {% endif %}
 
 Test results
 ============

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -17,6 +17,19 @@
    not a host platform.
 {% endmacro %}
 
+{% macro unconditional_pass(suite) %}
+The {{ suite }} suite is a pass/fail test suite integrated into the Ferrocene
+CI infrastructure.
+
+The {{ suite }} test suite is verified as part of
+:ref:`qualification-plan:ci-phase-full`. As indicated in
+:doc:`qualification-plan:development`, a PR is merged into the repository only
+when it passes full testing.
+
+As a result, the {{ suite }} test suite reports a **pass** for this
+qualification.
+{% endmacro %}
+
 {% macro invocations_summary(bootstrap_type, only_match_root_node=False) %}
 {% if platform_outcomes is none %}
 {{ no_outcomes_error() }}
@@ -215,16 +228,7 @@ Linkchecker Test Suite
 **Test suite:** :id:`TS4_LINK`
 
 {% if host == target %}
-The linkchecker test suite is a pass/fail test suite integrated into the
-Ferrocene CI infrastructure.
-
-The linkchecker test suite is verified as part of
-:ref:`qualification-plan:ci-phase-full`. As indicated in :doc:`Qualification
-Plan : Development Process <qualification-plan:development>`, a PR is merged
-into the repository only when it passes full testing.
-
-As a result, the linkchecker test suite reports a **pass** for this
-qualification.
+{{ unconditional_pass("linkchecker") }}
 {% else %}
 {{ only_on_hosts("linkchecker") }}
 {% endif %}
@@ -246,15 +250,7 @@ Tidy Test Suite
 **Test suite:** :id:`TS7_TIDY`
 
 {% if host == target %}
-The tidy test suite is a pass/fail test suite integrated into the Ferrocene
-CI infrastructure.
-
-The tidy test suite is verified as part of
-:ref:`qualification-plan:ci-phase-full`. As indicated in :doc:`Qualification
-Plan : Development Process <qualification-plan:development>`, a PR is merged
-into the repository only when it passes full testing.
-
-As a result, the tidy test suite reports a **pass** for this qualification.
+{{ unconditional_pass("tidy") }}
 {% else %}
 {{ only_on_hosts("tidy") }}
 {% endif %}
@@ -265,16 +261,7 @@ Self-Test Test Suite
 **Test suite:** :id:`TS8_SELF`
 
 {% if host == target %}
-The self-test test suite is a pass/fail test suite integrated into the
-Ferrocene CI infrastructure.
-
-The self-test test suite is verified as part of
-:ref:`qualification-plan:ci-phase-full`. As indicated in :doc:`Qualification
-Plan : Development Process <qualification-plan:development>`, a PR is merged
-into the repository only when it passes full testing.
-
-As a result, the self-test test suite reports a **pass** for this
-qualification.
+{{ unconditional_pass("self-test") }}
 {% else %}
 {{ only_on_hosts("self-test") }}
 {% endif %}

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -59,12 +59,6 @@ For this qualification, testing is restricted to the following environments:
      - :target-with-triple:`{{ host }}`
    * - Compilation target:
      - :target-with-triple:`{{ target }}`
-   * - Supported languages:
-     - Rust
-
-.. note::
-
-   Only the Rust language, as described in the :doc:`specification:index`, is verified.
 
 {% if bare_metal_test_target %}
 Bare metal testing

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -10,6 +10,13 @@
    The test outcomes won't be populated until you configure it.
 {% endmacro %}
 
+{% macro only_on_hosts(suite) %}
+.. note::
+
+   The {{ suite }} test suite is not tested on :target:`{{ target }}`, as it is
+   not a host platform.
+{% endmacro %}
+
 {% macro invocations_summary(bootstrap_type, only_match_root_node=False) %}
 {% if platform_outcomes is none %}
 {{ no_outcomes_error() }}
@@ -199,10 +206,7 @@ Compiler Test Suite
 {{ invocations_summary("bootstrap::core::build_steps::test::CrateLibrustc") }}
 
 {% if host != target %}
-.. note::
-
-   The compiler test suite is not tested on :target:`{{ target }}`, as it is not
-   a host platform.
+{{ only_on_hosts("compiler") }}
 {% endif %}
 
 Linkchecker Test Suite
@@ -227,6 +231,10 @@ Build System Test Suite
 **Test suite:** :id:`TS6_BSYS`
 
 {{ invocations_summary("bootstrap::core::build_steps::test::Bootstrap") }}
+
+{% if host != target %}
+{{ only_on_hosts("build system") }}
+{% endif %}
 
 Tidy Test Suite
 ---------------
@@ -260,10 +268,7 @@ into the repository only when it passes full testing.
 As a result, the self-test test suite reports a **pass** for this
 qualification.
 {% else %}
-.. note::
-
-   The self-test test suite is not tested on :target:`{{ target }}`, as it is
-   not a host platform.
+{{ only_on_hosts("self-test") }}
 {% endif %}
 
 Known Problems

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -77,9 +77,6 @@ qualification.
 :target:`{{ target }}`
 {{ "=" * 256 }} {# Sphinx requires the line to be at least as long as the title #}
 
-Testing scope
-=============
-
 This page outlines the testing of Ferrocene |ferrocene_version| (based on Rust
 |rust_version|) in the following environment:
 

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -214,6 +214,7 @@ Linkchecker Test Suite
 
 **Test suite:** :id:`TS4_LINK`
 
+{% if host == target %}
 The linkchecker test suite is a pass/fail test suite integrated into the
 Ferrocene CI infrastructure.
 
@@ -224,6 +225,9 @@ into the repository only when it passes full testing.
 
 As a result, the linkchecker test suite reports a **pass** for this
 qualification.
+{% else %}
+{{ only_on_hosts("linkchecker") }}
+{% endif %}
 
 Build System Test Suite
 -----------------------
@@ -241,6 +245,7 @@ Tidy Test Suite
 
 **Test suite:** :id:`TS7_TIDY`
 
+{% if host == target %}
 The tidy test suite is a pass/fail test suite integrated into the Ferrocene
 CI infrastructure.
 
@@ -250,6 +255,9 @@ Plan : Development Process <qualification-plan:development>`, a PR is merged
 into the repository only when it passes full testing.
 
 As a result, the tidy test suite reports a **pass** for this qualification.
+{% else %}
+{{ only_on_hosts("tidy") }}
+{% endif %}
 
 Self-Test Test Suite
 --------------------

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -186,12 +186,6 @@ Library Test Suite
 
 {{ cargo_tests_summary("bootstrap::core::build_steps::test::Crate", only_match_root_node=True) }}
 
-.. note::
-
-   The library test suite uses the ``stage1`` library because a ``stage2``
-   library is never built, and the ``stage2`` Ferrocene compiler reuses the
-   ``stage1`` library.
-
 {% if bare_metal_test_target %}
 .. note::
 

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -255,13 +255,6 @@ Self-Test Test Suite
 {{ only_on_hosts("self-test") }}
 {% endif %}
 
-Known Problems
-==============
-
-KPs identified through the lifecycle of Ferrocene for :target:`{{ target }}`
-are tracked in the :doc:`safety-manual:known-problems`. This document is made
-available to customers for consulting.
-
 Ignored Tests
 =============
 

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -51,14 +51,23 @@
 Testing scope
 =============
 
-For this qualification, testing is restricted to the following environments:
+This page outlines the testing of Ferrocene |ferrocene_version| (based on Rust
+|rust_version|) in the following environment:
 
 .. list-table::
+   :header-rows: 1
+
+   * -
+     - Target name
+     - Target triple
 
    * - Host platform:
-     - :target-with-triple:`{{ host }}`
+     - :target:`{{ host }}`
+     - ``{{ host }}``
+
    * - Compilation target:
-     - :target-with-triple:`{{ target }}`
+     - :target:`{{ target }}`
+     - ``{{ target }}``
 
 {% if bare_metal_test_target %}
 Bare metal testing
@@ -83,24 +92,6 @@ crate, which is not present in the ``{{ target }}`` target (and consequently
 not shipped to customers), we can conclude that the test results of
 ``{{ bare_metal_test_target }}`` are also valid for ``{{ target }}``.
 {% endif %}
-
-Release Notes
--------------
-
-The |ferrocene_version| version of the Ferrocene toolset contains the following
-tools:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Tool
-     - Version
-   * - Cargo
-     - |rust_version|
-   * - rustc
-     - |rust_version|
-   * - rustdoc
-     - |rust_version|
 
 Test results
 ============

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2492,6 +2492,22 @@ impl Step for Crate {
     /// Currently this runs all tests for a DAG by passing a bunch of `-p foo`
     /// arguments, and those arguments are discovered from `cargo metadata`.
     fn run(self, builder: &Builder<'_>) {
+        // The current way build metrics are gathered means there is a single test_suite node
+        // emitted for every execution of this step. As we want crate granularity in the metrics,
+        // when CI passes the --ferrocene-test-one-crate-per-cargo-call flag, we will split this
+        // step into one step per crate.
+        if builder.config.cmd.ferrocene_test_one_crate_per_cargo_call() && self.crates.len() > 1 {
+            for krate in &self.crates {
+                builder.ensure(Crate {
+                    compiler: self.compiler,
+                    target: self.target,
+                    mode: self.mode,
+                    crates: vec![*krate],
+                });
+            }
+            return;
+        }
+
         let compiler = self.compiler;
         let target = self.target;
         let mode = self.mode;

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -598,6 +598,7 @@ mod dist {
             skip: vec![],
             extra_checks: None,
             coverage: false,
+            ferrocene_test_one_crate_per_cargo_call: false,
         };
 
         let build = Build::new(config);
@@ -677,6 +678,7 @@ mod dist {
             only_modified: false,
             extra_checks: None,
             coverage: false,
+            ferrocene_test_one_crate_per_cargo_call: false,
         };
         // Make sure rustfmt binary not being found isn't an error.
         config.channel = "beta".to_string();
@@ -737,6 +739,7 @@ mod dist {
             only_modified: false,
             extra_checks: None,
             coverage: true,
+            ferrocene_test_one_crate_per_cargo_call: false,
         };
         let build = Build::new(config);
         let mut builder = Builder::new(&build);

--- a/src/bootstrap/src/core/config/flags.rs
+++ b/src/bootstrap/src/core/config/flags.rs
@@ -393,6 +393,10 @@ pub enum Subcommand {
         /// generate coverage for tests
         #[arg(long)]
         coverage: bool,
+        /// Test only one crate per Cargo invocation. This is needed by the Ferrocene qualification
+        /// documents to ensure there is enough granularity for the test outcomes report.
+        #[arg(long)]
+        ferrocene_test_one_crate_per_cargo_call: bool,
     },
     /// Build and run some benchmarks
     Bench {
@@ -607,6 +611,15 @@ impl Subcommand {
     pub fn json(&self) -> bool {
         match *self {
             Subcommand::Doc { json, .. } => json,
+            _ => false,
+        }
+    }
+
+    pub fn ferrocene_test_one_crate_per_cargo_call(&self) -> bool {
+        match *self {
+            Subcommand::Test { ferrocene_test_one_crate_per_cargo_call, .. } => {
+                ferrocene_test_one_crate_per_cargo_call
+            }
             _ => false,
         }
     }

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -235,7 +235,7 @@ impl<P: Step> Step for SphinxBook<P> {
             .arg("-D")
             .arg(format!(
                 "rust_version={}",
-                std::fs::read_to_string(&builder.src.join("src").join("version")).unwrap(),
+                std::fs::read_to_string(&builder.src.join("src").join("version")).unwrap().trim(),
             ))
             .arg("-D")
             .arg(format!(

--- a/src/etc/completions/x.py.fish
+++ b/src/etc/completions/x.py.fish
@@ -302,6 +302,7 @@ complete -c x.py -n "__fish_seen_subcommand_from test" -l force-rerun -d 'rerun 
 complete -c x.py -n "__fish_seen_subcommand_from test" -l only-modified -d 'only run tests that result has been changed'
 complete -c x.py -n "__fish_seen_subcommand_from test" -l rustfix-coverage -d 'enable this to generate a Rustfix coverage file, which is saved in `/<build_base>/rustfix_missing_coverage.txt`'
 complete -c x.py -n "__fish_seen_subcommand_from test" -l coverage -d 'generate coverage for tests'
+complete -c x.py -n "__fish_seen_subcommand_from test" -l ferrocene-test-one-crate-per-cargo-call -d 'Test only one crate per Cargo invocation. This is needed by the Ferrocene qualification documents to ensure there is enough granularity for the test outcomes report'
 complete -c x.py -n "__fish_seen_subcommand_from test" -s v -l verbose -d 'use verbose output (-vv for very verbose)'
 complete -c x.py -n "__fish_seen_subcommand_from test" -s i -l incremental -d 'use incremental compilation'
 complete -c x.py -n "__fish_seen_subcommand_from test" -l include-default-paths -d 'include default paths in addition to the provided ones'

--- a/src/etc/completions/x.py.ps1
+++ b/src/etc/completions/x.py.ps1
@@ -375,6 +375,7 @@ Register-ArgumentCompleter -Native -CommandName 'x.py' -ScriptBlock {
             [CompletionResult]::new('--only-modified', 'only-modified', [CompletionResultType]::ParameterName, 'only run tests that result has been changed')
             [CompletionResult]::new('--rustfix-coverage', 'rustfix-coverage', [CompletionResultType]::ParameterName, 'enable this to generate a Rustfix coverage file, which is saved in `/<build_base>/rustfix_missing_coverage.txt`')
             [CompletionResult]::new('--coverage', 'coverage', [CompletionResultType]::ParameterName, 'generate coverage for tests')
+            [CompletionResult]::new('--ferrocene-test-one-crate-per-cargo-call', 'ferrocene-test-one-crate-per-cargo-call', [CompletionResultType]::ParameterName, 'Test only one crate per Cargo invocation. This is needed by the Ferrocene qualification documents to ensure there is enough granularity for the test outcomes report')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'use verbose output (-vv for very verbose)')
             [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'use verbose output (-vv for very verbose)')
             [CompletionResult]::new('-i', 'i', [CompletionResultType]::ParameterName, 'use incremental compilation')

--- a/src/etc/completions/x.py.sh
+++ b/src/etc/completions/x.py.sh
@@ -2500,7 +2500,7 @@ _x.py() {
             return 0
             ;;
         x.py__test)
-            opts="-v -i -j -h --no-fail-fast --skip --test-args --rustc-args --no-doc --doc --bless --extra-checks --force-rerun --only-modified --compare-mode --pass --run --rustfix-coverage --coverage --verbose --incremental --config --build-dir --build --host --target --exclude --include-default-paths --rustc-error-format --on-fail --dry-run --dump-bootstrap-shims --stage --keep-stage --keep-stage-std --src --jobs --warnings --error-format --json-output --color --bypass-bootstrap-lock --llvm-skip-rebuild --rust-profile-generate --rust-profile-use --llvm-profile-use --llvm-profile-generate --enable-bolt-settings --skip-stage0-validation --reproducible-artifact --set --help [PATHS]... [ARGS]..."
+            opts="-v -i -j -h --no-fail-fast --skip --test-args --rustc-args --no-doc --doc --bless --extra-checks --force-rerun --only-modified --compare-mode --pass --run --rustfix-coverage --coverage --ferrocene-test-one-crate-per-cargo-call --verbose --incremental --config --build-dir --build --host --target --exclude --include-default-paths --rustc-error-format --on-fail --dry-run --dump-bootstrap-shims --stage --keep-stage --keep-stage-std --src --jobs --warnings --error-format --json-output --color --bypass-bootstrap-lock --llvm-skip-rebuild --rust-profile-generate --rust-profile-use --llvm-profile-use --llvm-profile-generate --enable-bolt-settings --skip-stage0-validation --reproducible-artifact --set --help [PATHS]... [ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/src/etc/completions/x.py.zsh
+++ b/src/etc/completions/x.py.zsh
@@ -376,6 +376,7 @@ _arguments "${_arguments_options[@]}" \
 '--only-modified[only run tests that result has been changed]' \
 '--rustfix-coverage[enable this to generate a Rustfix coverage file, which is saved in \`/<build_base>/rustfix_missing_coverage.txt\`]' \
 '--coverage[generate coverage for tests]' \
+'--ferrocene-test-one-crate-per-cargo-call[Test only one crate per Cargo invocation. This is needed by the Ferrocene qualification documents to ensure there is enough granularity for the test outcomes report]' \
 '*-v[use verbose output (-vv for very verbose)]' \
 '*--verbose[use verbose output (-vv for very verbose)]' \
 '-i[use incremental compilation]' \


### PR DESCRIPTION
This PR makes multiple changes to the test outcomes pages:

* The blurb about bare metal targets has been moved to the qualification plan, since it will be shared by multiple targets in the future, and on the report there is now a link to it.
* Unified the wording for tests always passing and tests only executed on hosts.
* Noted that tidy and linkchecker are only executed on hosts, rather than all targets.
* Switched to a table to display compiletest outcomes.
* Switched to a table to display cargo test outcomes.
* Moved the KP statement to the statement page, rather than duplicating it for each target.
* Removed the note around stages, as we don't expose them anymore.
* Changes CI to emit separate metrics for each crate.