### PR TITLE
Configure the ferrocene channel through config.toml

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -887,6 +887,12 @@
 # =============================================================================
 [ferrocene]
 
+# The channel for the Ferrocene build to produce. This is merged with Rust's
+# channel to determine the full channel name.
+#
+# Can be "rolling", "beta" or "stable".
+#channel = "rolling"
+
 # Mode of operations for the traceability matrix tool. This changes the links
 # included in the report. Can be either "local" or "ci".
 #traceability-matrix-mode = "local"

--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -231,13 +231,18 @@ add --set target.wasm32-unknown-unknown.profiler=false
 add --enable-lld
 
 # Set the release channel for this branch. The channel is read from the
-# `src/ci/channel` file to easily allow tools and automation to know and update
-# the current channel.
+# `src/ci/channel` file to easily allow tools and automations to know and
+# update the current channel.
 #
 # Changing the release channel to `nightly` enables unstable features, and it
 # should not be done for any build shipped to customers.
 release_channel="$(cat src/ci/channel)"
 add "--release-channel=${release_channel}"
+
+# Set the Ferrocene channel for this branch. The channel is read from
+# `ferrocene/ci/channel` file to easily allow tools and automations to know and
+# update the current channel.
+add --set "ferrocene.channel=$(cat ferrocene/ci/channel)"
 
 # Run the traceability matrix tool in CI mode, producing the correct links.
 #

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -337,6 +337,7 @@ pub struct Config {
     pub paths: Vec<PathBuf>,
 
     // Ferrocene-specific configuration
+    pub ferrocene_raw_channel: String,
     pub ferrocene_aws_profile: Option<String>,
     pub ferrocene_traceability_matrix_mode: FerroceneTraceabilityMatrixMode,
     pub ferrocene_test_outcomes: FerroceneTestOutcomes,
@@ -1177,6 +1178,7 @@ define_config! {
 
 define_config! {
     struct Ferrocene {
+        channel: Option<String> = "channel",
         aws_profile: Option<String> = "aws-profile",
         traceability_matrix_mode: Option<String> = "traceability-matrix-mode",
         test_outcomes: Option<String> = "test-outcomes",
@@ -1216,6 +1218,8 @@ impl Config {
 
         config.stdout_is_tty = std::io::stdout().is_terminal();
         config.stderr_is_tty = std::io::stderr().is_terminal();
+
+        config.ferrocene_raw_channel = "rolling".into();
 
         // set by build.rs
         config.build = TargetSelection::from_user(&env!("BUILD_TRIPLE"));
@@ -1896,6 +1900,7 @@ impl Config {
         }
 
         if let Some(f) = toml.ferrocene {
+            set(&mut config.ferrocene_raw_channel, f.channel);
             config.ferrocene_traceability_matrix_mode = match f.traceability_matrix_mode.as_deref()
             {
                 Some("local") | None => FerroceneTraceabilityMatrixMode::Local,

--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -352,10 +352,9 @@ impl Step for GenerateBuildMetadata {
 
         let dist_dir = "build/dist";
 
-        let ferrocene_channel = t!(fs::read_to_string("ferrocene/ci/channel"));
-        let ferrocene_channel = ferrocene_channel.trim();
         let ferrocene_version = t!(fs::read_to_string("ferrocene/version"));
         let ferrocene_version = ferrocene_version.trim();
+        let ferrocene_channel = &builder.config.ferrocene_raw_channel;
         let src_version = t!(fs::read_to_string("src/version"));
         let src_version = src_version.trim();
 
@@ -367,8 +366,7 @@ impl Step for GenerateBuildMetadata {
             );
         }
 
-        let channel =
-            crate::ferrocene::ferrocene_channel(builder, ferrocene_channel, ferrocene_version);
+        let channel = crate::ferrocene::ferrocene_channel(builder, ferrocene_version);
 
         let sha1_full = t!(std::process::Command::new("git").arg("rev-parse").arg("HEAD").output());
         let sha1_full = t!(String::from_utf8(sha1_full.stdout));

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -238,18 +238,7 @@ impl<P: Step> Step for SphinxBook<P> {
                 std::fs::read_to_string(&builder.src.join("src").join("version")).unwrap(),
             ))
             .arg("-D")
-            .arg(format!(
-                "channel={}",
-                ferrocene_channel(
-                    builder,
-                    std::fs::read_to_string(
-                        &builder.src.join("ferrocene").join("ci").join("channel")
-                    )
-                    .unwrap()
-                    .trim(),
-                    &ferrocene_version
-                ),
-            ))
+            .arg(format!("channel={}", ferrocene_channel(builder, &ferrocene_version)))
             // Load extensions from the shared resources as well:
             .env("PYTHONPATH", relative_path(&src, &shared_resources.join("exts")));
 

--- a/src/bootstrap/src/ferrocene/mod.rs
+++ b/src/bootstrap/src/ferrocene/mod.rs
@@ -99,12 +99,8 @@ pub(crate) fn ignored_tests_for_suite(
         .collect()
 }
 
-fn ferrocene_channel(
-    builder: &Builder<'_>,
-    ferrocene_channel: &str,
-    ferrocene_version: &str,
-) -> String {
-    match (&*builder.config.channel, ferrocene_channel) {
+fn ferrocene_channel(builder: &Builder<'_>, ferrocene_version: &str) -> String {
+    match (&*builder.config.channel, &*builder.config.ferrocene_raw_channel) {
         ("nightly" | "dev", "rolling") => "nightly".to_owned(),
         ("beta", "rolling") => "pre-rolling".to_owned(),
         ("stable", "rolling") => "rolling".to_owned(),


### PR DESCRIPTION
The Ferrocene channel is used to determine the overall channel of the release, by combining it with the Rust channel. Not all combinations are valid though, and some result in a bootstrap error.

Before this commit, the Ferrocene channel was read directly from the source (ferrocene/ci/channel), while the Rust channel was configured through config.toml and defaulted to "dev". This caused problems when the Ferrocene channel was not "rolling" (like in beta-24.05), as only rolling is compatible with the Rust "dev".

To address the problem, this commit moves the configuration of the Ferrocene channel to config.toml too, with a default of "rolling". This way, either the user configures both the Rust and Ferrocene channel together, or they don't configure either.

This should fix the failure in https://github.com/ferrocene/ferrocene/pull/317