### PR TITLE
Rework installation instructions with the updated content

### DIFF
--- a/ferrocene/doc/user-manual/src/install.rst
+++ b/ferrocene/doc/user-manual/src/install.rst
@@ -6,52 +6,93 @@ Installing Ferrocene
 
 This chapter describes how to install and validate the Ferrocene toolchain.
 
+Before proceeding, you should identify the :doc:`targets <targets/index>` you
+want to install. You must pick the target of the host platform you're going to
+install Ferrocene on, and optionally one or more cross-compilation targets
+(depending on the hardware you'll deploy the executable or library on).
+
 Prerequisites
 -------------
 
-Ferrocene has platform-specific prerequisites, that vary based on the
-compilation targets you want to use. Follow the "Prerequisites" section of the
-target page for each of the targets you plan to use.
+The prerequisites of Ferrocene depend on the targets you are going to install.
+For each of the targets you identified above, follow the "prerequisites"
+section of the target documentation.
 
 Installation
 ------------
 
-Ferrocene is shipped as multiple tarballs, and all of them need to be
-installed. Refer to the list provided to you after the sale for the set of
-tarballs you need to download and install.
+.. note::
 
-Once each tarball is downloaded, extract it inside the directory you want the
-Ferrocene toolchain to be installed (in the rest of this page denoted as
-``path_to_install_dir``):
+   We are developing a tool similar to ``rustup``, able to manage your
+   Ferrocene installations and install Ferrocene without relying on a web
+   browser. It will be available soon.
+
+Manual installation
+~~~~~~~~~~~~~~~~~~~
+
+Ferrocene installation archives are available for manual download at
+`releases.ferrocene.dev <https://releases.ferrocene.dev>`_. The website
+requires authentication through the customer portal, and doesn't allow
+programmatic access.
+
+On the channel list, select the "|channel|" channel to view the latest release
+published in that channel and its files. For each of the targets you identified
+above, download all the archives listed in the "installation archives" section
+of the target documentation.
+
+You must extract all downloaded archives in the **same** directory to finish
+the Ferrocene installation. Ferrocene binaries will then be available in the
+``bin`` subdirectory inside of the extraction location.
+
+For example, to install Ferrocene in ``/opt/ferrocene`` you can run:
 
 .. code-block::
 
-   $ tar -C path_to_install_dir -xf tarball_name.tar.xz
+   sudo tar -C /opt/ferrocene -xf path/to/first-archive.tar.xz
+   sudo tar -C /opt/ferrocene -xf path/to/second-archive.tar.xz
+   # ...repeat for all the downloaded archives
 
-Finally, if ``path_to_install_dir`` is not in your system ``$PATH``, consult the
-manual of your operative system on how to add ``path_to_install_dir`` to your
-``$PATH``.
+To make Ferrocene available system-wide, consult the manual of your operating
+system on how to add the ``bin`` sub-directory into the system ``$PATH``.
+
+.. note::
+
+   Ferrocene can be installed anywhere on the system, including inside of a
+   user's home directory. It is portable, can be moved to different
+   storage locations after its installation, and you can have multiple
+   installations of Ferrocene in different directories.
+
+.. caution::
+
+   Ferrocene does **not** support in-place upgrades: you cannot install
+   Ferrocene inside a directory that contains another Ferrocene installation.
+   To upgrade Ferrocene, you must remove all the contents of the existing
+   directory before extracting the new Ferrocene version.
+
+   Because of this, we do not recommend installing Ferrocene in shared
+   directories like ``/usr/local``, as removing old Ferrocene versions would
+   prove tricky.
 
 Validation
 ----------
 
-The Ferrocene contains a checker called ``ferrocene-self-test`` for
-verifying the installation of the Ferrocene toolchain in a non-certification
-context.  The tool itself is not qualified. Consequently, in certification
-context, manual check of the :doc:`Safety Manual Constraints
-<safety-manual:constraints>` is necessary.
+.. caution::
 
-To execute the checker, run:
+   The procedure described below relies on a tool that is not qualified, and
+   thus can't be used in a safety critical environment: in that case, you must
+   follow the instructions in :qualification:id:`CSTR_0010_INSTALL`.
+
+The Ferrocene toolchain contains a validation binary called
+``ferrocene-self-test``, useful to verify the installation of the Ferrocene
+toolchain. The tool will analyze the installation and the surrounding
+environment, and note if known installation problems are detected. To execute
+the tool, run:
 
 .. code-block::
 
-   $ path_to_install_dir/bin/ferrocene-self-test
+   PATH_TO_INSTALLATION_DIRECTORY/bin/ferrocene-self-test
 
-The Ferrocene self-test tool emits all the checks it performs to ``stderr``.
-
-In case the Ferrocene toolchain was not properly installed, the Ferrocene
-self-test tool should report an error, followed by an error code.
-
-For detailed explanation of error codes, along with common causes and
-suggestions, please consult the
-:doc:`Ferrocene self-test error codes <user-manual:self-test/error-codes>`.
+All the performed checks will be displayed. If any check fails, an error will
+be emitted along with an ID. You can look up the identifier in :doc:`the error
+codes list <self-test/error-codes>` to learn more about the failure and ways to
+fix it.

--- a/ferrocene/doc/user-manual/src/targets/aarch64-unknown-none.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-unknown-none.rst
@@ -14,6 +14,14 @@ Prerequisites
 
 This target has no pre-requisites.
 
+Archives to install
+-------------------
+
+The following archives are needed when :doc:`installing <../install>` this
+target as a cross-compilation target:
+
+* ``rust-std-aarch64-unknown-none``
+
 Required compiler flags
 -----------------------
 

--- a/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
@@ -34,6 +34,21 @@ On Ubuntu 18.04 LTS you can install a suitable C compiler with:
 
    $ sudo apt install gcc
 
+Archives to install
+-------------------
+
+The following archives are needed when :doc:`installing <../install>` this
+target as a host platform:
+
+* ``rustc-x86_64-unknown-linux-gnu``
+* ``rust-std-x86_64-unknown-linux-gnu``
+* ``ferrocene-self-test-x86_64-unknown-linux-gnu``
+
+The following archives are needed when :doc:`installing <../install>` this
+target as a cross-compilation target:
+
+* ``rust-std-x86_64-unknown-linux-gnu``
+
 Required compiler flags
 -----------------------
 


### PR DESCRIPTION
This PR reworks the installation instructions with the new installation method, using releases.ferrocene.dev to download binaries and the new tarball naming scheme (to be implemented). It also adds the list of which packages to install in the user manual.

This is half of https://app.clickup.com/t/8693phhyj