### PR TITLE
Use the new tarball naming scheme

### DIFF
--- a/ferrocene/ci/scripts/calculate-release-job-matrix.py
+++ b/ferrocene/ci/scripts/calculate-release-job-matrix.py
@@ -211,7 +211,9 @@ def build_metadata(ctx, commit):
             ferrocene_version=ferrocene_version,
             channel=channel
         )
-    elif metadata["metadata_version"] == 3:
+    elif metadata["metadata_version"] in (3, 4):
+        # For the purposes of this script, metadata versions 3 and 4 are
+        # equivalent (the only difference is the tarball naming scheme).
         return BuildMetadata(
             rust_version=metadata["rust_version"],
             rust_channel=metadata["rust_channel"],

--- a/ferrocene/ci/scripts/run-self-test.sh
+++ b/ferrocene/ci/scripts/run-self-test.sh
@@ -5,8 +5,10 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+COMMIT="$(git rev-parse HEAD)"
+
 BUCKET="ferrocene-ci-artifacts"
-PREFIX="ferrocene/dist/$(git rev-parse HEAD)"
+PREFIX="ferrocene/dist/${COMMIT}"
 
 root="$(mktemp -d)"
 cleanup() {
@@ -18,9 +20,8 @@ case "$(cat ferrocene/ci/channel)" in
     stable)
         version="$(cat ferrocene/version)"
         ;;
-    beta)
-    rolling)
-        version="$(git rev-parse --short=9 HEAD)"
+    beta|rolling)
+        version="${COMMIT:0:9}"  # First 9 chars of the commit hash
         ;;
     *)
         echo "error: unexpected content of ferrocene/ci/channel"

--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -383,7 +383,7 @@ impl Step for GenerateBuildMetadata {
         // accordingly. Note that new releases *won't* be made until publish-release and
         // this use the same version number.
         let data = json!({
-            "metadata_version": 3,
+            "metadata_version": 4,
             "rust_version": src_version,
             "rust_channel": builder.config.channel,
             "ferrocene_version": ferrocene_version,


### PR DESCRIPTION
This PR implements the new tarball naming scheme agreed in https://designs.ferrocene.dev/tarball-names.html. It also bumps the metadata version from 3 to 4, so that the release process can identify which naming scheme to use.