### PR TITLE
Don't checkout the full history in automation-update-lockfiles

### DIFF
--- a/.github/workflows/automation-update-lockfiles.yml
+++ b/.github/workflows/automation-update-lockfiles.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout the Ferrocene repository
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Fetch all the history
+          fetch-depth: 1
           ref: ${{ matrix.branch }}
 
       - name: Install dependencies


### PR DESCRIPTION
Mistake from basing it off of the subtree sync. We don't need the history here.