### PR TITLE
Release scheduling changes

### DIFF
--- a/ferrocene/ci/scripts/calculate-release-job-matrix.py
+++ b/ferrocene/ci/scripts/calculate-release-job-matrix.py
@@ -345,7 +345,7 @@ class Context:
 
     def env(self):
         if self.manual:
-            return self.envent_data["inputs"]["env"]
+            return self.event_data["inputs"]["env"]
         else:
             return "prod"
 

--- a/ferrocene/ci/scripts/calculate-release-job-matrix.py
+++ b/ferrocene/ci/scripts/calculate-release-job-matrix.py
@@ -151,10 +151,10 @@ def prepare_github_actions_output(ctx, pending_releases):
         name_suffix = "manual"
         command_suffix = ""
 
-        if inputs["override-existing"] == "true":
+        if inputs.get("override-existing") == "true":
             command_suffix += " --allow-overriding-existing-releases"
             name_suffix += ", allow overriding"
-        if inputs["allow-duplicate"] == "true":
+        if inputs.get("allow-duplicate") == "true":
             command_suffix += " --allow-duplicate-releases"
             name_suffix += ", allow duplicates"
 
@@ -264,7 +264,7 @@ def run():
         commits = commits_in_release_branches(ctx)
         releases = filter_automated_channels(commits_to_releases(ctx, commits))
     elif ctx.event_name == "workflow_dispatch":
-        if ctx.event_data["inputs"]["verbatim-ref"] == "true":
+        if ctx.event_data["inputs"].get("verbatim-ref") == "true":
             commit = ctx.event_data["inputs"]["ref"]
         else:
             commit = resolve_ref(ctx, ctx.event_data["inputs"]["ref"])

--- a/ferrocene/ci/scripts/calculate-release-job-matrix.py
+++ b/ferrocene/ci/scripts/calculate-release-job-matrix.py
@@ -184,11 +184,11 @@ def build_metadata(ctx, commit):
         except:
             raise RuntimeError(f"unknown rust channel `{rust}`")
 
-    if  metadata["metadata_version"] == 2:
-        rust_channel=metadata["rust_channel"]
-        ferrocene_channel=metadata["ferrocene_channel"]
-        ferrocene_version=metadata["ferrocene_version"]
-        rust_version=metadata["rust_version"]
+    if metadata["metadata_version"] == 2:
+        rust_channel = metadata["rust_channel"]
+        ferrocene_channel = metadata["ferrocene_channel"]
+        ferrocene_version = metadata["ferrocene_version"]
+        rust_version = metadata["rust_version"]
 
         if ferrocene_version == "rolling":
             ferrocene_major = ferrocene_version
@@ -198,7 +198,7 @@ def build_metadata(ctx, commit):
         if ferrocene_channel == "rolling":
             channel = rustc_to_channel_rolling(metadata["rust_channel"])
         elif ferrocene_channel == "beta":
-            channel =  f"beta-{ferrocene_major}"
+            channel = f"beta-{ferrocene_major}"
         elif ferrocene_channel == "stable":
             channel = f"stable-{ferrocene_major}"
         else:
@@ -209,7 +209,7 @@ def build_metadata(ctx, commit):
             rust_channel=rust_channel,
             ferrocene_channel=ferrocene_channel,
             ferrocene_version=ferrocene_version,
-            channel=channel
+            channel=channel,
         )
     elif metadata["metadata_version"] in (3, 4):
         # For the purposes of this script, metadata versions 3 and 4 are
@@ -219,7 +219,7 @@ def build_metadata(ctx, commit):
             rust_channel=metadata["rust_channel"],
             ferrocene_channel=metadata["ferrocene_channel"],
             ferrocene_version=metadata["ferrocene_version"],
-            channel=metadata["channel"]
+            channel=metadata["channel"],
         )
     else:
         raise RuntimeError(

--- a/ferrocene/ci/scripts/calculate-release-job-matrix.py
+++ b/ferrocene/ci/scripts/calculate-release-job-matrix.py
@@ -4,6 +4,13 @@
 
 # This script is responsible for calculating the list of release jobs we should
 # start, as part of the .github/workflows/release.yml GitHub Actions workflow.
+#
+# The script is meant to be executed inside of GitHub Actions, and relies on
+# environment variables set by it. There are helpers to run it locally though:
+#
+#     calculate-release-job-matrix.py local-test schedule
+#     calculate-release-job-matrix.py local-test dispatch key1=value1 key2=value2
+#
 
 from dataclasses import dataclass, field
 import base64

--- a/ferrocene/ci/scripts/calculate-release-job-matrix.py
+++ b/ferrocene/ci/scripts/calculate-release-job-matrix.py
@@ -148,7 +148,7 @@ def prepare_github_actions_output(ctx, pending_releases):
     if ctx.manual:
         inputs = ctx.event_data["inputs"]
 
-        environment = f"release-{inputs['env']}-manual"
+        environment = f"release-{ctx.env()}-manual"
         name_suffix = "manual"
         command_suffix = ""
 
@@ -159,7 +159,7 @@ def prepare_github_actions_output(ctx, pending_releases):
             command_suffix += " --allow-duplicate-releases"
             name_suffix += ", allow duplicates"
     else:
-        environment = "release-prod-automated"
+        environment = f"release-{ctx.env()}-automated"
         name_suffix = "automated"
         command_suffix = ""
 
@@ -282,6 +282,12 @@ class Context:
 
     s3: object = field(default_factory=lambda: boto3.client("s3"))
     http: object = field(default_factory=setup_http_client)
+
+    def env(self):
+        if self.manual:
+            return self.envent_data["inputs"]["env"]
+        else:
+            return "prod"
 
 
 class UnsupportedMetadataVersion(Exception):

--- a/ferrocene/ci/scripts/calculate-release-job-matrix.py
+++ b/ferrocene/ci/scripts/calculate-release-job-matrix.py
@@ -76,7 +76,7 @@ def commits_to_releases(ctx, all_commits):
         except UnsupportedMetadataVersion as e:
             note(f"skipping `{commit}` (unsupported metadata version {e.version})")
             if ctx.manual:
-                exit(1)
+                error("manual mode early exits on unsupported metadata versions")
             continue
         yield PendingRelease(commit, metadata)
 
@@ -220,8 +220,7 @@ def run():
             try:
                 key, value = argument.split("=")
             except ValueError:
-                print(f"error: input must be key=value: {argument}", file=sys.stderr)
-                exit(1)
+                error(f"input must be key=value: {argument}")
             event["inputs"][key] = value
         ctx = Context(
             repo=LOCAL_TEST_REPO,
@@ -229,8 +228,7 @@ def run():
             event_data=event,
         )
     else:
-        print("error: invalid arguments", file=sys.stderr)
-        exit(1)
+        error("invalid arguments")
 
     if ctx.manual:
         if ctx.event_data["inputs"].get("verbatim-ref") == "true":
@@ -254,6 +252,11 @@ def setup_http_client():
 
 def note(message):
     print(f"note: {message}", file=sys.stderr)
+
+
+def error(message):
+    print(f"error: {message}", file=sys.stderr)
+    exit(1)
 
 
 @dataclass


### PR DESCRIPTION
This PR makes four major changes to the release scheduling code:

* Adds easier support for local testing, as explained in the comment at the top of the file.
* Drops support for metadata version 2, which is not supported by publish-release anymore.
* Changed the script to gracefully handle unknown metadata version: commits with unknown metadata will be skipped.
* During scheduled releases (not manual ones) the script will now check the latest released commit for each release, and skip it if it's the same as the commit we're trying to publish. Publishing duplicate releases is already catched and blocked by publish-release, but it would result in a build failure. Hopefully this change will make the Actions page be less red.