### PR TITLE
Fixup doc lint in the dist task

### DIFF
--- a/src/bootstrap/src/utils/tarball.rs
+++ b/src/bootstrap/src/utils/tarball.rs
@@ -303,7 +303,7 @@ impl<'a> Tarball<'a> {
     /// * For any other build where we have git information, the short commit hash.
     /// * Otherwise, the string "custom".
     ///
-    /// See https://designs.ferrocene.dev/tarball-names.html
+    /// See <https://designs.ferrocene.dev/tarball-names.html>
     fn package_name(&self) -> String {
         let mut name = self.component.clone();
         if let Some(target) = &self.target {


### PR DESCRIPTION
While noodling with how CI tasks are split up locally I bumped into a documentation lint which caused this command (which the CI runs) to fail:

```bash
./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist)
```

Here is a snippet of the relevant output:

```bash
Documenting stage2 bootstrap (x86_64-unknown-linux-gnu)
# ...
    Checking build_helper v0.1.0 (/home/ana/git/ferrocene/ferrocene/src/tools/build_helper)
 Documenting bootstrap v0.0.0 (/home/ana/git/ferrocene/ferrocene/src/bootstrap)
error: this URL is not a hyperlink
   --> src/utils/tarball.rs:306:13
    |
306 |     /// See https://designs.ferrocene.dev/tarball-names.html
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://designs.ferrocene.dev/tarball-names.html>`
    |
    = note: bare URLs are not automatically turned into clickable links
    = note: `-D rustdoc::bare-urls` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(rustdoc::bare_urls)]`

error: could not document `bootstrap`

Caused by:
  process didn't exit successfully: `/home/ana/git/ferrocene/ferrocene/build/bootstrap/debug/rustdoc --edition=2021 --crate-type lib --crate-name bootstrap src/lib.rs --target x86_64-unknown-linux-gnu -o /home/ana/git/ferrocene/ferrocene/build/x86_64-unknown-linux-gnu/stage2-tools/x86_64-unknown-linux-gnu/doc # ...
Build completed unsuccessfully in 0:11:38
```
