### PR TITLE
Remove file operations related to non-existent CONTRIBUTING.md

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -966,7 +966,6 @@ impl Step for PlainSourceTarball {
             "COPYRIGHT",
             "LICENSE-APACHE",
             "LICENSE-MIT",
-            "CONTRIBUTING.md",
             "README.md",
             "RELEASES.md",
             "configure",


### PR DESCRIPTION
While attempting to pretend to be the CI with the following command:

```bash
RUST_BACKTRACE=1 ./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist) -vv
```

I was encountering this error related to the `CONTRIBUTING.md` being expected to exist:

```
Copy "/home/ana/git/ferrocene/ferrocene/COPYRIGHT" to "/home/ana/git/ferrocene/ferrocene/build/tmp/tarball/rustc/src/image/COPYRIGHT"
Copy "/home/ana/git/ferrocene/ferrocene/LICENSE-APACHE" to "/home/ana/git/ferrocene/ferrocene/build/tmp/tarball/rustc/src/image/LICENSE-APACHE"
Copy "/home/ana/git/ferrocene/ferrocene/LICENSE-MIT" to "/home/ana/git/ferrocene/ferrocene/build/tmp/tarball/rustc/src/image/LICENSE-MIT"
Copy "/home/ana/git/ferrocene/ferrocene/CONTRIBUTING.md" to "/home/ana/git/ferrocene/ferrocene/build/tmp/tarball/rustc/src/image/CONTRIBUTING.md"
thread 'main' panicked at src/lib.rs:1651:24:
src.symlink_metadata() failed with No such file or directory (os error 2)
stack backtrace:
   0: rust_begin_unwind
             at /rustc/04ba4521971a83d71477a406b5ce7a479e9d7af8/library/std/src/panicking.rs:647:5
   1: core::panicking::panic_fmt
             at /rustc/04ba4521971a83d71477a406b5ce7a479e9d7af8/library/core/src/panicking.rs:72:14
   2: bootstrap::Build::copy_internal
             at ./src/bootstrap/src/lib.rs:1651:24
   3: bootstrap::Build::copy
             at ./src/bootstrap/src/lib.rs:1639:9
   4: <bootstrap::core::build_steps::dist::PlainSourceTarball as bootstrap::core::builder::Step>::run
             at ./src/bootstrap/src/core/build_steps/dist.rs:985:13
   5: bootstrap::core::builder::Builder::ensure
             at ./src/bootstrap/src/core/builder.rs:2260:23
   6: <bootstrap::core::build_steps::dist::PlainSourceTarball as bootstrap::core::builder::Step>::make_run
             at ./src/bootstrap/src/core/build_steps/dist.rs:951:9
   7: bootstrap::core::builder::StepDescription::maybe_run
             at ./src/bootstrap/src/core/builder.rs:328:13
   8: bootstrap::core::builder::StepDescription::run
             at ./src/bootstrap/src/core/builder.rs:367:21
   9: bootstrap::core::builder::Builder::run_step_descriptions
             at ./src/bootstrap/src/core/builder.rs:1029:9
  10: bootstrap::core::builder::Builder::execute_cli
             at ./src/bootstrap/src/core/builder.rs:1010:9
  11: bootstrap::Build::build
             at ./src/bootstrap/src/lib.rs:685:13
  12: bootstrap::main
             at ./src/bootstrap/src/bin/main.rs:76:5
  13: core::ops::function::FnOnce::call_once
             at /rustc/04ba4521971a83d71477a406b5ce7a479e9d7af8/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
Traceback (most recent call last):
  File "/home/ana/git/ferrocene/ferrocene/./x.py", line 50, in <module>
    bootstrap.main()
  File "/home/ana/git/ferrocene/ferrocene/src/bootstrap/bootstrap.py", line 1162, in main
    bootstrap(args)
  File "/home/ana/git/ferrocene/ferrocene/src/bootstrap/bootstrap.py", line 1138, in bootstrap
    run(args, env=env, verbose=build.verbose, is_bootstrap=True)
  File "/home/ana/git/ferrocene/ferrocene/src/bootstrap/bootstrap.py", line 187, in run
    raise RuntimeError(err)
RuntimeError: failed to run: /home/ana/git/ferrocene/ferrocene/build/bootstrap/debug/bootstrap --stage 2 dist --exclude=extended --exclude=ferrocene-docs --exclude=ferrocene-oxidos --exclude=ferrocene-src --exclude=ferrocene-test-outcomes --exclude=rust-docs --exclude=rust-src --exclude=rustc-src --exclude=doc::standalone -vv

```

I am not sure if we want to remove this reference, create a stub file, or some other remedy.