### PR TITLE
Split up dist tasks a bit more

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -139,6 +139,18 @@ jobs:
       - ferrocene-job-dist:
           restore-from-job: x86_64-linux-build
 
+  x86_64-linux-dist-tools:
+    executor: docker-ubuntu-18
+    resource_class: xlarge # 8-core
+    environment:
+      FERROCENE_HOST: x86_64-unknown-linux-gnu
+      SCRIPT: |
+        # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
+        ./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist:tools)
+    steps:
+      - ferrocene-job-dist:
+          restore-from-job: x86_64-linux-build
+
   x86_64-linux-dist-targets:
     executor: docker-ubuntu-18
     resource_class: large # 4-core
@@ -449,6 +461,9 @@ workflows:
       - x86_64-linux-traceability-matrix:
           requires: *test-outcomes-dependencies
       - x86_64-linux-dist:
+          requires:
+            - x86_64-linux-build
+      - x86_64-linux-dist-tools:
           requires:
             - x86_64-linux-build
       - x86_64-linux-dist-targets:

--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -55,7 +55,7 @@ JOBS_DEFINITION = {
         # Build the documentation on a different jobs, since building it takes
         # a while and with a separate job we can run dist inside the same job
         # as linkchecker (which also needs to generate docs).
-        "docs": ["ferrocene-docs", "ferrocene-test-outcomes"],
+        "docs": ["rustc-docs", "ferrocene-docs", "ferrocene-test-outcomes"],
 
         # Build the source code tarball on a different job, since that requires
         # a (slower) clone of the whole LLVM submodule, not just the subset,
@@ -63,6 +63,8 @@ JOBS_DEFINITION = {
         "src": ["rust-src", "ferrocene-src"],
 
         "oxidos": ["ferrocene-oxidos"],
+
+        "tools": ["rust-analyzer", "clippy", "rustfmt"],
 
         # The "None" job contains the tasks that should never be executed,
         # regardless of which job is requested.

--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -55,7 +55,7 @@ JOBS_DEFINITION = {
         # Build the documentation on a different jobs, since building it takes
         # a while and with a separate job we can run dist inside the same job
         # as linkchecker (which also needs to generate docs).
-        "docs": ["rustc-docs", "ferrocene-docs", "ferrocene-test-outcomes"],
+        "docs": ["ferrocene-docs", "ferrocene-test-outcomes"],
 
         # Build the source code tarball on a different job, since that requires
         # a (slower) clone of the whole LLVM submodule, not just the subset,
@@ -79,6 +79,7 @@ JOBS_DEFINITION = {
             # Upstream's documentation tarball is replaced by the
             # "ferrocene-docs" step, so we avoid executing it.
             "rust-docs",
+            "rustc-docs",
         ],
     },
 


### PR DESCRIPTION
Right now the `x86_64-linux-dist` task takes about 21 minutes. We'd like that to take less time!

The next fastest job (aarch64-linux-compile) is about 17 minutes, so we could in theory shave up 4 minutes off the CI just modifying this one job.

Reviewing the 'Resource utilization report' uncovered that we were building a few tools:

* `clippy` at ~7s + ~129s = ~136s:
  ![image](https://github.com/ferrocene/ferrocene/assets/130903/e3f36945-5aa1-4106-b186-9d42d75a5383)

* `rustfmt` at ~7s + ~70s = ~77s:
  ![image](https://github.com/ferrocene/ferrocene/assets/130903/b26efbee-4520-455f-ac37-70ac1718b4b3)

* `rust-analyzer` at ~14s + ~184s = ~198s
  ![image](https://github.com/ferrocene/ferrocene/assets/130903/10e2a0bf-9b3c-42f4-a74e-31a881722bba)

Since each of these are fairly independent tasks, we could extract them into an independent runner.

I split those out into a `dist:tools` job.

During my experimenting we also noticed the `rustc-docs` task could set to `None`.

## Evaluation

I created a very rudimentary script.

<details>

<summary>Script</summary>

```fish
#!/usr/bin/fish

argparse 't/tools' 'f/folder=' -- $argv or return
# Now we have $_flag_tools and $_flag_folder

mkdir -p "$_flag_folder"

echo "Doing dist"
rm -f build/metrics.json
./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist | string split " ") &> "$_flag_folder"/output-dist.log
ferrocene/ci/scripts/generate-resources-usage-report.py build/metrics.json > "$_flag_folder"/report-dist.html 

echo "Doing dist:docs"
rm -f build/metrics.json
./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist:docs | string split " ") &> "$_flag_folder"/output-dist-docs.log
ferrocene/ci/scripts/generate-resources-usage-report.py build/metrics.json > "$_flag_folder"/report-docs.html 


if test $_flag_tools
    echo "Doing dist:tools"
    rm -f build/metrics.json
    ./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist:tools | string split " ") &> "$_flag_folder"/output-dist-tools.log
    ferrocene/ci/scripts/generate-resources-usage-report.py build/metrics.json > "$_flag_folder"/report-tools.html
else
    echo "Skipped tools, pass --tools to build tools"
end
```


</details>

... then ran `./run.sh --folder=pre-split` on the main branch, then ran `./run.sh --tools --folder=post-split` on this branch.

The resulting utilization reports for pre-split (on my local machine):

* `dist`: ~610s
* `dist:docs`: ~227s

For post split:

* `dist`: ~228s
* `dist:docs`: ~244s
* `dist:tools`: ~207s

This results in a ~175s savings on `dist`+`dist:tools` locally which coarse estimates suggest will be ~3min on the CI. Note that `dist:docs` has grown slightly longer as consequence.

The reports are included here for reference:
[Archive.tar.gz](https://github.com/ferrocene/ferrocene/files/14515690/Archive.tar.gz)

