### PR TITLE
Make dist-tools task a dep of the self-test task

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -514,6 +514,7 @@ workflows:
       - x86_64-linux-self-test:
           requires:
             - x86_64-linux-dist
+            - x86_64-linux-dist-tools
             - x86_64-linux-dist-targets
 
       - finish-build:


### PR DESCRIPTION
Embarassingly, https://github.com/ferrocene/ferrocene/pull/372 had a bug. https://github.com/ferrocene/ferrocene/pull/372#discussion_r1517420354 suggests a solution. This PR follows that.