### PR TITLE
Add experimental armv8r-none-eabihf target

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -156,7 +156,7 @@ jobs:
     resource_class: large # 4-core
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
-      FERROCENE_TARGETS: aarch64-unknown-none,aarch64-unknown-linux-gnu,thumbv7em-none-eabi,thumbv7em-none-eabihf,wasm32-unknown-unknown
+      FERROCENE_TARGETS: aarch64-unknown-none,aarch64-unknown-linux-gnu,thumbv7em-none-eabi,thumbv7em-none-eabihf,armv8r-none-eabihf,wasm32-unknown-unknown
       SCRIPT: |
         ./x.py --stage 2 dist rust-std
     steps:

--- a/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
@@ -43,11 +43,8 @@ RUN apt-get update \
         g++-aarch64-linux-gnu \
         binutils-aarch64-linux-gnu \
         libc6-dev-arm64-cross \
-        # Needed for thumbv7em-none-eabihf cross-compilation
+        # Needed for thumbv7em-none-eabihf & armv8r-none-eabihf cross-compilation
         gcc-arm-none-eabi \
-        # Needed for armv8r-none-eabihf
-        arm-none-eabi-gcc \
-        arm-none-eabi-g++ \
         # Needed for the wasm32-unknown-unknown target
         clang \
         # Needed to install AWS CLI during the build:
@@ -137,6 +134,8 @@ ENV CC_aarch64_unknown_none=aarch64-linux-gnu-gcc
 ENV CXX_aarch64_unknown_none=aarch64-linux-gnu-g++
 ENV CC_aarch64_unknown_ferrocenecoretest=aarch64-linux-gnu-gcc
 ENV CXX_aarch64_unknown_ferrocenecoretest=aarch64-linux-gnu-g++
+ENV CC_armv8r_none_eabihf=arm-none-eabi-gcc
+ENV CXX_armv8r_none_eabihf=arm-none-eabi-g++
 
 RUN mkdir /home/ci \
     && addgroup --gid 1000 ci \

--- a/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
@@ -136,7 +136,7 @@ ENV CC_aarch64_unknown_ferrocenecoretest=aarch64-linux-gnu-gcc
 ENV CXX_aarch64_unknown_ferrocenecoretest=aarch64-linux-gnu-g++
 ENV CC_armv8r_none_eabihf=arm-none-eabi-gcc
 ENV CXX_armv8r_none_eabihf=arm-none-eabi-g++
-ENV CFLAGS_armv8r_none_eabihf=-march=armv8-r
+ENV CFLAGS_armv8r_none_eabihf="-march=armv8-r -C target-feature=+fp64,+d32,+neon"
 
 RUN mkdir /home/ci \
     && addgroup --gid 1000 ci \

--- a/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
@@ -45,6 +45,9 @@ RUN apt-get update \
         libc6-dev-arm64-cross \
         # Needed for thumbv7em-none-eabihf cross-compilation
         gcc-arm-none-eabi \
+        # Needed for armv8r-none-eabihf
+        arm-none-eabi-gcc \
+        arm-none-eabi-g++ \
         # Needed for the wasm32-unknown-unknown target
         clang \
         # Needed to install AWS CLI during the build:

--- a/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
@@ -136,6 +136,7 @@ ENV CC_aarch64_unknown_ferrocenecoretest=aarch64-linux-gnu-gcc
 ENV CXX_aarch64_unknown_ferrocenecoretest=aarch64-linux-gnu-g++
 ENV CC_armv8r_none_eabihf=arm-none-eabi-gcc
 ENV CXX_armv8r_none_eabihf=arm-none-eabi-g++
+ENV CFLAGS_armv8r_none_eabihf=-march=armv8-r
 
 RUN mkdir /home/ci \
     && addgroup --gid 1000 ci \

--- a/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
@@ -136,7 +136,9 @@ ENV CC_aarch64_unknown_ferrocenecoretest=aarch64-linux-gnu-gcc
 ENV CXX_aarch64_unknown_ferrocenecoretest=aarch64-linux-gnu-g++
 ENV CC_armv8r_none_eabihf=arm-none-eabi-gcc
 ENV CXX_armv8r_none_eabihf=arm-none-eabi-g++
-ENV CFLAGS_armv8r_none_eabihf="-march=armv8-r -C target-feature=+fp64,+d32,+neon"
+
+# Automatic CFLAGs do not work for some targets.
+ENV CFLAGS_armv8r_none_eabihf="-march=armv8-r -mfpu=fp-armv8"
 
 RUN mkdir /home/ci \
     && addgroup --gid 1000 ci \

--- a/ferrocene/doc/release-notes/src/next.rst
+++ b/ferrocene/doc/release-notes/src/next.rst
@@ -9,6 +9,18 @@ Next Ferrocene release
 This page contains the changes to be introduced in the upcoming Ferrocene
 release.
 
+New experimental features
+-------------------------
+
+Experimental features are not qualified for safety critical use, and are
+shipped as a preview.
+
+* Experimental support has been added for a new cross-compilation target.
+  Note that experimental targets are not qualified for safety critical use. The
+  new target is:
+
+  * :target-with-triple:`armv8r-none-eabihf`
+
 Changes
 -------
 

--- a/ferrocene/doc/target-names.toml
+++ b/ferrocene/doc/target-names.toml
@@ -10,5 +10,6 @@
 aarch64-unknown-none     = "Armv8-A bare-metal"
 thumbv7em-none-eabi      = "Armv7E-M bare-metal (soft-float)"
 thumbv7em-none-eabihf    = "Armv7E-M bare-metal (hard-float)"
+armv8r-none-eabihf       = "Armv8-R bare-metal (hard-float)"
 wasm32-unknown-unknown   = "WASM bare-metal"
 x86_64-unknown-linux-gnu = "x86-64 Linux (glibc)"

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -82,6 +82,12 @@ should not be used in production.
      - Cross-compilation
      - Bare-metal
      - \-
+  
+   * - :target:`armv8r-none-eabihf`
+     - ``armv8r-none-eabihf``
+     - Cross-compilation
+     - Bare-metal
+     - \-
 
    * - :target:`wasm32-unknown-unknown`
      - ``wasm32-unknown-unknown``

--- a/ferrocene/packages.toml
+++ b/ferrocene/packages.toml
@@ -71,6 +71,7 @@ targets = [
   "aarch64-unknown-linux-gnu",
   "thumbv7em-none-eabi",
   "thumbv7em-none-eabihf",
+  "armv8r-none-eabihf",
   "wasm32-unknown-unknown",
 ]
 


### PR DESCRIPTION
Adds an experimental `armv8r-none-eabihf` which is untested.