### PR TITLE
make "additional tools" release note more simple

### DIFF
--- a/ferrocene/doc/release-notes/src/24.05.0.rst
+++ b/ferrocene/doc/release-notes/src/24.05.0.rst
@@ -39,10 +39,12 @@ shipped as a preview.
   according to the new requirements for linkers. Note that the self-testing
   tool is not qualified for safety critical use yet.
 
-* Host targets now distribute all the official Rust dev tools. Additionally to
-  ``rustc`` and ``cargo`` which were already included before, ``clippy``,
-  ``rustfmt``, ``rust-analyzer`` and ``rust-demangler`` are build and bundled
-  now as well.
+* These tools from upstream toolchain are now distributed with Ferrocene:
+
+  - ``clippy``
+  - ``rustfmt``
+  - ``rust-analyzer``
+  - ``rust-demangler``
 
 Changes
 -------

--- a/ferrocene/doc/release-notes/src/conf.py
+++ b/ferrocene/doc/release-notes/src/conf.py
@@ -14,6 +14,7 @@ extensions = [
     "ferrocene_toctrees",
     "ferrocene_qualification",
     "ferrocene_relnotes",
+    "ferrocene_autoglossary",
 
     "sphinx.ext.intersphinx",
     "ferrocene_intersphinx_support",

--- a/ferrocene/doc/release-notes/src/index.rst
+++ b/ferrocene/doc/release-notes/src/index.rst
@@ -23,3 +23,8 @@ in Ferrocene releases.
    :maxdepth: 1
 
    23.06.0
+
+.. appendices::
+   :caption: Appendices:
+
+   terms

--- a/ferrocene/doc/release-notes/src/terms.rst
+++ b/ferrocene/doc/release-notes/src/terms.rst
@@ -1,0 +1,4 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+.. include:: ../../glossary.rst


### PR DESCRIPTION
It had a typo, but I also found it more complex than it needed to be