### PR TITLE
Fix downloading tarballs from CI after the renaming

### DIFF
--- a/ferrocene/doc/internal-procedures/src/setup-local-env.rst
+++ b/ferrocene/doc/internal-procedures/src/setup-local-env.rst
@@ -119,8 +119,5 @@ content in it:
    [rust]
    lld = true
 
-   [llvm]
-   download-ci-llvm = false
-
 There are a lot of other options available: you can look at the documentation
 for all of them in the ``config.toml.example`` file for further details.

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2121,15 +2121,15 @@ impl Config {
     pub(crate) fn artifact_version_part(&self, commit: &str) -> String {
         let (channel, version) = if self.rust_info.is_managed_git_subrepository() {
             let mut channel = self.git();
-            channel.arg("show").arg(format!("{commit}:src/ci/channel"));
+            channel.arg("show").arg(format!("{commit}:ferrocene/ci/channel"));
             let channel = output(&mut channel);
             let mut version = self.git();
-            version.arg("show").arg(format!("{commit}:src/version"));
+            version.arg("show").arg(format!("{commit}:ferrocene/version"));
             let version = output(&mut version);
             (channel.trim().to_owned(), version.trim().to_owned())
         } else {
-            let channel = fs::read_to_string(self.src.join("src/ci/channel"));
-            let version = fs::read_to_string(self.src.join("src/version"));
+            let channel = fs::read_to_string(self.src.join("ferrocene/ci/channel"));
+            let version = fs::read_to_string(self.src.join("ferrocene/version"));
             match (channel, version) {
                 (Ok(channel), Ok(version)) => {
                     (channel.trim().to_owned(), version.trim().to_owned())
@@ -2141,22 +2141,17 @@ impl Config {
                         "HELP: consider using a git checkout or ensure these files are readable"
                     );
                     if let Err(channel) = channel {
-                        eprintln!("reading {src}/src/ci/channel failed: {channel:?}");
+                        eprintln!("reading {src}/ferrocene/ci/channel failed: {channel:?}");
                     }
                     if let Err(version) = version {
-                        eprintln!("reading {src}/src/version failed: {version:?}");
+                        eprintln!("reading {src}/ferrocene/version failed: {version:?}");
                     }
                     panic!();
                 }
             }
         };
 
-        match channel.as_str() {
-            "stable" => version,
-            "beta" => channel,
-            "nightly" => channel,
-            other => unreachable!("{:?} is not recognized as a valid channel", other),
-        }
+        if channel == "stable" { version } else { commit[..9].to_string() }
     }
 
     /// Try to find the relative path of `bindir`, otherwise return it in full.

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -732,7 +732,7 @@ download-rustc = false
             &self.stage0_metadata.config.artifacts_server
         };
         let version = self.artifact_version_part(llvm_sha);
-        let filename = format!("rust-dev-{}-{}.tar.xz", version, self.build.triple);
+        let filename = format!("rust-dev-{}-{}.tar.xz", self.build.triple, version);
         let tarball = rustc_cache.join(&filename);
         if !tarball.exists() {
             let help_on_error = "ERROR: failed to download llvm from ci

--- a/src/bootstrap/src/ferrocene/test_outcomes.rs
+++ b/src/bootstrap/src/ferrocene/test_outcomes.rs
@@ -7,7 +7,6 @@ use build_helper::git::get_git_merge_base;
 use std::path::PathBuf;
 
 static DOWNLOAD_PREFIX: &str = "s3://ferrocene-ci-artifacts/ferrocene/dist";
-static TARBALL_NAME: &str = "ferrocene-test-outcomes-nightly.tar.xz";
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub(super) struct TestOutcomesDir;
@@ -47,7 +46,8 @@ fn download_and_extract_outcomes(builder: &Builder<'_>, commit: &str) -> PathBuf
 
     if !tarball_file.exists() {
         builder.info(&format!("Downloading test outcomes for commit {commit}"));
-        let url = format!("{DOWNLOAD_PREFIX}/{commit}/{TARBALL_NAME}");
+        let version = builder.config.artifact_version_part(commit);
+        let url = format!("{DOWNLOAD_PREFIX}/{commit}/ferrocene-test-outcomes-{version}.tar.xz");
         builder.create_dir(&tarballs_dir);
         builder.config.download_file(&url, &tarball_file, "Could not download the test outcomes.");
     }


### PR DESCRIPTION
In #342 we switched to a new tarball naming scheme, but we didn't update the bootstrap code that downloads them to use the new naming. This PR fixes that.

Also, with this and #376 downloading LLVM from CI works again! I thus updated the docs to remove the need to disable CI-downloaded LLVMs.