### PR TITLE
Allow configuring the max number of PRs in pulls from upstream

### DIFF
--- a/.github/workflows/automation-pull-upstream.yml
+++ b/.github/workflows/automation-pull-upstream.yml
@@ -9,7 +9,13 @@ on:
   schedule:
     - cron: '0 5 * * 1-5'
   # Allow to run this manually from the GitHub UI
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      max_merges_per_pr:
+        description: Max number of PRs to be included
+        type: number
+        default: 30
+        required: true
 
 permissions:
   contents: write
@@ -74,3 +80,4 @@ jobs:
         run: python3 ferrocene/tools/pull-upstream/automation.py ${{ matrix.branch }} ${{ steps.create_branch.outputs.name || 'main' }}
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MAX_MERGES_PER_PR: "${{ github.event_name == 'workflow_dispatch' && inputs.max_merges_per_pr || 30 }}"

--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -7,9 +7,14 @@ IFS=$'\n\t'
 
 UPSTREAM_REPO="https://github.com/rust-lang/rust"
 TEMP_BRANCH="pull-upstream-temp--do-not-use-for-real-code"
-MAX_MERGES_PER_PR=30
 DIRECTORIES_CONTAINING_LOCKFILES=("" "src/bootstrap/")
 GENERATED_COMPLETIONS_DIR="src/etc/completions/"
+
+# Set a default max of merges per PR to 30, if it was not overridden in the
+# environment.
+if [[ -z "${MAX_MERGES_PER_PR+x}" ]]; then
+    MAX_MERGES_PER_PR=30
+fi
 
 # Print all files with the `ferrocene-avoid-pulling-from-upstream` attribute.
 #


### PR DESCRIPTION
This allows to customize how many PRs are included in pulls from upstream when manually starting the workflow.