### PR TITLE
Remove channel sphinx substitution

### DIFF
--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/__init__.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/__init__.py
@@ -20,7 +20,6 @@ def setup(app):
     app.add_config_value("ferrocene_private_signature_files_dir", None, "env", [str])
     app.add_config_value("ferrocene_version", None, "env", [str])
     app.add_config_value("rust_version", None, "env", [str])
-    app.add_config_value("channel", None, "env", [str])
 
     return {
         "version": "0",

--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/substitutions.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/substitutions.py
@@ -39,10 +39,6 @@ class AddCustomSubstitutions(SphinxTransform):
             "rust_version",
             self.app.config["rust_version"],
         )
-        self.add_substitution(
-            "channel",
-            self.app.config["channel"],
-        )
 
     def add_substitution(self, name, value):
         substitution = nodes.substitution_definition()

--- a/ferrocene/doc/user-manual/src/install.rst
+++ b/ferrocene/doc/user-manual/src/install.rst
@@ -35,10 +35,10 @@ Ferrocene installation archives are available for manual download at
 requires authentication through the customer portal, and doesn't allow
 programmatic access.
 
-On the channel list, select the "|channel|" channel to view the latest release
-published in that channel and its files. For each of the targets you identified
-above, download all the archives listed in the "installation archives" section
-of the target documentation.
+On the channel list, select the channel you want to view the latest release
+published in it (and its files). For each of the targets you identified above,
+download all the archives listed in the "installation archives" section of the
+target documentation.
 
 You must extract all downloaded archives in the **same** directory to finish
 the Ferrocene installation. Ferrocene binaries will then be available in the

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -3,7 +3,6 @@
 
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::core::config::TargetSelection;
-use crate::ferrocene::ferrocene_channel;
 use crate::ferrocene::sign::CacheSignatureFiles;
 use crate::ferrocene::test_outcomes::TestOutcomesDir;
 use std::collections::HashMap;
@@ -237,8 +236,6 @@ impl<P: Step> Step for SphinxBook<P> {
                 "rust_version={}",
                 std::fs::read_to_string(&builder.src.join("src").join("version")).unwrap().trim(),
             ))
-            .arg("-D")
-            .arg(format!("channel={}", ferrocene_channel(builder, &ferrocene_version)))
             // Load extensions from the shared resources as well:
             .env("PYTHONPATH", relative_path(&src, &shared_resources.join("exts")));
 


### PR DESCRIPTION
Turns out we can't inject the channel name in our documentation! Our document signature scheme depends on the content of the signature not to change between the beta and stable branch (as we need to keep the same document IDs and signatures between the two), while injecting the channel implies the signatures would be invalidated.

Figured this out while signing documents with Florian.