### PR TITLE
Fix typo in github actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
     # Unfortunately checking whether a list is empty is not possible in a nice
     # way due to GitHub Actions expressions limits. This hacky solution is from
     # https://github.com/orgs/community/discussions/27085#discussioncomment-3533174
-    if: fromJSON(needs.scheduler.output.jobs)[0] != null
+    if: fromJSON(needs.scheduler.outputs.jobs)[0] != null
 
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since https://github.com/ferrocene/ferrocene/pull/403 the release workflow started failing with an internal GitHub error. Looking at the change, I noticed a typo in the configuration. Hopefully this will fix it, otherwise we'll have to contact GitHub support.