### PR TITLE
Refactor `ferrocene-self-test` more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,6 +1862,7 @@ dependencies = [
  "atty",
  "insta",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/ferrocene/tools/self-test/Cargo.toml
+++ b/ferrocene/tools/self-test/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [dependencies]
 atty = "0.2.14"
 tempfile = "3.3.0"
+thiserror = "1"
 
 [dev-dependencies]
 insta = { version = "1.31.0" }

--- a/ferrocene/tools/self-test/Cargo.toml
+++ b/ferrocene/tools/self-test/Cargo.toml
@@ -7,9 +7,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-atty = "0.2.14"
-tempfile = "3.3.0"
+atty = "0.2"
+tempfile = "3.3"
 thiserror = "1"
 
 [dev-dependencies]
-insta = { version = "1.31.0" }
+insta = "1.31"

--- a/ferrocene/tools/self-test/src/binaries.rs
+++ b/ferrocene/tools/self-test/src/binaries.rs
@@ -191,7 +191,7 @@ mod tests {
         std::fs::create_dir_all(&bin_dir).unwrap();
 
         let mut perms = bin_dir.metadata().unwrap().permissions();
-        perms.set_mode(0);
+        perms.set_mode(0o0);
         std::fs::set_permissions(&bin_dir, perms).unwrap();
 
         match check_binary(utils.reporter(), utils.sysroot(), "rustc", CommitHashOf::Rust) {

--- a/ferrocene/tools/self-test/src/binaries.rs
+++ b/ferrocene/tools/self-test/src/binaries.rs
@@ -5,10 +5,10 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Command;
 
+use crate::env;
 use crate::error::Error;
 use crate::report::Reporter;
 use crate::utils::run_command;
-use crate::{CFG_RELEASE, SELFTEST_CARGO_HASH, SELFTEST_RUST_HASH, SELFTEST_TARGET};
 
 /// Check that the executables exist in the expected path, and that they have the correct permissions.
 ///
@@ -94,8 +94,8 @@ fn parse_version_output(output: &str) -> Option<VersionOutput> {
 
 fn check_version(version: VersionOutput, hash: CommitHashOf, name: &str) -> Result<(), Error> {
     for (field, expected, found) in [
-        ("host", SELFTEST_TARGET, version.host),
-        ("release", CFG_RELEASE, version.release),
+        ("host", env::SELFTEST_TARGET, version.host),
+        ("release", env::CFG_RELEASE, version.release),
         ("commit hash", hash.fetch().unwrap_or("unknown"), version.commit_hash),
     ] {
         if expected != found {
@@ -140,8 +140,8 @@ enum CommitHashOf {
 impl CommitHashOf {
     fn fetch(&self) -> Option<&'static str> {
         match self {
-            CommitHashOf::Rust => SELFTEST_RUST_HASH,
-            CommitHashOf::Cargo => SELFTEST_CARGO_HASH,
+            CommitHashOf::Rust => env::SELFTEST_RUST_HASH,
+            CommitHashOf::Cargo => env::SELFTEST_CARGO_HASH,
         }
     }
 }

--- a/ferrocene/tools/self-test/src/compile.rs
+++ b/ferrocene/tools/self-test/src/compile.rs
@@ -8,11 +8,11 @@ use std::process::Command;
 
 use tempfile::TempDir;
 
+use crate::env;
 use crate::error::Error;
 use crate::report::Reporter;
 use crate::targets::Target;
 use crate::utils::run_command;
-use crate::SELFTEST_TARGET;
 
 static SAMPLE_PROGRAMS: &[SampleProgram] = &[
     SampleProgram {
@@ -91,8 +91,9 @@ fn check_target(
         compile(&ctx, program)?;
         expected_artifacts.check(program.name)?;
 
-        let should_run =
-            (ctx.target.triple == SELFTEST_TARGET).then_some(program.executable_output).flatten();
+        let should_run = (ctx.target.triple == env::SELFTEST_TARGET)
+            .then_some(program.executable_output)
+            .flatten();
         if let Some(expected_output) = should_run {
             run(&ctx, program, expected_output)?
         }

--- a/ferrocene/tools/self-test/src/env.rs
+++ b/ferrocene/tools/self-test/src/env.rs
@@ -11,11 +11,11 @@ use std::ffi::OsString;
 // Compile-time environment variables
 //
 /// The Rust release ferrocene-self-test is being compiled for
-pub const CFG_RELEASE: &str = env!("CFG_RELEASE");
+pub(crate) const CFG_RELEASE: &str = env!("CFG_RELEASE");
 /// The target-triple ferroce-self-test is being compiled for
-pub const SELFTEST_TARGET: &str = env!("SELFTEST_TARGET");
-pub const SELFTEST_RUST_HASH: Option<&str> = option_env!("SELFTEST_RUST_HASH");
-pub const SELFTEST_CARGO_HASH: Option<&str> = option_env!("SELFTEST_CARGO_HASH");
+pub(crate) const SELFTEST_TARGET: &str = env!("SELFTEST_TARGET");
+pub(crate) const SELFTEST_RUST_HASH: Option<&str> = option_env!("SELFTEST_RUST_HASH");
+pub(crate) const SELFTEST_CARGO_HASH: Option<&str> = option_env!("SELFTEST_CARGO_HASH");
 
 /// Run-time environment variables
 pub(crate) struct Env {
@@ -25,11 +25,11 @@ pub(crate) struct Env {
     ///
     /// Usually this variable is present in most operating systems and does not
     /// need to be set explicitly.
-    pub path: Option<OsString>,
+    pub(crate) path: Option<OsString>,
 }
 
 impl Env {
-    pub fn gather() -> Self {
+    pub(crate) fn gather() -> Self {
         Self { path: std::env::var_os("PATH") }
     }
 }

--- a/ferrocene/tools/self-test/src/env.rs
+++ b/ferrocene/tools/self-test/src/env.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: The Ferrocene Developers
+
+//! Environment variables which act as input parameters.
+//!
+//! There are compile-time and run-time environment variables. Compile-time
+//! variables are constants. Run-time variables are fields of [Env].
+
+use std::ffi::OsString;
+
+// Compile-time environment variables
+//
+/// The Rust release ferrocene-self-test is being compiled for
+pub const CFG_RELEASE: &str = env!("CFG_RELEASE");
+/// The target-triple ferroce-self-test is being compiled for
+pub const SELFTEST_TARGET: &str = env!("SELFTEST_TARGET");
+pub const SELFTEST_RUST_HASH: Option<&str> = option_env!("SELFTEST_RUST_HASH");
+pub const SELFTEST_CARGO_HASH: Option<&str> = option_env!("SELFTEST_CARGO_HASH");
+
+/// Run-time environment variables
+pub(crate) struct Env {
+    /// `PATH` environment variable.
+    ///
+    /// Specifies a set of directories where executable programs are located.
+    ///
+    /// Usually this variable is present in most operating systems and does not
+    /// need to be set explicitly.
+    pub path: Option<OsString>,
+}
+
+impl Env {
+    pub fn gather() -> Self {
+        Self { path: std::env::var_os("PATH") }
+    }
+}

--- a/ferrocene/tools/self-test/src/error.rs
+++ b/ferrocene/tools/self-test/src/error.rs
@@ -205,23 +205,10 @@ pub(crate) enum CommandErrorKind {
     NonUtf8Output,
 }
 
-#[derive(Debug)]
+#[derive(Debug, ThisError)]
 pub(crate) enum FindBinaryInPathError {
+    #[error("the PATH environment variable is not set")]
     NoEnvironmentVariable,
+    #[error("binary {name} is not present in the system PATH")]
     MissingBinary { name: String },
-}
-
-impl std::error::Error for FindBinaryInPathError {}
-
-impl Display for FindBinaryInPathError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            FindBinaryInPathError::NoEnvironmentVariable => {
-                write!(f, "the PATH environment variable is not set")
-            }
-            FindBinaryInPathError::MissingBinary { name } => {
-                write!(f, "binary {name} is not present in the system PATH")
-            }
-        }
-    }
 }

--- a/ferrocene/tools/self-test/src/error.rs
+++ b/ferrocene/tools/self-test/src/error.rs
@@ -8,16 +8,6 @@ use std::process::Output;
 
 use thiserror::Error as ThisError;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(crate) enum LinkerArgsErrorKind {
-    UnknownArgument,
-    DisallowedPlugin,
-    NoArgsFile,
-    InvalidArgsFile,
-    EmptyArgsFile,
-    MissingArg,
-}
-
 #[derive(Debug, ThisError)]
 pub(crate) enum Error {
     #[error("could not detect the sysroot of the Ferrocene installation")]
@@ -211,4 +201,14 @@ pub(crate) enum FindBinaryInPathError {
     NoEnvironmentVariable,
     #[error("binary {name} is not present in the system PATH")]
     MissingBinary { name: String },
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum LinkerArgsErrorKind {
+    UnknownArgument,
+    DisallowedPlugin,
+    NoArgsFile,
+    InvalidArgsFile,
+    EmptyArgsFile,
+    MissingArg,
 }

--- a/ferrocene/tools/self-test/src/linkers.rs
+++ b/ferrocene/tools/self-test/src/linkers.rs
@@ -22,7 +22,7 @@ const RANDOM_LINKER_ARG: &str = "--rand456256146871864165842156=xyz";
 
 /// What kind of C compiler does a target require
 #[derive(Debug)]
-pub enum Linker {
+pub(crate) enum Linker {
     /// No C compiler required
     BundledLld,
     /// The system's native C compiler is required

--- a/ferrocene/tools/self-test/src/linkers.rs
+++ b/ferrocene/tools/self-test/src/linkers.rs
@@ -10,11 +10,11 @@ use std::process::Command;
 
 use argparse::LinkerArg;
 
+use crate::env::{self, Env};
 use crate::error::{Error, LinkerArgsErrorKind};
 use crate::report::Reporter;
 use crate::targets::Target;
 use crate::utils::{find_binary_in_path, run_command};
-use crate::{Environment, SELFTEST_TARGET};
 
 /// The linker arg we ask the C compiler to add, to check it can add arbitrary
 /// arguments.
@@ -38,7 +38,7 @@ pub enum Linker {
 /// each target's rustflags field.
 pub(crate) fn check_and_add_rustflags(
     reporter: &dyn Reporter,
-    environment: &Environment,
+    env: &Env,
     sysroot: &Path,
     targets: &mut [Target],
 ) -> Result<(), Error> {
@@ -72,7 +72,7 @@ pub(crate) fn check_and_add_rustflags(
                     })?;
                     let compiler_name = format!("{cc_prefix}{compiler_kind}");
                     let cc_result = check_system_compiler(
-                        environment,
+                        env,
                         target.triple,
                         &compiler_name,
                         lld_dir,
@@ -224,14 +224,14 @@ where
 /// Returns the path to the C compiler, and a list of arguments that the C
 /// compiler gives to the linker.
 fn check_system_compiler(
-    environment: &Environment,
+    env: &Env,
     target: &str,
     compiler_name: &str,
     lld_dir: &Path,
     temp_dir: &Path,
     extra_args: &[String],
 ) -> Result<(PathBuf, Vec<String>), Error> {
-    let cc_path = find_binary_in_path(environment, compiler_name)
+    let cc_path = find_binary_in_path(env, compiler_name)
         .map_err(|error| Error::CCompilerNotFound { name: compiler_name.into(), error })?;
 
     // Part 1. Check with the real ld.lld - can we make a binary?
@@ -413,7 +413,7 @@ fn check_compiler_linker_args(
 /// Look for the bundled `rust-lld` program in the given sysroot.
 fn find_bundled_lld(reporter: &dyn Reporter, sysroot: &Path) -> Result<PathBuf, Error> {
     let path =
-        sysroot.join("lib").join("rustlib").join(SELFTEST_TARGET).join("bin").join("rust-lld");
+        sysroot.join("lib").join("rustlib").join(env::SELFTEST_TARGET).join("bin").join("rust-lld");
 
     if path.is_file() {
         reporter.success("bundled linker detected");
@@ -428,7 +428,7 @@ fn find_bundled_lld_wrapper(reporter: &dyn Reporter, sysroot: &Path) -> Result<P
     let path = sysroot
         .join("lib")
         .join("rustlib")
-        .join(SELFTEST_TARGET)
+        .join(env::SELFTEST_TARGET)
         .join("bin")
         .join("gcc-ld")
         .join("ld.lld");
@@ -462,7 +462,7 @@ mod tests {
     #[test]
     fn test_find_bundled_lld() {
         let utils = TestUtils::new();
-        utils.bin("rust-lld").for_target(SELFTEST_TARGET).create();
+        utils.bin("rust-lld").for_target(env::SELFTEST_TARGET).create();
 
         find_bundled_lld(utils.reporter(), utils.sysroot()).unwrap();
         utils.assert_report_success("bundled linker detected");
@@ -483,7 +483,7 @@ mod tests {
     #[test]
     fn test_find_bundled_lld_wrapper() {
         let utils = TestUtils::new();
-        utils.bin("gcc-ld/ld.lld").for_target(SELFTEST_TARGET).create();
+        utils.bin("gcc-ld/ld.lld").for_target(env::SELFTEST_TARGET).create();
 
         find_bundled_lld_wrapper(utils.reporter(), utils.sysroot()).unwrap();
         utils.assert_report_success("bundled linker-wrapper detected");

--- a/ferrocene/tools/self-test/src/linkers/argparse.rs
+++ b/ferrocene/tools/self-test/src/linkers/argparse.rs
@@ -5,7 +5,7 @@
 
 /// Linker options we know about
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum LinkerArg<'a> {
+pub(crate) enum LinkerArg<'a> {
     // Unqualified option
     /// An input file (an argument with no option before it)
     Input(&'a str),
@@ -129,7 +129,7 @@ where
 
 /// Clean up split linker arguments so they can be more easily processed
 #[rustfmt::skip]
-pub fn rationalise_linker_args<'a, I>(mut args_iter: I) -> Vec<LinkerArg<'a>>
+pub(crate) fn rationalise_linker_args<'a, I>(mut args_iter: I) -> Vec<LinkerArg<'a>>
 where
     I: Iterator<Item = &'a str>,
 {

--- a/ferrocene/tools/self-test/src/main.rs
+++ b/ferrocene/tools/self-test/src/main.rs
@@ -3,6 +3,7 @@
 
 mod binaries;
 mod compile;
+mod env;
 mod error;
 mod linkers;
 mod report;
@@ -12,30 +13,11 @@ mod utils;
 #[cfg(test)]
 mod test_utils;
 
-use std::ffi::OsString;
 use std::path::PathBuf;
 
+use crate::env::Env;
 use crate::error::Error;
 use crate::report::{Reporter, StderrReporter};
-
-// Compile-time environment variables
-/// The Rust release ferrocene-self-test is being compiled for
-const CFG_RELEASE: &str = env!("CFG_RELEASE");
-/// The target-triple ferroce-self-test is being compiled for
-const SELFTEST_TARGET: &str = env!("SELFTEST_TARGET");
-const SELFTEST_RUST_HASH: Option<&str> = option_env!("SELFTEST_RUST_HASH");
-const SELFTEST_CARGO_HASH: Option<&str> = option_env!("SELFTEST_CARGO_HASH");
-
-/// Run-time environment variables set by the caller of the binary.
-struct Environment {
-    path: Option<OsString>,
-}
-
-impl Environment {
-    fn gather() -> Self {
-        Self { path: std::env::var_os("PATH") }
-    }
-}
 
 /// The user manual states to extract all archives to the same directory.
 /// Therefore the sysroot is the grandparent of `ferrocene-self-test`
@@ -46,14 +28,14 @@ fn get_sysroot() -> Option<PathBuf> {
 }
 
 fn main_inner(reporter: &dyn Reporter) -> Result<(), Error> {
-    let environment = Environment::gather();
+    let env = Env::gather();
 
     let sysroot = get_sysroot().ok_or(Error::NoSysroot)?;
     reporter.info(&format!("using sysroot {}", sysroot.display()));
 
     binaries::check(reporter, &sysroot)?;
     let mut targets = targets::check(reporter, &sysroot)?;
-    linkers::check_and_add_rustflags(reporter, &environment, &sysroot, &mut targets)?;
+    linkers::check_and_add_rustflags(reporter, &env, &sysroot, &mut targets)?;
     compile::check(reporter, &sysroot, &targets)?;
     linkers::report_linker_flags(reporter, &targets);
 

--- a/ferrocene/tools/self-test/src/main.rs
+++ b/ferrocene/tools/self-test/src/main.rs
@@ -13,19 +13,10 @@ mod utils;
 #[cfg(test)]
 mod test_utils;
 
-use std::path::PathBuf;
-
 use crate::env::Env;
 use crate::error::Error;
 use crate::report::{Reporter, StderrReporter};
-
-/// The user manual states to extract all archives to the same directory.
-/// Therefore the sysroot is the grandparent of `ferrocene-self-test`
-/// (`PATH_TO_INSTALLATION_DIRECTORY/bin/ferrocene-self-test`).
-fn get_sysroot() -> Option<PathBuf> {
-    let current_exe = std::env::current_exe().ok()?;
-    Some(current_exe.parent()?.parent()?.to_path_buf())
-}
+use crate::utils::get_sysroot;
 
 fn main_inner(reporter: &dyn Reporter) -> Result<(), Error> {
     let env = Env::gather();

--- a/ferrocene/tools/self-test/src/test_utils.rs
+++ b/ferrocene/tools/self-test/src/test_utils.rs
@@ -96,32 +96,27 @@ pub(crate) struct BinBuilder<'a> {
 }
 
 impl<'a> BinBuilder<'a> {
-    #[must_use]
     pub(crate) fn mode(mut self, mode: u32) -> Self {
         self.mode = Some(mode);
         self
     }
 
-    #[must_use]
     pub(crate) fn stdout(mut self, stdout: &str) -> Self {
         self.stdout = Some(stdout.into());
         self
     }
 
-    #[must_use]
     pub(crate) fn stderr(mut self, stderr: &str) -> Self {
         self.stderr = Some(stderr.into());
         self
     }
 
-    #[must_use]
     pub(crate) fn exit(mut self, exit: i32) -> Self {
         self.exit = Some(exit);
         self
     }
 
     #[allow(non_snake_case)]
-    #[must_use]
     pub(crate) fn behaves_like_vV(self) -> Self {
         let stdout = format!(
             "release: {}
@@ -134,7 +129,6 @@ impl<'a> BinBuilder<'a> {
         self.stdout(&stdout).stderr("").exit(0).expected_args(&["-vV"])
     }
 
-    #[must_use]
     pub(crate) fn for_target(mut self, target: &str) -> Self {
         if let BinaryDestinaton::Sysroot = self.dest {
             self.dest = BinaryDestinaton::Target(target.into());
@@ -144,13 +138,11 @@ impl<'a> BinBuilder<'a> {
         }
     }
 
-    #[must_use]
     pub(crate) fn expected_args(mut self, args: &'a [&'a str]) -> Self {
         self.expected_args = Some(args);
         self
     }
 
-    #[must_use]
     pub(crate) fn program_source(mut self, source: &'static str) -> Self {
         self.program = source;
         self
@@ -250,7 +242,6 @@ pub(crate) struct TargetBuilder<'a> {
 }
 
 impl<'a> TargetBuilder<'a> {
-    #[must_use]
     pub(crate) fn lib(mut self, name: &'a str, hash: &'a str) -> Self {
         self.libraries.push((name, hash));
         self

--- a/ferrocene/tools/self-test/src/utils.rs
+++ b/ferrocene/tools/self-test/src/utils.rs
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn test_find_binary_in_path_missing_path() {
-        let env = Env { path: None, ..Env::gather() };
+        let env = Env { path: None };
 
         let err = find_binary_in_path(&env, "vim").unwrap_err();
         assert!(matches!(err, FindBinaryInPathError::NoEnvironmentVariable));

--- a/ferrocene/tools/self-test/src/utils.rs
+++ b/ferrocene/tools/self-test/src/utils.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use crate::error::{CommandError, CommandErrorKind, FindBinaryInPathError};
-use crate::Environment;
+use crate::Env;
 
 pub(crate) fn run_command(command: &mut Command) -> Result<CommandOutput, CommandError> {
     command.stdout(Stdio::piped());
@@ -44,11 +44,8 @@ pub(crate) struct CommandOutput {
     pub(crate) stdout: String,
 }
 
-pub(crate) fn find_binary_in_path(
-    environment: &Environment,
-    name: &str,
-) -> Result<PathBuf, FindBinaryInPathError> {
-    let Some(path) = &environment.path else {
+pub(crate) fn find_binary_in_path(env: &Env, name: &str) -> Result<PathBuf, FindBinaryInPathError> {
+    let Some(path) = &env.path else {
         return Err(FindBinaryInPathError::NoEnvironmentVariable);
     };
 
@@ -68,7 +65,7 @@ mod tests {
 
     #[test]
     fn test_find_binary_in_path_missing_path() {
-        let env = Environment { path: None, ..Environment::gather() };
+        let env = Env { path: None, ..Env::gather() };
 
         let err = find_binary_in_path(&env, "vim").unwrap_err();
         assert!(matches!(err, FindBinaryInPathError::NoEnvironmentVariable));
@@ -147,7 +144,7 @@ mod tests {
         assert_eq!(bin2, find_binary_in_path(&env, "vim").unwrap());
     }
 
-    fn path_env(paths: &[&Path]) -> Environment {
-        Environment { path: Some(std::env::join_paths(paths).unwrap()) }
+    fn path_env(paths: &[&Path]) -> Env {
+        Env { path: Some(std::env::join_paths(paths).unwrap()) }
     }
 }

--- a/ferrocene/tools/self-test/src/utils.rs
+++ b/ferrocene/tools/self-test/src/utils.rs
@@ -58,6 +58,14 @@ pub(crate) fn find_binary_in_path(env: &Env, name: &str) -> Result<PathBuf, Find
     Err(FindBinaryInPathError::MissingBinary { name: name.into() })
 }
 
+/// The user manual states to extract all archives to the same directory.
+/// Therefore the sysroot is the grandparent of `ferrocene-self-test`
+/// (`PATH_TO_INSTALLATION_DIRECTORY/bin/ferrocene-self-test`).
+pub(crate) fn get_sysroot() -> Option<PathBuf> {
+    let current_exe = std::env::current_exe().ok()?;
+    Some(current_exe.parent()?.parent()?.to_path_buf())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Apart from some small cleanups, the highlights of this refactor are:
- Combining all environment variable related stuff in the `env` module.
- Using `thiserror` to save 50+ lines of code.
- ~~Use `pub` instead of `pub(crate)`, because that's the same in binary crates.~~