### PR TITLE
Refactor `ferrocene/ci/split-tasks.py`

### DIFF
--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -9,7 +9,7 @@
 # an --exclude without actually executing the test in another job.
 
 
-from typing import Iterable
+from typing import Iterable, TypeAlias
 import itertools
 import shlex
 import sys
@@ -49,9 +49,11 @@ class Task:
         return self.weight < other.weight
 
 
-type JobsDefinition = dict[str, Kind]
-type Kind = dict[str, Job]
-type Job = list[str]
+# TODO: this should be `type Job = list[str]` etc., but this requires CI to update
+# to python 9.12 or above
+Job: TypeAlias = list[str]
+Kind: TypeAlias = dict[str, Job]
+JobsDefinition: TypeAlias = dict[str, Kind]
 
 # fmt: off
 JOBS_DEFINITION: JobsDefinition = {

--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -19,24 +19,20 @@ import pathlib
 REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 
 
-def find_all_compiletests(
-    *, exclude: list[str] | None = None, deprioritize: list[str] | None = None
-):
+def find_all_compiletests(exclude: list[str] | None, deprioritize: list[str] | None):
     if exclude is None:
         exclude = []
     if deprioritize is None:
-        prioritize = []
+        deprioritize = []
 
     found = []
     for entry in (REPOSITORY_ROOT / "tests").iterdir():
         if not entry.is_dir():
             continue
-        if entry.name in exclude:
+        elif entry.name in exclude:
             continue
 
-        weight = 0
-        if entry.name in deprioritize:
-            weight = 1
+        weight = 1 if entry.name in deprioritize else 0
 
         found.append(Task(str(entry.relative_to(REPOSITORY_ROOT)), weight))
     return found


### PR DESCRIPTION
This PR
- adds type hints to most functions
- refactors `find_all_compiletests` a bit

**Question:** `find_all_compiletests` is written rather generically, but I only see it called one time in the whole repository? Why is it written like that? If it does not need to be that generic we can also change the types of the arguments to be not `None`.