### PR TITLE
CI: Update `actions/checkout` to `v4`

### DIFF
--- a/.github/workflows/automation-backport.yml
+++ b/.github/workflows/automation-backport.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout the Ferrocene repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch all the history
 

--- a/.github/workflows/automation-pull-subtrees.yml
+++ b/.github/workflows/automation-pull-subtrees.yml
@@ -30,7 +30,7 @@ jobs:
     environment: automation-pull-subtrees
     steps:
       - name: Checkout the Ferrocene repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch all the history
           ref: ${{ matrix.branch }}

--- a/.github/workflows/automation-pull-upstream.yml
+++ b/.github/workflows/automation-pull-upstream.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout the Ferrocene repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch all the history
 

--- a/.github/workflows/automation-update-lockfiles.yml
+++ b/.github/workflows/automation-update-lockfiles.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout the Ferrocene repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           ref: ${{ matrix.branch }}

--- a/.github/workflows/backport-labels.yml
+++ b/.github/workflows/backport-labels.yml
@@ -53,7 +53,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Fetch the whole history
           fetch-depth: 0

--- a/.github/workflows/docs-to-github-pages.yml
+++ b/.github/workflows/docs-to-github-pages.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       jobs: ${{ steps.jobs.outputs.jobs }}
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y python3-requests python3-boto3
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Load AWS credentials into the environment
         run: ferrocene/ci/scripts/assume-aws-oidc-role.sh

--- a/ferrocene/doc/sphinx-shared-resources/.github/workflows/ci.yml
+++ b/ferrocene/doc/sphinx-shared-resources/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lints
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Some Ferrocene builders require the use of Python 3.9. Use that on CI
       # to make sure there are no surprises when we import into Ferrocene.


### PR DESCRIPTION
This should silence the warning:

![Screenshot from 2024-03-27 17-08-46](https://github.com/ferrocene/ferrocene/assets/37087391/410ee89a-91e3-4957-9e0a-51ff632d2a3d)

