### PR TITLE
Minor - doc: add aws-profile key to to config.example.toml

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -971,3 +971,8 @@
 # Download URL for the qualification technical report. If omitted, the
 # technical report will not be included in the documentation.
 #technical-report-url = <none> (url)
+
+# Amazon Web Services profile that you may have to set to work with AWS resources
+# while working locally.
+# https://public-docs.ferrocene.dev/main/qualification/internal-procedures/setup-local-env.html#configuring-aws-cli
+#aws-profile = "ferrocene-ci"


### PR DESCRIPTION
I think adding public doc link to the key section in example config is good but please correct me if I am mistaken.