### PR TITLE
Add some missing targets to self-test

### DIFF
--- a/ferrocene/tools/self-test/src/targets.rs
+++ b/ferrocene/tools/self-test/src/targets.rs
@@ -17,6 +17,9 @@ static SUPPORTED_TARGETS: &[TargetSpec] = &[
         linker: Linker::CrossCC(&["aarch64-linux-gnu-"]),
     },
     TargetSpec { triple: "aarch64-unknown-none", std: false, linker: Linker::BundledLld },
+    TargetSpec { triple: "armv8r-none-eabihf", std: false, linker: Linker::BundledLld },
+    TargetSpec { triple: "thumbv7em-none-eabihf", std: false, linker: Linker::BundledLld },
+    TargetSpec { triple: "thumbv7em-none-eabi", std: false, linker: Linker::BundledLld },
 ];
 
 #[derive(Debug)]


### PR DESCRIPTION
This adds `armv8r-none-eabihf`, `thumbv7em-none-eabihf`, and `thumbv7em-none-eabi` to `ferrocene-self-test`'s checks.

It avoids `wasm32-unknown-unknown` at this time as it is uncompatible with current methodology:

```bash
❯ ./ferrocene-self-test
    Info: using sysroot /tmp/tmp.jJc1x3RaAO/sysroot
 Success: binary rustc is valid
 Success: binary rustdoc is valid
 Success: binary cargo is valid
 Success: target installed correctly: x86_64-unknown-linux-gnu
 Success: target installed correctly: aarch64-unknown-linux-gnu
 Success: target installed correctly: aarch64-unknown-none
 Success: target installed correctly: armv8r-none-eabihf
 Success: target installed correctly: thumbv7em-none-eabihf
 Success: target installed correctly: thumbv7em-none-eabi
 Success: target installed correctly: wasm32-unknown-unknown
 Success: bundled linker detected
 Success: bundled linker-wrapper detected
 Success: Found C compiler `cc` for target `x86_64-unknown-linux-gnu`
 Success: Found C compiler `aarch64-linux-gnu-gcc` for target `aarch64-unknown-linux-gnu`
 Skipped: Target `aarch64-unknown-none` does not require a C compiler
 Skipped: Target `armv8r-none-eabihf` does not require a C compiler
 Skipped: Target `thumbv7em-none-eabihf` does not require a C compiler
 Skipped: Target `thumbv7em-none-eabi` does not require a C compiler
 Skipped: Target `wasm32-unknown-unknown` does not require a C compiler
 Success: compiled sample program `addition.rs` for target x86_64-unknown-linux-gnu
 Success: compiled sample program `subtraction.rs` for target x86_64-unknown-linux-gnu
 Success: compiled sample program `subtraction-sys.rs` for target x86_64-unknown-linux-gnu
 Success: compiled and ran sample program `assertion.rs` for target x86_64-unknown-linux-gnu
 Success: compiled sample program `addition.rs` for target aarch64-unknown-linux-gnu
 Success: compiled sample program `subtraction.rs` for target aarch64-unknown-linux-gnu
 Success: compiled sample program `subtraction-sys.rs` for target aarch64-unknown-linux-gnu
 Success: compiled sample program `assertion.rs` for target aarch64-unknown-linux-gnu
 Success: compiled sample program `addition.rs` for target aarch64-unknown-none
 Success: compiled sample program `subtraction.rs` for target aarch64-unknown-none
 Success: compiled sample program `subtraction-sys.rs` for target aarch64-unknown-none
 Success: compiled sample program `assertion.rs` for target aarch64-unknown-none
 Success: compiled sample program `addition.rs` for target armv8r-none-eabihf
 Success: compiled sample program `subtraction.rs` for target armv8r-none-eabihf
 Success: compiled sample program `subtraction-sys.rs` for target armv8r-none-eabihf
 Success: compiled sample program `assertion.rs` for target armv8r-none-eabihf
 Success: compiled sample program `addition.rs` for target thumbv7em-none-eabihf
 Success: compiled sample program `subtraction.rs` for target thumbv7em-none-eabihf
 Success: compiled sample program `subtraction-sys.rs` for target thumbv7em-none-eabihf
 Success: compiled sample program `assertion.rs` for target thumbv7em-none-eabihf
 Success: compiled sample program `addition.rs` for target thumbv7em-none-eabi
 Success: compiled sample program `subtraction.rs` for target thumbv7em-none-eabi
 Success: compiled sample program `subtraction-sys.rs` for target thumbv7em-none-eabi
 Success: compiled sample program `assertion.rs` for target thumbv7em-none-eabi
 Success: compiled sample program `addition.rs` for target wasm32-unknown-unknown
 Success: compiled sample program `subtraction.rs` for target wasm32-unknown-unknown
 Success: compiled sample program `subtraction-sys.rs` for target wasm32-unknown-unknown
   Error: unexpected compilation artifact 'assertion.wasm' after compiling sample program `assertion.rs`
    Note: the error code is FST_022
```

The checker needs to be aware of target specific extensions. (Eg on Windows `.exe` will likely be an issue as well!)