### PR TITLE
adds missing proxied binaries to the tarball list

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -394,6 +394,9 @@ impl Step for Rustc {
 
         tarball.ferrocene_proxied_binary("bin/rustc");
         tarball.ferrocene_proxied_binary("bin/rustdoc");
+        tarball.ferrocene_proxied_binary("bin/rust-gdb");
+        tarball.ferrocene_proxied_binary("bin/rust-gdbgui");
+        tarball.ferrocene_proxied_binary("bin/rust-lldb");
         return tarball.generate();
 
         fn prepare_image(builder: &Builder<'_>, compiler: Compiler, image: &Path) {

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1081,8 +1081,8 @@ impl Step for Cargo {
         tarball.add_renamed_file(etc.join("cargo.bashcomp.sh"), "etc/bash_completion.d", "cargo");
         tarball.add_dir(etc.join("man"), "share/man/man1");
         tarball.add_legal_and_readme_to("share/doc/cargo");
-        tarball.ferrocene_proxied_binary("bin/cargo");
 
+        tarball.ferrocene_proxied_binary("bin/cargo");
         Some(tarball.generate())
     }
 }
@@ -1215,6 +1215,9 @@ impl Step for Clippy {
         tarball.add_file(clippy, "bin", 0o755);
         tarball.add_file(cargoclippy, "bin", 0o755);
         tarball.add_legal_and_readme_to("share/doc/clippy");
+
+        tarball.ferrocene_proxied_binary("bin/clippy");
+        tarball.ferrocene_proxied_binary("bin/cargo-clippy");
         Some(tarball.generate())
     }
 }
@@ -1408,6 +1411,9 @@ impl Step for Rustfmt {
         tarball.add_file(rustfmt, "bin", 0o755);
         tarball.add_file(cargofmt, "bin", 0o755);
         tarball.add_legal_and_readme_to("share/doc/rustfmt");
+
+        tarball.ferrocene_proxied_binary("bin/rustfmt");
+        tarball.ferrocene_proxied_binary("bin/cargofmt");
         Some(tarball.generate())
     }
 }

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1413,7 +1413,7 @@ impl Step for Rustfmt {
         tarball.add_legal_and_readme_to("share/doc/rustfmt");
 
         tarball.ferrocene_proxied_binary("bin/rustfmt");
-        tarball.ferrocene_proxied_binary("bin/cargofmt");
+        tarball.ferrocene_proxied_binary("bin/cargo-fmt");
         Some(tarball.generate())
     }
 }

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1216,7 +1216,8 @@ impl Step for Clippy {
         tarball.add_file(cargoclippy, "bin", 0o755);
         tarball.add_legal_and_readme_to("share/doc/clippy");
 
-        tarball.ferrocene_proxied_binary("bin/clippy");
+        // the name of the binary is set in the tools.rs and not here
+        tarball.ferrocene_proxied_binary("bin/clippy-driver");
         tarball.ferrocene_proxied_binary("bin/cargo-clippy");
         Some(tarball.generate())
     }

--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -298,7 +298,7 @@ impl Step for SelfTest {
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         let self_test = builder.ensure(crate::ferrocene::tool::SelfTest { target: self.target });
 
-        let tarball = Tarball::new(builder, "ferrocene-self-test", &self.target.triple);
+        let mut tarball = Tarball::new(builder, "ferrocene-self-test", &self.target.triple);
         tarball.add_file(self_test, "bin", 0o755);
 
         tarball.ferrocene_proxied_binary("bin/ferrocene-self-test");

--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -300,6 +300,8 @@ impl Step for SelfTest {
 
         let tarball = Tarball::new(builder, "ferrocene-self-test", &self.target.triple);
         tarball.add_file(self_test, "bin", 0o755);
+
+        tarball.ferrocene_proxied_binary("bin/ferrocene-self-test");
         tarball.generate()
     }
 }


### PR DESCRIPTION
adds proxy symlink to the following:

- rust-gdb
- rust-gdbgui
- rust-lldb
- clippy-driver
- cargo-clippy
- rustfmt
- cargo-fmt
- ferrocene-self-test

To test: 

- Run the full build using `bors try`.
- Then fetch the tarballs from the run's aws s3 bucket
- Untar and check the JSON files in `share/criticaltrust/ferrocene/` 
- The right binaries should have `needs-proxy: true` in the `signed` section/key


Ticket: 86944n9mwhe