### PR TITLE
avoid confusion and simplify

### DIFF
--- a/ferrocene/doc/user-manual/src/using-compiler/executable.rst
+++ b/ferrocene/doc/user-manual/src/using-compiler/executable.rst
@@ -4,8 +4,7 @@
 Building an executable
 ======================
 
-This chapter describes how to build an executable using Ferrocene's rustc
-compiler.
+This chapter describes how to build an executable using rustc.
 
 The examples in this chapter assume the following directory structure:
 

--- a/ferrocene/doc/user-manual/src/using-compiler/file-formats.rst
+++ b/ferrocene/doc/user-manual/src/using-compiler/file-formats.rst
@@ -4,8 +4,7 @@
 File formats
 ============
 
-This chapter describes the file formats recognized by Ferrocene's rustc
-compiler.
+This chapter describes the file formats recognized by rustc.
 
 A `source file <../../specification/glossary.html#source-file>`_ that contains
 Rust code must have file extension ``rs``, for example:
@@ -20,7 +19,7 @@ Libraries
 A library is a reusable collection of non-volatile resources, such as
 functionality and data, used by another library or executable.
 
-Compiling a source file with name ``name`` using Ferrocene's rustc compiler
+Compiling a source file with name ``name`` using rustc
 produces a library with name ``libname``, where the file extension is either
 ``rlib`` for a Rust static library or ``so`` for a native dynamic library.
 
@@ -41,7 +40,7 @@ Executables
 An executable (or a binary) causes a computer to perform indicated tasks
 according to encoded instructions.
 
-Compiling a source file with name ``name`` using Ferrocene's rustc compiler
+Compiling a source file with name ``name`` using rustc
 produces an executable with name ``name``, without a file extension.
 
 The file format of an executable is target-dependent. Consult the documentation

--- a/ferrocene/doc/user-manual/src/using-compiler/library.rst
+++ b/ferrocene/doc/user-manual/src/using-compiler/library.rst
@@ -4,8 +4,7 @@
 Building a library
 ==================
 
-This chapter describes how to build a library using Ferrocene's rustc
-compiler.
+This chapter describes how to build a library using rustc.
 
 The examples in this chapter assume the following directory structure:
 


### PR DESCRIPTION
- This could lead people to think the behavior is different from upstream.
- "rustc" is short for Rust compiler... we need not add another "compiler"