### PR TITLE
Fix "last commit detection" in mirror-sphinx-shared-resources automation

### DIFF
--- a/ferrocene/ci/scripts/mirror-sphinx-shared-resources.py
+++ b/ferrocene/ci/scripts/mirror-sphinx-shared-resources.py
@@ -66,7 +66,7 @@ def get_last_mirrored_commit(mirror_repo_path: str) -> str:
     commit_messages = run(["git", "log", "--format=%B"], mirror_repo_path)
     for line in commit_messages.splitlines():
         if line.startswith(MIRRORED_MARKER):
-            hash = line.lstrip(MIRRORED_MARKER)
+            hash = line.removeprefix(MIRRORED_MARKER)
             return hash
     raise Exception("could not find mirrored-commit")
 


### PR DESCRIPTION
`str.lstrip` is too hungry[^1], therefore `str.removeprefix`[^2] will take over from now on and hopefully behave better.

`str.removeprefix` is new in Python 3.9, which is okay since the GitHub Actions Runner contains Python 3.10[^3].

[^1]: It ate a leading `e` of a commit hash 😱 
[^2]: https://docs.python.org/3/library/stdtypes.html#str.removeprefix
[^3]: https://github.com/actions/runner-images/blob/069e7c963c42992e601f64880bccd98681b953dc/images/ubuntu/Ubuntu2204-Readme.md?plain=1#L27