### PR TITLE
Check for `flip-link` updates every day

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    allow:
+      - dependency-name: "ferrocene/tools/flip-link"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Taken from https://stackoverflow.com/a/75078947.

The configuration[^1] seems to make sense, but I am unsure how to test it.

I also considered to set the update interval to to "weekly", since `flip-link` only receives updates rarely. But I want dependabot to pick up the update within a day _when_ we publish a new version.

[^1]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file