### PR TITLE
Refactor `ferrocene-self-test`

### DIFF
--- a/ferrocene/tools/self-test/src/compile.rs
+++ b/ferrocene/tools/self-test/src/compile.rs
@@ -64,10 +64,7 @@ pub(crate) fn check(
     sysroot: &Path,
     targets: &[Target],
 ) -> Result<(), Error> {
-    for target in targets {
-        check_target(reporter, sysroot, target, SAMPLE_PROGRAMS)?;
-    }
-    Ok(())
+    targets.iter().try_for_each(|target| check_target(reporter, sysroot, target, SAMPLE_PROGRAMS))
 }
 
 fn check_target(

--- a/ferrocene/tools/self-test/src/targets.rs
+++ b/ferrocene/tools/self-test/src/targets.rs
@@ -130,18 +130,15 @@ fn find_libraries_in(path: &Path) -> Result<HashMap<String, usize>, Error> {
 
 /// Extract `name` from `libname-hash.rlib`.
 fn extract_library_name(file_path: &Path) -> Option<&str> {
-    let (library, hash) = file_path
+    let (library_name, hash) = file_path
         .file_name()?
         .to_str()?
         .strip_prefix("lib")?
         .strip_suffix(".rlib")?
         .rsplit_once('-')?;
 
-    if hash.len() != 16 || hash.chars().any(|c| !c.is_ascii_hexdigit()) || library.is_empty() {
-        None
-    } else {
-        Some(library)
-    }
+    (hash.len() == 16 && hash.chars().all(|c| c.is_ascii_hexdigit()) && !library_name.is_empty())
+        .then_some(library_name)
 }
 
 #[cfg(test)]

--- a/ferrocene/tools/self-test/src/targets.rs
+++ b/ferrocene/tools/self-test/src/targets.rs
@@ -70,15 +70,11 @@ fn check_target(
         return Ok(CheckTargetOutcome::Missing);
     }
 
-    check_libraries(
-        target,
-        &target_dir,
-        if target.std {
-            &["core", "alloc", "std", "test", "proc_macro"]
-        } else {
-            &["core", "alloc"]
-        },
-    )?;
+    let expected_libs = match target.std {
+        true => ["core", "alloc", "std", "test", "proc_macro"].as_slice(),
+        false => ["core", "alloc"].as_slice(),
+    };
+    check_libraries(target, &target_dir, expected_libs)?;
 
     reporter.success(&format!("target installed correctly: {}", target.triple));
     Ok(CheckTargetOutcome::Found)

--- a/ferrocene/tools/self-test/src/targets.rs
+++ b/ferrocene/tools/self-test/src/targets.rs
@@ -256,17 +256,21 @@ mod tests {
 
     #[test]
     fn test_find_libraries_in() {
-        let dir = tempfile::tempdir().unwrap();
-        let dir = dir.path();
+        let triple = "x86_64-unknown-linux-gnu";
 
-        let create_lib = |name| std::fs::write(dir.join(name), b"").unwrap();
-        create_lib("libcore-0123456789abcdef.rlib");
-        create_lib("libcore-abcdef0123456789.rlib");
-        create_lib("liballoc-0123456789abcdef.rlib");
-        create_lib("libproc_macro-0123456789abcdef.rlib");
-        create_lib("foo-0123456789abcdef.so"); // Invalid files are not counted.
+        let utils = TestUtils::new();
+        utils
+            .target(triple)
+            .lib("core", "0123456789abcdef")
+            .lib("core", "abcdef0123456789")
+            .lib("alloc", "0123456789abcdef")
+            .lib("proc_macro", "0123456789abcdef")
+            .create();
 
-        let output = find_libraries_in(dir).unwrap();
+        let lib_dir = utils.target_dir(triple).join("lib");
+        std::fs::write(lib_dir.join("foo-0123456789abcdef.so"), b"").unwrap(); // Invalid files are not counted.
+
+        let output = find_libraries_in(&lib_dir).unwrap();
         assert_eq!(output.len(), 3);
         assert_eq!(output.get("core"), Some(&2));
         assert_eq!(output.get("alloc"), Some(&1));

--- a/ferrocene/tools/self-test/src/test_utils.rs
+++ b/ferrocene/tools/self-test/src/test_utils.rs
@@ -26,7 +26,7 @@ impl TestUtils {
         Self {
             env: Env { path: Some(std::env::join_paths([&sysroot.path().join("bin")]).unwrap()) },
             sysroot,
-            reports: ReportsCollector { reports: RefCell::new(Vec::new()) },
+            reports: ReportsCollector::new(),
         }
     }
 
@@ -262,6 +262,12 @@ impl<'a> TargetBuilder<'a> {
 
 struct ReportsCollector {
     reports: RefCell<Vec<Report>>,
+}
+
+impl ReportsCollector {
+    fn new() -> Self {
+        Self { reports: RefCell::new(Vec::new()) }
+    }
 }
 
 impl Reporter for ReportsCollector {

--- a/ferrocene/tools/self-test/src/test_utils.rs
+++ b/ferrocene/tools/self-test/src/test_utils.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: The Ferrocene Developers
 
+mod bin_builder;
+
 use std::cell::RefCell;
-use std::io::Write;
-use std::os::unix::prelude::PermissionsExt;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::path::Path;
 
 use tempfile::TempDir;
 
+use self::bin_builder::BinBuilder;
 use crate::env::{self, Env};
 use crate::error::Error;
 use crate::report::Reporter;
@@ -35,17 +35,7 @@ impl TestUtils {
     }
 
     pub(crate) fn bin<'a>(&'a self, name: &'a str) -> BinBuilder<'a> {
-        BinBuilder {
-            utils: self,
-            name,
-            mode: None,
-            stdout: None,
-            stderr: None,
-            exit: None,
-            expected_args: None,
-            dest: BinaryDestinaton::Sysroot,
-            program: BIN_PROGRAM,
-        }
+        BinBuilder::new(self, name)
     }
 
     pub(crate) fn target<'a>(&'a self, name: &'a str) -> TargetBuilder<'a> {
@@ -80,131 +70,6 @@ impl TestUtils {
     pub(crate) fn assert_no_reports(&self) {
         assert!(self.reports.reports.borrow_mut().is_empty());
     }
-}
-
-#[must_use]
-pub(crate) struct BinBuilder<'a> {
-    utils: &'a TestUtils,
-    name: &'a str,
-    mode: Option<u32>,
-    stdout: Option<String>,
-    stderr: Option<String>,
-    exit: Option<i32>,
-    expected_args: Option<&'a [&'a str]>,
-    dest: BinaryDestinaton,
-    program: &'static str,
-}
-
-impl<'a> BinBuilder<'a> {
-    pub(crate) fn mode(mut self, mode: u32) -> Self {
-        self.mode = Some(mode);
-        self
-    }
-
-    pub(crate) fn stdout(mut self, stdout: &str) -> Self {
-        self.stdout = Some(stdout.into());
-        self
-    }
-
-    pub(crate) fn stderr(mut self, stderr: &str) -> Self {
-        self.stderr = Some(stderr.into());
-        self
-    }
-
-    pub(crate) fn exit(mut self, exit: i32) -> Self {
-        self.exit = Some(exit);
-        self
-    }
-
-    #[allow(non_snake_case)]
-    pub(crate) fn behaves_like_vV(self) -> Self {
-        let stdout = format!(
-            "release: {}
-            host: {}
-            commit-hash: {}\n",
-            env::CFG_RELEASE,
-            env::SELFTEST_TARGET,
-            env::SELFTEST_RUST_HASH.unwrap_or("unknown")
-        );
-        self.stdout(&stdout).stderr("").exit(0).expected_args(&["-vV"])
-    }
-
-    pub(crate) fn for_target(mut self, target: &str) -> Self {
-        if let BinaryDestinaton::Sysroot = self.dest {
-            self.dest = BinaryDestinaton::Target(target.into());
-            self
-        } else {
-            panic!("called for_target() when another destination was already set");
-        }
-    }
-
-    pub(crate) fn expected_args(mut self, args: &'a [&'a str]) -> Self {
-        self.expected_args = Some(args);
-        self
-    }
-
-    pub(crate) fn program_source(mut self, source: &'static str) -> Self {
-        self.program = source;
-        self
-    }
-
-    pub(crate) fn create(self) -> PathBuf {
-        let bin_root = match self.dest {
-            BinaryDestinaton::Sysroot => self.utils.sysroot.path().join("bin"),
-            BinaryDestinaton::Target(target) => {
-                self.utils.sysroot.path().join("lib").join("rustlib").join(target).join("bin")
-            }
-        };
-        let bin = bin_root.join(self.name);
-        // self.name might have included a sub-directory, so re-fetch the
-        // containing directory's path
-        let bin_dir = bin.parent().expect("path should have a parent");
-
-        std::fs::create_dir_all(bin_dir).unwrap();
-        if bin.exists() {
-            std::fs::remove_file(&bin).unwrap();
-        }
-
-        let mut rustc_path = PathBuf::from(env!("CARGO"));
-        rustc_path.pop();
-        rustc_path.push("rustc");
-
-        let mut rustc = Command::new(rustc_path);
-        rustc.stdin(Stdio::piped());
-        rustc.arg("-");
-        rustc.arg("-o").arg(&bin);
-        rustc.args(["--edition", "2021"]);
-        if let Some(stdout) = self.stdout {
-            rustc.env("OVERRIDE_STDOUT", stdout);
-        }
-        if let Some(stderr) = self.stderr {
-            rustc.env("OVERRIDE_STDERR", stderr);
-        }
-        if let Some(exit) = self.exit {
-            rustc.env("OVERRIDE_EXIT", exit.to_string());
-        }
-        if let Some(expected_args) = self.expected_args {
-            rustc.env("EXPECTED_ARGS", expected_args.join("\t"));
-        }
-
-        let mut rustc = rustc.spawn().unwrap();
-        let stdin = rustc.stdin.as_mut().unwrap();
-        stdin.write_all(self.program.as_bytes()).unwrap();
-        assert!(rustc.wait().unwrap().success());
-
-        if let Some(mode) = self.mode {
-            let mut perms = bin.metadata().unwrap().permissions();
-            perms.set_mode(mode);
-            std::fs::set_permissions(&bin, perms).unwrap();
-        }
-
-        bin
-    }
-}
-
-enum BinaryDestinaton {
-    Sysroot,
-    Target(String),
 }
 
 pub(crate) struct CliVersionContent<'a> {
@@ -300,22 +165,3 @@ enum Report {
     Info(String),
     Error,
 }
-
-const BIN_PROGRAM: &str = r#"
-fn main() {
-    if let Some(expected_args) = option_env!("EXPECTED_ARGS") {
-        let expected = expected_args.split("\t").collect::<Vec<_>>();
-        let found = std::env::args().skip(1).collect::<Vec<_>>();
-        assert_eq!(expected, found);
-    }
-    if let Some(stdout) = option_env!("OVERRIDE_STDOUT") {
-        print!("{stdout}");
-    }
-    if let Some(stderr) = option_env!("OVERRIDE_STDERR") {
-        eprint!("{stderr}");
-    }
-    if let Some(code) = option_env!("OVERRIDE_EXIT") {
-        std::process::exit(code.parse().unwrap());
-    }
-}
-"#;

--- a/ferrocene/tools/self-test/src/test_utils.rs
+++ b/ferrocene/tools/self-test/src/test_utils.rs
@@ -4,7 +4,7 @@
 mod bin_builder;
 
 use std::cell::RefCell;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use tempfile::TempDir;
 
@@ -32,6 +32,10 @@ impl TestUtils {
 
     pub(crate) fn sysroot(&self) -> &Path {
         self.sysroot.path()
+    }
+
+    pub(crate) fn target_dir(&self, target: &str) -> PathBuf {
+        self.sysroot().join("lib").join("rustlib").join(target)
     }
 
     pub(crate) fn bin<'a>(&'a self, name: &'a str) -> BinBuilder<'a> {
@@ -113,7 +117,7 @@ impl<'a> TargetBuilder<'a> {
     }
 
     pub(crate) fn create(self) {
-        let target_dir = self.utils.sysroot().join("lib").join("rustlib").join(self.name);
+        let target_dir = self.utils.target_dir(self.name);
         std::fs::create_dir_all(&target_dir).unwrap();
 
         let lib_dir = target_dir.join("lib");

--- a/ferrocene/tools/self-test/src/test_utils/bin_builder.rs
+++ b/ferrocene/tools/self-test/src/test_utils/bin_builder.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: The Ferrocene Developers
+
+use std::io::Write;
+use std::os::unix::prelude::PermissionsExt;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use super::TestUtils;
+use crate::env;
+
+#[must_use]
+pub(crate) struct BinBuilder<'a> {
+    utils: &'a TestUtils,
+    name: &'a str,
+    mode: Option<u32>,
+    stdout: Option<String>,
+    stderr: Option<String>,
+    exit: Option<i32>,
+    expected_args: Option<&'a [&'a str]>,
+    dest: BinaryDestinaton,
+    program: &'static str,
+}
+
+impl<'a> BinBuilder<'a> {
+    pub(super) fn new(utils: &'a TestUtils, name: &'a str) -> Self {
+        Self {
+            utils,
+            name,
+            mode: None,
+            stdout: None,
+            stderr: None,
+            exit: None,
+            expected_args: None,
+            dest: BinaryDestinaton::Sysroot,
+            program: BIN_PROGRAM,
+        }
+    }
+
+    pub(crate) fn mode(mut self, mode: u32) -> Self {
+        self.mode = Some(mode);
+        self
+    }
+
+    pub(crate) fn stdout(mut self, stdout: &str) -> Self {
+        self.stdout = Some(stdout.into());
+        self
+    }
+
+    pub(crate) fn stderr(mut self, stderr: &str) -> Self {
+        self.stderr = Some(stderr.into());
+        self
+    }
+
+    pub(crate) fn exit(mut self, exit: i32) -> Self {
+        self.exit = Some(exit);
+        self
+    }
+
+    #[allow(non_snake_case)]
+    pub(crate) fn behaves_like_vV(self) -> Self {
+        let stdout = format!(
+            "release: {}
+            host: {}
+            commit-hash: {}\n",
+            env::CFG_RELEASE,
+            env::SELFTEST_TARGET,
+            env::SELFTEST_RUST_HASH.unwrap_or("unknown")
+        );
+        self.stdout(&stdout).stderr("").exit(0).expected_args(&["-vV"])
+    }
+
+    pub(crate) fn for_target(mut self, target: &str) -> Self {
+        if let BinaryDestinaton::Sysroot = self.dest {
+            self.dest = BinaryDestinaton::Target(target.into());
+            self
+        } else {
+            panic!("called for_target() when another destination was already set");
+        }
+    }
+
+    pub(crate) fn expected_args(mut self, args: &'a [&'a str]) -> Self {
+        self.expected_args = Some(args);
+        self
+    }
+
+    pub(crate) fn program_source(mut self, source: &'static str) -> Self {
+        self.program = source;
+        self
+    }
+
+    pub(crate) fn create(self) -> PathBuf {
+        let bin_root = match self.dest {
+            BinaryDestinaton::Sysroot => self.utils.sysroot.path().join("bin"),
+            BinaryDestinaton::Target(target) => {
+                self.utils.sysroot.path().join("lib").join("rustlib").join(target).join("bin")
+            }
+        };
+        let bin = bin_root.join(self.name);
+        // self.name might have included a sub-directory, so re-fetch the
+        // containing directory's path
+        let bin_dir = bin.parent().expect("path should have a parent");
+
+        std::fs::create_dir_all(bin_dir).unwrap();
+        if bin.exists() {
+            std::fs::remove_file(&bin).unwrap();
+        }
+
+        let mut rustc_path = PathBuf::from(env!("CARGO"));
+        rustc_path.pop();
+        rustc_path.push("rustc");
+
+        let mut rustc = Command::new(rustc_path);
+        rustc.stdin(Stdio::piped());
+        rustc.arg("-");
+        rustc.arg("-o").arg(&bin);
+        rustc.args(["--edition", "2021"]);
+        if let Some(stdout) = self.stdout {
+            rustc.env("OVERRIDE_STDOUT", stdout);
+        }
+        if let Some(stderr) = self.stderr {
+            rustc.env("OVERRIDE_STDERR", stderr);
+        }
+        if let Some(exit) = self.exit {
+            rustc.env("OVERRIDE_EXIT", exit.to_string());
+        }
+        if let Some(expected_args) = self.expected_args {
+            rustc.env("EXPECTED_ARGS", expected_args.join("\t"));
+        }
+
+        let mut rustc = rustc.spawn().unwrap();
+        let stdin = rustc.stdin.as_mut().unwrap();
+        stdin.write_all(self.program.as_bytes()).unwrap();
+        assert!(rustc.wait().unwrap().success());
+
+        if let Some(mode) = self.mode {
+            let mut perms = bin.metadata().unwrap().permissions();
+            perms.set_mode(mode);
+            std::fs::set_permissions(&bin, perms).unwrap();
+        }
+
+        bin
+    }
+}
+
+enum BinaryDestinaton {
+    Sysroot,
+    Target(String),
+}
+
+const BIN_PROGRAM: &str = r#"
+fn main() {
+    if let Some(expected_args) = option_env!("EXPECTED_ARGS") {
+        let expected = expected_args.split("\t").collect::<Vec<_>>();
+        let found = std::env::args().skip(1).collect::<Vec<_>>();
+        assert_eq!(expected, found);
+    }
+    if let Some(stdout) = option_env!("OVERRIDE_STDOUT") {
+        print!("{stdout}");
+    }
+    if let Some(stderr) = option_env!("OVERRIDE_STDERR") {
+        eprint!("{stderr}");
+    }
+    if let Some(code) = option_env!("OVERRIDE_EXIT") {
+        std::process::exit(code.parse().unwrap());
+    }
+}
+"#;


### PR DESCRIPTION
Changes
- move BinBuilder to own module
- reduce repetition in target tests
- use `TestUtils` in `test_find_libraries_in`
- some drive-by changes
- please double check the binary condition in `extract_library_name` is still correct (I inverted it to simplify the code)