### PR TITLE
Include `.gitmodules` in the source tarball

### DIFF
--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -111,6 +111,7 @@ impl Step for SourceTarball {
             "x",
             "x.py",
             "x.ps1",
+            ".gitmodules",
         ];
         const EXTRA_CARGO_TOMLS: &[&str] = &[
             "compiler/rustc_codegen_cranelift/Cargo.toml",


### PR DESCRIPTION
A recent-ish change in bootstrap (not sure exactly which PR) started requiring the .gitmodules file to be included in the source tarball, otherwise bootstrap will not start.

The upstream source tarball does include that file, so this commit replicates the change in Ferrocene too.