### PR TITLE
Refactor `tools/ferrocene/traceability-matrix`

### DIFF
--- a/ferrocene/tools/traceability-matrix/README.md
+++ b/ferrocene/tools/traceability-matrix/README.md
@@ -13,11 +13,11 @@ While it says "written" it is (fortunately) generated semi-automatically.
 
 How does it work?
 
-On the one hand, we have the Ferrocene Language Specification (FLS). Simply speaking, the FLS is a list of statements, which are grouped in sections and subsections. Each section, subsection and statement has a randombly-generated unique id, examples being `fls_wt81sbsecmu0` and `fls_3xvm61x0t251`.
+On the one hand, we have the Ferrocene Language Specification (FLS) and the specification of the command-line interface (CLI) of `rustc`. Simply speaking, both specifications are a list of statements, which are grouped in sections and subsections. Each section, subsection and statement has a randombly-generated unique id, examples being `fls_3xvm61x0t251` (for the FLS) and `um_rustc_cap_lints` (for the CLI).
 
-On the other hand we have tests. We need to find at least one test for each section from the FLS. This test is then annotated with the id of the statement. This annotating is happening through a comment which is getting added to the end of the file. It is possible to annotate one test with multiple ids.
+On the other hand we have tests. We need to find at least one test for each section of the specification. This test is then annotated with the id of the section. This annotating is happening through a comment which is getting added to the end of the file. It is possible to annotate one test with multiple ids.
 
-Currently we annotate tests in `tests/ui` (for the FLS) and `tests/run-make` (for the command-line interface).
+Currently we annotate tests in `tests/ui` (for the FLS), `tests/ui/ferrocene/compiler-arguments` (for the CLI) and `tests/run-make` (for the CLI).
 
 For example `tests/ui/borrowck/borrowck-break-uninit-2.rs` got annotated with `fls_3xvm61x0t251` ([file at c80de1f](https://github.com/ferrocene/ferrocene/blob/c80de1fa7eecdfbe4579b13e2aaa93fb0586f9c6/tests/ui/borrowck/borrowck-break-uninit-2.rs)):
 

--- a/ferrocene/tools/traceability-matrix/README.md
+++ b/ferrocene/tools/traceability-matrix/README.md
@@ -1,0 +1,101 @@
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: The Ferrocene Developers -->
+
+# traceability-matrix
+
+The traceability matrix is part of our qualification material. You can find it at https://public-docs.ferrocene.dev/main/qualification/traceability-matrix.html.
+
+In the overview it states that it is:
+
+> A matrix that ties the specifics of the Ferrocene Language Specification to the test suite. This was written to ensure that all documented requirements are covered.
+
+While it says "written" it is (fortunately) generated semi-automatically.
+
+How does it work?
+
+On the one hand we have the Ferrocene language specification (FLS). Simply speaking the FLS is a list of statements, which are grouped in sections and subsections. Each section, subsection and statement has a unique id, which look something like `fls_wt81sbsecmu0` or `fls_3xvm61x0t251`.
+
+On the other hand we have tests. We need to find at least one test for each statement from the FLS. This test is then annotated with the id of the statement. This annotating is happening through a comment which is getting added to the end of the file. It is possible to annotate one test with multiple ids.
+
+For example `tests/ui/borrowck/borrowck-break-uninit-2.rs` got annotated with `fls_3xvm61x0t251` ([file at c80de1f](https://github.com/ferrocene/ferrocene/blob/c80de1fa7eecdfbe4579b13e2aaa93fb0586f9c6/tests/ui/borrowck/borrowck-break-uninit-2.rs)):
+
+```rust
+fn foo() -> isize {
+    let x: isize;
+
+    while 1 != 2  {
+        break;
+        x = 0;
+    }
+
+    println!("{}", x); //~ ERROR E0381
+
+    return 17;
+}
+
+fn main() { println!("{}", foo()); }
+
+//
+// ferrocene-annotations: fls_3xvm61x0t251
+// Initialization
+```
+
+It is also possible to annotate bulks of tests. This happens through `ferrocene-annotations` files, which basically contain the same comments. For example `tests/ui/borrowck/ferrocene-annotations` contains three ids:
+
+```
+// ferrocene-annotations: fls_a14slch83hzn
+// Borrowing
+//
+// ferrocene-annotations: fls_411up5z0b6n6
+// Lexical Elements
+//
+// ferrocene-annotations: fls_fgnllgz5k3e6
+// Lexical Elements, Separators, and Punctuation
+```
+
+This annotates all the tests in `tests/ui/borrowck/` with those three ids.
+
+When using bulk annotation, individual tests can still be annotated with additional ids, as is the case for `tests/ui/borrowck/borrowck-break-uninit-2.rs`. It is annotated with four ids. The three from `tests/ui/borrowck/ferrocene-annotations` and one from the file itself.
+
+All of this was manual so far, so where does the automation come in?
+
+The automation is in the `traceability-matrix` tool (`ferrocene/tools/traceability-matrix`) and `bootstrap`.
+
+The `./x doc ferrocene/tools/traceability-matrix` (or `./x run` to be precise) implementation utilizes `compiletest` to go through all the tests in `tests/ui` and `tests/run-make` and collect the annotations from there. This required patching compiletest. It generates two json files in `build/x86_64-unknown-linux-gnu/ferrocene/test-annotations/` (one for each test suite).
+
+One of them is `tests-ui.json`:
+
+```json
+{
+    "bulk_annotations_file_name": "ferrocene-annotations",
+    "tests": [
+        // <...>
+        {
+            "file": "/home/urhengulas/Documents/github.com/ferrocene/ferrocene/tests/ui/borrowck/borrowck-break-uninit-2.rs",
+            "annotations": [
+                {
+                    "id": "fls_3xvm61x0t251",
+                    "file": "/home/urhengulas/Documents/github.com/ferrocene/ferrocene/tests/ui/borrowck/borrowck-break-uninit-2.rs"
+                },
+                {
+                    "id": "fls_a14slch83hzn",
+                    "file": "/home/urhengulas/Documents/github.com/ferrocene/ferrocene/tests/ui/borrowck/ferrocene-annotations"
+                },
+                {
+                    "id": "fls_411up5z0b6n6",
+                    "file": "/home/urhengulas/Documents/github.com/ferrocene/ferrocene/tests/ui/borrowck/ferrocene-annotations"
+                },
+                {
+                    "id": "fls_fgnllgz5k3e6",
+                    "file": "/home/urhengulas/Documents/github.com/ferrocene/ferrocene/tests/ui/borrowck/ferrocene-annotations"
+                }
+            ]
+        },
+        // <...>
+    ]
+}
+```
+
+The top-level object only contains two fields. The first is `bulk_annotations_file_name` which is the name of the file to annotate bulks of tests. The second is `tests` which is the interesting part, a list of test objects. There is one test object for each test file. A test object contains `file`, which is the path of the file, and `annotations`, which is a list of one or more annotation objects. A annotation object contains the `id` from the FLS and the `file` path the annotation is coming from. This is either the test file itself, or a bulk annotation file.
+
+The `traceability-matrix` tool then picks up the json files and generates the HTML report from it. Tada 🎉

--- a/ferrocene/tools/traceability-matrix/README.md
+++ b/ferrocene/tools/traceability-matrix/README.md
@@ -17,7 +17,7 @@ On the one hand, we have the Ferrocene Language Specification (FLS) and the spec
 
 On the other hand we have tests. We need to find at least one test for each section of the specification. This test is then annotated with the id of the section. This annotating is happening through a comment which is getting added to the end of the file. It is possible to annotate one test with multiple ids.
 
-Currently we annotate tests in `tests/ui` (for the FLS), `tests/ui/ferrocene/compiler-arguments` (for the CLI) and `tests/run-make` (for the CLI).
+Currently we annotate tests in `tests/ui` (for the FLS), `tests/ui/ferrocene/compiler-arguments` (for the CLI), and `tests/run-make` (also for the CLI).
 
 For example `tests/ui/borrowck/borrowck-break-uninit-2.rs` got annotated with `fls_3xvm61x0t251` ([file at c80de1f](https://github.com/ferrocene/ferrocene/blob/c80de1fa7eecdfbe4579b13e2aaa93fb0586f9c6/tests/ui/borrowck/borrowck-break-uninit-2.rs)):
 

--- a/ferrocene/tools/traceability-matrix/README.md
+++ b/ferrocene/tools/traceability-matrix/README.md
@@ -13,11 +13,11 @@ While it says "written" it is (fortunately) generated semi-automatically.
 
 How does it work?
 
-On the one hand, we have the Ferrocene Language Specification (FLS) and the specification of the command-line interface (CLI) of `rustc`. Simply speaking, both specifications are a list of statements, which are grouped in sections and subsections. Each section, subsection and statement has a randombly-generated unique id, examples being `fls_3xvm61x0t251` (for the FLS) and `um_rustc_cap_lints` (for the CLI).
+On the one hand, we have the Ferrocene Language Specification (FLS) and the specification of the command-line interface of `rustc` in the User Manual (UM). Simply speaking, both specifications are a list of statements, which are grouped in sections and subsections. Each section, subsection and statement has a randombly-generated unique id, examples being `fls_3xvm61x0t251` (for the FLS) and `um_rustc_cap_lints` (for the UM).
 
 On the other hand we have tests. We need to find at least one test for each section of the specification. This test is then annotated with the id of the section. This annotating is happening through a comment which is getting added to the end of the file. It is possible to annotate one test with multiple ids.
 
-Currently we annotate tests in `tests/ui` (for the FLS), `tests/ui/ferrocene/compiler-arguments` (for the CLI), and `tests/run-make` (also for the CLI).
+Currently we annotate tests in `tests/ui` (for the FLS), `tests/ui/ferrocene/compiler-arguments` (for the UM), and `tests/run-make` (also for the UM).
 
 For example `tests/ui/borrowck/borrowck-break-uninit-2.rs` got annotated with `fls_3xvm61x0t251` ([file at c80de1f](https://github.com/ferrocene/ferrocene/blob/c80de1fa7eecdfbe4579b13e2aaa93fb0586f9c6/tests/ui/borrowck/borrowck-break-uninit-2.rs)):
 

--- a/ferrocene/tools/traceability-matrix/README.md
+++ b/ferrocene/tools/traceability-matrix/README.md
@@ -17,6 +17,8 @@ On the one hand, we have the Ferrocene Language Specification (FLS). Simply spea
 
 On the other hand we have tests. We need to find at least one test for each section from the FLS. This test is then annotated with the id of the statement. This annotating is happening through a comment which is getting added to the end of the file. It is possible to annotate one test with multiple ids.
 
+Currently we annotate tests in `tests/ui` (for the FLS) and `tests/run-make` (for the command-line interface).
+
 For example `tests/ui/borrowck/borrowck-break-uninit-2.rs` got annotated with `fls_3xvm61x0t251` ([file at c80de1f](https://github.com/ferrocene/ferrocene/blob/c80de1fa7eecdfbe4579b13e2aaa93fb0586f9c6/tests/ui/borrowck/borrowck-break-uninit-2.rs)):
 
 ```rust

--- a/ferrocene/tools/traceability-matrix/README.md
+++ b/ferrocene/tools/traceability-matrix/README.md
@@ -13,9 +13,9 @@ While it says "written" it is (fortunately) generated semi-automatically.
 
 How does it work?
 
-On the one hand we have the Ferrocene language specification (FLS). Simply speaking the FLS is a list of statements, which are grouped in sections and subsections. Each section, subsection and statement has a unique id, which look something like `fls_wt81sbsecmu0` or `fls_3xvm61x0t251`.
+On the one hand, we have the Ferrocene Language Specification (FLS). Simply speaking, the FLS is a list of statements, which are grouped in sections and subsections. Each section, subsection and statement has a randombly-generated unique id, examples being `fls_wt81sbsecmu0` and `fls_3xvm61x0t251`.
 
-On the other hand we have tests. We need to find at least one test for each statement from the FLS. This test is then annotated with the id of the statement. This annotating is happening through a comment which is getting added to the end of the file. It is possible to annotate one test with multiple ids.
+On the other hand we have tests. We need to find at least one test for each section from the FLS. This test is then annotated with the id of the statement. This annotating is happening through a comment which is getting added to the end of the file. It is possible to annotate one test with multiple ids.
 
 For example `tests/ui/borrowck/borrowck-break-uninit-2.rs` got annotated with `fls_3xvm61x0t251` ([file at c80de1f](https://github.com/ferrocene/ferrocene/blob/c80de1fa7eecdfbe4579b13e2aaa93fb0586f9c6/tests/ui/borrowck/borrowck-break-uninit-2.rs)):
 

--- a/ferrocene/tools/traceability-matrix/src/annotations.rs
+++ b/ferrocene/tools/traceability-matrix/src/annotations.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: The Ferrocene Developers
 
-use crate::test_outcomes::TestOutcomes;
-use anyhow::Error;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
+
+use crate::test_outcomes::TestOutcomes;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct AnnotatedFile {
@@ -70,7 +70,7 @@ impl Annotations {
         dir: &Path,
         src_base: &Path,
         test_outcomes: Option<&TestOutcomes>,
-    ) -> Result<(), Error> {
+    ) -> anyhow::Result<()> {
         for entry in std::fs::read_dir(dir)? {
             let path = entry?.path();
             if !path.is_file() {
@@ -89,7 +89,7 @@ impl Annotations {
         file: &Path,
         src_base: &Path,
         test_outcomes: Option<&TestOutcomes>,
-    ) -> Result<(), Error> {
+    ) -> anyhow::Result<()> {
         #[derive(serde::Deserialize)]
         struct JsonOutput {
             bulk_annotations_file_name: String,
@@ -205,7 +205,7 @@ mod tests {
     use tempfile::{NamedTempFile, TempDir};
 
     #[test]
-    fn test_load_file() -> Result<(), Error> {
+    fn test_load_file() -> anyhow::Result<()> {
         let file = NamedTempFile::new()?;
         std::fs::write(file.path(), annotations_file_1()?)?;
 
@@ -251,7 +251,7 @@ mod tests {
     }
 
     #[test]
-    fn test_load_directory() -> Result<(), Error> {
+    fn test_load_directory() -> anyhow::Result<()> {
         let dir = TempDir::new()?;
         std::fs::write(dir.path().join("foo.json"), annotations_file_1()?)?;
         std::fs::write(dir.path().join("bar.json"), annotations_file_2()?)?;
@@ -317,7 +317,7 @@ mod tests {
         }
     }
 
-    fn annotations_file_1() -> Result<Vec<u8>, Error> {
+    fn annotations_file_1() -> anyhow::Result<Vec<u8>> {
         Ok(serde_json::to_vec(&serde_json::json!({
             "tests": [
                 {
@@ -365,7 +365,7 @@ mod tests {
         }))?)
     }
 
-    fn annotations_file_2() -> Result<Vec<u8>, Error> {
+    fn annotations_file_2() -> anyhow::Result<Vec<u8>> {
         Ok(serde_json::to_vec(&serde_json::json!({
             "tests": [
                 {
@@ -386,7 +386,7 @@ mod tests {
         }))?)
     }
 
-    fn annotations_file_3() -> Result<Vec<u8>, Error> {
+    fn annotations_file_3() -> anyhow::Result<Vec<u8>> {
         Ok(serde_json::to_vec(&serde_json::json!({
             "tests": [
                 {

--- a/ferrocene/tools/traceability-matrix/src/annotations.rs
+++ b/ferrocene/tools/traceability-matrix/src/annotations.rs
@@ -49,7 +49,7 @@ pub(crate) enum AnnotationSource {
     Makefile,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct Annotations {
     pub(crate) ids: BTreeMap<String, BTreeSet<AnnotatedFile>>,
     pub(crate) ignored_tests: BTreeMap<String, BTreeSet<String>>,
@@ -58,7 +58,11 @@ pub(crate) struct Annotations {
 
 impl Annotations {
     pub(crate) fn new() -> Self {
-        Annotations { considers_ignored_tests: true, ..Default::default() }
+        Annotations {
+            ids: BTreeMap::new(),
+            ignored_tests: BTreeMap::new(),
+            considers_ignored_tests: true,
+        }
     }
 
     pub(crate) fn load_directory(

--- a/ferrocene/tools/traceability-matrix/src/documentations.rs
+++ b/ferrocene/tools/traceability-matrix/src/documentations.rs
@@ -5,6 +5,7 @@ use anyhow::Error;
 use serde::Deserialize;
 use std::path::Path;
 
+#[derive(Debug)]
 pub(crate) struct Documentation {
     pub(crate) name: String,
     pub(crate) url: String,
@@ -52,6 +53,7 @@ pub(crate) struct CliOption {
     pub(crate) link: String,
 }
 
+/// Read `path` and parse it as [`TraceabilityIds`] (`ids` field of [`Documentation`]).
 pub(crate) fn load(name: &str, path: &Path, url: &str) -> Result<Documentation, Error> {
     Ok(Documentation {
         name: name.into(),

--- a/ferrocene/tools/traceability-matrix/src/documentations.rs
+++ b/ferrocene/tools/traceability-matrix/src/documentations.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: The Ferrocene Developers
 
-use anyhow::Error;
-use serde::Deserialize;
 use std::path::Path;
+
+use serde::Deserialize;
 
 #[derive(Debug)]
 pub(crate) struct Documentation {
@@ -54,7 +54,7 @@ pub(crate) struct CliOption {
 }
 
 /// Read `path` and parse it as [`TraceabilityIds`] (`ids` field of [`Documentation`]).
-pub(crate) fn load(name: &str, path: &Path, url: &str) -> Result<Documentation, Error> {
+pub(crate) fn load(name: &str, path: &Path, url: &str) -> anyhow::Result<Documentation> {
     Ok(Documentation {
         name: name.into(),
         url: url.into(),

--- a/ferrocene/tools/traceability-matrix/src/main.rs
+++ b/ferrocene/tools/traceability-matrix/src/main.rs
@@ -8,15 +8,15 @@ mod report;
 mod test_outcomes;
 mod utils;
 
+use std::path::PathBuf;
+
 use crate::annotations::Annotations;
 use crate::matrix::TraceabilityMatrix;
 use crate::report::Urls;
 use crate::test_outcomes::TestOutcomes;
 use crate::utils::capitalize;
-use anyhow::Error;
-use std::path::PathBuf;
 
-fn main() -> Result<(), Error> {
+fn main() -> anyhow::Result<()> {
     let annotations_path = env_path("ANNOTATIONS");
     let html_out = env_path("HTML_OUT");
     let src_base = env_path("SRC_BASE");
@@ -29,8 +29,7 @@ fn main() -> Result<(), Error> {
         documentations::load("UM", &env_path("UM_IDS"), &env_str("UM_URL"))?,
     ];
 
-    let test_outcomes =
-        if let Some(dir) = test_outcomes_dir { Some(TestOutcomes::load(&dir)?) } else { None };
+    let test_outcomes = test_outcomes_dir.map(|dir| TestOutcomes::load(&dir)).transpose()?;
 
     let mut annotations = Annotations::new();
     annotations.load_directory(&annotations_path, &src_base, test_outcomes.as_ref())?;
@@ -79,8 +78,9 @@ fn cli_summary(matrix: &TraceabilityMatrix) {
     }
 }
 
+/// Fetch a [`String`] environment varible.
 fn env_str(var: &str) -> String {
-    let var = format!("TRACEABILITY_MATRIX_{var}");
+    let var = env_var_name(var);
     if let Ok(content) = std::env::var(&var) {
         content
     } else {
@@ -88,8 +88,9 @@ fn env_str(var: &str) -> String {
     }
 }
 
+/// Fetch a [`PathBuf`] environment variable.
 fn env_path(var: &str) -> PathBuf {
-    let var = format!("TRACEABILITY_MATRIX_{var}");
+    let var = env_var_name(var);
     if let Some(content) = std::env::var_os(&var) {
         content.into()
     } else {
@@ -97,7 +98,13 @@ fn env_path(var: &str) -> PathBuf {
     }
 }
 
+/// Fetch an optional [`PathBuf`] environment variable.
 fn maybe_env_path(var: &str) -> Option<PathBuf> {
-    let var = format!("TRACEABILITY_MATRIX_{var}");
+    let var = env_var_name(var);
     std::env::var_os(var).map(|content| content.into())
+}
+
+/// Prefix the environment variable name with the application name.
+fn env_var_name(var: &str) -> String {
+    format!("TRACEABILITY_MATRIX_{var}")
 }

--- a/ferrocene/tools/traceability-matrix/src/matrix.rs
+++ b/ferrocene/tools/traceability-matrix/src/matrix.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 use std::ops::Deref;
 
 use crate::annotations::{AnnotatedFile, Annotations};
-use crate::documentations::Documentation;
+use crate::documentations::{CliOption, Documentation, Paragraph, Section};
 
 pub(crate) const ELEMENT_KIND_SECTION: ElementKind = ElementKind {
     singular: "section",
@@ -103,14 +103,7 @@ impl TraceabilityMatrix {
                 let has_annotations = self.sections.add(
                     annotations,
                     &extra_section_tests,
-                    Element {
-                        kind: &ELEMENT_KIND_SECTION,
-                        number: Some(ElementNumber(section.number.clone())),
-                        title: Some(section.title.clone()),
-                        id: section.id.clone(),
-                        link: to_url(&section.link),
-                        page: matrix_page.clone(),
-                    },
+                    Element::section(&matrix_page, section, to_url(&section.link)),
                 );
 
                 let extra_paragraph_tests = has_annotations
@@ -125,14 +118,7 @@ impl TraceabilityMatrix {
                     self.paragraphs.add(
                         annotations,
                         &extra_paragraph_tests,
-                        Element {
-                            kind: &ELEMENT_KIND_PARAGRAPH,
-                            id: paragraph.id.clone(),
-                            number: Some(ElementNumber(paragraph.number.clone())),
-                            title: None,
-                            link: to_url(&paragraph.link),
-                            page: matrix_page.clone(),
-                        },
+                        Element::paragraph(&matrix_page, paragraph, to_url(&paragraph.link)),
                     );
                 }
             }
@@ -142,14 +128,7 @@ impl TraceabilityMatrix {
                 self.cli_options.add(
                     annotations,
                     &[],
-                    Element {
-                        kind: &ELEMENT_KIND_CLI_OPTION,
-                        id: option.id.clone(),
-                        number: None,
-                        title: Some(format!("{} {}", option.program, option.option)),
-                        link: to_url(&option.link),
-                        page: matrix_page.clone(),
-                    },
+                    Element::cli_option(&matrix_page, option, to_url(&option.link)),
                 );
             }
         }
@@ -284,6 +263,39 @@ impl Element {
             (Some(number), None) => number.0.clone(),
             (None, Some(title)) => title.clone(),
             (None, None) => "no name".into(),
+        }
+    }
+
+    fn cli_option(matrix_page: &Page, option: &CliOption, link: String) -> Self {
+        Self {
+            kind: &ELEMENT_KIND_CLI_OPTION,
+            id: option.id.clone(),
+            number: None,
+            title: Some(format!("{} {}", option.program, option.option)),
+            link,
+            page: matrix_page.clone(),
+        }
+    }
+
+    fn paragraph(matrix_page: &Page, paragraph: &Paragraph, link: String) -> Self {
+        Self {
+            kind: &ELEMENT_KIND_PARAGRAPH,
+            id: paragraph.id.clone(),
+            number: Some(ElementNumber(paragraph.number.clone())),
+            title: None,
+            link,
+            page: matrix_page.clone(),
+        }
+    }
+
+    fn section(matrix_page: &Page, section: &Section, link: String) -> Self {
+        Self {
+            kind: &ELEMENT_KIND_SECTION,
+            number: Some(ElementNumber(section.number.clone())),
+            title: Some(section.title.clone()),
+            id: section.id.clone(),
+            link,
+            page: matrix_page.clone(),
         }
     }
 }

--- a/ferrocene/tools/traceability-matrix/src/matrix.rs
+++ b/ferrocene/tools/traceability-matrix/src/matrix.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: The Ferrocene Developers
 
-use crate::annotations::{AnnotatedFile, Annotations};
-use crate::documentations::Documentation;
-use anyhow::Error;
 use std::collections::{BTreeSet, HashSet};
 use std::fmt::Debug;
 use std::ops::Deref;
+
+use crate::annotations::{AnnotatedFile, Annotations};
+use crate::documentations::Documentation;
 
 pub(crate) const ELEMENT_KIND_SECTION: ElementKind = ElementKind {
     singular: "section",
@@ -32,7 +32,7 @@ pub(crate) const ELEMENT_KIND_CLI_OPTION: ElementKind = ElementKind {
 pub(crate) fn prepare(
     documentations: &[Documentation],
     annotations: &Annotations,
-) -> Result<TraceabilityMatrix, Error> {
+) -> anyhow::Result<TraceabilityMatrix> {
     let mut matrix = TraceabilityMatrix {
         paragraphs: MatrixAnalysis::new(&ELEMENT_KIND_PARAGRAPH),
         sections: MatrixAnalysis::new(&ELEMENT_KIND_SECTION),
@@ -359,7 +359,7 @@ mod tests {
     use std::path::Path;
 
     #[test]
-    fn test_prepare() -> Result<(), Error> {
+    fn test_prepare() -> anyhow::Result<()> {
         let documentations = [Documentation {
             name: "FLS".into(),
             url: "../fls".into(),

--- a/ferrocene/tools/traceability-matrix/src/report.rs
+++ b/ferrocene/tools/traceability-matrix/src/report.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: The Ferrocene Developers
 
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+
+use askama::Template;
+
 use crate::annotations::{AnnotationSource, Annotations};
 use crate::matrix::{ElementKind, LinkTest, Page, TraceabilityMatrix};
-use anyhow::Error;
-use askama::Template;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 #[derive(Template)]
 #[template(path = "report.html")]
@@ -53,7 +54,7 @@ pub(crate) fn generate(
     annotations: &Annotations,
     matrix: &TraceabilityMatrix,
     urls: Urls,
-) -> Result<String, Error> {
+) -> anyhow::Result<String> {
     Ok(Report {
         matrix,
         summary: build_summary(matrix),

--- a/ferrocene/tools/traceability-matrix/src/test_outcomes.rs
+++ b/ferrocene/tools/traceability-matrix/src/test_outcomes.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: The Ferrocene Developers
 
-use anyhow::{Context, Error};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::path::Path;
+
+use anyhow::Context;
 
 const EXPECTED_FORMAT_VERSION: usize = 1;
 
@@ -18,7 +19,7 @@ pub(crate) struct TestOutcomes {
 }
 
 impl TestOutcomes {
-    pub(crate) fn load(directory: &Path) -> Result<Self, Error> {
+    pub(crate) fn load(directory: &Path) -> anyhow::Result<Self> {
         let mut test_outcomes = TestOutcomes::default();
 
         for entry in std::fs::read_dir(directory)? {

--- a/ferrocene/tools/traceability-matrix/src/test_outcomes.rs
+++ b/ferrocene/tools/traceability-matrix/src/test_outcomes.rs
@@ -143,33 +143,23 @@ mod tests {
         // Assert
         assert_eq!(
             TestOutcomes {
-                executed_tests: BTreeMap::from([
-                    (
-                        "tests/ui/foo.rs".into(),
-                        BTreeSet::from(["aarch64-unknown-linux-gnu".into()])
-                    ),
-                    (
-                        "tests/ui/bar.rs".into(),
-                        BTreeSet::from(["aarch64-unknown-linux-gnu".into()])
-                    ),
-                    (
-                        "tests/run-make/foo.rs".into(),
-                        BTreeSet::from(["aarch64-unknown-linux-gnu".into()])
-                    ),
-                    (
-                        "tests/codegen/foo.rs".into(),
-                        BTreeSet::from(["aarch64-unknown-linux-gnu".into()])
-                    ),
+                executed_tests: arrange_tests([
+                    "tests/ui/foo.rs",
+                    "tests/ui/bar.rs",
+                    "tests/run-make/foo.rs",
+                    "tests/codegen/foo.rs",
                 ]),
-                ignored_tests: BTreeMap::from([(
-                    "tests/ui/baz.rs".into(),
-                    BTreeSet::from(["aarch64-unknown-linux-gnu".into()])
-                )]),
+                ignored_tests: arrange_tests(["tests/ui/baz.rs"])
             },
             outcomes,
         );
 
         Ok(())
+    }
+
+    fn arrange_tests<const N: usize>(tests: [&str; N]) -> BTreeMap<String, BTreeSet<String>> {
+        let targets = BTreeSet::from(["aarch64-unknown-linux-gnu".into()]);
+        tests.into_iter().map(Into::into).map(|test| (test, targets.clone())).collect()
     }
 
     fn content_1() -> serde_json::Result<Vec<u8>> {

--- a/ferrocene/tools/traceability-matrix/src/test_outcomes.rs
+++ b/ferrocene/tools/traceability-matrix/src/test_outcomes.rs
@@ -135,8 +135,8 @@ mod tests {
     fn test_load_outcomes() {
         let dir = TempDir::new().unwrap();
 
-        write_to_dir(content_1(), &dir, "runner1");
-        write_to_dir(content_2(), &dir, "runner2");
+        write_to_dir(content_1(), &dir, "runner1.json");
+        write_to_dir(content_2(), &dir, "runner2.json");
 
         let outcomes = TestOutcomes::load(dir.path()).unwrap();
 
@@ -172,7 +172,7 @@ mod tests {
     fn write_to_dir(json: serde_json::Value, dir: &TempDir, file_name: &str) {
         // format for ease of debugging
         let content = serde_json::to_string_pretty(&json).unwrap();
-        std::fs::write(dir.path().join(format!("{file_name}.json")), content).unwrap();
+        std::fs::write(dir.path().join(file_name), content).unwrap();
     }
 
     fn content_1() -> serde_json::Value {

--- a/ferrocene/tools/traceability-matrix/src/test_outcomes.rs
+++ b/ferrocene/tools/traceability-matrix/src/test_outcomes.rs
@@ -128,18 +128,19 @@ enum MetricsTestOutcome {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
     use tempfile::TempDir;
 
     #[test]
-    fn test_load_outcomes() {
-        let dir = TempDir::new().unwrap();
+    fn test_load_outcomes() -> anyhow::Result<()> {
+        // Arrange
+        let dir = TempDir::new()?;
+        std::fs::write(dir.path().join("runner1.json"), content_1()?)?;
+        std::fs::write(dir.path().join("runner2.json"), content_2()?)?;
 
-        write_to_dir(content_1(), &dir, "runner1.json");
-        write_to_dir(content_2(), &dir, "runner2.json");
-
+        // Act
         let outcomes = TestOutcomes::load(dir.path()).unwrap();
 
+        // Assert
         assert_eq!(
             TestOutcomes {
                 executed_tests: BTreeMap::from([
@@ -166,17 +167,13 @@ mod tests {
                 )]),
             },
             outcomes,
-        )
+        );
+
+        Ok(())
     }
 
-    fn write_to_dir(json: serde_json::Value, dir: &TempDir, file_name: &str) {
-        // format for ease of debugging
-        let content = serde_json::to_string_pretty(&json).unwrap();
-        std::fs::write(dir.path().join(file_name), content).unwrap();
-    }
-
-    fn content_1() -> serde_json::Value {
-        json!({
+    fn content_1() -> serde_json::Result<Vec<u8>> {
+        serde_json::to_vec(&serde_json::json!({
             "format_version": 1,
             "invocations": [
                 {
@@ -266,11 +263,11 @@ mod tests {
                     ],
                 },
             ],
-        })
+        }))
     }
 
-    fn content_2() -> serde_json::Value {
-        json!({
+    fn content_2() -> serde_json::Result<Vec<u8>> {
+        serde_json::to_vec(&serde_json::json!({
                 "format_version": 1,
                 "invocations": [
                     {
@@ -332,6 +329,6 @@ mod tests {
                         ],
                     },
                 ],
-        })
+        }))
     }
 }

--- a/ferrocene/tools/traceability-matrix/src/test_outcomes.rs
+++ b/ferrocene/tools/traceability-matrix/src/test_outcomes.rs
@@ -159,7 +159,7 @@ mod tests {
 
     fn arrange_tests<const N: usize>(tests: [&str; N]) -> BTreeMap<String, BTreeSet<String>> {
         let targets = BTreeSet::from(["aarch64-unknown-linux-gnu".into()]);
-        tests.into_iter().map(Into::into).map(|test| (test, targets.clone())).collect()
+        tests.into_iter().map(|test| (test.into(), targets.clone())).collect()
     }
 
     fn content_1() -> serde_json::Result<Vec<u8>> {

--- a/ferrocene/tools/traceability-matrix/src/test_outcomes.rs
+++ b/ferrocene/tools/traceability-matrix/src/test_outcomes.rs
@@ -38,8 +38,9 @@ impl TestOutcomes {
                 );
             }
 
-            let mut search_queue =
-                VecDeque::from_iter(metrics.invocations.into_iter().flat_map(|i| i.children));
+            let mut search_queue = VecDeque::from_iter(
+                metrics.invocations.into_iter().flat_map(|invocation| invocation.children),
+            );
             while let Some(node) = search_queue.pop_front() {
                 match node {
                     MetricsNode::RustbuildStep { children } => search_queue.extend(children),

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -727,6 +727,7 @@ impl<'a> Builder<'a> {
                 crate::ferrocene::tool::SelfTest,
                 crate::ferrocene::tool::flip_link::FlipLink,
                 tool::FerroceneGenerateTarball,
+                tool::FerroceneTraceabilityMatrix,
                 tool::RustdocGUITest,
                 tool::OptimizedDist,
                 tool::CoverageDump,


### PR DESCRIPTION
Noteable changes:
- Add README
- Use `anyhow::Result<T>` instead of `Result<T, anyhow::Error>` (it's shorter and saves the import)
- Document some functions (want to document more)
- Add `TraceabilityMatrix::analyze_document`
- Add `TestOutcome::insert`