### PR TITLE
Improve vendoring

### DIFF
--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1843,7 +1843,7 @@ impl<'a> Builder<'a> {
         if self.config.rust_remap_debuginfo {
             let mut env_var = OsString::new();
             if self.config.vendor {
-                let vendor = self.build.src.join("vendor");
+                let vendor = self.build.src.join("vendor").join("rust");
                 env_var.push(vendor);
                 env_var.push("=/rust/deps");
             } else {

--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -154,6 +154,7 @@ impl Step for SourceTarball {
         for extra in EXTRA_CARGO_TOMLS {
             vendor.arg("--sync").arg(&builder.src.join(extra));
         }
+        vendor.arg("--versioned-dirs"); // See https://github.com/rust-lang/rust/pull/122892
         if !builder.config.dry_run() {
             let config = crate::output(&mut vendor);
             builder.create_dir(&dest_dir.join(".cargo"));

--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -117,7 +117,9 @@ impl Step for SourceTarball {
         ];
         const EXTRA_CARGO_TOMLS: &[&str] = &[
             "compiler/rustc_codegen_cranelift/Cargo.toml",
+            "compiler/rustc_codegen_gcc/Cargo.toml",
             "src/bootstrap/Cargo.toml",
+            "src/tools/cargo/Cargo.toml",
             "src/tools/rust-analyzer/Cargo.toml",
         ];
 


### PR DESCRIPTION
This PR improves vendoring of dependencies in the source tarball by:

* Vendoring dependencies for `cargo` and `rustc_codegen_gcc` too, which are outside of the workspace.
* Using the correct path when remapping vendored dependencies, as we store our vendored crates in `vendor/rust` rather than just `vendor` (to support vendoring of other languages in the future).
* Passes `--versioned-dirs` to match upstream.