### PR TITLE
Prevent excluded steps from being executed at all

### DIFF
--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -55,6 +55,18 @@ Job: TypeAlias = list[str]
 Kind: TypeAlias = dict[str, Job]
 JobsDefinition: TypeAlias = dict[str, Kind]
 
+# If you are trying to exclude a step from being executed at all in our CI,
+# avoid changing the script to pass --exclude for it. Rather, change the
+# bootstrap source code to prevent the step from being invoked at all.
+#
+# This way, customers building from source will also avoid executing the step,
+# even if they don't rely on this script.
+#
+# See this commit for an example of how to do it:
+#
+#    https://github.com/ferrocene/ferrocene/commit/feb061293a968b0cd7122cb9e00a2409be3e3a39
+#
+
 # fmt: off
 JOBS_DEFINITION: JobsDefinition = {
     "dist": {
@@ -71,22 +83,6 @@ JOBS_DEFINITION: JobsDefinition = {
         "oxidos": ["ferrocene-oxidos"],
 
         "tools": ["rust-analyzer", "clippy", "rustfmt", "flip-link"],
-
-        # The "None" job contains the tasks that should never be executed,
-        # regardless of which job is requested.
-        None: [
-            # Combined tarballs: we can't produce those, since different
-            # customers will only be allowed to access a subset of Ferrocene
-            # components (for example due to proprietary targets).
-            "extended",
-            # Upstream's plain source tarball is replaced by the "ferrocene-src"
-            # step, so we avoid executing it.
-            "rustc-src",
-            # Upstream's documentation tarball is replaced by the
-            # "ferrocene-docs" step, so we avoid executing it.
-            "rust-docs",
-            "rustc-docs",
-        ],
     },
 
     "test": {
@@ -139,14 +135,6 @@ JOBS_DEFINITION: JobsDefinition = {
 }
 # fmt: on
 
-GLOBAL_EXCLUDE = [
-    # The "standalone" documentation includes upstream's index page, which
-    # often overrides our own custom index page. It also includes all the
-    # redirects used by upstream that we don't need. Avoid building it.
-    "doc::standalone",
-]
-
-
 def sorted_tasks(tasks: Iterable[str | Task]) -> list[Task]:
     tasks = list(tasks)
 
@@ -188,8 +176,6 @@ def cli():
         flags += get_flags_for_job(JOBS_DEFINITION, split[0], split[1])
     else:
         flags += get_flags_for_default_job(JOBS_DEFINITION, split[0])
-
-    flags += [shlex.quote(f"--exclude={path}") for path in GLOBAL_EXCLUDE]
 
     print(" ".join(flags))
 

--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -50,7 +50,7 @@ class Task:
 
 
 # TODO: this should be `type Job = list[str]` etc., but this requires CI to update
-# to python 9.12 or above
+# to python 3.12 or above
 Job: TypeAlias = list[str]
 Kind: TypeAlias = dict[str, Job]
 JobsDefinition: TypeAlias = dict[str, Kind]

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -56,11 +56,11 @@ pub struct Docs {
 
 impl Step for Docs {
     type Output = Option<GeneratedTarball>;
-    const DEFAULT: bool = true;
+    const DEFAULT: bool = false;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        let default = run.builder.config.docs;
-        run.alias("rust-docs").default_condition(default)
+        // Disabled by Ferrocene, as we have our own documentation tarball.
+        run.never()
     }
 
     fn make_run(run: RunConfig<'_>) {
@@ -127,12 +127,12 @@ pub struct RustcDocs {
 
 impl Step for RustcDocs {
     type Output = Option<GeneratedTarball>;
-    const DEFAULT: bool = true;
+    const DEFAULT: bool = false;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        let builder = run.builder;
-        run.alias("rustc-docs").default_condition(builder.config.compiler_docs)
+        // Disabled by Ferrocene, as we don't ship the compiler documentation.
+        run.never()
     }
 
     fn make_run(run: RunConfig<'_>) {
@@ -943,12 +943,12 @@ pub struct PlainSourceTarball;
 impl Step for PlainSourceTarball {
     /// Produces the location of the tarball generated
     type Output = GeneratedTarball;
-    const DEFAULT: bool = true;
+    const DEFAULT: bool = false;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        let builder = run.builder;
-        run.alias("rustc-src").default_condition(builder.config.rust_dist_src)
+        // Disabled by Ferrocene, as we have our own alternative for it.
+        run.never()
     }
 
     fn make_run(run: RunConfig<'_>) {
@@ -1501,12 +1501,12 @@ pub struct Extended {
 
 impl Step for Extended {
     type Output = ();
-    const DEFAULT: bool = true;
+    const DEFAULT: bool = false;
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        let builder = run.builder;
-        run.alias("extended").default_condition(builder.config.extended)
+        // Disabled by Ferrocene, as we don't support the extended tarball.
+        run.never()
     }
 
     fn make_run(run: RunConfig<'_>) {

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -294,11 +294,11 @@ pub struct Standalone {
 
 impl Step for Standalone {
     type Output = ();
-    const DEFAULT: bool = true;
+    const DEFAULT: bool = false;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        let builder = run.builder;
-        run.path("src/doc").alias("standalone").default_condition(builder.config.docs)
+        // Ferrocene has its own documentation index.
+        run.never()
     }
 
     fn make_run(run: RunConfig<'_>) {

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -304,7 +304,6 @@ mod dist {
 
         let a = TargetSelection::from_user("A");
 
-        assert_eq!(first(cache.all::<dist::Docs>()), &[dist::Docs { host: a },]);
         assert_eq!(first(cache.all::<dist::Mingw>()), &[dist::Mingw { host: a },]);
         assert_eq!(
             first(cache.all::<dist::Rustc>()),
@@ -330,10 +329,6 @@ mod dist {
         let b = TargetSelection::from_user("B");
 
         assert_eq!(
-            first(cache.all::<dist::Docs>()),
-            &[dist::Docs { host: a }, dist::Docs { host: b },]
-        );
-        assert_eq!(
             first(cache.all::<dist::Mingw>()),
             &[dist::Mingw { host: a }, dist::Mingw { host: b },]
         );
@@ -358,10 +353,6 @@ mod dist {
         let a = TargetSelection::from_user("A");
         let b = TargetSelection::from_user("B");
 
-        assert_eq!(
-            first(cache.all::<dist::Docs>()),
-            &[dist::Docs { host: a }, dist::Docs { host: b },]
-        );
         assert_eq!(
             first(cache.all::<dist::Mingw>()),
             &[dist::Mingw { host: a }, dist::Mingw { host: b },]
@@ -421,10 +412,6 @@ mod dist {
         let c = TargetSelection::from_user("C");
 
         assert_eq!(
-            first(cache.all::<dist::Docs>()),
-            &[dist::Docs { host: a }, dist::Docs { host: b }, dist::Docs { host: c },]
-        );
-        assert_eq!(
             first(cache.all::<dist::Mingw>()),
             &[dist::Mingw { host: a }, dist::Mingw { host: b }, dist::Mingw { host: c },]
         );
@@ -454,7 +441,6 @@ mod dist {
         let a = TargetSelection::from_user("A");
         let c = TargetSelection::from_user("C");
 
-        assert_eq!(first(cache.all::<dist::Docs>()), &[dist::Docs { host: c },]);
         assert_eq!(first(cache.all::<dist::Mingw>()), &[dist::Mingw { host: c },]);
         assert_eq!(
             first(cache.all::<dist::Std>()),
@@ -469,10 +455,6 @@ mod dist {
         let a = TargetSelection::from_user("A");
         let b = TargetSelection::from_user("B");
 
-        assert_eq!(
-            first(cache.all::<dist::Docs>()),
-            &[dist::Docs { host: a }, dist::Docs { host: b },]
-        );
         assert_eq!(
             first(cache.all::<dist::Mingw>()),
             &[dist::Mingw { host: a }, dist::Mingw { host: b },]


### PR DESCRIPTION
Before this PR, whenever we needed to exclude a step from CI because it didn't make sense for Ferrocene, we changed the split-tasks script to always `--exclude` it. That was a fine approach for CI, as the script controlled what we executed.

We have customers building from source now though, and they don't use the script (nor should they). This PR thus moves to a different way of permanently excluding those jobs: changing bootstrap to prevent executing the jobs at all.