### PR TITLE
Use a compatible shasum for Mac

### DIFF
--- a/ferrocene/ci/scripts/llvm-cache.sh
+++ b/ferrocene/ci/scripts/llvm-cache.sh
@@ -52,15 +52,15 @@ KEEP_LLVM_BINARIES=(
 get_llvm_cache_hash() {
     file="$(mktemp)"
 
-    sha256sum "$0" >> "${file}"
-    sha256sum ferrocene/ci/configure.sh >> "${file}"
-    sha256sum src/version >> "${file}"
-    git ls-files src/bootstrap ferrocene/ci/docker-images -z | sort -z | xargs -0 sha256sum >> "${file}"
+    shasum -a 256 "$0" >> "${file}"
+    shasum -a 256 ferrocene/ci/configure.sh >> "${file}"
+    shasum -a 256 src/version >> "${file}"
+    git ls-files src/bootstrap ferrocene/ci/docker-images -z | sort -z | xargs -0 shasum -a 256 >> "${file}"
     # Hashing all of the LLVM source code takes time. Instead we can simply get
     # the hash of the tree from git, saving time and achieving the same effect.
     git ls-tree HEAD src/llvm-project >> "${file}"
 
-    sha256sum "${file}" | awk '{print($1)}'
+    shasum -a 256 "${file}" | awk '{print($1)}'
     rm -f "${file}"
 }
 


### PR DESCRIPTION
`sha256sum` is not a valid binary on Mac, and appears to have been silently failing.

This is causing the llvm cache to not be used and adding ~20 mins to most Mac workflows.

```
$ sha256sum
Error: nu::shell::external_command

  × External command failed
   ╭─[entry #1:1:1]
 1 │ sha256sum
   · ────┬────
   ·     ╰── executable was not found
   ╰────
  help: No such file or directory (os error 2)

Exit status 1
$ shasum -a 256
asdasd^D
61b4c705859f4158d38090c1e38e8fdc4f3d29db007f012766276aa498835cf6  -
```

![image](https://github.com/ferrocene/ferrocene/assets/130903/0b2ab3ac-c775-43d3-b4c9-066d21ced5d1)
https://app.circleci.com/pipelines/github/ferrocene/ferrocene/3574/workflows/9f9f9a89-56a2-4074-bb18-ef5b7a29fa9f/jobs/17241