### PR TITLE
Lift the repeated FERROCENE_TARGETS bits into a workflow parameter

### DIFF
--- a/.circleci/calculate-parameters.py
+++ b/.circleci/calculate-parameters.py
@@ -45,13 +45,11 @@ LINUX_BUILT_CROSS_TARGETS = [
     "armv7r-none-eabihf",
     "armebv7r-none-eabihf",
 ]
-# Targets self-tested on Linux
-LINUX_SELF_TEST_TARGETS = LINUX_ONLY_TARGETS + LINUX_BUILT_CROSS_TARGETS
+LINUX_ALL_TARGETS = LINUX_ONLY_TARGETS + LINUX_BUILT_CROSS_TARGETS
 
 # Targets only built (and tested!) on Mac
 MAC_ONLY_TARGETS = ["aarch64-apple-darwin", "x86_64-apple-darwin"]
-# Targets self-tested on Mac
-MAC_SELF_TEST_TARGETS = MAC_ONLY_TARGETS + LINUX_BUILT_CROSS_TARGETS
+MAC_ALL_TARGETS = MAC_ONLY_TARGETS + LINUX_BUILT_CROSS_TARGETS
 
 s3 = boto3.client("s3", region_name=S3_REGION)
 ecr = boto3.client("ecr", region_name=ECR_REGION)
@@ -149,14 +147,14 @@ def calculate_targets(host_plus_stage):
             raise Exception(f"Host {host} not supported at this time, please add support")
     elif stage == "std-only":
         if host== "x86_64-unknown-linux-gnu":
-            targets += LINUX_BUILT_CROSS_TARGETS
+            targets += LINUX_ALL_TARGETS
         else:
             raise Exception("Only the `x86_64-unknown-linux-gnu` currently runs the `std-only` stage.")
     elif stage == "self-test":
         if host == "x86_64-unknown-linux-gnu":
-            targets += LINUX_SELF_TEST_TARGETS
+            targets += LINUX_ALL_TARGETS
         elif host == "aarch64-apple-darwin":
-            targets += MAC_SELF_TEST_TARGETS
+            targets += MAC_ALL_TARGETS
         else:
             raise Exception(f"Host {host} not supported at this time, please add support")
     else:

--- a/.circleci/calculate-parameters.py
+++ b/.circleci/calculate-parameters.py
@@ -137,39 +137,30 @@ def calculate_targets(host_plus_stage):
     """
     host, stage = host_plus_stage.split("--", 1)
     targets = []
-    match stage:
-        # The `build` stage should cover any toolchains the host is expected to build.
-        #
-        # Note `x86_64-unknown-linux-gnu` has an expanded list in a different step.
-        case "build":
-            match host:
-                case "x86_64-unknown-linux-gnu":
-                    targets += LINUX_ONLY_TARGETS
-                case "aarch64-apple-darwin":
-                    targets += MAC_ONLY_TARGETS
-                case _:
-                    raise Exception(f"Host {host} not supported at this time, please add support")
-        # The `std-only` stage should cover any cross compilation targets which the host
-        # is expected to build only `rust-std` for.
-        #
-        # When possible, prefer building targets on `x86_64-unknown-linux-gnu`.
-        case "std-only":
-            match host:
-                case "x86_64-unknown-linux-gnu":
-                    targets += LINUX_BUILT_CROSS_TARGETS
-                case _:
-                    raise Exception("Only the `x86_64-unknown-linux-gnu` currently runs the `std-only` stage.")
-        # The `self-test` stage should cover all targets the host can possibly build.
-        case "self-test":
-            match host:
-                case "x86_64-unknown-linux-gnu":
-                    targets += LINUX_SELF_TEST_TARGETS
-                case "aarch64-apple-darwin":
-                    targets += MAC_SELF_TEST_TARGETS
-                case _:
-                    raise Exception(f"Host {host} not supported at this time, please add support")
-        case _:
-            raise Exception("Stage not known, please add support")
+
+    # The CI does not run Python 3.10 and thus `match` statements don't exist yet
+    # in this universe.
+    if stage == "build":
+        if host == "x86_64-unknown-linux-gnu":
+            targets += LINUX_ONLY_TARGETS
+        elif host == "aarch64-apple-darwin":
+            targets += MAC_ONLY_TARGETS
+        else:
+            raise Exception(f"Host {host} not supported at this time, please add support")
+    elif stage == "std-only":
+        if host== "x86_64-unknown-linux-gnu":
+            targets += LINUX_BUILT_CROSS_TARGETS
+        else:
+            raise Exception("Only the `x86_64-unknown-linux-gnu` currently runs the `std-only` stage.")
+    elif stage == "self-test":
+        if host == "x86_64-unknown-linux-gnu":
+            targets += LINUX_SELF_TEST_TARGETS
+        elif host == "aarch64-apple-darwin":
+            targets += MAC_SELF_TEST_TARGETS
+        else:
+            raise Exception(f"Host {host} not supported at this time, please add support")
+    else:
+        raise Exception("Stage not known, please add support")
 
     return ",".join(targets)
 

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -40,7 +40,7 @@ parameters:
     default: false
   cross-compile-targets:
     type: string
-    default: aarch64-unknown-none,thumbv7em-none-eabi,thumbv7em-none-eabihf,armv8r-none-eabihf,wasm32-unknown-unknown,armv7r-none-eabihf,armebv7r-none-eabihf
+    default: ""
 
 orbs:
   aws-cli: circleci/aws-cli@4.0

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -38,7 +38,19 @@ parameters:
   llvm-rebuild--aarch64-apple-darwin:
     type: boolean
     default: false
-  cross-compile-targets:
+  targets--x86_64-unknown-linux-gnu--build:
+    type: string
+    default: ""
+  targets--x86_64-unknown-linux-gnu--self-test:
+    type: string
+    default: ""
+  targets--x86_64-unknown-linux-gnu--std-only:
+    type: string
+    default: ""
+  targets--aarch64-apple-darwin--build:
+    type: string
+    default: ""
+  targets--aarch64-apple-darwin--self-test:
     type: string
     default: ""
 
@@ -162,7 +174,7 @@ jobs:
     resource_class: large # 4-core
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
-      FERROCENE_TARGETS: aarch64-unknown-linux-gnu,<< pipeline.parameters.cross-compile-targets >>
+      FERROCENE_TARGETS: << pipeline.parameters.targets--x86_64-unknown-linux-gnu--std-only >>
       SCRIPT: |
         ./x.py --stage 2 dist rust-std
     steps:
@@ -297,7 +309,7 @@ jobs:
     resource_class: small # 1-core
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
-      FERROCENE_TARGETS: x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu,<< pipeline.parameters.cross-compile-targets >>
+      FERROCENE_TARGETS: << pipeline.parameters.targets--x86_64-unknown-linux-gnu--self-test >>
     steps:
       - aws-oidc-auth
       - ferrocene-git-shallow-clone:
@@ -336,7 +348,7 @@ jobs:
     resource_class: macos.m1.large.gen1 # 8 cores
     environment:
       FERROCENE_HOST: aarch64-apple-darwin
-      FERROCENE_TARGETS: x86_64-apple-darwin,aarch64-apple-darwin
+      FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-apple-darwin--build >>
       SCRIPT: |
         ferrocene/ci/scripts/llvm-cache.sh download
         ./x.py --stage 2 build library src/tools/rustdoc
@@ -351,7 +363,7 @@ jobs:
     resource_class: macos.m1.large.gen1 # 8 cores
     environment:
       FERROCENE_HOST: aarch64-apple-darwin
-      FERROCENE_TARGETS: x86_64-apple-darwin,aarch64-apple-darwin
+      FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-apple-darwin--build >>
       SCRIPT: |
         # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
         ./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist)
@@ -367,7 +379,7 @@ jobs:
     resource_class: macos.m1.large.gen1 # 8 cores
     environment:
       FERROCENE_HOST: aarch64-apple-darwin
-      FERROCENE_TARGETS: x86_64-apple-darwin,aarch64-apple-darwin
+      FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-apple-darwin--build >>
       SCRIPT: |
         # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
         ./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist:tools)
@@ -382,7 +394,7 @@ jobs:
     resource_class: macos.m1.medium.gen1 # 4 cores
     environment:
       FERROCENE_HOST: aarch64-apple-darwin
-      FERROCENE_TARGETS: aarch64-apple-darwin,x86_64-apple-darwin,<< pipeline.parameters.cross-compile-targets >>
+      FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-apple-darwin--self-test >>
     steps:
       - ferrocene-git-shallow-clone:
           depth: 1

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -38,6 +38,9 @@ parameters:
   llvm-rebuild--aarch64-apple-darwin:
     type: boolean
     default: false
+  cross-compile-targets:
+    type: string
+    default: aarch64-unknown-none,thumbv7em-none-eabi,thumbv7em-none-eabihf,armv8r-none-eabihf,wasm32-unknown-unknown,armv7r-none-eabihf,armebv7r-none-eabihf
 
 orbs:
   aws-cli: circleci/aws-cli@4.0
@@ -159,7 +162,7 @@ jobs:
     resource_class: large # 4-core
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
-      FERROCENE_TARGETS: aarch64-unknown-linux-gnu,aarch64-unknown-none,thumbv7em-none-eabi,thumbv7em-none-eabihf,armv8r-none-eabihf,wasm32-unknown-unknown,armv7r-none-eabihf,armebv7r-none-eabihf
+      FERROCENE_TARGETS: aarch64-unknown-linux-gnu,<< pipeline.parameters.cross-compile-targets >>
       SCRIPT: |
         ./x.py --stage 2 dist rust-std
     steps:
@@ -294,7 +297,7 @@ jobs:
     resource_class: small # 1-core
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
-      FERROCENE_TARGETS: aarch64-unknown-none,x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu,thumbv7em-none-eabi,thumbv7em-none-eabihf,armv8r-none-eabihf,wasm32-unknown-unknown,armv7r-none-eabihf,armebv7r-none-eabihf
+      FERROCENE_TARGETS: x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu,<< pipeline.parameters.cross-compile-targets >>
     steps:
       - aws-oidc-auth
       - ferrocene-git-shallow-clone:
@@ -379,7 +382,7 @@ jobs:
     resource_class: macos.m1.medium.gen1 # 4 cores
     environment:
       FERROCENE_HOST: aarch64-apple-darwin
-      FERROCENE_TARGETS: aarch64-apple-darwin,x86_64-apple-darwin,aarch64-unknown-none,thumbv7em-none-eabi,thumbv7em-none-eabihf,armv8r-none-eabihf,wasm32-unknown-unknown,armv7r-none-eabihf,armebv7r-none-eabihf
+      FERROCENE_TARGETS: aarch64-apple-darwin,x86_64-apple-darwin,<< pipeline.parameters.cross-compile-targets >>
     steps:
       - ferrocene-git-shallow-clone:
           depth: 1


### PR DESCRIPTION
Remove a potential footgun where we forget to self-test on a target.

This change will also be relevant to https://github.com/ferrocene/ferrocene/pull/544, since that causes our host platform support to diverge in new and interesting ways.