### PR TITLE
Address feedback from TÜV

### DIFF
--- a/ferrocene/doc/evaluation-report/src/tool-analysis.rst
+++ b/ferrocene/doc/evaluation-report/src/tool-analysis.rst
@@ -294,4 +294,4 @@ IEC 61508 Tool Classification
 
 Ferrocene provides a development environment capable of compiling,
 and linking programs for the target architecture to conform with automotive
-[|iso_ref|] TCL 3/ASIL D level and industrial [|iec_ref|] T3 TQL level.
+[|iso_ref|] TCL 3/ASIL D level and industrial [|iec_ref|] class T3.

--- a/ferrocene/doc/glossary.rst
+++ b/ferrocene/doc/glossary.rst
@@ -168,6 +168,3 @@ Abbreviated Terms
 
    TI
        Tool Impact
-
-   TQL
-       Tool Qualification Level

--- a/ferrocene/doc/index/index.html
+++ b/ferrocene/doc/index/index.html
@@ -89,7 +89,7 @@
                     </a>
                     <a href="qualification/plan/index.html">
                         <h3>Qualification Plan</h3>
-                        <p>Phases and activities that describe the qualification of the Ferrocene compiler with the TCL 3/ASIL D level in accordance with ISO-26262 standard and the T3 TQL level in accordance with the IEC-61508 standard.</p>
+                        <p>Phases and activities that describe the qualification of the Ferrocene compiler with the TCL 3/ASIL D level in accordance with ISO-26262 standard and the class T3 in accordance with the IEC-61508 standard.</p>
                     </a>
                     <a href="qualification/report/index.html">
                         <h3>Qualification Report</h3>

--- a/ferrocene/doc/release-notes/src/24.05.0.rst
+++ b/ferrocene/doc/release-notes/src/24.05.0.rst
@@ -56,6 +56,13 @@ Changes
   locate the system libraries needed for the linkage, and instructing LLD on
   where to find them.
 
+Breaking changes
+----------------
+
+* The ``--crate-type dylib``, ``--crate-type cdylib`` and ``--crate-type
+  proc-macro`` CLI flags are not qualified for safety critical use anymore.
+  Safety critical support for them will be added back in a future release.
+
 Bug fixes
 ---------
 

--- a/ferrocene/doc/sphinx-substitutions.toml
+++ b/ferrocene/doc/sphinx-substitutions.toml
@@ -8,7 +8,7 @@
 
 ferrocene_ASIL = "ASIL D"
 ferrocene_TCL = "TCL 3"
-ferrocene_TQL = "TQL T3"
+ferrocene_TQL = "class T3"
 
 iso_ref = "ISO-26262:2018"
 iso_doc = "Road Vehicles - Functional Safety"

--- a/ferrocene/doc/user-manual/src/cli.rst
+++ b/ferrocene/doc/user-manual/src/cli.rst
@@ -673,6 +673,11 @@ Command-Line Interface
 
    .. cli:option:: --crate-type <types>
 
+      .. caution::
+
+         Only the ``bin``, ``lib``, ``rlib`` and ``staticlib`` crate types can
+         be used in a safety critical context.
+
       Compiler argument ``--crate-type`` specifies the type of crate to build.
 
       ``<types>`` must be a comma-separated list of crate types. The list must


### PR DESCRIPTION
This PR addresses the feedback we got from TÜV on the 24.05.0 release:

* Replaces "TQL T3" with "class T3", and removes TQL from the glossary.
* Restricts the use of the `--crate-type` flag to prevent generating dynamic libraries, as our documents don't yet cover the use of dynamic libraries.