### PR TITLE
Prepare 1.76 for the next TÜV review

### DIFF
--- a/ferrocene/doc/document-list/signature/signature.toml
+++ b/ferrocene/doc/document-list/signature/signature.toml
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: The Ferrocene Developers
-
-[files]
-"pinned.toml" = "b25f6b4a-e954-4da7-8246-631df5d2b070"
-"safety-manager.cosign-bundle" = "f5983935-7506-45d9-b4fa-90b3449350a5"

--- a/ferrocene/doc/evaluation-plan/signature/signature.toml
+++ b/ferrocene/doc/evaluation-plan/signature/signature.toml
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: The Ferrocene Developers
-
-[files]
-"pinned.toml" = "fe3ed137-441b-44e0-a89a-612b47dcb61f"
-"safety-manager.cosign-bundle" = "b1a0ce70-6345-4159-9bdf-3c2d67b3c0c8"

--- a/ferrocene/doc/evaluation-report/signature/signature.toml
+++ b/ferrocene/doc/evaluation-report/signature/signature.toml
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: The Ferrocene Developers
-
-[files]
-"pinned.toml" = "9f0977f0-c0b3-453b-8a2b-83d858f7df71"
-"safety-manager.cosign-bundle" = "46db122c-33f6-4b03-8a71-c0d011558017"

--- a/ferrocene/doc/internal-procedures/signature/signature.toml
+++ b/ferrocene/doc/internal-procedures/signature/signature.toml
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: The Ferrocene Developers
-
-[files]
-"pinned.toml" = "c2c24453-7743-4814-94c8-5a7a990ed7da"
-"technical-lead.cosign-bundle" = "fd88e345-ce32-42a7-a821-44255421aa03"

--- a/ferrocene/doc/qualification-plan/signature/signature.toml
+++ b/ferrocene/doc/qualification-plan/signature/signature.toml
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: The Ferrocene Developers
-
-[files]
-"pinned.toml" = "93cbe8a9-5151-4282-8127-3880f7778910"
-"safety-manager.cosign-bundle" = "a79a6f76-bbb9-4cd9-95f3-da44e5989b52"

--- a/ferrocene/doc/qualification-report/signature/signature.toml
+++ b/ferrocene/doc/qualification-report/signature/signature.toml
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: The Ferrocene Developers
-
-[files]
-"pinned.toml" = "a1f4d7b2-8450-4737-b840-c43a45f33d9e"
-"safety-manager.cosign-bundle" = "ffafb66c-a003-491c-a330-c9f5baaa598c"

--- a/ferrocene/doc/release-notes/src/24.05.0.rst
+++ b/ferrocene/doc/release-notes/src/24.05.0.rst
@@ -1,8 +1,6 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-:upcoming-release:
-
 Ferrocene 24.05.0
 =================
 

--- a/ferrocene/doc/safety-manual/signature/signature.toml
+++ b/ferrocene/doc/safety-manual/signature/signature.toml
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: The Ferrocene Developers
-
-[files]
-"pinned.toml" = "aab11d02-1b5c-40c3-96e1-9e54f3cdb1d7"
-"safety-manager.cosign-bundle" = "7574d61e-c897-4b2c-8254-7864a97ac874"


### PR DESCRIPTION
This PR prepares the 1.76 release for the next review by TÜV, by removing the existing signatures and removing the "upcoming release" marker from 24.05.0. It needs to be merged before we backport PRs.