### PR TITLE
Fix documentation index page

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -397,11 +397,11 @@ pub struct Releases {
 
 impl Step for Releases {
     type Output = ();
-    const DEFAULT: bool = true;
+    const DEFAULT: bool = false;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        let builder = run.builder;
-        run.path("RELEASES.md").alias("releases").default_condition(builder.config.docs)
+        // Ferrocene has its own release notes.
+        run.never()
     }
 
     fn make_run(run: RunConfig<'_>) {

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -316,7 +316,10 @@ impl Step for Standalone {
     /// `STAMP` along with providing the various header/footer HTML we've customized.
     ///
     /// In the end, this is just a glorified wrapper around rustdoc!
+    #[allow(unused)]
     fn run(self, builder: &Builder<'_>) {
+        panic!("this step should not be invoked in Ferrocene");
+
         let target = self.target;
         let compiler = self.compiler;
         let _guard = builder.msg_doc(compiler, "standalone", target);

--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -54,6 +54,12 @@ const LINKCHECK_EXCEPTIONS: &[(&str, &[&str])] = &[
     ("core/primitive.slice.html", &["#method.to_ascii_uppercase", "#method.to_ascii_lowercase",
                                     "core/slice::sort_by_key", "core\\slice::sort_by_key",
                                     "#method.sort_by_cached_key"]),
+    // Ferrocene-specific:
+    //
+    // The technical report is missing most of the time, as it's only included in stable releases.
+    // This is fine though, because that section is hidden by the build system with `display: none`
+    // when the link is missing. We thus ignore it to avoid linkchecker complain.
+    ("index.html", &["qualification/technical-report.pdf"]),
 ];
 
 #[rustfmt::skip]


### PR DESCRIPTION
The documentation index page right now is showing upstream's index page, which is not what we want. To work around that, this PR changes that step to panic when trying to execute it, and disables another step that calls it.
