### PR TITLE
Require Linux targets for the macOS self-test job

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -605,6 +605,7 @@ workflows:
           requires:
             - aarch64-darwin-dist
             - aarch64-darwin-dist-tools
+            - x86_64-linux-dist-targets
 
       - finish-build:
           requires:


### PR DESCRIPTION
The macOS self test job might be executed slightly before the Linux cross-compilation targets get built. This causes spurious failures like we saw in https://github.com/ferrocene/ferrocene/pull/593.

cc @Hoverbear we want to do the same for the Windows PR