### PR TITLE
Make self-test easier to debug

### DIFF
--- a/ferrocene/ci/scripts/run-self-test.sh
+++ b/ferrocene/ci/scripts/run-self-test.sh
@@ -5,16 +5,20 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-COMMIT="$(git rev-parse HEAD)"
+COMMIT="${COMMIT:-$(git rev-parse HEAD)}"
+SKIP_CLEANUP="${SKIP_CLEANUP:-}"
 
 BUCKET="ferrocene-ci-artifacts"
 PREFIX="ferrocene/dist/${COMMIT}"
 
 root="$(mktemp -d)"
-cleanup() {
-    rm -rf "${root}"
-}
-trap cleanup EXIT
+
+if [[ -z "$SKIP_CLEANUP" ]]; then
+    cleanup() {
+        rm -rf "${root}"
+    }
+    trap cleanup EXIT
+fi
 
 case "$(cat ferrocene/ci/channel)" in
     stable)

--- a/ferrocene/tools/self-test/src/error.rs
+++ b/ferrocene/tools/self-test/src/error.rs
@@ -178,7 +178,12 @@ impl Display for CommandError {
                 write!(f, "failed to wait for `{cli}` to finish")
             }
             CommandErrorKind::Failure { output } => {
-                write!(f, "invoking `{cli}` failed with {}", output.status)
+                write!(
+                    f,
+                    "invoking `{cli}` failed with {}, stderr:\n{}",
+                    output.status,
+                    String::from_utf8_lossy(&output.stderr)
+                )
             }
             CommandErrorKind::NonUtf8Output => {
                 write!(f, "invoking `{cli}` returned non-UTF-8 data in its standard output")


### PR DESCRIPTION
While trying to debug a self-test failure in #595 I noticed two complicating issues:

* A cleanup of downloaded artifacts was always performed, meaning it was not possible to inspect a failed state.
* Command failures did not include `stderr`, making it very difficult to discern the source of the problem without reproducing the state manually (cleanup also happens here)

This PR:

* Adds `COMMIT="..."` so we can tell the script which commit to test against if we want.
* Adds `SKIP_CLEANUP=true` so we tell the script not to clean up downloaded artifacts.