### PR TITLE
Write `rustfmt` user manual

### DIFF
--- a/ferrocene/doc/user-manual/src/index.rst
+++ b/ferrocene/doc/user-manual/src/index.rst
@@ -39,6 +39,14 @@ Ferrocene User Manual
    targets/aarch64-unknown-none
    targets/x86_64-unknown-linux-gnu
 
+.. toctree::
+   :numbered:
+   :maxdepth: 2
+   :caption: rustfmt
+
+   rustfmt/install
+   rustfmt/usage
+
 .. appendices::
    :numbered:
    :maxdepth: 2

--- a/ferrocene/doc/user-manual/src/index.rst
+++ b/ferrocene/doc/user-manual/src/index.rst
@@ -53,6 +53,7 @@ Ferrocene User Manual
    :caption: Reference:
 
    rustc/cli
+   rustfmt/cli
    self-test/error-codes
 
 Indices and tables

--- a/ferrocene/doc/user-manual/src/rustc/cli.rst
+++ b/ferrocene/doc/user-manual/src/rustc/cli.rst
@@ -1,8 +1,8 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-Command-Line Interface
-======================
+``rustc`` Command-Line Interface
+================================
 
 .. cli:program:: rustc
 

--- a/ferrocene/doc/user-manual/src/rustfmt/cli.rst
+++ b/ferrocene/doc/user-manual/src/rustfmt/cli.rst
@@ -1,0 +1,70 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+``rustfmt`` Command-Line Interface
+==================================
+
+.. cli:program:: rustfmt
+
+   .. cli:option:: --check
+
+      Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits with 1 and prints a diff if formatting is required.
+
+   .. cli:option:: --emit [files|stdout|coverage|checkstyle|json]
+
+      What data to emit and how
+
+   .. cli:option:: --backup
+
+      Backup any modified files.
+
+   .. cli:option:: --config-path
+
+      Recursively searches the given path for the rustfmt.toml config file. If not found reverts to the input file path
+
+   .. cli:option:: --edition [2015|2018|2021]
+
+      Rust edition to use
+
+   .. cli:option:: --color [always|never|auto]
+
+      Use colored output (if supported)
+
+   .. cli:option:: --print-config [Path for the configuration file]
+
+      Dumps a default or minimal config to PATH. A minimal config is the subset of the current config file used for formatting the current program. ``current`` writes to stdout current config as if formatting the file at PATH.
+
+   .. cli:option:: --files-with-diff
+
+      Short option: ``-l``.
+
+      Prints the names of mismatched files that were formatted. Prints the names of files that would be formatted when used with ``--check`` mode.
+
+   .. cli:option:: --config [key1=val1,key2=val2...]
+
+      Set options from command line. These settings take priority over .rustfmt.toml
+
+   .. cli:option:: --verbose
+
+      Short option: ``-v``.
+
+      Print verbose output
+
+   .. cli:option:: --quiet
+
+      Short option: ``-q``.
+
+      Print less output
+
+   .. cli:option:: --version
+
+      Short option: ``-V``.
+
+      Show version information
+
+   .. cli:option:: --help [=TOPIC]
+
+      Short option: ``-h``.
+
+      Show this message or help about a specific topic: ``config`` or ``file-lines``
+   

--- a/ferrocene/doc/user-manual/src/rustfmt/install.rst
+++ b/ferrocene/doc/user-manual/src/rustfmt/install.rst
@@ -1,0 +1,9 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Installing ``rustfmt``
+======================
+
+Download the archive for your host target and follow the
+:doc:`installation instructions </rustc/install>`. Please refer to the target
+documentation of your host target to find which archive you need to download.

--- a/ferrocene/doc/user-manual/src/rustfmt/usage.rst
+++ b/ferrocene/doc/user-manual/src/rustfmt/usage.rst
@@ -9,7 +9,7 @@ Using ``rustfmt``
 ``rustfmt <file>...``
 ---------------------
 
-To format one or more files, just pass the paths to ``rusfmt``. This will format the passed files and all of their child modules.
+To format one or more files, just pass the paths to ``rusfmt``. This will format the files and all of their child modules.
 
 Assuming following project structure, ``rustfmt main.rs`` will format the whole project, while ``rustfmt mod1.rs`` will format ``mod1.rs``, ``mod1/mod10.rs`` and ``mod1/mod11.rs``, but neither ``mod2.rs`` nor ``mod2/mod20.rs``.
 
@@ -30,7 +30,7 @@ Assuming following project structure, ``rustfmt main.rs`` will format the whole 
 ``rustfmt --check <file>...``
 -----------------------------
 
-If the ``--check`` option is passed ``rusfmt`` checks if the files are well formatted. It reports what it would format, but will not modify any files. For example:
+If the ``--check`` option is used, ``rusfmt`` checks if the files are well formatted. It reports what it would format, but will not modify any files. For example:
 
 .. code-block::
 

--- a/ferrocene/doc/user-manual/src/rustfmt/usage.rst
+++ b/ferrocene/doc/user-manual/src/rustfmt/usage.rst
@@ -1,0 +1,58 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Using ``rustfmt``
+=================
+
+``rustfmt`` formats Rust code or checks if Rust code is well formatted.
+
+``rustfmt <file>...``
+---------------------
+
+To format one or more files, just pass the paths to ``rusfmt``. This will format the passed files and all of their child modules.
+
+Assuming following project structure, ``rustfmt main.rs`` will format the whole project, while ``rustfmt mod1.rs`` will format ``mod1.rs``, ``mod1/mod10.rs`` and ``mod1/mod11.rs``, but neither ``mod2.rs`` nor ``mod2/mod20.rs``.
+
+.. code-block::
+
+   $ tree src/
+   src/
+   ├── main.rs
+   ├── mod1
+   │   ├── mod10.rs
+   │   └── mod11.rs
+   ├── mod1.rs
+   ├── mod2
+   │   └── mod20.rs
+   └── mod2.rs
+
+
+``rustfmt --check <file>...``
+-----------------------------
+
+If the ``--check`` option is passed ``rusfmt`` checks if the files are well formatted. It reports what it would format, but will not modify any files. For example:
+
+.. code-block::
+
+   $ rustfmt --check src/main.rs 
+   Diff in /krate/src/main.rs at line 1:
+    fn main() {
+   -    println!(
+   -        "Hello, world!"
+   -    );
+   +    println!("Hello, world!");
+    }
+
+Exit codes
+----------
+
+When running with ``--check``, ``rustfmt`` will exit with ``0`` if ``rustfmt`` would not make any formatting changes to the input, and ``1`` if ``rustfmt`` would make changes. In other modes, ``rustfmt`` will exit with ``1`` if there was some error during formatting (for example a parsing or internal error) and ``0`` if formatting completed without error (whether or not changes were made).
+
+``cargo fmt``
+-------------
+
+.. caution::
+
+   Use of ``cargo fmt`` is not qualified, and thus can't be used in a safety critical environment: in that case, you must invoke ``rustfmt`` directly.
+
+``rustfmt`` can be used "through" ``cargo`` to improve the user experience. ``cargo fmt`` will format all the files in a cargo project. ``cargo fmt --check`` will check that all files in a cargo project are well formatted.

--- a/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
@@ -49,7 +49,7 @@ target as a cross-compilation target:
 
 * ``rust-std-x86_64-unknown-linux-gnu``
 
-To install the optional ``rustfmt`` tool following archive is needed:
+To install the optional ``rustfmt`` tool, the following archive is needed:
 
 * ``rustfmt-x86_64-unknown-linux-gnu``
 

--- a/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-unknown-linux-gnu.rst
@@ -49,6 +49,10 @@ target as a cross-compilation target:
 
 * ``rust-std-x86_64-unknown-linux-gnu``
 
+To install the optional ``rustfmt`` tool following archive is needed:
+
+* ``rustfmt-x86_64-unknown-linux-gnu``
+
 Required compiler flags
 -----------------------
 


### PR DESCRIPTION
This PR adds `rustfmt` to the user manual. Added sections are:
- installation
- usage
- command-line interface _(this section is bare bones atm and will be extended in a follow-up PR)_.

Are any sections missing? 

