### PR TITLE
Allow showing the technical report in the stable channel

### DIFF
--- a/ferrocene/doc/index/index.html
+++ b/ferrocene/doc/index/index.html
@@ -8,6 +8,7 @@
         <title>Ferrocene Documentation Index</title>
         <link rel="icon" href="index-assets/favicon.svg" sizes="any" type="image/svg+xml" />
         <link rel="stylesheet" href="index-assets/index.css">
+        <link rel="stylesheet" href="index-assets/subset-filters/signatures.css">
         <link rel="stylesheet" href="ferrocene-breadcrumbs.css">
     </head>
     <body>


### PR DESCRIPTION
We forgot to include the CSS file that shows the technical report link if the users have the signatures subset in their documentation. This has to be backported to 24.05.0.