### PR TITLE
Fix needs_proxy detection on Windows

### DIFF
--- a/ferrocene/tools/generate-tarball/src/generator.rs
+++ b/ferrocene/tools/generate-tarball/src/generator.rs
@@ -74,7 +74,7 @@ pub struct Generator {
     ferrocene_managed_prefix: Vec<String>,
     /// Path of a binary that should be proxied by criticalup.
     #[clap(long, value_name = "PATH")]
-    ferrocene_proxied_binary: Vec<String>,
+    ferrocene_proxied_binary: Vec<PathBuf>,
     /// Name of the Ferrocene component.
     #[clap(long, value_name = "NAME")]
     ferrocene_component: String,

--- a/ferrocene/tools/generate-tarball/src/generator.rs
+++ b/ferrocene/tools/generate-tarball/src/generator.rs
@@ -127,7 +127,7 @@ impl Generator {
                     component: &ferrocene_component,
                     commit_sha: &commit_sha,
                     package_dir: &package_dir,
-                    proxied_binaries: ferrocene_proxied_binary.iter().map(String::as_str).collect(),
+                    proxied_binaries: ferrocene_proxied_binary.iter().map(PathBuf::as_path).collect(),
                     managed_prefixes: &ferrocene_managed_prefix,
                 },
                 &key_arn,

--- a/ferrocene/tools/generate-tarball/src/generator.rs
+++ b/ferrocene/tools/generate-tarball/src/generator.rs
@@ -7,7 +7,7 @@ use crate::signatures::{sign_manifest_with_aws_kms, SignatureContext};
 use crate::tarballer::Tarballer;
 use crate::util::{copy_recursive, create_dir_all, path_to_str, remove_dir_all};
 use anyhow::Result;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, clap::Args)]
 pub struct Generator {

--- a/ferrocene/tools/generate-tarball/src/signatures.rs
+++ b/ferrocene/tools/generate-tarball/src/signatures.rs
@@ -151,7 +151,7 @@ mod tests {
                 component: "demo-package",
                 commit_sha: "000000",
                 package_dir: package_dir.path(),
-                proxied_binaries: ["bin/rustc"].into_iter().collect(),
+                proxied_binaries: [Path::new("bin/rustc")].into_iter().collect(),
                 managed_prefixes: &["lib/rustlib/x86_64-unknown-linux-gnu/lib/".into()],
             },
             &key,

--- a/ferrocene/tools/generate-tarball/src/signatures.rs
+++ b/ferrocene/tools/generate-tarball/src/signatures.rs
@@ -18,7 +18,7 @@ pub(crate) struct SignatureContext<'a> {
     pub(crate) component: &'a str,
     pub(crate) commit_sha: &'a str,
     pub(crate) package_dir: &'a Path,
-    pub(crate) proxied_binaries: HashSet<&'a str>,
+    pub(crate) proxied_binaries: HashSet<&'a Path>,
     pub(crate) managed_prefixes: &'a [String],
 }
 

--- a/ferrocene/tools/generate-tarball/src/signatures.rs
+++ b/ferrocene/tools/generate-tarball/src/signatures.rs
@@ -71,10 +71,15 @@ fn collect_files(
         let entry = entry?.path();
         let relative_path = entry
             .strip_prefix(ctx.package_dir)
-            .unwrap()
-            .to_str()
+            .unwrap();
+
+        #[cfg(windows)] // Ensure we're not checking for the `.exe` instead of the file name
+        let relative_path = relative_path.with_extension("");
+
+        let relative_path = relative_path.to_str()
             .ok_or_else(|| anyhow!("path {entry:?} is not utf-8"))?;
 
+            
         if entry.is_file() {
             package.files.push(PackageFile {
                 path: relative_path.into(),

--- a/ferrocene/tools/generate-tarball/src/signatures.rs
+++ b/ferrocene/tools/generate-tarball/src/signatures.rs
@@ -73,9 +73,11 @@ fn collect_files(
             .strip_prefix(ctx.package_dir)
             .unwrap();
 
+        #[cfg(not(windows))]
+        let needs_proxy = ctx.proxied_binaries.contains(&relative_path);
         #[cfg(windows)] // Ensure we're not checking for the `.exe` instead of the file name
-        let relative_path = relative_path.with_extension("");
-
+        let needs_proxy = ctx.proxied_binaries.contains(relative_path.with_extension(""));
+        
         let relative_path = relative_path.to_str()
             .ok_or_else(|| anyhow!("path {entry:?} is not utf-8"))?;
 
@@ -88,7 +90,7 @@ fn collect_files(
                 posix_mode: entry.metadata()?.mode(),
                 #[cfg(windows)]
                 posix_mode: 0,
-                needs_proxy: ctx.proxied_binaries.contains(&relative_path),
+                needs_proxy,
             });
         } else if entry.is_dir() {
             collect_files(package, ctx, &entry)?;

--- a/ferrocene/tools/generate-tarball/src/signatures.rs
+++ b/ferrocene/tools/generate-tarball/src/signatures.rs
@@ -76,7 +76,7 @@ fn collect_files(
         #[cfg(not(windows))]
         let needs_proxy = ctx.proxied_binaries.contains(&relative_path);
         #[cfg(windows)] // Ensure we're not checking for the `.exe` instead of the file name
-        let needs_proxy = ctx.proxied_binaries.contains(relative_path.with_extension(""));
+        let needs_proxy = ctx.proxied_binaries.contains(&relative_path.with_extension("").as_path());
         
         let relative_path = relative_path.to_str()
             .ok_or_else(|| anyhow!("path {entry:?} is not utf-8"))?;

--- a/src/bootstrap/src/utils/tarball.rs
+++ b/src/bootstrap/src/utils/tarball.rs
@@ -123,7 +123,7 @@ pub(crate) struct Tarball<'a> {
     is_preview: bool,
     permit_symlinks: bool,
 
-    proxied_binaries: Vec<String>,
+    proxied_binaries: Vec<PathBuf>,
     managed_prefixes: Vec<String>,
 }
 
@@ -169,8 +169,8 @@ impl<'a> Tarball<'a> {
     }
 
     /// Register a binary that should have a proxy created by criticalup.
-    pub(crate) fn ferrocene_proxied_binary(&mut self, path: &str) {
-        self.proxied_binaries.push(path.into());
+    pub(crate) fn ferrocene_proxied_binary(&mut self, path: impl AsRef<Path>) {
+        self.proxied_binaries.push(path.as_ref().to_path_buf());
     }
 
     /// Register a path prefix that criticalup should prevent non-Ferrocene files from existing


### PR DESCRIPTION
I noticed that some of the manifests in the produced packages did not have `needs-proxy` set correctly. This should fix that.