### PR TITLE
Fix release scheduler to account for channel metadata v3

### DIFF
--- a/ferrocene/ci/scripts/calculate-release-job-matrix.py
+++ b/ferrocene/ci/scripts/calculate-release-job-matrix.py
@@ -185,6 +185,8 @@ def discard_branches_with_no_changes(ctx, releases):
         channel_metadata = json.loads(response["Body"].read())
         if channel_metadata["metadata_version"] == 2:
             last_commit = channel_metadata["latest_release"]["sha1_full"]
+        elif channel_metadata["metadata_version"] == 3:
+            last_commit = channel_metadata["releases"][-1]["sha1_full"]
         else:
             note(
                 f"Channel API metadata version {channel_metadata['metadata_version']} "

--- a/ferrocene/ci/scripts/calculate-release-job-matrix.py
+++ b/ferrocene/ci/scripts/calculate-release-job-matrix.py
@@ -188,7 +188,7 @@ def discard_branches_with_no_changes(ctx, releases):
         else:
             note(
                 f"Channel API metadata version {channel_metadata['metadata_version']} "
-                f"for channel {metadata.release.channel} is not supported. "
+                f"for channel {release.metadata.channel} is not supported. "
                 '"No changes" check will be skipped.'
             )
             last_commit = "Z"  # Will never match :)

--- a/ferrocene/ci/scripts/calculate-release-job-matrix.py
+++ b/ferrocene/ci/scripts/calculate-release-job-matrix.py
@@ -102,7 +102,7 @@ def filter_automated_channels(releases):
             version = [int(num) for num in release.metadata.rust_version.split(".")]
             rolling_releases.append((version, release))
         else:
-            note("channel {release.metadata.channel} cannot be released automatically")
+            note(f"channel {release.metadata.channel} cannot be released automatically")
 
     rolling_releases.sort(key=lambda vr: vr[0])
     # When starting from a squashed repo with no release branches yielding the
@@ -187,8 +187,8 @@ def discard_branches_with_no_changes(ctx, releases):
             last_commit = channel_metadata["latest_release"]["sha1_full"]
         else:
             note(
-                "Channel API metadata version {channel_metadata['metadata_version']} "
-                "for channel {metadata.release.channel} is not supported. "
+                f"Channel API metadata version {channel_metadata['metadata_version']} "
+                f"for channel {metadata.release.channel} is not supported. "
                 '"No changes" check will be skipped.'
             )
             last_commit = "Z"  # Will never match :)


### PR DESCRIPTION
In https://github.com/ferrocene/publish-release/pull/51 we introduced channel metadata v3, to store the full list of releases rather than just the last release. This PR adds support for it in the release matrix calculation.

Also, it fixes two unrelated problems I discovered while developing this.