### PR TITLE
Refactor `.circleci/calculate-parameters.py`

### DIFF
--- a/.circleci/calculate-parameters.py
+++ b/.circleci/calculate-parameters.py
@@ -16,6 +16,7 @@ import sys
 import datetime
 import urllib.parse
 import subprocess
+from typing import Callable
 
 
 # Path of the YAML file to extract the needed parameters from.
@@ -173,9 +174,9 @@ def calculate_targets(host_plus_stage):
 
 def prepare_parameters():
     with open(CIRCLECI_CONFIGURATION) as f:
-        config = yaml.safe_load(f)
+        config: dict[str, dict[str, str]] = yaml.safe_load(f)
 
-    replacements = {
+    replacements: dict[str, Callable[[str], str]] = {
         "docker-image-tag--": calculate_docker_image_tag,
         "docker-image-rebuild--": calculate_docker_image_rebuild,
         "docker-repository-url--": calculate_docker_repository_url,
@@ -183,7 +184,7 @@ def prepare_parameters():
         "targets--": calculate_targets,
     }
 
-    parameters = {}
+    parameters: dict[str, str] = {}
     for parameter in config["parameters"].keys():
         for prefix, func in replacements.items():
             if parameter.startswith(prefix):

--- a/.circleci/calculate-parameters.py
+++ b/.circleci/calculate-parameters.py
@@ -7,15 +7,16 @@
 # tries to find a value for all the defined parameters automatically, and exits
 # with an error if it can't calculate the value of one parameter.
 
+
+import boto3
+import datetime
 import hashlib
 import json
 import os
-import yaml
-import boto3
-import sys
-import datetime
-import urllib.parse
 import subprocess
+import sys
+import urllib.parse
+import yaml
 from typing import Callable
 
 

--- a/.circleci/calculate-parameters.py
+++ b/.circleci/calculate-parameters.py
@@ -61,7 +61,7 @@ s3 = boto3.client("s3", region_name=S3_REGION)
 ecr = boto3.client("ecr", region_name=ECR_REGION)
 
 
-def calculate_docker_image_tag(image):
+def calculate_docker_image_tag(image: str):
     """
     Calculates the value of parameters starting with `docker-image-tag--`.
     """
@@ -69,7 +69,7 @@ def calculate_docker_image_tag(image):
     if not os.path.exists(os.path.join(path, "Dockerfile")):
         raise ScriptError(f"unknown Docker image: {image}")
 
-    all_files = []
+    all_files: list[str] = []
     for root, _, files in os.walk(path):
         for file in files:
             all_files.append(os.path.join(root, file))
@@ -86,7 +86,7 @@ def calculate_docker_image_tag(image):
     return f"{image}-{hash.hexdigest()}"
 
 
-def calculate_docker_image_rebuild(repo_plus_image):
+def calculate_docker_image_rebuild(repo_plus_image: str) -> bool:
     """
     Calculate the value of parameters starting with `docker-image-rebuild--`
     """
@@ -102,11 +102,11 @@ def calculate_docker_image_rebuild(repo_plus_image):
 
     # FIXME: .utcnow should be .now(datetime.UTC), but CI is on python 3.9
     now = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
-    delta = now - image["imagePushedAt"]
+    delta: datetime.timedelta = now - image["imagePushedAt"]
     return delta.days >= REBUILD_IMAGES_OLDER_THAN_DAYS
 
 
-def calculate_docker_repository_url(repo):
+def calculate_docker_repository_url(repo: str) -> str:
     """
     Calculates the value of parameters starting with `docker-repository-url--`
     """
@@ -117,15 +117,17 @@ def calculate_docker_repository_url(repo):
     return repos["repositories"][0]["repositoryUri"]
 
 
-def calculate_llvm_rebuild(target):
+def calculate_llvm_rebuild(target: str):
     """
     Calculates the value of parameters starting with `llvm-rebuild--`
     """
-    url = urllib.parse.urlparse(subprocess.run(
-        ["ferrocene/ci/scripts/llvm-cache.sh", "s3-url"],
-        env={"FERROCENE_HOST": target},
-        stdout=subprocess.PIPE,
-    ).stdout.strip()).decode("utf-8")
+    url: urllib.parse.ParseResult = urllib.parse.urlparse(
+        subprocess.run(
+            ["ferrocene/ci/scripts/llvm-cache.sh", "s3-url"],
+            env={"FERROCENE_HOST": target},
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+    ).decode("utf-8")
     assert url.scheme == "s3"
 
     try:
@@ -135,7 +137,7 @@ def calculate_llvm_rebuild(target):
         return True
 
 
-def calculate_targets(host_plus_stage):
+def calculate_targets(host_plus_stage: str):
     """
     Calculates the list of targets to pass.
 

--- a/.circleci/calculate-parameters.py
+++ b/.circleci/calculate-parameters.py
@@ -131,42 +131,42 @@ def calculate_llvm_rebuild(target):
     except s3.exceptions.ClientError:
         return True
 
+
 def calculate_targets(host_plus_stage):
     """
     Calculates the list of targets to pass.
 
-    :param str host_plus_stage: The Rust target hosting this job, then "--", then one of `build`, `std-only`, or `self-test` 
+    :param str host_plus_stage: The Rust target hosting this job, then "--", then one of `build`, `std-only`, or `self-test`
     """
     host, stage = host_plus_stage.split("--", 1)
-    targets = []
 
     # The CI does not run Python 3.10 and thus `match` statements don't exist yet
     # in this universe.
     if stage == "build":
         if host == "x86_64-unknown-linux-gnu":
-            targets += LINUX_ONLY_TARGETS
+            targets = LINUX_ONLY_TARGETS
         elif host == "aarch64-apple-darwin":
-            targets += MAC_ONLY_TARGETS
+            targets = MAC_ONLY_TARGETS
         elif host == "x86_64-pc-windows-msvc":
-            targets += WINDOWS_ONLY_TARGETS
+            targets = WINDOWS_ONLY_TARGETS
         else:
             raise Exception(f"Host {host} not supported at this time, please add support")
     elif stage == "std-only":
-        if host== "x86_64-unknown-linux-gnu":
-            targets += LINUX_ALL_TARGETS
+        if host == "x86_64-unknown-linux-gnu":
+            targets = LINUX_ALL_TARGETS
         else:
             raise Exception("Only the `x86_64-unknown-linux-gnu` currently runs the `std-only` stage.")
     elif stage == "self-test":
         if host == "x86_64-unknown-linux-gnu":
-            targets += LINUX_ALL_TARGETS
+            targets = LINUX_ALL_TARGETS
         elif host == "aarch64-apple-darwin":
-            targets += MAC_ALL_TARGETS
+            targets = MAC_ALL_TARGETS
         elif host == "x86_64-pc-windows-msvc":
-            targets += WINDOWS_ALL_TARGETS
+            targets = WINDOWS_ALL_TARGETS
         else:
             raise Exception(f"Host {host} not supported at this time, please add support")
     else:
-        raise Exception("Stage not known, please add support")
+        raise Exception(f"Stage {stage} not known, please add support")
 
     return ",".join(targets)
 
@@ -188,7 +188,7 @@ def prepare_parameters():
         for prefix, func in replacements.items():
             if parameter.startswith(prefix):
                 # Anything after the prefix gets passed as a parameter
-                parameters[parameter] = func(parameter[len(prefix):])
+                parameters[parameter] = func(parameter[len(prefix) :])
                 break
         # In Python, the `else` is executed when the for loop finished
         # normally, without any `break` being executed. In this case, it's

--- a/.circleci/calculate-parameters.py
+++ b/.circleci/calculate-parameters.py
@@ -100,6 +100,7 @@ def calculate_docker_image_rebuild(repo_plus_image):
         # Image doesn't exist, build it.
         return True
 
+    # FIXME: .utcnow should be .now(datetime.UTC), but CI is on python 3.9
     now = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
     delta = now - image["imagePushedAt"]
     return delta.days >= REBUILD_IMAGES_OLDER_THAN_DAYS


### PR DESCRIPTION
This PR
- mostly adds type hints so that I get information about the variables and functions when hovering over them
- replaces deprecated `.utcnow()`
- in `calcualte_paramameters`, I switched from `target +=` to `target =`, because iiuc exactly one case will always match.
- sort imports alphabetically :smile:

---

PS. I also wanted to find a type for the global `s3` and `ecr` variable, but unfortunately I could not https://github.com/ferrocene/ferrocene/blob/a5a6acb2f0c1f84468c82c760c83d5a883a56a9e/.circleci/calculate-parameters.py#L58-L59

Python reports `botocore.client.S3` and `botocore.client.ECR`, but I am unable to import that:
```python
>>> import boto3
>>> type(boto3.client("s3", region_name="us-east-1"))
<class 'botocore.client.S3'>
>>> from botocore.client import S3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'S3' from 'botocore.client' (/usr/lib/python3.12/site-packages/botocore/client.py)
```