### PR TITLE
Improve `OUTSIDE_FERROUS=1` when configuring

### DIFF
--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -322,9 +322,9 @@ fi
 #
 # If this is not provided, the report will not be included in the generated
 # documentation. This should only be set in stable, qualified releases.
-if is_internal; then
-    #add --set ferrocene.technical-report-url="s3://ferrocene-ci-mirrors/manual/tuv-technical-reports/YYYY-MM-DD-ferrocene-YY.MM.N-technical-report.pdf"
-fi
+#if is_internal; then
+#    add --set ferrocene.technical-report-url="s3://ferrocene-ci-mirrors/manual/tuv-technical-reports/YYYY-MM-DD-ferrocene-YY.MM.N-technical-report.pdf"
+#fi
 
 # When building Ferrocene outside of Ferrous Systems, folks will not have
 # access to the document signature files stored in AWS. In that case, configure

--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -322,7 +322,9 @@ fi
 #
 # If this is not provided, the report will not be included in the generated
 # documentation. This should only be set in stable, qualified releases.
-#add --set ferrocene.technical-report-url="s3://ferrocene-ci-mirrors/manual/tuv-technical-reports/YYYY-MM-DD-ferrocene-YY.MM.N-technical-report.pdf"
+if is_internal; then
+    #add --set ferrocene.technical-report-url="s3://ferrocene-ci-mirrors/manual/tuv-technical-reports/YYYY-MM-DD-ferrocene-YY.MM.N-technical-report.pdf"
+fi
 
 ###############################################
 #                                             #

--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -326,6 +326,13 @@ if is_internal; then
     #add --set ferrocene.technical-report-url="s3://ferrocene-ci-mirrors/manual/tuv-technical-reports/YYYY-MM-DD-ferrocene-YY.MM.N-technical-report.pdf"
 fi
 
+# When building Ferrocene outside of Ferrous Systems, folks will not have
+# access to the document signature files stored in AWS. In that case, configure
+# the build system to ignore document signatures.
+if ! is_internal; then
+    add --set ferrocene.ignore-document-signatures=true
+fi
+
 ###############################################
 #                                             #
 #  Write the configuration to `config.toml`   #


### PR DESCRIPTION
This PR changes the configure script to better take `OUTSIDE_FERROUS=1` into account:

* It now prevents including the technical report, as it is hosted in AWS.
* It now disables including document signatures, as that requires AWS access.