### PR TITLE
Fix `x.py install`

### DIFF
--- a/ferrocene/tools/generate-tarball/src/compression.rs
+++ b/ferrocene/tools/generate-tarball/src/compression.rs
@@ -82,7 +82,7 @@ impl CompressionFormat {
                         // produced by rust-lang/promote-release which hosts recompression logic
                         // and is tuned for optimal compression.
                         xz2::stream::MtStreamBuilder::new().threads(6).preset(9).encoder().unwrap()
-                    },
+                    }
                     CompressionProfile::NoOp => panic!(
                         "compression profile 'no-op' should not call `CompressionFormat::encode`."
                     ),

--- a/ferrocene/tools/generate-tarball/src/compression.rs
+++ b/ferrocene/tools/generate-tarball/src/compression.rs
@@ -13,6 +13,7 @@ pub enum CompressionProfile {
     #[default]
     Balanced,
     Best,
+    NoOp,
 }
 
 impl FromStr for CompressionProfile {
@@ -23,6 +24,7 @@ impl FromStr for CompressionProfile {
             "fast" => Self::Fast,
             "balanced" => Self::Balanced,
             "best" => Self::Best,
+            "no-op" => Self::NoOp,
             other => anyhow::bail!("invalid compression profile: {other}"),
         })
     }
@@ -34,6 +36,7 @@ impl fmt::Display for CompressionProfile {
             CompressionProfile::Fast => f.write_str("fast"),
             CompressionProfile::Balanced => f.write_str("balanced"),
             CompressionProfile::Best => f.write_str("best"),
+            CompressionProfile::NoOp => f.write_str("no-op"),
         }
     }
 }
@@ -79,7 +82,10 @@ impl CompressionFormat {
                         // produced by rust-lang/promote-release which hosts recompression logic
                         // and is tuned for optimal compression.
                         xz2::stream::MtStreamBuilder::new().threads(6).preset(9).encoder().unwrap()
-                    }
+                    },
+                    CompressionProfile::NoOp => panic!(
+                        "compression profile 'no-op' should not call `CompressionFormat::encode`."
+                    ),
                 };
 
                 let compressor = XzEncoder::new_stream(std::io::BufWriter::new(file), encoder);

--- a/ferrocene/tools/generate-tarball/src/tarballer.rs
+++ b/ferrocene/tools/generate-tarball/src/tarballer.rs
@@ -42,6 +42,10 @@ pub struct Tarballer {
 impl Tarballer {
     /// Generates the actual tarballs
     pub fn run(self) -> Result<()> {
+        if let CompressionProfile::NoOp = self.compression_profile {
+            return Ok(());
+        }
+
         let Self { input, output, work_dir, compression_profile, compression_formats } = self;
         let tarball_name = output + ".tar";
         let encoder = CombinedEncoder::new(

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -978,6 +978,7 @@ impl<'a> Builder<'a> {
                 // install::Rustc,
                 crate::ferrocene::install::Docs,
                 crate::ferrocene::install::Std,
+                crate::ferrocene::install::Rustc,
                 crate::ferrocene::install::Cargo,
                 crate::ferrocene::install::RustAnalyzer,
                 crate::ferrocene::install::Rustfmt,

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 
 use crate::core::build_steps::tool::{self, SourceType};
 use crate::core::build_steps::{
-    check, clean, clippy, compile, dist, doc, install, llvm, run, setup, test, vendor,
+    check, clean, clippy, compile, dist, doc, llvm, run, setup, test, vendor,
 };
 use crate::core::config::flags::{Color, Subcommand};
 use crate::core::config::{DryRun, SplitDebuginfo, TargetSelection};
@@ -960,21 +960,32 @@ impl<'a> Builder<'a> {
                 crate::ferrocene::partners::oxidos::DistOxidOs,
             ),
             Kind::Install => describe!(
-                install::Docs,
-                install::Std,
-                // During the Rust compiler (rustc) installation process, we copy the entire sysroot binary
-                // path (build/host/stage2/bin). Since the building tools also make their copy in the sysroot
-                // binary path, we must install rustc before the tools. Otherwise, the rust-installer will
-                // install the same binaries twice for each tool, leaving backup files (*.old) as a result.
-                install::Rustc,
-                install::Cargo,
-                install::RustAnalyzer,
-                install::Rustfmt,
-                install::RustDemangler,
-                install::Clippy,
-                install::Miri,
-                install::LlvmTools,
-                install::Src,
+                // install::Docs,
+                // install::Std,
+                // // During the Rust compiler (rustc) installation process, we copy the entire sysroot binary
+                // // path (build/host/stage2/bin). Since the building tools also make their copy in the sysroot
+                // // binary path, we must install rustc before the tools. Otherwise, the rust-installer will
+                // // install the same binaries twice for each tool, leaving backup files (*.old) as a result.
+                // install::Rustc,
+                // install::Cargo,
+                // install::RustAnalyzer,
+                // install::Rustfmt,
+                // install::RustDemangler,
+                // install::Clippy,
+                // install::Miri,
+                // install::LlvmTools,
+                // install::Src,
+                // install::Rustc,
+                crate::ferrocene::install::Docs,
+                crate::ferrocene::install::Std,
+                crate::ferrocene::install::Cargo,
+                crate::ferrocene::install::RustAnalyzer,
+                crate::ferrocene::install::Rustfmt,
+                crate::ferrocene::install::RustDemangler,
+                crate::ferrocene::install::Clippy,
+                crate::ferrocene::install::Miri,
+                crate::ferrocene::install::LlvmTools,
+                crate::ferrocene::install::Src,
             ),
             Kind::Run => describe!(
                 crate::ferrocene::run::TraceabilityMatrix,

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -976,7 +976,6 @@ impl<'a> Builder<'a> {
                 // install::LlvmTools,
                 // install::Src,
                 // install::Rustc,
-                crate::ferrocene::install::Docs,
                 crate::ferrocene::install::Std,
                 crate::ferrocene::install::Rustc,
                 crate::ferrocene::install::Cargo,

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -987,6 +987,9 @@ impl<'a> Builder<'a> {
                 crate::ferrocene::install::Miri,
                 crate::ferrocene::install::LlvmTools,
                 crate::ferrocene::install::Src,
+                crate::ferrocene::install::FlipLink,
+                crate::ferrocene::install::SelfTest,
+                crate::ferrocene::install::FerroceneDocs,
             ),
             Kind::Run => describe!(
                 crate::ferrocene::run::TraceabilityMatrix,

--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -20,7 +20,7 @@ use crate::utils::tarball::{GeneratedTarball, Tarball};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct Docs {
-    target: TargetSelection,
+    pub(crate) target: TargetSelection,
 }
 
 impl Step for Docs {

--- a/src/bootstrap/src/ferrocene/install.rs
+++ b/src/bootstrap/src/ferrocene/install.rs
@@ -1,0 +1,332 @@
+// Based off ../core/build_steps/install.rs
+
+//! Implementation of the install aspects of the compiler.
+//!
+//! This module is responsible for installing the standard library,
+//! compiler, and documentation.
+
+use std::env;
+use std::fs;
+use std::path::{PathBuf, Path};
+// use std::process::Command;
+
+use crate::core::build_steps::dist;
+use crate::core::builder::{Builder, RunConfig, ShouldRun, Step};
+use crate::core::config::{Config, TargetSelection};
+use crate::utils::helpers::t;
+use crate::utils::tarball::GeneratedTarball;
+use crate::{Compiler, Kind};
+
+// #[cfg(target_os = "illumos")]
+// const SHELL: &str = "bash";
+// #[cfg(not(target_os = "illumos"))]
+// const SHELL: &str = "sh";
+
+// /// We have to run a few shell scripts, which choke quite a bit on both `\`
+// /// characters and on `C:\` paths, so normalize both of them away.
+// fn sanitize_sh(path: &Path) -> String {
+//     let path = path.to_str().unwrap().replace('\\', "/");
+//     return change_drive(unc_to_lfs(&path)).unwrap_or(path);
+
+//     fn unc_to_lfs(s: &str) -> &str {
+//         s.strip_prefix("//?/").unwrap_or(s)
+//     }
+
+//     fn change_drive(s: &str) -> Option<String> {
+//         let mut ch = s.chars();
+//         let drive = ch.next().unwrap_or('C');
+//         if ch.next() != Some(':') {
+//             return None;
+//         }
+//         if ch.next() != Some('/') {
+//             return None;
+//         }
+//         Some(format!("/{}/{}", drive, &s[drive.len_utf8() + 2..]))
+//     }
+// }
+
+// fn is_dir_writable_for_user(dir: &Path) -> bool {
+//     let tmp = dir.join(".tmp");
+//     match fs::create_dir_all(&tmp) {
+//         Ok(_) => {
+//             fs::remove_dir_all(tmp).unwrap();
+//             true
+//         }
+//         Err(e) => {
+//             if e.kind() == std::io::ErrorKind::PermissionDenied {
+//                 false
+//             } else {
+//                 panic!("Failed the write access check for the current user. {}", e);
+//             }
+//         }
+//     }
+// }
+
+fn install_sh(
+    builder: &Builder<'_>,
+    package: &str,
+    stage: u32,
+    host: Option<TargetSelection>,
+    tarball: &GeneratedTarball,
+) {
+    let _guard = builder.msg(Kind::Install, stage, package, host, host);
+
+    let prefix = default_path(&builder.config.prefix, "/usr/local");
+    let sysconfdir = prefix.join(default_path(&builder.config.sysconfdir, "/etc"));
+    let destdir_env = env::var_os("DESTDIR").map(PathBuf::from);
+
+    // let datadir = prefix.join(default_path(&builder.config.datadir, "share"));
+    // let docdir = prefix.join(default_path(&builder.config.docdir, &format!("share/doc/{package}")));
+    // let mandir = prefix.join(default_path(&builder.config.mandir, "share/man"));
+    // let libdir = prefix.join(default_path(&builder.config.libdir, "lib"));
+    // let bindir = prefix.join(&builder.config.bindir); // Default in config.rs
+
+    let empty_dir = builder.out.join("tmp/empty_dir");
+    t!(fs::create_dir_all(&empty_dir));
+
+   
+    
+    let tarball_output = tarball.work_dir();
+    let image_dir = tarball_output.join("image");
+
+    
+    println!("Invoked\npackage: {package:#?}\nstage: {stage:#?}\ntarball: {tarball:#?}\nprefix: {prefix:#?}\nsysconfdir: {sysconfdir:#?}\ndestdir_env: {destdir_env:#?}\n");
+    sync_dir(image_dir, empty_dir).unwrap();
+}
+
+fn sync_dir(from: impl AsRef<Path>, to: impl AsRef<Path>) -> std::io::Result<()> {
+    // println!("\tfrom {:#?}\n\tto {:#?}", from.as_ref(), to.as_ref());
+    fs::create_dir_all(&to)?;
+    // println!("\tcreated {:#?}", to.as_ref());
+    for maybe_entry in fs::read_dir(from)? {
+        let entry = maybe_entry?;
+        // println!("\tEntry {:#?}", entry);
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            sync_dir(entry.path(), to.as_ref().join(entry.file_name()))?;
+        } else {
+            fs::copy(entry.path(), to.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}
+
+fn default_path(config: &Option<PathBuf>, default: &str) -> PathBuf {
+    config.as_ref().cloned().unwrap_or_else(|| PathBuf::from(default))
+}
+
+// fn prepare_dir(destdir_env: &Option<PathBuf>, mut path: PathBuf) -> String {
+//     // The DESTDIR environment variable is a standard way to install software in a subdirectory
+//     // while keeping the original directory structure, even if the prefix or other directories
+//     // contain absolute paths.
+//     //
+//     // More information on the environment variable is available here:
+//     // https://www.gnu.org/prep/standards/html_node/DESTDIR.html
+//     if let Some(destdir) = destdir_env {
+//         let without_destdir = path.clone();
+//         path.clone_from(destdir);
+//         // Custom .join() which ignores disk roots.
+//         for part in without_destdir.components() {
+//             if let Component::Normal(s) = part {
+//                 path.push(s)
+//             }
+//         }
+//     }
+
+//     // The installation command is not executed from the current directory, but from a temporary
+//     // directory. To prevent relative paths from breaking this converts relative paths to absolute
+//     // paths. std::fs::canonicalize is not used as that requires the path to actually be present.
+//     if path.is_relative() {
+//         path = std::env::current_dir().expect("failed to get the current directory").join(path);
+//         assert!(path.is_absolute(), "could not make the path relative");
+//     }
+
+//     sanitize_sh(&path)
+// }
+
+macro_rules! install {
+    (($sel:ident, $builder:ident, $_config:ident),
+       $($name:ident,
+       $condition_name: ident = $path_or_alias: literal,
+       $default_cond:expr,
+       only_hosts: $only_hosts:expr,
+       $run_item:block $(, $c:ident)*;)+) => {
+        $(
+            #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+        pub struct $name {
+            pub compiler: Compiler,
+            pub target: TargetSelection,
+        }
+
+        impl $name {
+            #[allow(dead_code)]
+            fn should_build(config: &Config) -> bool {
+                config.extended && config.tools.as_ref()
+                    .map_or(true, |t| t.contains($path_or_alias))
+            }
+        }
+
+        impl Step for $name {
+            type Output = ();
+            const DEFAULT: bool = true;
+            const ONLY_HOSTS: bool = $only_hosts;
+            $(const $c: bool = true;)*
+
+            fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+                let $_config = &run.builder.config;
+                run.$condition_name($path_or_alias).default_condition($default_cond)
+            }
+
+            fn make_run(run: RunConfig<'_>) {
+                run.builder.ensure($name {
+                    compiler: run.builder.compiler(run.builder.top_stage, run.builder.config.build),
+                    target: run.target,
+                });
+            }
+
+            fn run($sel, $builder: &Builder<'_>) {
+                $run_item
+            }
+        })+
+    }
+}
+
+install!((self, builder, _config),
+    Docs, path = "src/doc", _config.docs, only_hosts: false, {
+        let tarball = builder.ensure(dist::Docs { host: self.target }).expect("missing docs");
+        install_sh(builder, "docs", self.compiler.stage, Some(self.target), &tarball);
+    };
+    Std, path = "library/std", true, only_hosts: false, {
+        // `expect` should be safe, only None when host != build, but this
+        // only runs when host == build
+        let tarball = builder.ensure(dist::Std {
+            compiler: self.compiler,
+            target: self.target
+        }).expect("missing std");
+        install_sh(builder, "std", self.compiler.stage, Some(self.target), &tarball);
+    };
+    Cargo, alias = "cargo", Self::should_build(_config), only_hosts: true, {
+        let tarball = builder
+            .ensure(dist::Cargo { compiler: self.compiler, target: self.target })
+            .expect("missing cargo");
+        install_sh(builder, "cargo", self.compiler.stage, Some(self.target), &tarball);
+    };
+    RustAnalyzer, alias = "rust-analyzer", Self::should_build(_config), only_hosts: true, {
+        if let Some(tarball) =
+            builder.ensure(dist::RustAnalyzer { compiler: self.compiler, target: self.target })
+        {
+            install_sh(builder, "rust-analyzer", self.compiler.stage, Some(self.target), &tarball);
+        } else {
+            builder.info(
+                &format!("skipping Install rust-analyzer stage{} ({})", self.compiler.stage, self.target),
+            );
+        }
+    };
+    Clippy, alias = "clippy", Self::should_build(_config), only_hosts: true, {
+        let tarball = builder
+            .ensure(dist::Clippy { compiler: self.compiler, target: self.target })
+            .expect("missing clippy");
+        install_sh(builder, "clippy", self.compiler.stage, Some(self.target), &tarball);
+    };
+    Miri, alias = "miri", Self::should_build(_config), only_hosts: true, {
+        if let Some(tarball) = builder.ensure(dist::Miri { compiler: self.compiler, target: self.target }) {
+            install_sh(builder, "miri", self.compiler.stage, Some(self.target), &tarball);
+        } else {
+            // Miri is only available on nightly
+            builder.info(
+                &format!("skipping Install miri stage{} ({})", self.compiler.stage, self.target),
+            );
+        }
+    };
+    LlvmTools, alias = "llvm-tools", Self::should_build(_config), only_hosts: true, {
+        if let Some(tarball) = builder.ensure(dist::LlvmTools { target: self.target }) {
+            install_sh(builder, "llvm-tools", self.compiler.stage, Some(self.target), &tarball);
+        } else {
+            builder.info(
+                &format!("skipping llvm-tools stage{} ({}): external LLVM", self.compiler.stage, self.target),
+            );
+        }
+    };
+    Rustfmt, alias = "rustfmt", Self::should_build(_config), only_hosts: true, {
+        if let Some(tarball) = builder.ensure(dist::Rustfmt {
+            compiler: self.compiler,
+            target: self.target
+        }) {
+            install_sh(builder, "rustfmt", self.compiler.stage, Some(self.target), &tarball);
+        } else {
+            builder.info(
+                &format!("skipping Install Rustfmt stage{} ({})", self.compiler.stage, self.target),
+            );
+        }
+    };
+    RustDemangler, alias = "rust-demangler", Self::should_build(_config), only_hosts: true, {
+        // NOTE: Even though `should_build` may return true for `extended` default tools,
+        // dist::RustDemangler may still return None, unless the target-dependent `profiler` config
+        // is also true, or the `tools` array explicitly includes "rust-demangler".
+        if let Some(tarball) = builder.ensure(dist::RustDemangler {
+            compiler: self.compiler,
+            target: self.target
+        }) {
+            install_sh(builder, "rust-demangler", self.compiler.stage, Some(self.target), &tarball);
+        } else {
+            builder.info(
+                &format!("skipping Install RustDemangler stage{} ({})",
+                         self.compiler.stage, self.target),
+            );
+        }
+    };
+    Rustc, path = "compiler/rustc", true, only_hosts: true, {
+        let tarball = builder.ensure(dist::Rustc {
+            compiler: builder.compiler(builder.top_stage, self.target),
+        });
+        install_sh(builder, "rustc", self.compiler.stage, Some(self.target), &tarball);
+    };
+    RustcCodegenCranelift, alias = "rustc-codegen-cranelift", Self::should_build(_config), only_hosts: true, {
+        if let Some(tarball) = builder.ensure(dist::CodegenBackend {
+            compiler: self.compiler,
+            backend: "cranelift".to_string(),
+        }) {
+            install_sh(builder, "rustc-codegen-cranelift", self.compiler.stage, Some(self.target), &tarball);
+        } else {
+            builder.info(
+                &format!("skipping Install CodegenBackend(\"cranelift\") stage{} ({})",
+                         self.compiler.stage, self.target),
+            );
+        }
+    };
+    LlvmBitcodeLinker, alias = "llvm-bitcode-linker", Self::should_build(_config), only_hosts: true, {
+        if let Some(tarball) = builder.ensure(dist::LlvmBitcodeLinker { compiler: self.compiler, target: self.target }) {
+            install_sh(builder, "llvm-bitcode-linker", self.compiler.stage, Some(self.target), &tarball);
+        } else {
+            builder.info(
+                &format!("skipping llvm-bitcode-linker stage{} ({})", self.compiler.stage, self.target),
+            );
+        }
+    };
+);
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct Src {
+    pub stage: u32,
+}
+
+impl Step for Src {
+    type Output = ();
+    const DEFAULT: bool = true;
+    const ONLY_HOSTS: bool = true;
+
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+        let config = &run.builder.config;
+        let cond = config.extended && config.tools.as_ref().map_or(true, |t| t.contains("src"));
+        run.path("src").default_condition(cond)
+    }
+
+    fn make_run(run: RunConfig<'_>) {
+        run.builder.ensure(Src { stage: run.builder.top_stage });
+    }
+
+    fn run(self, builder: &Builder<'_>) {
+        let tarball = builder.ensure(dist::Src);
+        install_sh(builder, "src", self.stage, None, &tarball);
+    }
+}

--- a/src/bootstrap/src/ferrocene/install.rs
+++ b/src/bootstrap/src/ferrocene/install.rs
@@ -5,10 +5,8 @@
 //! This module is responsible for installing the standard library,
 //! compiler, and documentation.
 
-// use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-// use std::process::Command;
 
 use walkdir::WalkDir;
 

--- a/src/bootstrap/src/ferrocene/install.rs
+++ b/src/bootstrap/src/ferrocene/install.rs
@@ -7,7 +7,7 @@
 
 // use std::env;
 use std::fs;
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 // use std::process::Command;
 
 use walkdir::WalkDir;
@@ -51,10 +51,10 @@ fn install(
         }
         prefix
     };
-    
+
     let remap = |from: &Path, to: &Path| -> std::io::Result<()> {
         if !from.exists() {
-            return Ok(())
+            return Ok(());
         }
         for maybe_entry in WalkDir::new(&from) {
             let entry = maybe_entry.unwrap();

--- a/src/bootstrap/src/ferrocene/install.rs
+++ b/src/bootstrap/src/ferrocene/install.rs
@@ -139,10 +139,6 @@ macro_rules! install {
 }
 
 install!((self, builder, _config),
-    Docs, path = "src/doc", _config.docs, only_hosts: false, {
-        let tarball = builder.ensure(dist::Docs { host: self.target }).expect("missing docs");
-        install(builder, "docs", self.compiler.stage, Some(self.target), &tarball);
-    };
     Std, path = "library/std", true, only_hosts: false, {
         // `expect` should be safe, only None when host != build, but this
         // only runs when host == build

--- a/src/bootstrap/src/ferrocene/install.rs
+++ b/src/bootstrap/src/ferrocene/install.rs
@@ -250,6 +250,20 @@ install!((self, builder, _config),
             );
         }
     };
+    FlipLink, alias = "flip-link", Self::should_build(_config), only_hosts: true, {
+        let tarball = builder.ensure(crate::ferrocene::dist::flip_link::FlipLink { target: self.target });
+        install(builder, "flip-link", self.compiler.stage, Some(self.target), &tarball);
+    };
+    SelfTest, alias = "self-test", Self::should_build(_config), only_hosts: true, {
+        let tarball = builder.ensure(crate::ferrocene::dist::SelfTest { target: self.target });
+        install(builder, "self-test", self.compiler.stage, Some(self.target), &tarball);
+    };
+    FerroceneDocs, alias = "ferrocene-docs", Self::should_build(_config), only_hosts: true, {
+        let tarballs = builder.ensure(crate::ferrocene::dist::Docs { target: self.target });
+        for tarball in tarballs {
+            install(builder, "ferrocene-docs", self.compiler.stage, Some(self.target), &tarball);
+        }
+    };
 );
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/src/bootstrap/src/ferrocene/mod.rs
+++ b/src/bootstrap/src/ferrocene/mod.rs
@@ -4,13 +4,13 @@
 pub(crate) mod code_coverage;
 pub(crate) mod dist;
 pub(crate) mod doc;
+pub(crate) mod install;
 pub(crate) mod partners;
 pub(crate) mod run;
 pub(crate) mod sign;
 pub(crate) mod test;
 pub(crate) mod test_outcomes;
 pub(crate) mod tool;
-pub(crate) mod install;
 
 use crate::builder::Builder;
 use crate::core::config::{Config, TargetSelection};

--- a/src/bootstrap/src/ferrocene/mod.rs
+++ b/src/bootstrap/src/ferrocene/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod sign;
 pub(crate) mod test;
 pub(crate) mod test_outcomes;
 pub(crate) mod tool;
+pub(crate) mod install;
 
 use crate::builder::Builder;
 use crate::core::config::{Config, TargetSelection};


### PR DESCRIPTION
@pietroalbini noticed that `x.py install` was broken due to some of the changes we'd made.

This is largely due to us packaging our tarballs slightly differently and not generating an `install.sh`.

This PR creates a new ferrocene specific install step for each package that directly renames the tarball outputs to their configured destinations.

It supports all the `config.toml` options as well as `DESTDIR`.

### Testing

* [ ] Test `x.py install` with a `install.prefix` set in `config.toml`
* [ ] Test `x.py install` with any number of `install.*dir` set in `config.toml`
* [ ] Test `x.py install` with a `install.prefix` and any number of `install.*dir` set in `config.toml`
* [ ] Test `x.py install` with the `DESTDIR` env set
* [ ] Test `x.py install` with the `DESTDIR` env set and a `install.prefix` set in `config.toml`
* [ ] Test `x.py install` with the `DESTDIR` env set and any number of `install.*dir` set in `config.toml`
* [ ] Test `x.py install` with the `DESTDIR` env set and a `install.prefix` set in `config.toml` and any number of `install.*dir` set in `config.toml`