### PR TITLE
Installation docs for x86_64-pc-windows-msvc

### DIFF
--- a/ferrocene/doc/user-manual/src/index.rst
+++ b/ferrocene/doc/user-manual/src/index.rst
@@ -38,6 +38,7 @@ Ferrocene User Manual
    targets/index
    targets/aarch64-unknown-none
    targets/x86_64-unknown-linux-gnu
+   targets/x86_64-pc-windows-msvc
 
 .. toctree::
    :numbered:

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -120,7 +120,7 @@ should not be used in production.
      - Full
      - \-
 
-   * - :target:`x86_64-pc-windows-msvc`
+   * - :ref:`x86_64-pc-windows-msvc`
      - ``x86_64-pc-windows-msvc``
      - Host platform
      - Full

--- a/ferrocene/doc/user-manual/src/targets/x86_64-pc-windows-msvc.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-pc-windows-msvc.rst
@@ -24,6 +24,11 @@ Alternatively, you can `install Build Tools via winget
 
     winget install --id=Microsoft.VisualStudio.2022.BuildTools  -e
 
-For further support with Microsoft Windows installer please check the
-`documentation for Ferrocene toolchain manager - CriticalUp
-<https://criticalup.ferrocene.dev/install.html#windows>`_.
+You can also check the `instructions for installing the Windows
+MSVC tools for Rust
+<https://rust-lang.github.io/rustup/installation/windows-msvc.html>`_.
+
+.. note::
+   For further support with our Windows installer please check the
+   `documentation for Ferrocene toolchain manager - CriticalUp
+   <https://criticalup.ferrocene.dev/install.html#windows>`_.

--- a/ferrocene/doc/user-manual/src/targets/x86_64-pc-windows-msvc.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-pc-windows-msvc.rst
@@ -13,9 +13,7 @@
    target. They are provided as a preview, with limited support available. They
    should not be used in production.
 
-The ``x86_64-pc-windows-msvc`` Ferrocene target provides support for Host as
-well as Cross-compilation for Microsoft Windows on x86_64 using the native
-ABI (MSVC).
+The ``x86_64-pc-windows-msvc`` Ferrocene target provides support Microsoft Windows on x86_64 using MSVC.
 
 Prerequisites
 -------------

--- a/ferrocene/doc/user-manual/src/targets/x86_64-pc-windows-msvc.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-pc-windows-msvc.rst
@@ -1,0 +1,29 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+.. _x86_64-pc-windows-msvc:
+
+:target:`x86_64-pc-windows-msvc`
+================================
+
+The ``x86_64-pc-windows-msvc`` Ferrocene target provides support for Host as
+well as Cross-compilation for Microsoft Windows on x86_64 using the native
+ABI (MSVC).
+
+Prerequisites
+-------------
+
+You need to install Microsoft Build Tools either via
+`installing Visual Studio <https://visualstudio.microsoft.com/downloads/>`_
+or installing the Build Tools directly via the same installer.
+
+Alternatively, you can `install Build Tools via winget
+<https://winstall.app/apps/Microsoft.VisualStudio.2022.BuildTools>`_.
+
+.. code-block::
+
+    winget install --id=Microsoft.VisualStudio.2022.BuildTools  -e
+
+For further support with Microsoft Windows installer please check the
+`documentation for Ferrocene toolchain manager - CriticalUp
+<https://criticalup.ferrocene.dev/install.html#windows>`_.

--- a/ferrocene/doc/user-manual/src/targets/x86_64-pc-windows-msvc.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-pc-windows-msvc.rst
@@ -6,6 +6,13 @@
 :target:`x86_64-pc-windows-msvc`
 ================================
 
+.. warning::
+   
+   Experimental targets cannot be used in safety-critical contexts, and there is
+   no guarantee that the Ferrocene test suite is successfully executed on the
+   target. They are provided as a preview, with limited support available. They
+   should not be used in production.
+
 The ``x86_64-pc-windows-msvc`` Ferrocene target provides support for Host as
 well as Cross-compilation for Microsoft Windows on x86_64 using the native
 ABI (MSVC).
@@ -13,22 +20,62 @@ ABI (MSVC).
 Prerequisites
 -------------
 
-You need to install Microsoft Build Tools either via
-`installing Visual Studio <https://visualstudio.microsoft.com/downloads/>`_
-or installing the Build Tools directly via the same installer.
+This target uses Microsoft's ``Link.exe`` linker. It can be obtained from
+`the Visual Studio installation page <https://visualstudio.microsoft.com/downloads/>`_.
 
-Alternatively, you can `install Build Tools via winget
-<https://winstall.app/apps/Microsoft.VisualStudio.2022.BuildTools>`_.
+.. note::
+
+   Your organization may require a Visual Studio license from Microsoft. See the
+   `Licensing Terms <https://visualstudio.microsoft.com/license-terms/>`_.
+
+Install one of:
+
+* The Visual Studio edition best suited for you, or
+* `Build Tools for Visual Studio 2022` under `Tools for Visual Studio`
+
+`Build Tools for Visual Studio 2022`` can be installed via ``winget``:
 
 .. code-block::
 
     winget install --id=Microsoft.VisualStudio.2022.BuildTools  -e
 
-You can also check the `instructions for installing the Windows
-MSVC tools for Rust
-<https://rust-lang.github.io/rustup/installation/windows-msvc.html>`_.
+If prompted for which components to enable, enable `Desktop
+development with C++`, or select all of the following individual components:
 
-.. note::
-   For further support with our Windows installer please check the
-   `documentation for Ferrocene toolchain manager - CriticalUp
-   <https://criticalup.ferrocene.dev/install.html#windows>`_.
+* MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest)
+* Windows 11 SDK (10.0.22621.0)
+
+The specific versions of these components do not particularly matter to Ferrocene,
+you may use whatever version your dependencies require.
+
+Archives to install
+-------------------
+
+
+The following archives are needed when :doc:`installing </rustc/install>` this
+target as a host platform:
+
+* ``rustc-x86_64-pc-windows-msvc``
+* ``rust-std-x86_64-pc-windows-msvc``
+* ``ferrocene-self-test-x86_64-pc-windows-msvc``
+
+The following archives are needed when :doc:`installing </rustc/install>` this
+target as a cross-compilation target:
+
+* ``rust-std-x86_64-pc-windows-msvc``
+
+To install the optional ``rustfmt`` tool, the following archive is needed:
+
+* ``rustfmt-x86_64-pc-windows-msvc``
+
+Required compiler flags
+-----------------------
+
+To use the target, the following additional flags must be provided to
+``rustc``:
+
+- ``--target=x86_64-pc-windows-msvc``
+
+- ``-C linker=<your-c-compiler>``
+
+  - e.g. ``-C linker='C://Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.335.19\bin\HostX64\x64\link.exe'``

--- a/ferrocene/doc/user-manual/src/targets/x86_64-pc-windows-msvc.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-pc-windows-msvc.rst
@@ -40,8 +40,8 @@ Install one of:
 If prompted for which components to enable, enable `Desktop
 development with C++`, or select all of the following individual components:
 
-* MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest)
-* Windows 11 SDK (10.0.22621.0)
+* The most recent "C++ x64/x86 build tools"
+* The most recent "Windows 11 SDK"
 
 The specific versions of these components do not particularly matter to Ferrocene,
 you may use whatever version your dependencies require.
@@ -73,7 +73,3 @@ To use the target, the following additional flags must be provided to
 ``rustc``:
 
 - ``--target=x86_64-pc-windows-msvc``
-
-- ``-C linker=<your-c-compiler>``
-
-  - e.g. ``-C linker='C://Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.335.19\bin\HostX64\x64\link.exe'``


### PR DESCRIPTION
MSVC Windows on x86_64 needs some prerequisites. This PR adds those prerequisites.

- Adds a new page for MSVC Windows on x86_64.
- Links to that page from targets page's Experiemental targets section.