### PR TITLE
Installation docs for aarch64-apple-darwin

### DIFF
--- a/ferrocene/doc/user-manual/src/index.rst
+++ b/ferrocene/doc/user-manual/src/index.rst
@@ -39,6 +39,7 @@ Ferrocene User Manual
    targets/aarch64-unknown-none
    targets/x86_64-unknown-linux-gnu
    targets/x86_64-pc-windows-msvc
+   targets/aarch64-apple-darwin
 
 .. toctree::
    :numbered:

--- a/ferrocene/doc/user-manual/src/targets/aarch64-apple-darwin.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-apple-darwin.rst
@@ -65,7 +65,3 @@ To use the target, the following additional flags must be provided to
 ``rustc``:
 
 - ``--target=x86_64-unknown-linux-gnu``
-
-- ``-C linker=<your-c-compiler>``
-
-  - e.g. ``-C linker=/usr/bin/clang``

--- a/ferrocene/doc/user-manual/src/targets/aarch64-apple-darwin.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-apple-darwin.rst
@@ -59,7 +59,7 @@ To install the optional ``rustfmt`` tool, the following archive is needed:
 * ``rustfmt-aarch64-apple-darwin``
 
 Required compiler flags
-----------------------
+-----------------------
 
 To use the target, the following additional flags must be provided to
 ``rustc``:

--- a/ferrocene/doc/user-manual/src/targets/aarch64-apple-darwin.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-apple-darwin.rst
@@ -1,0 +1,71 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+.. _aarch64-apple-darwin:
+
+:target:`aarch64-apple-darwin`
+================================
+
+.. warning::
+   
+   Experimental targets cannot be used in safety-critical contexts, and there is
+   no guarantee that the Ferrocene test suite is successfully executed on the
+   target. They are provided as a preview, with limited support available. They
+   should not be used in production.
+
+The ``aarch64-apple-darwin`` Ferrocene target provides support for macOS (Darwin) on
+aarch64.
+
+Prerequisites
+-------------
+
+This target uses the LLVM ``ld.lld`` linker. In order to locate the system C
+libraries required to link a functional macOS binary, this target drives the
+``ld.lld`` linker using your system's C compiler as a linker driver.
+
+Install one of:
+
+* `Xcode command line tools`, or
+* `Xcode <https://developer.apple.com/xcode/resources/>`_
+
+.. note::
+
+   If using `Xcode`, you will require an `Apple Developer Program <https://developer.apple.com/programs/>`_ membership.
+
+`Xcode command line tools` can be installed via ``xcode-select``:
+
+.. code-block::
+
+    xcode-select --install
+
+
+Archives to install
+-------------------
+
+The following archives are needed when :doc:`installing </rustc/install>` this
+target as a host platform:
+
+* ``rustc-aarch64-apple-darwin``
+* ``rust-std-aarch64-apple-darwin``
+* ``ferrocene-self-test-aarch64-apple-darwin``
+
+The following archives are needed when :doc:`installing </rustc/install>` this
+target as a cross-compilation target:
+
+* ``rust-std-aarch64-apple-darwin``
+
+To install the optional ``rustfmt`` tool, the following archive is needed:
+
+* ``rustfmt-aarch64-apple-darwin``
+
+Required compiler flags
+----------------------
+
+To use the target, the following additional flags must be provided to
+``rustc``:
+
+- ``--target=x86_64-unknown-linux-gnu``
+
+- ``-C linker=<your-c-compiler>``
+
+  - e.g. ``-C linker=/usr/bin/clang``

--- a/ferrocene/doc/user-manual/src/targets/aarch64-apple-darwin.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-apple-darwin.rst
@@ -14,7 +14,7 @@
    should not be used in production.
 
 The ``aarch64-apple-darwin`` Ferrocene target provides support for macOS (Darwin) on
-aarch64.
+Apple Silicon.
 
 Prerequisites
 -------------

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -112,9 +112,9 @@ should not be used in production.
      - ``x86_64-apple-darwin``
      - Cross-compilation
      - Full
-     - Available as a cross-compile target on :target:`aarch64-apple-darwin`.
+     - Available as a cross-compile target on :ref:`aarch64-apple-darwin`.
 
-   * - :target:`aarch64-apple-darwin`
+   * - :ref:`aarch64-apple-darwin`
      - ``aarch64-apple-darwin``
      - Host platform
      - Full


### PR DESCRIPTION
Similar to #664, but Apple flavored instead of glass-flavored.