### PR TITLE
`llvm-cache s3-url` outputting the same on Windows and Linux

### DIFF
--- a/ferrocene/ci/scripts/llvm-cache.sh
+++ b/ferrocene/ci/scripts/llvm-cache.sh
@@ -74,8 +74,20 @@ get_llvm_cache_hash() {
     # the hash of the tree from git, saving time and achieving the same effect.
     git ls-tree HEAD src/llvm-project >> "${file}"
 
+    if [[ "${OSTYPE}" = "msys" ]]; then
+        # For some reason, Windows has different shasum output than Linux.
+        # Lines are, inexplicably:
+        # $CHECKSUM *$PATH
+        # Instead of:
+        # $CHECKSUM  $PATH
+        # So, remove that. Also fix the line endings (\015)
+        new_file="$(mktemp)"
+        cat "${file}" | tr '*' ' ' | tr -d '\r' > "${new_file}"
+        mv "${new_file}" "${file}"
+    fi
+
     ${SHA_CMD[@]} "${file}" | awk '{print($1)}'
-    rm -f "${file}"
+    # rm -f "${file}"
 }
 
 # Build LLVM and generate a tarball we can cache with all the build artifacts.

--- a/ferrocene/ci/scripts/llvm-cache.sh
+++ b/ferrocene/ci/scripts/llvm-cache.sh
@@ -80,9 +80,9 @@ get_llvm_cache_hash() {
         # $CHECKSUM *$PATH
         # Instead of:
         # $CHECKSUM  $PATH
-        # So, remove that. Also fix the line endings (\015)
+        # So, remove that. Also fix the line endings (\r)
         new_file="$(mktemp)"
-        cat "${file}" | tr '*' ' ' | tr -d '\r' > "${new_file}"
+        cat "${file}" | tr '*' ' ' | sed 's.\r$..' > "${new_file}"
         mv "${new_file}" "${file}"
     fi
 

--- a/ferrocene/ci/scripts/llvm-cache.sh
+++ b/ferrocene/ci/scripts/llvm-cache.sh
@@ -87,7 +87,7 @@ get_llvm_cache_hash() {
     fi
 
     ${SHA_CMD[@]} "${file}" | awk '{print($1)}'
-    # rm -f "${file}"
+    rm -f "${file}"
 }
 
 # Build LLVM and generate a tarball we can cache with all the build artifacts.


### PR DESCRIPTION
@tshepang's sharp eye noticed this. :)

Eg of the tempfiole on windows:

```
dc8ef67ed19367be8fd39e5b0dad9e2786f689d70e2ec1759e5a677f57a42ea6 *ferrocene/ci/docker-images/ubuntu-20/Dockerfile
efca746f02c4fdadc95c44341d528b92ff7fe94e6bc1ca34f0c53b06f9c2c944 *ferrocene/ci/docker-images/ubuntu-20/reuse-requirements.txt
f6b6e44fadcee8e16cf14f8e69016777b3952a5af9b3e66acf74fae08a958fa9 *ferrocene/ci/docker-images/ubuntu-20/sudoers
a8620cc38d451cceb5c62c808d0fb47456ead11ef590731862adfef62df71a2e *ferrocene/ci/docker-images/ubuntu-23/Dockerfile
efca746f02c4fdadc95c44341d528b92ff7fe94e6bc1ca34f0c53b06f9c2c944 *ferrocene/ci/docker-images/ubuntu-23/reuse-requirements.txt
f0782d7254d0a6303995b50936b788e6ddc97e037ba33f0ca290ff0d9eb9418f *src/bootstrap/Cargo.lock
64e3e230fa1ef87ed304a12b98ffc19ba5b59d25f9a8f57dbcccb7de006dc68b *src/bootstrap/Cargo.toml
79089a865c934d108e76516d0ecb6e9e17f4240404674f125e131560adcddbae *src/bootstrap/README.md
afb9f542546a3f236d5efedd929072a40678d5629353e05f70e1acf25f1137da *src/bootstrap/bootstrap.py
7bbe83a4a5b028aa6f24c8e21dc8ad1cd94871ef21e51cc32f5e091886c990c6 *src/bootstrap/bootstrap_test.py
b915f3fcc1a17f580131d76a1530d06561a989d4b3f05943a3dcb2d86972568e *src/bootstrap/build.rs
2fd321429d48276f47f72f8f42a464c831b910044618dbb3367562a211ee3b8f *src/bootstrap/configure.py
```

Meanwhile on Linux: 

```
7c16844a7fbeb0d0a1bf217df6dae85cc923500c1aa6e2784cb1f3a6e3893908  ./ferrocene/ci/scripts/llvm-cache.sh
2e12f36359535ae5c72ddace7bdfdfa49c148b68445e5f945f059ca88a626c4b  ferrocene/ci/configure.sh
1cb49918acdf75802ef99971dbd732b0b34847ef03a8d830e53c237c0fe9c94b  src/version
dc8ef67ed19367be8fd39e5b0dad9e2786f689d70e2ec1759e5a677f57a42ea6  ferrocene/ci/docker-images/ubuntu-20/Dockerfile
efca746f02c4fdadc95c44341d528b92ff7fe94e6bc1ca34f0c53b06f9c2c944  ferrocene/ci/docker-images/ubuntu-20/reuse-requirements.txt
f6b6e44fadcee8e16cf14f8e69016777b3952a5af9b3e66acf74fae08a958fa9  ferrocene/ci/docker-images/ubuntu-20/sudoers
a8620cc38d451cceb5c62c808d0fb47456ead11ef590731862adfef62df71a2e  ferrocene/ci/docker-images/ubuntu-23/Dockerfile
efca746f02c4fdadc95c44341d528b92ff7fe94e6bc1ca34f0c53b06f9c2c944  ferrocene/ci/docker-images/ubuntu-23/reuse-requirements.txt
f0782d7254d0a6303995b50936b788e6ddc97e037ba33f0ca290ff0d9eb9418f  src/bootstrap/Cargo.lock
64e3e230fa1ef87ed304a12b98ffc19ba5b59d25f9a8f57dbcccb7de006dc68b  src/bootstrap/Cargo.toml
79089a865c934d108e76516d0ecb6e9e17f4240404674f125e131560adcddbae  src/bootstrap/README.md
afb9f542546a3f236d5efedd929072a40678d5629353e05f70e1acf25f1137da  src/bootstrap/bootstrap.py
7bbe83a4a5b028aa6f24c8e21dc8ad1cd94871ef21e51cc32f5e091886c990c6  src/bootstrap/bootstrap_test.py
```