### PR TITLE
Enable 2 of 3 compiler-arguments target tests on all architectures

### DIFF
--- a/tests/ui/ferrocene/compiler-arguments/target/target_invalid.rs
+++ b/tests/ui/ferrocene/compiler-arguments/target/target_invalid.rs
@@ -1,6 +1,5 @@
 //@ check-fail
 //@ compile-flags: --target=x86_64-invalid-linux-gnu
-//@ only-x86_64-unknown-linux-gnu
 //@ needs-llvm-components:
 
 fn main() {}

--- a/tests/ui/ferrocene/compiler-arguments/target/target_not-available.rs
+++ b/tests/ui/ferrocene/compiler-arguments/target/target_not-available.rs
@@ -1,7 +1,6 @@
 //~ ERROR [E0463]
 //@ check-fail
 //@ compile-flags: --target=x86_64-unknown-none
-//@ only-x86_64-unknown-linux-gnu
 //@ needs-llvm-components:
 fn main() {}
 


### PR DESCRIPTION
The output of these two tests does not contain any host specific strings, so there is no reason not to run these only on one target.