### PR TITLE
Enable compiler-arguments/target test on all platforms

### DIFF
--- a/tests/ui/ferrocene/compiler-arguments/target/target.rs
+++ b/tests/ui/ferrocene/compiler-arguments/target/target.rs
@@ -1,6 +1,5 @@
 //@ check-pass
-//@ compile-flags: --target=x86_64-unknown-linux-gnu
-//@ only-x86_64-unknown-linux-gnu
+//@ compile-flags: --target={{target}}
 //@ needs-llvm-components:
 
 fn main() {}


### PR DESCRIPTION
Allows enabling the remaining target test after https://github.com/ferrocene/ferrocene/pull/679