### PR TITLE
Update stamp following this change

### DIFF
--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -6,4 +6,4 @@ Last change is for: https://github.com/rust-lang/rust/pull/125141
 
 (white space intentional to avoid merge conflicts)
 
-Last Ferrocene change is for: https://github.com/ferrocene/ferrocene/pull/98
+Last Ferrocene change is for: https://github.com/ferrocene/ferrocene/pull/691


### PR DESCRIPTION
Following changes in:
https://github.com/rust-lang/rust/pull/125141
in [ff25b24](https://github.com/ferrocene/ferrocene/pull/691/commits/ff25b24a10ffcf10ae0dcddea60710cf4c12cbb5), only upstream download configuration was changed.