### PR TITLE
attempt to circumvent libc failure

### DIFF
--- a/ferrocene/library/libc/src/lib.rs
+++ b/ferrocene/library/libc/src/lib.rs
@@ -2,6 +2,10 @@
 #![crate_name = "libc"]
 #![crate_type = "rlib"]
 #![allow(
+    dead_code, // Ferrocene specific
+    elided_lifetimes_in_paths, // Ferrocene specific
+    hidden_glob_reexports, // Ferrocene specific
+    ambiguous_glob_reexports, // Ferrocene specific
     renamed_and_removed_lints, // Keep this order.
     unknown_lints, // Keep this order.
     bad_style,
@@ -12,11 +16,6 @@
     redundant_semicolons,
     unused_macros,
     unused_macro_rules,
-    // Ferrocene-specific:
-    dead_code,
-    elided_lifetimes_in_paths,
-    hidden_glob_reexports,
-    ambiguous_glob_reexports
 )]
 #![cfg_attr(libc_deny_warnings, deny(warnings))]
 // Attributes needed when building as part of the standard library


### PR DESCRIPTION
https://github.com/rust-lang/libc/blame/libc-0.2/src/lib.rs
(this contains a duplicate of `dead_code` that we will remove later)