### PR TITLE
Reformat tables in rustc tool-analysis

### DIFF
--- a/ferrocene/doc/evaluation-plan/src/method.rst
+++ b/ferrocene/doc/evaluation-plan/src/method.rst
@@ -93,15 +93,15 @@ HazOp analysis:
 
 .. list-table::
 
-   * - Error identifier 
+   * - Error identifier
      - ERR_TOOLID_XXX where TOOLID is the name of the tool causing the error, and XXX a number.
-   * - Use case 
+   * - Use case
      - The use case where the error is determined.
-   * - Description 
+   * - Description
      - The potential error descriptions.
-   * - Risk 
+   * - Risk
      - Possible effects of the potential error.
-   * - Mitigation 
+   * - Mitigation
      - The detection or mitigation method identifier, if available.
    * - Detectable
      - YES or NO, indicates if the error could be detected.
@@ -120,6 +120,10 @@ table describes a countermeasure entry:
      - The description of the check or the avoidance mechanism.
 
 .. end of table
+
+If all use cases of all potential errors in the table are exactly the same, the
+column can be omitted and instead a list of use cases has to be added after the
+table. This is to avoid repetition.
 
 HazOp Organization
 ^^^^^^^^^^^^^^^^^^

--- a/ferrocene/doc/evaluation-report/src/rustc/potential-errors.rst
+++ b/ferrocene/doc/evaluation-report/src/rustc/potential-errors.rst
@@ -9,37 +9,65 @@ Potential Errors and Tests Traceability
 .. list-table::
    :align: left
    :header-rows: 1
-   :widths: 35, 65
 
    * - Potential error
      - Tests
    * - :id:`RUSTC_ERR_INSTALL_01`
      - :id:`RUSTC_TS8_SELF`
    * - :id:`RUSTC_ERR_DRIVER_04`
-     - :id:`RUSTC_TS1_COMP`, :id:`RUSTC_TS2_LIBR`, :id:`RUSTC_TS3_CRAT`, :id:`RUSTC_TS4_LINK`, :id:`RUSTC_TS6_BSYS`, :id:`RUSTC_TS7_TIDY`
+     - | :id:`RUSTC_TS1_COMP`,
+       | :id:`RUSTC_TS2_LIBR`,
+       | :id:`RUSTC_TS3_CRAT`,
+       | :id:`RUSTC_TS4_LINK`,
+       | :id:`RUSTC_TS6_BSYS`,
+       | :id:`RUSTC_TS7_TIDY`
    * - :id:`RUSTC_ERR_DRIVER_05`
-     - :id:`RUSTC_TS1_COMP`, :id:`RUSTC_TS2_LIBR`, :id:`RUSTC_TS3_CRAT`, :id:`RUSTC_TS6_BSYS`, :id:`RUSTC_TS7_TIDY`
+     - | :id:`RUSTC_TS1_COMP`,
+       | :id:`RUSTC_TS2_LIBR`,
+       | :id:`RUSTC_TS3_CRAT`,
+       | :id:`RUSTC_TS6_BSYS`,
+       | :id:`RUSTC_TS7_TIDY`
    * - :id:`RUSTC_ERR_DRIVER_08`
-     - :id:`RUSTC_TS1_COMP`, :id:`RUSTC_TS2_LIBR`, :id:`RUSTC_TS3_CRAT`, :id:`RUSTC_TS6_BSYS`
+     - | :id:`RUSTC_TS1_COMP`,
+       | :id:`RUSTC_TS2_LIBR`,
+       | :id:`RUSTC_TS3_CRAT`,
+       | :id:`RUSTC_TS6_BSYS`
    * - :id:`RUSTC_ERR_DRIVER_09`
-     - :id:`RUSTC_TS1_COMP`, :id:`RUSTC_TS3_CRAT`, :id:`RUSTC_TS6_BSYS`
+     - | :id:`RUSTC_TS1_COMP`,
+       | :id:`RUSTC_TS3_CRAT`,
+       | :id:`RUSTC_TS6_BSYS`
    * - :id:`RUSTC_ERR_RUST_FE_11`
      - :id:`RUSTC_TS1_COMP`
    * - :id:`RUSTC_ERR_RUST_FE_13`
-     - :id:`RUSTC_TS1_COMP`, :id:`RUSTC_TS2_LIBR`, :id:`RUSTC_TS3_CRAT`, :id:`RUSTC_TS6_BSYS`, :id:`RUSTC_TS7_TIDY`
+     - | :id:`RUSTC_TS1_COMP`,
+       | :id:`RUSTC_TS2_LIBR`,
+       | :id:`RUSTC_TS3_CRAT`,
+       | :id:`RUSTC_TS6_BSYS`,
+       | :id:`RUSTC_TS7_TIDY`
    * - :id:`RUSTC_ERR_RUST_FE_15`
      - :id:`RUSTC_TS1_COMP`
    * - :id:`RUSTC_ERR_LLVM_17`
      - :id:`RUSTC_TS1_COMP`
    * - :id:`RUSTC_ERR_LLVM_19`
-     - :id:`RUSTC_TS1_COMP`, :id:`RUSTC_TS2_LIBR`, :id:`RUSTC_TS3_CRAT`, :id:`RUSTC_TS6_BSYS`, :id:`RUSTC_TS7_TIDY`
+     - | :id:`RUSTC_TS1_COMP`,
+       | :id:`RUSTC_TS2_LIBR`,
+       | :id:`RUSTC_TS3_CRAT`,
+       | :id:`RUSTC_TS6_BSYS`,
+       | :id:`RUSTC_TS7_TIDY`
    * - :id:`RUSTC_ERR_LLVM_21`
-     - :id:`RUSTC_TS1_COMP`, :id:`RUSTC_TS2_LIBR`
+     - | :id:`RUSTC_TS1_COMP`,
+       | :id:`RUSTC_TS2_LIBR`
    * - :id:`RUSTC_ERR_LLVM_22`
-     - :id:`RUSTC_TS1_COMP`, :id:`RUSTC_TS6_BSYS`
+     - | :id:`RUSTC_TS1_COMP`,
+       | :id:`RUSTC_TS6_BSYS`
    * - :id:`RUSTC_ERR_LINK_24`
      - :id:`RUSTC_TS1_COMP`
    * - :id:`RUSTC_ERR_LINK_28`
-     - :id:`RUSTC_TS1_COMP`, :id:`RUSTC_TS2_LIBR`, :id:`RUSTC_TS3_CRAT`, :id:`RUSTC_TS4_LINK`, :id:`RUSTC_TS6_BSYS`, :id:`RUSTC_TS7_TIDY`
+     - | :id:`RUSTC_TS1_COMP`,
+       | :id:`RUSTC_TS2_LIBR`,
+       | :id:`RUSTC_TS3_CRAT`,
+       | :id:`RUSTC_TS4_LINK`,
+       | :id:`RUSTC_TS6_BSYS`,
+       | :id:`RUSTC_TS7_TIDY`
 
 .. end of table

--- a/ferrocene/doc/evaluation-report/src/rustc/tool-analysis.rst
+++ b/ferrocene/doc/evaluation-report/src/rustc/tool-analysis.rst
@@ -51,8 +51,11 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - An used environment variable is set to an incorrect value
-     - Undefined behavior
+     - | An used environment
+       | variable is set to an
+       | incorrect value
+     - | Undefined
+       | behavior
      - :id:`RUSTC_AVD_CHECK_CLEAN_ENV_002`
      - YES
    * - .. id:: RUSTC_ERR_DRIVER_03
@@ -61,8 +64,10 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - An invalid option is passed
-     - Undefined behavior
+     - | An invalid option is
+       | passed
+     - | Undefined
+       | behavior
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - YES
    * - .. id:: RUSTC_ERR_DRIVER_04
@@ -71,8 +76,10 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - Error diagnostics are not correctly emited
-     - Undefined behavior
+     - | Error diagnostics are
+       | not correctly emited
+     - | Undefined
+       | behavior
      - | :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`,
        | :id:`RUSTC_AVD_TEST_007`
      - NO
@@ -82,8 +89,11 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - The output is generated with missing part
-     - Wrong code
+     - | The output is
+       | generated with
+       | missing part
+     - | Wrong
+       | code
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_06
@@ -92,8 +102,12 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - The behavior is incorrect because of concurrent modification
-     - Undefined behavior
+     - | The behavior is
+       | incorrect because
+       | of concurrent
+       | modification
+     - | Undefined
+       | behavior
      - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_07
@@ -102,8 +116,10 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - A warning is generated instead of an error
-     - Undefined behavior
+     - | A warning is generated
+       | instead of an error
+     - | Undefined
+       | behavior
      - :id:`RUSTC_AVD_WARNING_AS_ERROR_005`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_08
@@ -112,8 +128,10 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - The compilation has a wrong behavior
-     - Wrong code
+     - | The compilation has
+       | a wrong behavior
+     - | Wrong
+       | code
      - :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_09
@@ -122,8 +140,11 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - An incomplete input is accepted leading to an undefined behavior
-     - Undefined behavior
+     - | An incomplete input is
+       | accepted leading to an
+       | undefined behavior
+     - | Undefined
+       | behavior
      - :id:`RUSTC_AVD_TEST_007`
      - YES
    * - .. id:: RUSTC_ERR_DRIVER_10
@@ -132,8 +153,11 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - Some object files are silently not generated
-     - Use an artifact from a previous build
+     - | Some object files are
+       | silently not generated
+     - | Use an artifact
+       | from a previous
+       | build
      - :id:`RUSTC_AVD_CLEAN_004`
      - NO
 

--- a/ferrocene/doc/evaluation-report/src/rustc/tool-analysis.rst
+++ b/ferrocene/doc/evaluation-report/src/rustc/tool-analysis.rst
@@ -15,7 +15,6 @@ Installation
 .. list-table::
    :align: left
    :header-rows: 1
-   :widths: 15, 15, 25, 20, 25, 5
 
    * - Error identifier
      - Use case
@@ -39,7 +38,6 @@ Rust Driver
 .. list-table::
    :align: left
    :header-rows: 1
-   :widths: 15, 15, 25, 20, 25, 5
 
    * - Error identifier
      - Use case
@@ -148,7 +146,6 @@ Rust Front-End
 .. list-table::
    :align: left
    :header-rows: 1
-   :widths: 15, 15, 25, 20, 25, 5
 
    * - Error identifier
      - Use case
@@ -226,7 +223,6 @@ LLVM
 .. list-table::
    :align: left
    :header-rows: 1
-   :widths: 15, 15, 25, 20, 25, 5
 
    * - Error identifier
      - Use case
@@ -306,7 +302,6 @@ Linking
 .. list-table::
    :align: left
    :header-rows: 1
-   :widths: 15, 15, 25, 20, 25, 5
 
    * - Error identifier
      - Use case

--- a/ferrocene/doc/evaluation-report/src/rustc/tool-analysis.rst
+++ b/ferrocene/doc/evaluation-report/src/rustc/tool-analysis.rst
@@ -17,19 +17,22 @@ Installation
    :header-rows: 1
 
    * - Error identifier
-     - Use case
      - Description
      - Risk
-     - Mitigation
      - Detectable
+     - Mitigation
    * - .. id:: RUSTC_ERR_INSTALL_01
-     - :id:`RUSTC_UC0_INST`
      - Ferrocene was not correctly installed
      - Undefined behavior
-     - :id:`RUSTC_AVD_CHECK_INSTALL_001`
      - NO
+     - :id:`RUSTC_AVD_CHECK_INSTALL_001`
 
 .. end of table
+
+Use cases
+*********
+
+* :id:`RUSTC_UC0_INST`
 
 
 Rust Driver
@@ -40,104 +43,67 @@ Rust Driver
    :header-rows: 1
 
    * - Error identifier
-     - Use case
      - Description
      - Risk
-     - Mitigation
      - Detectable
+     - Mitigation
    * - .. id:: RUSTC_ERR_DRIVER_02
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - An used environment variable is set to an incorrect value
      - Undefined behavior
-     - :id:`RUSTC_AVD_CHECK_CLEAN_ENV_002`
      - YES
+     - :id:`RUSTC_AVD_CHECK_CLEAN_ENV_002`
    * - .. id:: RUSTC_ERR_DRIVER_03
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - An invalid option is passed
      - Undefined behavior
-     - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - YES
+     - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
    * - .. id:: RUSTC_ERR_DRIVER_04
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Error diagnostics are not correctly emited
      - Undefined behavior
+     - NO
      - | :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`,
        | :id:`RUSTC_AVD_TEST_007`
-     - NO
    * - .. id:: RUSTC_ERR_DRIVER_05
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - The output is generated with missing part
      - Wrong code
-     - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - NO
+     - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
    * - .. id:: RUSTC_ERR_DRIVER_06
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - The behavior is incorrect because of concurrent modification
      - Undefined behavior
-     - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
      - NO
+     - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
    * - .. id:: RUSTC_ERR_DRIVER_07
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - A warning is generated instead of an error
      - Undefined behavior
-     - :id:`RUSTC_AVD_WARNING_AS_ERROR_005`
      - NO
+     - :id:`RUSTC_AVD_WARNING_AS_ERROR_005`
    * - .. id:: RUSTC_ERR_DRIVER_08
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - The compilation has a wrong behavior
      - Wrong code
-     - :id:`RUSTC_AVD_TEST_007`
      - NO
+     - :id:`RUSTC_AVD_TEST_007`
    * - .. id:: RUSTC_ERR_DRIVER_09
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - An incomplete input is accepted leading to an undefined behavior
      - Undefined behavior
-     - :id:`RUSTC_AVD_TEST_007`
      - YES
+     - :id:`RUSTC_AVD_TEST_007`
    * - .. id:: RUSTC_ERR_DRIVER_10
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Some object files are silently not generated
      - Use an artifact from a previous build
-     - :id:`RUSTC_AVD_CLEAN_004`
      - NO
+     - :id:`RUSTC_AVD_CLEAN_004`
 
 .. end of table
+
+Use cases
+*********
+
+* :id:`RUSTC_UC1_RLIB`,
+* :id:`RUSTC_UC2_STATICLIB`,
+* :id:`RUSTC_UC3_EXEC`,
+* :id:`RUSTC_UC4_EXEC_RLIB`,
+* :id:`RUSTC_UC5_EXEC_CLIB`
 
 
 Rust Front-End
@@ -148,73 +114,51 @@ Rust Front-End
    :header-rows: 1
 
    * - Error identifier
-     - Use case
      - Description
      - Risk
-     - Mitigation
      - Detectable
+     - Mitigation
    * - .. id:: RUSTC_ERR_RUST_FE_11
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Input has invalid contents
      - Invalid code generated
-     - :id:`RUSTC_AVD_TEST_007`
      - YES
+     - :id:`RUSTC_AVD_TEST_007`
    * - .. id:: RUSTC_ERR_RUST_FE_12
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Error diagnostics is invalid
      - Invalid code generated
-     - :id:`RUSTC_AVD_WARNING_AS_ERROR_005`
      - NO
+     - :id:`RUSTC_AVD_WARNING_AS_ERROR_005`
    * - .. id:: RUSTC_ERR_RUST_FE_13
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Invalid output generated from valid input
      - Invalid code generated
-     - :id:`RUSTC_AVD_TEST_007`
      - NO
+     - :id:`RUSTC_AVD_TEST_007`
    * - .. id:: RUSTC_ERR_RUST_FE_14
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - The behavior is incorrect because of concurrent modifications
      - Invalid code generated
-     - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
      - NO
+     - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
    * - .. id:: RUSTC_ERR_RUST_FE_15
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Invalid input is accepted
      - Undefined behavior
-     - :id:`RUSTC_AVD_TEST_007`
      - YES
+     - :id:`RUSTC_AVD_TEST_007`
    * - .. id:: RUSTC_ERR_RUST_FE_16
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Incorrect number of inputs are accepted
      - Undefined behavior
-     - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - YES
+     - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
 
 .. end of table
+
+Use cases
+*********
+
+* :id:`RUSTC_UC1_RLIB`,
+* :id:`RUSTC_UC2_STATICLIB`,
+* :id:`RUSTC_UC3_EXEC`,
+* :id:`RUSTC_UC4_EXEC_RLIB`,
+* :id:`RUSTC_UC5_EXEC_CLIB`
 
 
 LLVM
@@ -225,75 +169,53 @@ LLVM
    :header-rows: 1
 
    * - Error identifier
-     - Use case
      - Description
      - Risk
-     - Mitigation
      - Detectable
+     - Mitigation
    * - .. id:: RUSTC_ERR_LLVM_17
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Input parameter has invalid value
      - Most likely LLVM will crash. Invalid code could also be generated
-     - :id:`RUSTC_AVD_TEST_007`
      - NO
+     - :id:`RUSTC_AVD_TEST_007`
    * - .. id:: RUSTC_ERR_LLVM_18
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - An object file is invalid
      - Invalid code generated
-     - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - NO
+     - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
    * - .. id:: RUSTC_ERR_LLVM_19
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - An object file or static library is not correctly translated to machine code
      - Undefined behavior
-     - :id:`RUSTC_AVD_TEST_007`
      - NO
+     - :id:`RUSTC_AVD_TEST_007`
    * - .. id:: RUSTC_ERR_LLVM_20
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - The behavior is incorrect because of concurrent modifications
      - Invalid code generated
-     - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
      - NO
+     - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
    * - .. id:: RUSTC_ERR_LLVM_21
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - An object or static library exposes additional symbols
      - Internal functionality might become callable from the outside
-     - :id:`RUSTC_AVD_TEST_007`
      - NO
+     - :id:`RUSTC_AVD_TEST_007`
    * - .. id:: RUSTC_ERR_LLVM_22
-     - | :id:`RUSTC_UC1_RLIB`,
-       | :id:`RUSTC_UC2_STATICLIB`,
-       | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Output does not contain expected variables or functions
      - Invalid code generated
+     - NO
      - | :id:`RUSTC_AVD_CHECK_CLEAN_ENV_002`,
        | :id:`RUSTC_AVD_CLEAN_004`,
        | :id:`RUSTC_AVD_TEST_007`
-     - NO
 
 .. end of table
+
+Use cases
+*********
+
+* :id:`RUSTC_UC1_RLIB`,
+* :id:`RUSTC_UC2_STATICLIB`,
+* :id:`RUSTC_UC3_EXEC`,
+* :id:`RUSTC_UC4_EXEC_RLIB`,
+* :id:`RUSTC_UC5_EXEC_CLIB`
 
 
 Linking
@@ -304,61 +226,49 @@ Linking
    :header-rows: 1
 
    * - Error identifier
-     - Use case
      - Description
      - Risk
-     - Mitigation
      - Detectable
+     - Mitigation
    * - .. id:: RUSTC_ERR_LINK_23
-     - | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Invalid input is accepted
      - Undefined behavior
-     - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - NO
+     - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
    * - .. id:: RUSTC_ERR_LINK_24
-     - | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Invalid executable or library produced
      - Undefined behavior
-     - :id:`RUSTC_AVD_TEST_007`
      - NO
+     - :id:`RUSTC_AVD_TEST_007`
    * - .. id:: RUSTC_ERR_LINK_25
-     - | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - The behavior is incorrect because of concurrent modifications
      - Undefined behavior
-     - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
      - NO
+     - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
    * - .. id:: RUSTC_ERR_LINK_26
-     - | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Incorrect number of inputs are accepted
      - Undefined behavior
-     - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - YES
+     - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
    * - .. id:: RUSTC_ERR_LINK_27
-     - | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - An input is missing
      - Invalid code generated but won't run
-     - :id:`RUSTC_AVD_CHECK_INSTALL_001`
      - YES
+     - :id:`RUSTC_AVD_CHECK_INSTALL_001`
    * - .. id:: RUSTC_ERR_LINK_28
-     - | :id:`RUSTC_UC3_EXEC`,
-       | :id:`RUSTC_UC4_EXEC_RLIB`,
-       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Error diagnostics not emmited
      - Invalid or missing code not detected by user may be linked against subsequent stage
-     - :id:`RUSTC_AVD_TEST_007`
      - NO
+     - :id:`RUSTC_AVD_TEST_007`
 
 .. end of table
+
+Use cases
+*********
+
+* :id:`RUSTC_UC3_EXEC`,
+* :id:`RUSTC_UC4_EXEC_RLIB`,
+* :id:`RUSTC_UC5_EXEC_CLIB`
 
 
 Detection Measures and Usage Restriction

--- a/ferrocene/doc/evaluation-report/src/rustc/tool-analysis.rst
+++ b/ferrocene/doc/evaluation-report/src/rustc/tool-analysis.rst
@@ -51,11 +51,8 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - | An used environment
-       | variable is set to an
-       | incorrect value
-     - | Undefined
-       | behavior
+     - An used environment variable is set to an incorrect value
+     - Undefined behavior
      - :id:`RUSTC_AVD_CHECK_CLEAN_ENV_002`
      - YES
    * - .. id:: RUSTC_ERR_DRIVER_03
@@ -64,10 +61,8 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - | An invalid option is
-       | passed
-     - | Undefined
-       | behavior
+     - An invalid option is passed
+     - Undefined behavior
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - YES
    * - .. id:: RUSTC_ERR_DRIVER_04
@@ -76,10 +71,8 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - | Error diagnostics are
-       | not correctly emited
-     - | Undefined
-       | behavior
+     - Error diagnostics are not correctly emited
+     - Undefined behavior
      - | :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`,
        | :id:`RUSTC_AVD_TEST_007`
      - NO
@@ -89,11 +82,8 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - | The output is
-       | generated with
-       | missing part
-     - | Wrong
-       | code
+     - The output is generated with missing part
+     - Wrong code
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_06
@@ -102,12 +92,8 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - | The behavior is
-       | incorrect because
-       | of concurrent
-       | modification
-     - | Undefined
-       | behavior
+     - The behavior is incorrect because of concurrent modification
+     - Undefined behavior
      - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_07
@@ -116,10 +102,8 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - | A warning is generated
-       | instead of an error
-     - | Undefined
-       | behavior
+     - A warning is generated instead of an error
+     - Undefined behavior
      - :id:`RUSTC_AVD_WARNING_AS_ERROR_005`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_08
@@ -128,10 +112,8 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - | The compilation has
-       | a wrong behavior
-     - | Wrong
-       | code
+     - The compilation has a wrong behavior
+     - Wrong code
      - :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_09
@@ -140,11 +122,8 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - | An incomplete input is
-       | accepted leading to an
-       | undefined behavior
-     - | Undefined
-       | behavior
+     - An incomplete input is accepted leading to an undefined behavior
+     - Undefined behavior
      - :id:`RUSTC_AVD_TEST_007`
      - YES
    * - .. id:: RUSTC_ERR_DRIVER_10
@@ -153,11 +132,8 @@ Rust Driver
        | :id:`RUSTC_UC3_EXEC`,
        | :id:`RUSTC_UC4_EXEC_RLIB`,
        | :id:`RUSTC_UC5_EXEC_CLIB`
-     - | Some object files are
-       | silently not generated
-     - | Use an artifact
-       | from a previous
-       | build
+     - Some object files are silently not generated
+     - Use an artifact from a previous build
      - :id:`RUSTC_AVD_CLEAN_004`
      - NO
 

--- a/ferrocene/doc/evaluation-report/src/rustc/tool-analysis.rst
+++ b/ferrocene/doc/evaluation-report/src/rustc/tool-analysis.rst
@@ -48,55 +48,92 @@ Rust Driver
      - Mitigation
      - Detectable
    * - .. id:: RUSTC_ERR_DRIVER_02
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - An used environment variable is set to an incorrect value
      - Undefined behavior
      - :id:`RUSTC_AVD_CHECK_CLEAN_ENV_002`
      - YES
    * - .. id:: RUSTC_ERR_DRIVER_03
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - An invalid option is passed
      - Undefined behavior
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - YES
    * - .. id:: RUSTC_ERR_DRIVER_04
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Error diagnostics are not correctly emited
      - Undefined behavior
-     - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003` AND :id:`RUSTC_AVD_TEST_007`
+     - | :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`,
+       | :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_05
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - The output is generated with missing part
      - Wrong code
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_06
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - The behavior is incorrect because of concurrent modification
      - Undefined behavior
      - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_07
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - A warning is generated instead of an error
      - Undefined behavior
      - :id:`RUSTC_AVD_WARNING_AS_ERROR_005`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_08
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - The compilation has a wrong behavior
      - Wrong code
      - :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_09
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - An incomplete input is accepted leading to an undefined behavior
      - Undefined behavior
      - :id:`RUSTC_AVD_TEST_007`
      - YES
    * - .. id:: RUSTC_ERR_DRIVER_10
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Some object files are silently not generated
      - Use an artifact from a previous build
      - :id:`RUSTC_AVD_CLEAN_004`
@@ -120,37 +157,61 @@ Rust Front-End
      - Mitigation
      - Detectable
    * - .. id:: RUSTC_ERR_RUST_FE_11
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Input has invalid contents
      - Invalid code generated
      - :id:`RUSTC_AVD_TEST_007`
      - YES
    * - .. id:: RUSTC_ERR_RUST_FE_12
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Error diagnostics is invalid
      - Invalid code generated
      - :id:`RUSTC_AVD_WARNING_AS_ERROR_005`
      - NO
    * - .. id:: RUSTC_ERR_RUST_FE_13
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Invalid output generated from valid input
      - Invalid code generated
      - :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_RUST_FE_14
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - The behavior is incorrect because of concurrent modifications
      - Invalid code generated
      - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
      - NO
    * - .. id:: RUSTC_ERR_RUST_FE_15
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Invalid input is accepted
      - Undefined behavior
      - :id:`RUSTC_AVD_TEST_007`
      - YES
    * - .. id:: RUSTC_ERR_RUST_FE_16
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Incorrect number of inputs are accepted
      - Undefined behavior
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
@@ -174,40 +235,66 @@ LLVM
      - Mitigation
      - Detectable
    * - .. id:: RUSTC_ERR_LLVM_17
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Input parameter has invalid value
      - Most likely LLVM will crash. Invalid code could also be generated
      - :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_LLVM_18
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - An object file is invalid
      - Invalid code generated
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - NO
    * - .. id:: RUSTC_ERR_LLVM_19
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - An object file or static library is not correctly translated to machine code
      - Undefined behavior
      - :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_LLVM_20
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - The behavior is incorrect because of concurrent modifications
      - Invalid code generated
      - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
      - NO
    * - .. id:: RUSTC_ERR_LLVM_21
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - An object or static library exposes additional symbols
      - Internal functionality might become callable from the outside
      - :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_LLVM_22
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC1_RLIB`,
+       | :id:`RUSTC_UC2_STATICLIB`,
+       | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Output does not contain expected variables or functions
      - Invalid code generated
-     - :id:`RUSTC_AVD_CHECK_CLEAN_ENV_002` AND :id:`RUSTC_AVD_CLEAN_004` AND :id:`RUSTC_AVD_TEST_007`
+     - | :id:`RUSTC_AVD_CHECK_CLEAN_ENV_002`,
+       | :id:`RUSTC_AVD_CLEAN_004`,
+       | :id:`RUSTC_AVD_TEST_007`
      - NO
 
 .. end of table
@@ -228,37 +315,49 @@ Linking
      - Mitigation
      - Detectable
    * - .. id:: RUSTC_ERR_LINK_23
-     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Invalid input is accepted
      - Undefined behavior
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - NO
    * - .. id:: RUSTC_ERR_LINK_24
-     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Invalid executable or library produced
      - Undefined behavior
      - :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_LINK_25
-     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - The behavior is incorrect because of concurrent modifications
      - Undefined behavior
      - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
      - NO
    * - .. id:: RUSTC_ERR_LINK_26
-     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Incorrect number of inputs are accepted
      - Undefined behavior
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - YES
    * - .. id:: RUSTC_ERR_LINK_27
-     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - An input is missing
      - Invalid code generated but won't run
      - :id:`RUSTC_AVD_CHECK_INSTALL_001`
      - YES
    * - .. id:: RUSTC_ERR_LINK_28
-     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - | :id:`RUSTC_UC3_EXEC`,
+       | :id:`RUSTC_UC4_EXEC_RLIB`,
+       | :id:`RUSTC_UC5_EXEC_CLIB`
      - Error diagnostics not emmited
      - Invalid or missing code not detected by user may be linked against subsequent stage
      - :id:`RUSTC_AVD_TEST_007`


### PR DESCRIPTION
# Motivation

I find it hard to view the tables in the rustc tool analysis. One problem are the very wide columns. Therefore this PRs aims to reduce the column width. In turn it introduces some whitespace, which isn't pretty either, but okayish.

Obviously it would be better if this formatting would be automated, because manual formatting takes quite a lot of time. Either with a script or with CSS.

# Changes

- [x] arrange IDs vertically
- [x] remove `:widths:` (because it seems to have no effect)
- [ ] ~~manually format columns~~
- [x] Move use cases out of table if all use cases of all potential errors are the same (which is the case for all of the tables).


# Before

![Screenshot from 2024-06-21 16-30-31](https://github.com/ferrocene/ferrocene/assets/37087391/a0d90954-0634-44c2-b2ea-fcc368b276b5)
![Screenshot from 2024-06-21 16-30-18](https://github.com/ferrocene/ferrocene/assets/37087391/03fe27df-32c5-40d6-b238-932cf067bb76)

# After

![Screenshot from 2024-07-08 14-04-54](https://github.com/ferrocene/ferrocene/assets/37087391/dd2bbe18-cb36-4b3a-9e0b-f80475f09db5)
![Screenshot from 2024-07-08 14-04-38](https://github.com/ferrocene/ferrocene/assets/37087391/3c75c9bc-b7ea-4682-8baf-58dd53e6af6e)


