### PR TITLE
Only try serving the docs when building html docs

### DIFF
--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -188,7 +188,11 @@ impl<P: Step + IsSphinxBook> Step for SphinxBook<P> {
             .collect::<Vec<_>>()
             .join("/");
 
-        let should_serve = builder.should_serve::<P>();
+        let should_serve = match self.mode {
+            SphinxMode::Html => builder.should_serve::<P>(),
+            SphinxMode::XmlDoctrees => false,
+            SphinxMode::OnlyObjectsInv => false,
+        };
 
         let ferrocene_version =
             std::fs::read_to_string(&builder.src.join("ferrocene").join("version")).unwrap();


### PR DESCRIPTION
Serving multiple docs at the same time is not supported by the build system, since we can only have one server running at the time. To enforce that, there is a check in bootstrap ensuring the `builder.should_serve()` function is only called once.

A previous refactor broke the flag though, because it resulted in the `builder.should_serve()` method being called by all `objects.inv` gathering steps in addition to the html building step. This PR fixes the problem.