### PR TITLE
[1.79] Add Ferrocene and Rust version to the Safety Manual

### DIFF
--- a/ferrocene/doc/safety-manual/src/environment.rst
+++ b/ferrocene/doc/safety-manual/src/environment.rst
@@ -4,6 +4,9 @@
 Environment
 ===========
 
+This qualification applies to Ferrocene |ferrocene_version|, which includes
+Rust |rust_version|.
+
 This qualification is restricted to the following environment:
 
 .. list-table::


### PR DESCRIPTION
This is required by ISO 26262 part 8 clause 11.4.4.1.a, which links to the environment page in our [standard traceability page](https://public-docs.ferrocene.dev/main/qualification/plan/standards/iso-26262.html). I discovered we are not doing that during a routine reading of the documents.

For now this fix just targets the next 24.08 release, I'll send a larger refactoring to the main branch in a followup PR.