### PR TITLE
Add `no_traceability_matrix` flag to `cli:program` directive

### DIFF
--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_domain_cli/__init__.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_domain_cli/__init__.py
@@ -27,6 +27,5 @@ def setup(app):
         #
         # Version history:
         # - 0: initial implementation
-        # - 1: add no_traceability_matrix flag
-        "env_version": "1",
+        "env_version": "0",
     }

--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_domain_cli/__init__.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_domain_cli/__init__.py
@@ -27,5 +27,6 @@ def setup(app):
         #
         # Version history:
         # - 0: initial implementation
-        "env_version": "0",
+        # - 1: add no_traceability_matrix flag
+        "env_version": "1",
     }

--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_domain_cli/traceability_ids.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_domain_cli/traceability_ids.py
@@ -12,6 +12,9 @@ def write_traceability_ids(app):
 
     options_by_document = defaultdict(list)
     for option in env.get_domain("cli").get_options().values():
+        if option.no_traceability_matrix:
+            continue
+
         options_by_document[option.document].append(
             {
                 "id": option.id(),

--- a/ferrocene/doc/user-manual/src/rustfmt/cli.rst
+++ b/ferrocene/doc/user-manual/src/rustfmt/cli.rst
@@ -5,6 +5,7 @@
 ==================================
 
 .. cli:program:: rustfmt
+   :no_traceability_matrix:
 
    .. cli:option:: --check
 
@@ -88,4 +89,3 @@
 
       Show this message or help about a specific topic: ``config`` or
       ``file-lines``.
-


### PR DESCRIPTION
We do not want to (i.e. need to) test the cli options of `rustfmt`, therefore this PR allows disabling the generation of entries in the traceability matrix. It also sets the flag for the rustfmt cli.

Before there was a red "UM: rustfmt Command-Line Interface" entry. After this PR it will be gone.

Before: ![Screenshot from 2024-07-05 13-10-06](https://github.com/ferrocene/ferrocene/assets/37087391/7490d85a-99c3-4acc-b06e-b76e0d5db477)

After: ![Screenshot from 2024-07-05 13-10-20](https://github.com/ferrocene/ferrocene/assets/37087391/3bb81920-cd64-48f5-bac2-89d4bf592d60)
