### PR TITLE
Add Ferrocene 24.08 release notes

### DIFF
--- a/ferrocene/doc/release-notes/src/24.08.0.rst
+++ b/ferrocene/doc/release-notes/src/24.08.0.rst
@@ -1,0 +1,61 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+:upcoming-release:
+
+Ferrocene 24.08.0
+=================
+
+Ferrocene 24.08.0 is the second major release of Ferrocene.
+
+The highlights of this release are the inclusion of Rust 1.79.0 and new
+experimental platform support, including Windows and macOS as hosts, and QNX as
+cross-compilation targets.
+
+New features
+------------
+
+* The Rust version has been updated to 1.79.0.
+
+New experimental features
+-------------------------
+
+Experimental features are not qualified for safety critical use, and are
+shipped as a preview.
+
+* Experimental support has been added for new cross-compilation targets.
+  Note that experimental targets are not qualified for safety critical use. The
+  new targets are:
+
+  * :target-with-triple:`armv8r-none-eabihf`
+  * :target-with-triple:`armv7r-none-eabihf`
+  * :target-with-triple:`armebv7r-none-eabihf`
+  * :target-with-triple:`x86_64-apple-darwin`
+  * :target-with-triple:`aarch64-unknown-nto-qnx710`
+  * :target-with-triple:`x86_64-pc-nto-qnx710`
+
+* Experimental support has been added for a new host platform.
+  Note that experimental targets are not qualified for safety critical use. The
+  new target is:
+
+  * :target-with-triple:`aarch64-apple-darwin`
+  * :target-with-triple:`x86_64-pc-windows-msvc`
+
+Changes
+-------
+
+* The :target-with-triple:`x86_64-unknown-linux-gnu` target now requires
+  glibc version of 2.31 or higher.
+
+Rust changes
+------------
+
+This release includes the following changes introduced by the upstream Rust
+project. Note that this changelog is maintained by upstream. The target support
+changes described here describe Rust's support levels, and have no correlation
+to the targets and platforms supported by Ferrocene.
+
+.. rust-changelog::
+   :from: 1.77.0
+   :to: 1.79.0
+

--- a/ferrocene/doc/release-notes/src/24.08.0.rst
+++ b/ferrocene/doc/release-notes/src/24.08.0.rst
@@ -34,9 +34,9 @@ shipped as a preview.
   * :target-with-triple:`aarch64-unknown-nto-qnx710`
   * :target-with-triple:`x86_64-pc-nto-qnx710`
 
-* Experimental support has been added for a new host platform.
-  Note that experimental targets are not qualified for safety critical use. The
-  new target is:
+* Experimental support has been added for new host platforms. Note that
+  experimental targets are not qualified for safety critical use. The new
+  targets are:
 
   * :target-with-triple:`aarch64-apple-darwin`
   * :target-with-triple:`x86_64-pc-windows-msvc`

--- a/ferrocene/doc/release-notes/src/index.rst
+++ b/ferrocene/doc/release-notes/src/index.rst
@@ -13,6 +13,12 @@ in Ferrocene releases.
    next
 
 .. toctree::
+   :caption: Ferrocene 24.08 series:
+   :maxdepth: 1
+
+   24.08.0
+
+.. toctree::
    :caption: Ferrocene 24.05 series:
    :maxdepth: 1
 

--- a/ferrocene/doc/release-notes/src/next.rst
+++ b/ferrocene/doc/release-notes/src/next.rst
@@ -9,32 +9,4 @@ Next Ferrocene release
 This page contains the changes to be introduced in the upcoming Ferrocene
 release.
 
-New experimental features
--------------------------
-
-Experimental features are not qualified for safety critical use, and are
-shipped as a preview.
-
-* Experimental support has been added for new cross-compilation targets.
-  Note that experimental targets are not qualified for safety critical use. The
-  new targets are:
-
-  * :target-with-triple:`armv8r-none-eabihf`
-  * :target-with-triple:`armv7r-none-eabihf`
-  * :target-with-triple:`armebv7r-none-eabihf`
-  * :target-with-triple:`x86_64-apple-darwin`
-  * :target-with-triple:`aarch64-unknown-nto-qnx710`
-  * :target-with-triple:`x86_64-pc-nto-qnx710`
-
-* Experimental support has been added for a new host platform.
-  Note that experimental targets are not qualified for safety critical use. The
-  new target is:
-
-  * :target-with-triple:`aarch64-apple-darwin`
-  * :target-with-triple:`x86_64-pc-windows-msvc`
-
-Changes
--------
-
-* The :target-with-triple:`x86_64-unknown-linux-gnu` target now requires
-  glibc version of 2.31 or higher.
+*No changes yet.*


### PR DESCRIPTION
Will *manually* backport them to the 24.08 beta branch later.