### PR TITLE
Bump specification

### DIFF
--- a/ferrocene/doc/specification/exts/ferrocene_spec/__init__.py
+++ b/ferrocene/doc/specification/exts/ferrocene_spec/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: The Ferrocene Developers
 
 from . import definitions, informational, syntax_directive, std_role, paragraph_ids
-from . import items_with_rubric
+from . import items_with_rubric, sphinx_fixes
 from sphinx.domains import Domain
 
 
@@ -41,6 +41,7 @@ def setup(app):
     paragraph_ids.setup(app)
     informational.setup(app)
     items_with_rubric.setup(app)
+    sphinx_fixes.setup(app)
 
     app.add_config_value(
         name="spec_std_docs_url",

--- a/ferrocene/doc/specification/exts/ferrocene_spec/definitions/__init__.py
+++ b/ferrocene/doc/specification/exts/ferrocene_spec/definitions/__init__.py
@@ -21,7 +21,7 @@ KINDS = [
 class DefIdNode(nodes.Element):
     def __init__(self, kind, text):
         text, id = parse_target_from_text(text)
-        super().__init__(def_kind=kind, def_text=text, def_id=id_from_text(id))
+        super().__init__(def_kind=kind, def_text=text, def_id=id_from_text(kind, id))
 
     def astext(self):
         return self["def_text"]
@@ -35,7 +35,7 @@ class DefRefNode(nodes.Element):
             ref_kind=kind,
             ref_source_doc=source_doc,
             ref_text=text,
-            ref_target=id_from_text(target),
+            ref_target=id_from_text(kind, target),
         )
 
     def astext(self):
@@ -211,8 +211,17 @@ def get_object_types():
     return result
 
 
-def id_from_text(text):
-    return "".join(c if c.isalnum() else "_" for c in text.lower())
+def id_from_text(kind, text):
+    # We lowercase the text so that capitalization does not matter for
+    # references and definitions, which is sometimes the case for when they are
+    # used at the start of a sentence.
+    # Notably though, this breaks for paragraph ids which are unique randomized
+    # strings where capitalization matters for hyperlinking, so we don't do so
+    # for those
+    return "".join(
+        c if c.isalnum() else "_"
+        for c in (text if kind == "paragraph" else text.lower())
+    )
 
 
 def setup(app):

--- a/ferrocene/doc/specification/exts/ferrocene_spec/sphinx_fixes.py
+++ b/ferrocene/doc/specification/exts/ferrocene_spec/sphinx_fixes.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+from docutils import nodes
+from sphinx.transforms import SphinxTransform, SortIds
+
+
+# Sphinx by default sorts all ids of the form `id[0-9]+` to the end.
+# Our IDs are section name and fls_ id pairs, so in some cases this transform
+# will instead sort the section name to the back, but not always!
+# So we overwrite the transform instead so that our fls ids are sorted to the back.
+# In addition to that we normalize them, as sphinx turns the `_` in `fls_{id}`
+# into `fls-{id}` which can break the link check from working correctly.
+class FerroceneSortIds(SphinxTransform):
+    # Run this step after sphinx sorted.
+    default_priority = SortIds.default_priority + 1
+
+    def apply(self):
+        for node in self.document.findall(nodes.section):
+            for n, id in enumerate(node["ids"]):
+                node["ids"][n] = normalize_fls_id(id)
+            # sort the fls id to the back
+            if len(node["ids"]) > 1 and node["ids"][0].startswith("fls_"):
+                node["ids"] = node["ids"][1:] + [node["ids"][0]]
+
+
+class NormalizeFlsReferences(SphinxTransform):
+    default_priority = 500
+
+    def apply(self):
+        for reference in self.document.findall(nodes.reference):
+            if "internal" not in reference or not reference["internal"]:
+                continue
+            if "refuri" not in reference or "#" not in reference["refuri"]:
+                continue
+            path, hash = reference["refuri"].rsplit("#", 1)
+            reference["refuri"] = f"{path}#{normalize_fls_id(hash)}"
+
+
+def normalize_fls_id(id):
+    if id.startswith("fls-"):
+        return id.replace("fls-", "fls_", 1)
+    else:
+        return id
+
+
+def setup(app):
+    app.add_transform(FerroceneSortIds)
+    app.add_post_transform(NormalizeFlsReferences)

--- a/ferrocene/doc/specification/src/attributes.rst
+++ b/ferrocene/doc/specification/src/attributes.rst
@@ -122,6 +122,7 @@ Built-in Attributes
        AutomaticallyDerivedContent
      | CfgAttrContent
      | CfgContent
+     | CollapseDebuginfoContent
      | ColdContent
      | CrateNameContent
      | CrateTypeContent
@@ -1240,7 +1241,7 @@ Attribute ``no_main``
 
 :dp:`fls_6qig3s3qpj0i`
 :t:`Attribute` :dc:`no_main` indicates that the symbols of the
-:t:`main function` will not be present in a binary.
+:t:`program entry point` will not be present in a binary.
 
 .. rubric:: Examples
 
@@ -1448,6 +1449,42 @@ Attribute ``type_length_limit``
 
 Macros Attributes
 ~~~~~~~~~~~~~~~~~
+
+.. _fls_qyudjGHZfyJH:
+
+Attribute ``collapse_debuginfo``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. rubric:: Syntax
+
+.. syntax::
+
+   CollapseDebuginfoContent ::=
+       $$collapse_debuginfo$$  $$($$ CollapseDebuginfoKind $$)$$
+   CollapseDebuginfoKind ::=
+       $$no
+     | $$external$$
+     | $$yes$$
+
+.. rubric:: Legality Rules
+
+:dp:`fls_EzKHtWHmXMAZ`
+:t:`Attribute` :c:`collapse_debuginfo` shall apply to :t:`[declarative macro]s`.
+
+:dp:`fls_BCvJpfQMYEcD`
+:t:`Attribute` :dc:`collapse_debuginfo` changes the debug location information
+for the expanded code of the :t:`declarative macro` to its invocation site. This
+repeats recursively to the top most expansion of a :t:`declarative macro` that
+is not annotated with :t:`attribute` :c:`collapse_debuginfo`.
+
+.. rubric:: Examples
+
+.. code-block:: rust
+
+   #[collapse_debuginfo(yes)]
+   macro_rules! m {
+       () => {};
+   }
 
 .. _fls_e0a96eb6ux3y:
 

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -188,4 +188,4 @@ language changes in Rust 1.77.0
 .. Note: for the publicly rendered version of the FLS we want to link to
    upstream's release notes. In the Ferrocene subtree this should be replaced
    to the link to the Ferrocene release notes!
-.. _release notes: https://doc.rust-lang.org/releases.html
+.. _release notes: ../release-notes/index.html

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -1,0 +1,191 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+.. default-domain:: spec
+.. informational-page::
+
+FLS Changelog
+=============
+
+This page describes the changes that have been applied to the FLS itself to
+address changes and new features introduced in each Rust release. Every item
+listed in the "Language" section of the release note is reproduced here, along
+with the change that has been applied due to it.
+
+.. caution::
+
+   This page is **not** an exhaustive list of all of the changes in a release,
+   just the language changes that had an impact to the FLS. See the `release
+   notes`_ for a full list of changes.
+
+Language changes in Rust 1.79.0
+-------------------------------
+
+* `Stabilize inline \`const {}\` expressions. <https://github.com/rust-lang/rust/pull/104087/>`_
+
+  * New section: :ref:`fls_G59PiNQkVUnQ`
+
+* `Prevent opaque types being instantiated twice with different regions within the same function. <https://github.com/rust-lang/rust/pull/116935/>`_
+
+  * No change: already described in :p:`fls_hza5n5eb18ta`
+
+* `Stabilize WebAssembly target features that are in phase 4 and 5. <https://github.com/rust-lang/rust/pull/117457/>`_
+
+  * No change: ``cfg`` and ``cfg_attr`` configuration predicates are not part of the FLS
+
+* `Add the \`redundant_lifetimes\` lint to detect lifetimes which are semantically redundant. <https://github.com/rust-lang/rust/pull/118391/>`_
+
+  * No change: lints are not part of the FLS
+
+* `Stabilize the \`unnameable_types\` lint for public types that can't be named. <https://github.com/rust-lang/rust/pull/120144/>`_
+
+  * No change: lints are not part of the FLS
+
+* `Enable debuginfo in macros, and stabilize \`-C collapse-macro-debuginfo\` and \`#[collapse_debuginfo]\`. <https://github.com/rust-lang/rust/pull/120845/>`_
+
+  * New section: :ref:`fls_qyudjGHZfyJH`
+
+* `Propagate temporary lifetime extension into \`if\` and \`match\` expressions. <https://github.com/rust-lang/rust/pull/121346/>`_
+
+  * New paragraphs: :p:`fls_Rj9zhVutfQod`, :p:`fls_oodpp3LpXC13`, :p:`fls_xGThCPoTUSAi`
+
+* `Restrict promotion of \`const fn\` calls. <https://github.com/rust-lang/rust/pull/121557/>`_
+
+  * No change: already described in :p:`fls_3h5vr7xk2rrt`
+
+* `Warn against refining impls of crate-private traits with \`refining_impl_trait\` lint. <https://github.com/rust-lang/rust/pull/121720/>`_
+
+  * No change: lints are not part of the FLS
+
+* `Stabilize associated type bounds (RFC 2289). <https://github.com/rust-lang/rust/pull/122055/>`_
+
+  * New paragraph: :p:`fls_mcUMWsYcxzmZ`
+
+* `Stabilize importing \`main\` from other modules or crates. <https://github.com/rust-lang/rust/pull/122060/>`_
+
+  * No change: this lifted restriction was not previously described in the FLS
+
+  * While updating the FLS to account for this feature, we realized that the
+    way the FLS described crate types was incorrect. We rectified this:
+
+    * New section: :ref:`fls_8JB3SJqamdpU`
+    * New glossary entry: :t:`crate type`
+    * New paragraphs: :p:`fls_unxalgMqIr3v`, :p:`fls_e7jGvXvTsFpC`, :p:`fls_kQiJPwb2Hjcc`, :p:`fls_OyFwBtDGVimT`
+    * Updated glossary entries: :t:`binary crate`, :t:`library crate`, :t:`proc-macro crate`
+    * Updated paragraphs: :p:`fls_9ub6ks8qrang`, :p:`fls_Mf62VqAhoZ3c`, :p:`fls_d9nn4yuiw1ja`
+    * Moved paragraph: :p:`fls_sbGnkm8Ephiu`
+
+* `Check return types of function types for well-formedness <https://github.com/rust-lang/rust/pull/115538>`_
+
+  * No change: the exact trait resolution implementation is not part of the FLS
+
+* `Rework \`impl Trait\` lifetime inference <https://github.com/rust-lang/rust/pull/116891/>`_
+
+  * New paragraphs: :p:`fls_3aKZB0ILIkZw`, :p:`fls_Xo1ODwOyX7Vm`, :p:`fls_kTGFLFymTWch`
+
+* `Change inductive trait solver cycles to be ambiguous <https://github.com/rust-lang/rust/pull/122791>`_
+
+  * No change: the exact trait solver is not part of the FLS
+
+Language changes in Rust 1.78.0
+-------------------------------
+
+* `Stabilize \`#[cfg(target_abi = ...)]\` <https://github.com/rust-lang/rust/pull/119590/>`_
+
+  * No change: ``cfg`` and ``cfg_attr`` configuration predicates are not part of the FLS
+
+* `Stabilize the \`#[diagnostic]\` namespace and \`#[diagnostic::on_unimplemented]\` attribute <https://github.com/rust-lang/rust/pull/119888/>`_
+
+  * No change: tool attributes are not part of the FLS
+
+* `Make async-fn-in-trait implementable with concrete signatures <https://github.com/rust-lang/rust/pull/120103/>`_
+
+  * No change: no paragraph in the FLS forbids this prior incompatability
+
+* `Make matching on NaN a hard error, and remove the rest of \`illegal_floating_point_literal_pattern\` <https://github.com/rust-lang/rust/pull/116284/>`_
+
+  * New paragraph: :p:`fls_JP8YSbxSN0Ym`
+
+* `static mut: allow mutable reference to arbitrary types, not just slices and arrays <https://github.com/rust-lang/rust/pull/117614/>`_
+
+  * No change: this lifted restriction was not previously described in the FLS
+
+* `Extend \`invalid_reference_casting\` to include references casting to bigger memory layout <https://github.com/rust-lang/rust/pull/118983/>`_
+
+  * No change: lints are not part of the FLS
+
+* `Add \`non_contiguous_range_endpoints\` lint for singleton gaps after exclusive ranges <https://github.com/rust-lang/rust/pull/118879/>`_
+
+  * No change: lints are not part of the FLS
+
+* `Add \`wasm_c_abi\` lint for use of older wasm-bindgen versions <https://github.com/rust-lang/rust/pull/117918/>`_
+
+  * No change: lints are not part of the FLS
+
+* `Update \`indirect_structural_match\` and \`pointer_structural_match\` lints to match RFC <https://github.com/rust-lang/rust/pull/120423/>`_
+
+  * No change: lints are not part of the FLS
+
+* `Make non-\`PartialEq\`-typed consts as patterns a hard error <https://github.com/rust-lang/rust/pull/120805/>`_
+
+  * No change: already described in :p:`fls_zCswsyuitexI`
+
+* `Split \`refining_impl_trait\` lint into \`_reachable\`, \`_internal\` variants <https://github.com/rust-lang/rust/pull/121720/>`_
+
+  * No change: lints are not part of the FLS
+
+* `Remove unnecessary type inference when using associated types inside of higher ranked \`where\`-bounds <https://github.com/rust-lang/rust/pull/119849>`_
+
+  * No change: the FLS does not specify type inference to such a degree
+
+* `Weaken eager detection of cyclic types during type inference <https://github.com/rust-lang/rust/pull/119989>`_
+
+  * No change: the FLS does not specify type inference to such a degree
+
+* `\`trait Trait: Auto {}\`: allow upcasting from \`dyn Trait\` to \`dyn Trait + Auto\` <https://github.com/rust-lang/rust/pull/119338>`_
+
+  * New paragraph: :p:`fls_SYnFJBhi0IWj`
+
+language changes in Rust 1.77.0
+-------------------------------
+
+* `Reveal opaque types within the defining body for exhaustiveness checking. <https://github.com/rust-lang/rust/pull/116821/>`_
+
+  * No change: the FLS does not specify introspection of the concrete type of the match expression scrutinee to such a degree
+
+* `Stabilize C-string literals. <https://github.com/rust-lang/rust/pull/117472/>`_
+
+  * New section: :ref:`fls_U1gHCy16emVe`
+
+* `Stabilize THIR unsafeck. <https://github.com/rust-lang/rust/pull/117673/>`_
+
+  * No change: not a language change
+
+* `Add lint \`static_mut_refs\` to warn on references to mutable statics. <https://github.com/rust-lang/rust/pull/117556/>`_
+
+  * No change: lints are not part of the FLS
+
+* `Support async recursive calls (as long as they have indirection). <https://github.com/rust-lang/rust/pull/117703/>`_
+
+  * No change: this lifted restriction was not previously described in the FLS
+
+* `Undeprecate lint \`unstable_features\` and make use of it in the compiler. <https://github.com/rust-lang/rust/pull/118639/>`_
+
+  * No change: lints are not part of the FLS
+
+* `Make inductive cycles in coherence ambiguous always. <https://github.com/rust-lang/rust/pull/118649/>`_
+
+  * No change: the FLS does not describe the trait solver to such a degree
+
+* `Get rid of type-driven traversal in const-eval interning <https://github.com/rust-lang/rust/pull/119044/>`_, only as a `future compatibility lint <https://github.com/rust-lang/rust/pull/122204>`_ for now.
+
+  * No change: this lifted restriction was not previously described in the FLS
+
+* `Deny braced macro invocations in let-else. <https://github.com/rust-lang/rust/pull/119062/>`_
+
+  * New paragraph: :p:`fls_1s1UikGU5YQb`
+
+.. Note: for the publicly rendered version of the FLS we want to link to
+   upstream's release notes. In the Ferrocene subtree this should be replaced
+   to the link to the Ferrocene release notes!
+.. _release notes: https://doc.rust-lang.org/releases.html

--- a/ferrocene/doc/specification/src/conf.py
+++ b/ferrocene/doc/specification/src/conf.py
@@ -61,4 +61,4 @@ html_short_title = "Language Specification"
 
 lint_alphabetical_section_titles = ["glossary"]
 
-lint_no_paragraph_ids = ["index"]
+lint_no_paragraph_ids = ["index", "changelog"]

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -496,6 +496,10 @@ related :t:`let statement` appears.
 The :t:`binding` of a :t:`match arm` is :t:`in scope` within its related
 :t:`[expression]s` and related :t:`match arm guard`.
 
+:dp:`fls_eBacCVlDaKYK`
+A :t:`binding` declared outside of a :t:`const block expression` is not :t:`in
+scope` within such a :t:`const block expression`.
+
 .. _fls_ftphlagzd2te:
 
 Generic Parameter Scope

--- a/ferrocene/doc/specification/src/expressions.rst
+++ b/ferrocene/doc/specification/src/expressions.rst
@@ -20,6 +20,7 @@ Expressions
        OuterAttributeOrDoc* (
            AsyncBlockExpression
          | BlockExpression
+         | ConstBlockExpression
          | IfExpression
          | IfLetExpression
          | LoopExpression
@@ -315,6 +316,9 @@ A :t:`constant context` is a :t:`construct` that requires a
 
 * :dp:`fls_ib8p7dfwddx2`
   The :t:`static initializer` of a :t:`static`.
+
+* :dp:`fls_ucFupTeCyylb`
+  The :t:`block expression` of a :t:`const block expression`.
 
 :dp:`fls_ox6sgl9n43g2`
 It is a static error to create a :t:`mutable reference` in a
@@ -781,6 +785,48 @@ the :t:`[capture target]s` of the :t:`async block expression`.
 .. code-block:: rust
 
    async {
+       42
+   }
+
+.. _fls_G59PiNQkVUnQ:
+
+Const Blocks
+~~~~~~~~~~~~
+
+.. rubric:: Syntax
+
+.. syntax::
+
+   ConstBlockExpression ::=
+       $$const$$ BlockExpression
+
+.. rubric:: Legality Rules
+
+:dp:`fls_0lcunL4bo8ka`
+A :t:`const block expression` is a :t:`block expression` that is specified
+with :t:`keyword` ``const`` and encapsulates behavior which is evaluated
+statically.
+
+:dp:`fls_veEGzEbpT4ny`
+An :t:`const block expression` denotes a new :t:`control flow boundary`.
+
+:dp:`fls_PiUS1hF3dv9U`
+The :t:`block expression` of a :t:`const block expression` shall be a
+:t:`constant expression`.
+
+:dp:`fls_wuwb0SnpP6Zu`
+The :t:`type` of a :t:`const block expression` is the :t:`type` of the
+containing :t:`block expression`.
+
+:dp:`fls_2i7TD7VoQk4B`
+The :t:`value` of a :t:`const block expression` is the :t:`value` of the
+contained :t:`block expression`.
+
+.. rubric:: Examples
+
+.. code-block:: rust
+
+   const {
        42
    }
 

--- a/ferrocene/doc/specification/src/functions.rst
+++ b/ferrocene/doc/specification/src/functions.rst
@@ -176,34 +176,6 @@ An :t:`unsafe function` is a :t:`function` subject to :t:`keyword` ``unsafe``.
 :dp:`fls_5hn8fkf7rcvz`
 The invocation of an :t:`unsafe function` shall require :t:`unsafe context`.
 
-:dp:`fls_nw49shkqx40b`
-A :t:`main function` is a :t:`function` that acts as an entry point into a
-program. A :t:`main function` is subject to the following restrictions:
-
-* :dp:`fls_o4fxok23134r`
-  It lacks :t:`[function qualifier]s` ``async`` and ``unsafe``,
-
-* :dp:`fls_bk755pvc1l53`
-  Its :t:`ABI` is Rust,
-
-* :dp:`fls_5j2vbkt2hitj`
-  Its :t:`name` is the word ``main``,
-
-* :dp:`fls_a3je4wc53bmo`
-  It lacks :t:`[generic parameter]s`,
-
-* :dp:`fls_w8q15zp7kyl0`
-  It lacks :t:`[function parameter]s`,
-
-* :dp:`fls_4psnfphsgdek`
-  It lacks a :t:`return type`,
-
-* :dp:`fls_m7xfrhqif74`
-  It lacks a :t:`where clause`,
-
-* :dp:`fls_qq9fzrw4aykd`
-  It has a :t:`function body`.
-
 .. rubric:: Examples
 
 .. code-block:: rust

--- a/ferrocene/doc/specification/src/general.rst
+++ b/ferrocene/doc/specification/src/general.rst
@@ -238,8 +238,8 @@ external interactions:
   passed to it;
 
 * :dp:`fls_3iekobt8qqi`
-  Any result returned or :t:`panic` propagated from a :t:`main function` or an
-  :t:`exported function` to an external caller;
+  Any result returned or :t:`panic` propagated from a :t:`program entry point`
+  or an :t:`exported function` to an external caller;
 
 * :dp:`fls_qx9fxf4py0j0`
   The imported and exported :t:`[value]s` at the time of any other interaction

--- a/ferrocene/doc/specification/src/generics.rst
+++ b/ferrocene/doc/specification/src/generics.rst
@@ -311,12 +311,16 @@ Generic Arguments
 
    GenericArgument ::=
        BindingArgument
+     | BindingBoundArgument
      | ConstantArgument
      | LifetimeArgument
      | TypeArgument
 
    BindingArgument ::=
        Identifier $$=$$ TypeSpecification
+
+   BindingBoundArgument ::=
+       Identifier $$:$$ TypeBoundList
 
    ConstantArgument ::=
        BlockExpression
@@ -348,6 +352,16 @@ A :s:`LifetimeArgument` shall precede :s:`[BindingArgument]s`,
 :dp:`fls_9pda3ja0ihks`
 A :t:`binding argument` is a :t:`generic argument` that supplies the :t:`type`
 of an :t:`associated trait type`.
+
+:dp:`fls_mcUMWsYcxzmZ`
+A :t:`binding bound argument` is a :t:`generic argument` that further imposes
+:t:`[bound]s` on an :t:`associated trait type`.
+
+:dp:`fls_dxMfAI4EZVS5`
+A :t:`binding bound argument` shall only be used within the confines of a
+:t:`type bound predicate`'s :t:`[bound]s`, :t:`[impl trait type]`'s
+:t:`[bound]s`, :t:`associated type`'s :t:`[bound]s` or :t:`trait`'s
+:t:`[supertrait]s`.
 
 :dp:`fls_i3z9ueoe99zd`
 A :t:`constant argument` is a :t:`generic argument` that supplies the

--- a/ferrocene/doc/specification/src/glossary.rst
+++ b/ferrocene/doc/specification/src/glossary.rst
@@ -655,7 +655,7 @@ binary crate
 ^^^^^^^^^^^^
 
 :dp:`fls_8gfe7hajxkd7`
-A :dt:`binary crate` is a :t:`crate` that contains a :t:`main function`.
+A :dt:`binary crate` is a :t:`crate` whose :t:`crate type` is ``bin``.
 
 .. _fls_or4o65fyt28y:
 
@@ -696,6 +696,15 @@ binding argument
 :dp:`fls_9lzcasl4tw7k`
 A :dt:`binding argument` is a :t:`generic argument` that supplies the :t:`type`
 of an :t:`associated trait type`.
+
+.. _fls_t2cit5QOte8U:
+
+binding bound argument
+^^^^^^^^^^^^^^^^^^^^^^
+
+:dp:`fls_D3i3n4RIReCA`
+A :dt:`binding bound argument` is a :t:`generic argument` that further imposes
+:t:`[bound]s` on an :t:`associated trait type`.
 
 .. _fls_bv1k866tai6j:
 
@@ -1333,6 +1342,16 @@ to either ``true`` or ``false``, and controls :t:`conditional compilation`.
 :dp:`fls_99ioki0M64fD`
 See :s:`ConfigurationPredicate`.
 
+.. _fls_vuBjK3kdImTn:
+
+const block expression
+^^^^^^^^^^^^^^^^^^^^^^
+
+:dp:`fls_5ApoJzRSTZGH`
+A :dt:`const block expression` is a :t:`block expression` that is specified
+with :t:`keyword` ``const`` and encapsulates behavior which is evaluated
+statically.
+
 .. _fls_yw57di94gwpf:
 
 constant
@@ -1556,6 +1575,16 @@ crate root module
 :dp:`fls_oo4nmqv78wno`
 A :dt:`crate root module` is the root of the nested :t:`module` tree of a
 :t:`crate`.
+
+.. _fls_lVpE4uFDsXH4:
+
+crate type
+^^^^^^^^^^
+
+:dp:`fls_eaxsgPMFNH7f`
+The :dt:`crate type` of a :t:`crate` is the value of the :t:`attribute`
+``crate_type`` of a :t:`crate` or the value of ``--crate-type`` flag passed to
+the tool compiling the :t:`crate`.
 
 .. _fls_76cj65bptdpn:
 
@@ -3721,8 +3750,8 @@ library crate
 ^^^^^^^^^^^^^
 
 :dp:`fls_3m8lg4mdc2x0`
-A :dt:`library crate` is either a :t:`crate` without a :t:`main function` or a
-:t:`crate` subject to :t:`attribute` :c:`no_main`.
+A :dt:`library crate` is a :t:`crate` whose :t:`crate type` is ``lib``, ``rlib``,
+``staticlib``, ``dylib``, or ``cdylib``.
 
 .. _fls_vdhaa61g6kah:
 
@@ -4058,14 +4087,14 @@ macro transcription
 :dt:`Macro transcription` is the process of producing the expansion of a
 :t:`declarative macro`.
 
-.. _fls_dz192n9muwpg:
+.. _fls_MJ1YWiOpxAa8:
 
-main function
-^^^^^^^^^^^^^
+main function signature
+^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_au3ovrkenr59`
-A :dt:`main function` is a :t:`function` that acts as an entry point into
-a program.
+:dp:`fls_QijObGZEIykU`
+A :dt:`main function signature` is a :t:`function signature` subject to specific
+restrictions.
 
 .. _fls_fizf1byuspv2:
 
@@ -5037,6 +5066,14 @@ primitive representation
 :dt:`Primitive representation` is the :t:`type representation` of
 :t:`[integer type]s`.
 
+.. _fls_mk3sa7OvtJvB:
+
+principal trait
+^^^^^^^^^^^^^^^
+
+:dp:`fls_YtYOHoPaMPFX`
+The :dt:`principal trait` of :t:`trait object type` is its first :t:`trait bound`.
+
 .. _fls_v1u1mevpj0kj:
 
 private visibility
@@ -5055,7 +5092,7 @@ proc-macro crate
 .. _fls_AjjdLZWiL9Tq:
 
 :dp:`fls_DfTszT1PjV7o`
-A :dt:`proc-macro crate` is a :t:`crate` that contains :t:`[procedural macro]s`.
+A :dt:`proc-macro crate` is a :t:`crate` whose :t:`crate type` is ``proc-macro``.
 
 .. _fls_sp5wdsxwmxf:
 
@@ -5065,6 +5102,15 @@ procedural macro
 :dp:`fls_u4utpx4zgund`
 A :dt:`procedural macro` is a :t:`macro` that encapsulates syntactic
 transformations in a :t:`function`.
+
+.. _fls_SIFecOZqloyx:
+
+program entry point
+^^^^^^^^^^^^^^^^^^^
+
+:dp:`fls_9m37hN9zgEQf`
+A :dt:`program entry point` is a :t:`function` that is invoked at the start of
+a Rust program.
 
 .. _fls_v2rjlovqsdyr:
 
@@ -5188,7 +5234,7 @@ A :dt:`range pattern` is a :t:`pattern` that matches :t:`[value]s` which fall
 within a range.
 
 :dp:`fls_r36uf3y2denr`
-See ``RangePattern.``
+See ``RangePattern``.
 
 .. _fls_3ls9xlgt8ei1:
 

--- a/ferrocene/doc/specification/src/index.rst
+++ b/ferrocene/doc/specification/src/index.rst
@@ -40,6 +40,7 @@ Ferrocene Language Specification
    licenses
    glossary
    undefined-behavior
+   changelog
 
 Indices and tables
 ------------------

--- a/ferrocene/doc/specification/src/ownership-and-deconstruction.rst
+++ b/ferrocene/doc/specification/src/ownership-and-deconstruction.rst
@@ -625,6 +625,18 @@ An :dt:`extending expression` is either
   :t:`array expression`, a :t:`borrow expression`, a :t:`struct expression`, a
   :t:`tuple expression`, or a :t:`type cast expression`, or
 
+* :dp:`fls_Rj9zhVutfQod`
+  The :t:`block expression` and :t:`else expression` of an :t:`if expression`
+  that is an :t:`extending expression`.
+
+* :dp:`fls_oodpp3LpXC13`
+  The :t:`expression` of an :t:`else expression` that is an :t:`extending
+  expression`.
+
+* :dp:`fls_xGThCPoTUSAi`
+  The :t:`expression` of a :t:`match arm` of a :t:`match expression` that is an
+  :t:`extending expression`.
+
 * :dp:`fls_iqw0d1l1lj3i`
   The :t:`tail expression` of a :t:`block expression` that is an
   :t:`extending expression`.

--- a/ferrocene/doc/specification/src/program-structure-and-compilation.rst
+++ b/ferrocene/doc/specification/src/program-structure-and-compilation.rst
@@ -113,22 +113,42 @@ Crates
 A :t:`crate` is a unit of compilation and linking that contains a tree of
 nested :t:`[module]s`.
 
+:dp:`fls_unxalgMqIr3v`
+The :t:`crate type` of a :t:`crate` is the value of the :t:`attribute`
+``crate_type`` of a :t:`crate` or the value of ``--crate-type`` flag passed to
+the tool compiling the :t:`crate`.
+
+:dp:`fls_e7jGvXvTsFpC`
+The :t:`crate type` of a :t:`crate` if not specified is ``bin``.
+
+:dp:`fls_kQiJPwb2Hjcc`
+A :t:`crate` may be subject to multiple :t:`[crate type]s`, treating each type
+as a separate :t:`crate`.
+
 :dp:`fls_9ub6ks8qrang`
-A :t:`binary crate` is a :t:`crate` that contains a :t:`main function`. A tool
-can compile a :t:`binary crate` to an executable.
+A :t:`binary crate` is a :t:`crate` whose :t:`crate type` is ``bin``.
+
+:dp:`fls_OyFwBtDGVimT`
+A :t:`binary crate` that is not subject to :t:`attribute` ``no_main`` shall have
+a :t:`function` in scope of its :t:`crate root module` under the :t:`name`
+``main`` with a :t:`main function signature`.
+
+:dp:`fls_jQqXxPyND1ds`
+The :t:`function` in scope of a :t:`binary crate`'s :t:`crate root module` under
+the :t:`name` ``main`` with a :t:`main function signature` is the :t:`binary
+crate`'s :t:`program entry point`.
 
 :dp:`fls_d9nn4yuiw1ja`
-A :t:`library crate` is either a :t:`crate` without a :t:`main function` or a
-:t:`crate` subject to :t:`attribute` :c:`no_main`. A tool is free to compile a
-:t:`library crate` to a shared library.
+A :t:`library crate` is a :t:`crate` whose :t:`crate type` is ``lib``, ``rlib``,
+``staticlib``, ``dylib``, or ``cdylib``.
 
 :dp:`fls_Mf62VqAhoZ3c`
-A :t:`proc-macro crate` is a :t:`crate` that contains :t:`[procedural macro]s`.
-A tool is free to compile a :t:`proc-macro crate` to a shared library.
+A :t:`proc-macro crate` is a :t:`crate` whose :t:`crate type` is ``proc-macro``.
 
-:dp:`fls_cXLyCjs9T3Mj`
-A :t:`proc-macro crate` shall not declare :t:`[item]s` with
-:t:`public visibility` unless the :t:`item` is a :t:`procedural macro`.
+:dp:`fls_RJJmN4tP7j4m`
+A :t:`proc-macro crate` shall not declare :t:`[item]s` in its :t:`crate root
+module` with  :t:`public visibility` unless the :t:`item` is a :t:`procedural
+macro`.
 
 :dp:`fls_h93C3wfbAoz1`
 Only a :t:`proc-macro crate` shall declare :t:`[procedural macro]s`.
@@ -224,3 +244,39 @@ for all :t:`[attribute]s` up to the invoked :t:`attribute` :c:`cfg`.
 An :t:`attribute` :c:`cfg_attr` where the related :t:`configuration predicate`
 evaluates to ``false`` is not considered part of a Rust program.
 
+
+.. _fls_8JB3SJqamdpU:
+
+Program Entry Point
+-------------------
+
+.. rubric:: Legality Rules
+
+:dp:`fls_dp64b08em9BJ`
+A :t:`program entry point` is a :t:`function` that is invoked at the start of
+a Rust program.
+
+:dp:`fls_sbGnkm8Ephiu`
+A :t:`main function signature` is a :t:`function signature` subject to the
+following restrictions:
+
+* :dp:`fls_o4fxok23134r`
+  It lacks :t:`[function qualifier]s` ``async`` and ``unsafe``,
+
+* :dp:`fls_bk755pvc1l53`
+  Its :t:`ABI` is Rust,
+
+* :dp:`fls_a3je4wc53bmo`
+  It lacks :t:`[generic parameter]s`,
+
+* :dp:`fls_w8q15zp7kyl0`
+  It lacks :t:`[function parameter]s`,
+
+* :dp:`fls_4psnfphsgdek`
+  It lacks a :t:`return type`,
+
+* :dp:`fls_m7xfrhqif74`
+  It lacks a :t:`where clause`,
+
+* :dp:`fls_qq9fzrw4aykd`
+  It has a :t:`function body`.

--- a/ferrocene/doc/specification/src/types-and-traits.rst
+++ b/ferrocene/doc/specification/src/types-and-traits.rst
@@ -1123,6 +1123,21 @@ An :t:`impl trait type` is a :t:`type` that implements a :t:`trait`, where the
 An :t:`impl trait type` shall appear only within a :t:`function parameter` or
 the :t:`return type` of a :t:`function`.
 
+:dp:`fls_3aKZB0ILIkZw`
+An :t:`anonymous return type` is an :t:`impl trait type` ascribed to a
+:t:`function` :t:`return type`.
+
+:dp:`fls_Xo1ODwOyX7Vm`
+An :t:`anonymous return type` behaves as if it contained all declared :t:`[type
+parameter]s` of the :t:`return type`'s :t:`function` and its parent :t:`trait`
+or :t:`implementation`.
+
+:dp:`fls_kTGFLFymTWch`
+An :t:`anonymous return type` derived from an :t:`async function` behaves as if
+it contained all declared :t:`[type parameter]s` and :t:`[lifetime parameter]s`
+of the :t:`return type`'s :t:`function` and its parent :t:`trait` or
+:t:`implementation`.
+
 :dp:`fls_ECjhEI7eCwAj`
 An :t:`impl trait type` shall not contain :t:`[opt-out trait bound]s`.
 
@@ -1156,10 +1171,14 @@ Trait Object Types
 A :t:`trait object type` is a :t:`type` that implements a :t:`trait`, where the
 :t:`type` is not known at compile time.
 
+:dp:`fls_eWac7zOda3lh`
+The :t:`principal trait` of :t:`trait object type` is the first :t:`trait bound`.
+
 :dp:`fls_9z8oleh0wdel`
-The first :t:`trait bound` of a :t:`trait object type` shall denote an
-:t:`object safe` :t:`trait`. Any subsequent :t:`[trait bound]s` shall denote
-:t:`[auto trait]s`.
+The :t:`principal trait` shall denote an :t:`object safe` :t:`trait`.
+
+:dp:`fls_hJII8XYAtZeY`
+All non-:t:`principal trait` :t:`[trait bound]s` shall denote :t:`[auto trait]s`.
 
 :dp:`fls_s0oy2c8t4yz9`
 A :t:`trait object type` shall not contain :t:`[opt-out trait bound]s`.
@@ -1991,6 +2010,11 @@ occur when:
 * :dp:`fls_sf0c3fbx8z57`
   The source :t:`type` is the :t:`never type` and the target :t:`type` is any
   :t:`type`.
+
+* :dp:`fls_SYnFJBhi0IWj`
+  The source :t:`type` is a :t:`trait object type` and the target :t:`type` is a
+  :t:`trait object type` with the same :t:`[trait bound]s` and additional
+  :t:`[auto trait]s`.
 
 :dp:`fls_iiiu2q7pym4p`
 An :t:`unsized coercion` is a :t:`type coercion` that converts a :t:`sized type`


### PR DESCRIPTION
This PR updates the specification subtree, and in the last commit it replaces the release notes link with Ferrocene's, rather than upstream's.