### PR TITLE
Simplify the traceability matrix

### DIFF
--- a/ferrocene/tools/traceability-matrix/src/documentations.rs
+++ b/ferrocene/tools/traceability-matrix/src/documentations.rs
@@ -40,9 +40,7 @@ pub(crate) struct Section {
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Paragraph {
-    pub(crate) id: String,
-    pub(crate) number: String,
-    pub(crate) link: String,
+    // We don't care about the fields in the paragraph.
 }
 
 #[derive(Debug, Deserialize)]

--- a/ferrocene/tools/traceability-matrix/src/matrix.rs
+++ b/ferrocene/tools/traceability-matrix/src/matrix.rs
@@ -159,6 +159,10 @@ impl MatrixAnalysis {
             true
         }
     }
+
+    pub(crate) fn informational_count(&self) -> usize {
+        self.linked.iter().filter(|l| l.informational()).count()
+    }
 }
 
 fn filter_targets_from_tests<F>(tests: &[LinkTest], getter: F) -> BTreeSet<&String>

--- a/ferrocene/tools/traceability-matrix/src/matrix.rs
+++ b/ferrocene/tools/traceability-matrix/src/matrix.rs
@@ -188,10 +188,6 @@ impl Deref for Link {
 }
 
 impl Link {
-    pub(crate) fn hide_in_annotation_mode(&self) -> bool {
-        self.tests.iter().all(|t| t.hide_in_annotation_mode())
-    }
-
     pub(crate) fn informational(&self) -> bool {
         self.tests.iter().any(|t| matches!(t, LinkTest::Informational))
     }
@@ -205,14 +201,6 @@ pub(crate) enum LinkTest {
 }
 
 impl LinkTest {
-    fn hide_in_annotation_mode(&self) -> bool {
-        match self {
-            LinkTest::File(_) => false,
-            LinkTest::NoParagraphsInSection => true,
-            LinkTest::Informational => true,
-        }
-    }
-
     fn unwrap_file(&self) -> Option<&AnnotatedFile> {
         match self {
             LinkTest::File(annotated) => Some(annotated),

--- a/ferrocene/tools/traceability-matrix/src/matrix.rs
+++ b/ferrocene/tools/traceability-matrix/src/matrix.rs
@@ -8,8 +8,11 @@ use std::ops::Deref;
 use crate::annotations::{AnnotatedFile, Annotations};
 use crate::documentations::{CliOption, Documentation, Section};
 
-pub(crate) const ELEMENT_KIND_SECTION: ElementKind =
-    ElementKind { singular: "section", plural: "sections", include_title_when_copying: true };
+pub(crate) const ELEMENT_KIND_SECTION: ElementKind = ElementKind {
+    singular: "specification section",
+    plural: "specification sections",
+    include_title_when_copying: true,
+};
 
 pub(crate) const ELEMENT_KIND_CLI_OPTION: ElementKind = ElementKind {
     singular: "command line option",

--- a/ferrocene/tools/traceability-matrix/src/matrix.rs
+++ b/ferrocene/tools/traceability-matrix/src/matrix.rs
@@ -8,11 +8,8 @@ use std::ops::Deref;
 use crate::annotations::{AnnotatedFile, Annotations};
 use crate::documentations::{CliOption, Documentation, Section};
 
-pub(crate) const ELEMENT_KIND_SECTION: ElementKind = ElementKind {
-    singular: "section",
-    plural: "sections",
-    include_title_when_copying: true,
-};
+pub(crate) const ELEMENT_KIND_SECTION: ElementKind =
+    ElementKind { singular: "section", plural: "sections", include_title_when_copying: true };
 
 pub(crate) const ELEMENT_KIND_CLI_OPTION: ElementKind = ElementKind {
     singular: "command line option",
@@ -190,6 +187,10 @@ impl Link {
     pub(crate) fn hide_in_annotation_mode(&self) -> bool {
         self.tests.iter().all(|t| t.hide_in_annotation_mode())
     }
+
+    pub(crate) fn informational(&self) -> bool {
+        self.tests.iter().any(|t| matches!(t, LinkTest::Informational))
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
@@ -365,10 +366,7 @@ mod tests {
                                 title: "Example subsection".into(),
                                 link: "example.html#example-subsection".into(),
                                 informational: false,
-                                paragraphs: vec![
-                                    Paragraph {},
-                                    Paragraph {},
-                                ],
+                                paragraphs: vec![Paragraph {}, Paragraph {}],
                             },
                             Section {
                                 id: "fls_05".into(),

--- a/ferrocene/tools/traceability-matrix/src/matrix.rs
+++ b/ferrocene/tools/traceability-matrix/src/matrix.rs
@@ -11,14 +11,12 @@ use crate::documentations::{CliOption, Documentation, Section};
 pub(crate) const ELEMENT_KIND_SECTION: ElementKind = ElementKind {
     singular: "section",
     plural: "sections",
-    hide_in_annotation_mode: false,
     include_title_when_copying: true,
 };
 
 pub(crate) const ELEMENT_KIND_CLI_OPTION: ElementKind = ElementKind {
     singular: "command line option",
     plural: "command line options",
-    hide_in_annotation_mode: false,
     include_title_when_copying: false,
 };
 
@@ -265,7 +263,6 @@ impl Element {
 pub(crate) struct ElementKind {
     pub(crate) singular: &'static str,
     pub(crate) plural: &'static str,
-    pub(crate) hide_in_annotation_mode: bool,
     pub(crate) include_title_when_copying: bool,
 }
 

--- a/ferrocene/tools/traceability-matrix/templates/report.html
+++ b/ferrocene/tools/traceability-matrix/templates/report.html
@@ -95,7 +95,6 @@
         {% endif %}
 
         {% for analysis in matrix.analyses_by_kind() %}
-            {% if analysis.kind.hide_in_annotation_mode %}<div class="hide-in-annotation-mode">{% endif %}
             <h2>All {{ analysis.kind.plural }}</h2>
             <table>
                 <thead>
@@ -125,7 +124,6 @@
                     {% endfor %}
                 </tbody>
             </table>
-            {% if analysis.kind.hide_in_annotation_mode %}</div>{% endif %}
         {% endfor %}
 
         {% if !ignored_tests.is_empty() %}

--- a/ferrocene/tools/traceability-matrix/templates/report.html
+++ b/ferrocene/tools/traceability-matrix/templates/report.html
@@ -98,6 +98,9 @@
 
         {% for analysis in matrix.analyses_by_kind() %}
             <h2>All {{ analysis.kind.plural }}</h2>
+            {% if analysis.informational_count() > 0 %}
+                <p>{{ analysis.informational_count() }} informational {{ analysis.kind.plural }} are not included in this table.</p>
+            {% endif %}
             <table>
                 <thead>
                     <tr>
@@ -154,6 +157,7 @@
 </html>
 
 {%- macro row_with_tests(color, link) -%}
+    {% if !link.informational() %}
     <tr id="{{ link.element.id }}" {% if link.hide_in_annotation_mode() %} class="hide-in-annotation-mode"{% endif %}>
         <td><div class="circle {{ color }}"></div></td>
         <td>{% call page_link(link.element.page) %}</td>
@@ -188,6 +192,7 @@
             {% endif %}
         </td>
     </tr>
+    {% endif %}
 {%- endmacro -%}
 
 {%- macro page_link(page) -%}

--- a/ferrocene/tools/traceability-matrix/templates/report.html
+++ b/ferrocene/tools/traceability-matrix/templates/report.html
@@ -11,6 +11,7 @@
     <body>
         <header>
             <h1>Traceability matrix report</h1>
+            <a href="../index.html">Go back to the documentation index</a>
         </header>
 
         {% if !considers_ignored_tests %}

--- a/ferrocene/tools/traceability-matrix/templates/report.html
+++ b/ferrocene/tools/traceability-matrix/templates/report.html
@@ -33,7 +33,7 @@
                 <tr>
                     <th colspan="2"></th>
                     {% for kind in summary[0].kinds %}
-                        <th colspan="3">{{ kind.kind.plural|capitalize }}</th>
+                        <th colspan="4">{{ kind.kind.plural|capitalize }}</th>
                     {% endfor %}
                 </tr>
                 <tr>
@@ -41,6 +41,7 @@
                     <th>Page</th>
                     {% for _ in summary[0].kinds %}
                         <th>Linked #</th>
+                        <th>Informational #</th>
                         <th>Total #</th>
                         <th>Completion</th>
                     {% endfor %}
@@ -60,9 +61,10 @@
                         </td>
                         {% for kind in row.kinds %}
                             {% if kind.total == 0 %}
-                                <td colspan="3"></td>
+                                <td colspan="4"></td>
                             {% else %}
                                 <td>{{ kind.linked }}</td>
+                                <td>{{ kind.informational }}</td>
                                 <td>{{ kind.total }}</td>
                                 <td>{{ kind.percentage|fmt("{:.2}") }}%</td>
                             {% endif %}

--- a/ferrocene/tools/traceability-matrix/templates/report.html
+++ b/ferrocene/tools/traceability-matrix/templates/report.html
@@ -21,13 +21,6 @@
         </div>
         {% endif %}
 
-        <label class="top-note">
-            <input type="checkbox" id="toggle-annotation-mode">
-            Enable section linking mode. This hides informational and empty
-            sections. This also allows clicking on an ID to copy the
-            annotation.
-        </label>
-
         <table>
             <thead>
                 <tr>
@@ -158,7 +151,7 @@
 
 {%- macro row_with_tests(color, link) -%}
     {% if !link.informational() %}
-    <tr id="{{ link.element.id }}" {% if link.hide_in_annotation_mode() %} class="hide-in-annotation-mode"{% endif %}>
+    <tr id="{{ link.element.id }}">
         <td><div class="circle {{ color }}"></div></td>
         <td>{% call page_link(link.element.page) %}</td>
         <td>{% call element_link(link.element) %}</td>

--- a/ferrocene/tools/traceability-matrix/templates/report.html
+++ b/ferrocene/tools/traceability-matrix/templates/report.html
@@ -23,9 +23,9 @@
 
         <label class="top-note">
             <input type="checkbox" id="toggle-annotation-mode">
-            Enable section linking mode. This hides informational sections,
-            empty sections and all paragraphs. This also allows clicking on an
-            ID to copy the annotation.
+            Enable section linking mode. This hides informational and empty
+            sections. This also allows clicking on an ID to copy the
+            annotation.
         </label>
 
         <table>
@@ -175,8 +175,6 @@
                     {% match test %}
                         {% when LinkTest::File with (file) %}
                             {% call file_link(file) %}
-                        {% when LinkTest::InheritFromSection with { section_id, section_number} %}
-                            inherited from <a href="#{{ section_id }}">section {{ section_number }}</a>
                         {% when LinkTest::Informational %}
                             informational
                         {% when LinkTest::NoParagraphsInSection %}

--- a/ferrocene/tools/traceability-matrix/templates/report.js
+++ b/ferrocene/tools/traceability-matrix/templates/report.js
@@ -3,26 +3,11 @@
 
 "use strict";
 
-let toggleAnnotationMode = document.getElementById("toggle-annotation-mode");
 let popup = document.getElementById("annotation-copied-popup");
 let popupTimeout = null;
 
-let refreshAnnotationMode = () => {
-    if (toggleAnnotationMode.checked) {
-        document.body.classList.add("annotation-mode");
-    } else {
-        document.body.classList.remove("annotation-mode");
-    }
-};
-toggleAnnotationMode.addEventListener("change", refreshAnnotationMode);
-refreshAnnotationMode();
-
 document.querySelectorAll(".copiable").forEach(elem => {
     elem.addEventListener("click", (event => {
-        // Only enable this when annotation mode is enabled.
-        if (!toggleAnnotationMode.checked) {
-            return;
-        }
         event.preventDefault();
 
         let text = "// ferrocene-annotations: " + elem.innerText + "\n";

--- a/ferrocene/tools/traceability-matrix/templates/style.css
+++ b/ferrocene/tools/traceability-matrix/templates/style.css
@@ -15,8 +15,7 @@ a {
 header {
     color: #fff;
     background: #194e80;
-    margin: -1em;
-    margin-bottom: 0;
+    margin: -1em -1em 1em -1em;
     padding: 1em;
 }
 
@@ -120,7 +119,7 @@ div.circle.green {
 
 div.top-error {
     padding: 1em;
-    margin: 0 -1em;
+    margin: -1em -1em 1em -1em;
 
     border-bottom: 1px solid #f00;
     background: #fee;

--- a/ferrocene/tools/traceability-matrix/templates/style.css
+++ b/ferrocene/tools/traceability-matrix/templates/style.css
@@ -129,23 +129,10 @@ div.top-error {
 
 /* Annotation mode */
 
-label.top-note {
-    display: block;
-    cursor: pointer;
-
-    padding: 1em;
-    margin: 0 -1em 1em -1em;
-    border-bottom: 1px solid #ccc;
-}
-
-body.annotation-mode .copiable {
+.copiable {
     cursor: pointer;
     text-decoration: underline;
     text-decoration-style: dotted;
-}
-
-body.annotation-mode .hide-in-annotation-mode {
-    display: none;
 }
 
 /* Popup messages */

--- a/ferrocene/tools/traceability-matrix/templates/style.css
+++ b/ferrocene/tools/traceability-matrix/templates/style.css
@@ -17,11 +17,19 @@ header {
     background: #194e80;
     margin: -1em -1em 1em -1em;
     padding: 1em;
+
+    display: flex;
+    align-items: center;
+    gap: 1.5em;
 }
 
 header h1 {
     margin: 0;
     font-size: 1.25em;
+}
+
+header a {
+    color: #fff;
 }
 
 /* Lists */


### PR DESCRIPTION
This PR includes a lot of changes I wanted to make to the traceability matrix for a long time, and I finally got annoyed enough to implement them:

* Completely removed paragraphs from the traceability matrix. Those were added originally while we were still planning to link tests to individual paragraphs, but as we are not doing that there is little point in bloating our documents with useless lines.

* Changed informational sections to be always hidden, with no way to show them back. They have been replaced with a simple count of the informational sections. This continues to reduce the bloat by not including 700+ lines for each glossary entry.

* Removed the opt-in checkbox for annotations mode, and made it the default. With the paragraphs and the glossary sections removed there is little benefit for that to be opt-in.

* Added a link back to the documentation index.

This PR is best reviewed commit-by-commit.