### PR TITLE
Merge `ferrocene_intersphinx_support` in `ferrocene_qualification`

### DIFF
--- a/ferrocene/doc/document-list/src/conf.py
+++ b/ferrocene/doc/document-list/src/conf.py
@@ -14,9 +14,6 @@ extensions = [
     "ferrocene_document_list",
     "ferrocene_toctrees",
     "ferrocene_qualification",
-
-    "sphinx.ext.intersphinx",
-    "ferrocene_intersphinx_support",
 ]
 
 html_theme = "ferrocene"

--- a/ferrocene/doc/evaluation-plan/src/conf.py
+++ b/ferrocene/doc/evaluation-plan/src/conf.py
@@ -9,9 +9,6 @@ extensions = [
     "ferrocene_toctrees",
     "ferrocene_qualification",
     "ferrocene_autoglossary",
-
-    "sphinx.ext.intersphinx",
-    "ferrocene_intersphinx_support",
 ]
 
 html_theme = "ferrocene"

--- a/ferrocene/doc/evaluation-report/src/conf.py
+++ b/ferrocene/doc/evaluation-report/src/conf.py
@@ -9,9 +9,6 @@ extensions = [
     "ferrocene_toctrees",
     "ferrocene_qualification",
     "ferrocene_autoglossary",
-
-    "sphinx.ext.intersphinx",
-    "ferrocene_intersphinx_support",
 ]
 
 html_theme = "ferrocene"

--- a/ferrocene/doc/internal-procedures/src/conf.py
+++ b/ferrocene/doc/internal-procedures/src/conf.py
@@ -9,9 +9,6 @@ extensions = [
     "ferrocene_toctrees",
     "ferrocene_qualification",
     "ferrocene_autoglossary",
-
-    "sphinx.ext.intersphinx",
-    "ferrocene_intersphinx_support",
     "sphinx.ext.autosectionlabel",
 ]
 

--- a/ferrocene/doc/internal-procedures/src/docs/sphinx-extensions.rst
+++ b/ferrocene/doc/internal-procedures/src/docs/sphinx-extensions.rst
@@ -18,6 +18,9 @@ documents the features of each extension.
 This extension implements "global" features that are not tied to any specific
 document, and should be imported in each document.
 
+The extension also enables ``sphinx.ext.intersphinx`` without the need to
+manually enable it in ``conf.py``.
+
 Defining and linking to IDs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -215,12 +218,6 @@ each document containing a glossary. It serves two purposes:
 
 * Automatically adds links to terms defined in ``glossary`` directives across
   the document, without the need to manually use the builtin ``:term:`` role.
-
-``ferrocene_intersphinx_support`` extension
--------------------------------------------
-
-This extension is required by the build system to enable interlinking between
-documents. It must be added to all documents and requires no maintainer action.
 
 ``ferrocene_document_list`` extension
 -------------------------------------

--- a/ferrocene/doc/qualification-plan/src/conf.py
+++ b/ferrocene/doc/qualification-plan/src/conf.py
@@ -9,9 +9,6 @@ extensions = [
     "ferrocene_toctrees",
     "ferrocene_qualification",
     "ferrocene_autoglossary",
-
-    "sphinx.ext.intersphinx",
-    "ferrocene_intersphinx_support",
     "sphinx.ext.autosectionlabel",
 ]
 

--- a/ferrocene/doc/qualification-report/src/conf.py
+++ b/ferrocene/doc/qualification-report/src/conf.py
@@ -15,9 +15,6 @@ extensions = [
     "ferrocene_qualification",
     "ferrocene_test_outcomes",
     "ferrocene_autoglossary",
-
-    "sphinx.ext.intersphinx",
-    "ferrocene_intersphinx_support",
 ]
 
 ferrocene_id = "QR"

--- a/ferrocene/doc/release-notes/src/conf.py
+++ b/ferrocene/doc/release-notes/src/conf.py
@@ -15,9 +15,6 @@ extensions = [
     "ferrocene_qualification",
     "ferrocene_relnotes",
     "ferrocene_autoglossary",
-
-    "sphinx.ext.intersphinx",
-    "ferrocene_intersphinx_support",
 ]
 
 html_theme = "ferrocene"

--- a/ferrocene/doc/safety-manual/src/conf.py
+++ b/ferrocene/doc/safety-manual/src/conf.py
@@ -10,9 +10,6 @@ extensions = [
     "ferrocene_qualification",
     "ferrocene_domain_cli",
     "ferrocene_autoglossary",
-
-    "sphinx.ext.intersphinx",
-    "ferrocene_intersphinx_support",
     "sphinx.ext.autosectionlabel",
 ]
 

--- a/ferrocene/doc/specification/src/conf.py
+++ b/ferrocene/doc/specification/src/conf.py
@@ -23,12 +23,10 @@ author = "The Ferrocene Developers"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "ferrocene_intersphinx_support",
     "ferrocene_qualification",
     "ferrocene_spec",
     "ferrocene_spec_lints",
     "ferrocene_toctrees",
-    "sphinx.ext.intersphinx",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/__init__.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/__init__.py
@@ -1,7 +1,14 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: The Ferrocene Developers
 
-from . import substitutions, document_id, domain, signature_page, target
+from . import (
+    substitutions,
+    document_id,
+    domain,
+    signature_page,
+    target,
+    intersphinx_support,
+)
 import string
 
 
@@ -11,6 +18,7 @@ def setup(app):
     domain.setup(app)
     signature_page.setup(app)
     target.setup(app)
+    intersphinx_support.setup(app)
 
     app.connect("config-inited", validate_config)
     app.add_config_value("ferrocene_id", None, "env", [str])

--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/intersphinx_support.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/intersphinx_support.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: The Ferrocene Developers
 
-# This extension adds some helpers needed to integrate Ferrocene's build system
+# This module adds some helpers needed to integrate Ferrocene's build system
 # with InterSphinx. More specifically, the extension:
 #
 # - Defines the "ferrocene-intersphinx" Sphinx builder, which only produces the
@@ -18,6 +18,7 @@ from sphinx.builders import Builder
 from sphinx.builders.html import StandaloneHTMLBuilder
 import json
 import sphinx
+import sphinx.ext.intersphinx
 
 
 class IntersphinxBuilder(Builder):
@@ -81,13 +82,11 @@ def inject_intersphinx_mappings(app, config):
 
 
 def setup(app):
+    # Automatically enable the sphinx.ext.intersphinx extension without
+    # requiring users to configure it in their conf.py.
+    sphinx.ext.intersphinx.setup(app)
+
     app.add_builder(IntersphinxBuilder)
 
     app.add_config_value("ferrocene_intersphinx_mappings", None, "env", [str])
     app.connect("config-inited", inject_intersphinx_mappings, priority=1)
-
-    return {
-        "version": "0",
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }

--- a/ferrocene/doc/user-manual/src/conf.py
+++ b/ferrocene/doc/user-manual/src/conf.py
@@ -6,16 +6,11 @@ copyright = "The Ferrocene Developers"
 author = "The Ferrocene Developers"
 
 extensions = [
-    # ferrocene
-    "ferrocene_intersphinx_support",
+    "ferrocene_autoglossary",
+    "ferrocene_domain_cli",
     "ferrocene_qualification",
     "ferrocene_toctrees",
-    "ferrocene_domain_cli",
-    "ferrocene_autoglossary",
-    # 3rd-party
     "myst_parser",
-    # sphinx.ext
-    "sphinx.ext.intersphinx",
     "sphinx.ext.autosectionlabel",
 ]
 


### PR DESCRIPTION
This also initializes `sphinx.ext.intersphinx` inside of `ferrocene_qualification`, so that there is no need to depend from the extension manually. This is a pre-requisite for the `sphinx-needs` integration.