### PR TITLE
It's qualified to use `rust-lld` if you play by the rules

### DIFF
--- a/ferrocene/doc/evaluation-plan/src/qualification-scope.rst
+++ b/ferrocene/doc/evaluation-plan/src/qualification-scope.rst
@@ -19,6 +19,7 @@ Qualified tools are:
 
 * ``rustc``
 * ``rustfmt``
+* ``rust-lld`` when used according to the :doc:`safety-manual:rustc/options`
 
 Other development tools are not qualified and are distributed for convenience
 only. This includes but is not limited to:


### PR DESCRIPTION
Note that `rust-lld` is, in fact, qualified so long as you use it within the rules laid out in https://public-docs.ferrocene.dev/main/safety-manual/rustc/options.html#linker-options.