### PR TITLE
Test sphinx-shared-resources on pull requests to monorepo

### DIFF
--- a/.github/workflows/test-sphinx-shared-resources.yml
+++ b/.github/workflows/test-sphinx-shared-resources.yml
@@ -2,17 +2,24 @@
 # SPDX-FileCopyrightText: The Ferrocene Developers
 
 ---
-
-name: CI
-on: [push, pull_request]
+name: Test sphinx-shared-resources
+on:
+  pull_request:
+    paths:
+      - .github/workflows/test-sphinx-shared-resources.yml
+      - ferrocene/doc/sphinx-shared-resources/**
 
 permissions:
   contents: read
 
+defaults:
+  run:
+    working-directory: ferrocene/doc/sphinx-shared-resources/
+
 jobs:
   lint:
     name: Lints
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-sphinx-shared-resources.yml
+++ b/.github/workflows/test-sphinx-shared-resources.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Install linting dependencies
         run: python3 -m pip install reuse black flake8
 
-      - name: Verify licensing metadata
-        run: reuse lint
-
       - name: Verify Python code formatting
         run: black . --check --diff --color
 

--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_domain_cli/domain.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_domain_cli/domain.py
@@ -38,7 +38,8 @@ class ProgramDirective(SphinxDirective):
             "no_traceability_matrix" in self.options,
         )
 
-        # parse and process content of `ProgramDirective`` (one or more `OptionDirective`s)
+        # parse and process content of `ProgramDirective`` (one or more
+        # `OptionDirective`s)
         node = nodes.container()
         self.state.nested_parse(self.content, self.content_offset, node)
 


### PR DESCRIPTION
Before the workflow was run in [ferrocene/sphinx-shared-resources](https://github.com/ferrocene/sphinx-shared-resources/), but since we don't make changes in that repo anymore, and instead make changes to the monorepo and sync them, it was not run anymore.

@Hoverbear Is this okay as a Github Action or does it need to be converted to CircleCI? I would want this to block a PR if it fails.