### PR TITLE
fix for incompatible SemVer

### DIFF
--- a/ferrocene/doc/release-notes/exts/ferrocene_relnotes/rust_changelog.py
+++ b/ferrocene/doc/release-notes/exts/ferrocene_relnotes/rust_changelog.py
@@ -83,6 +83,9 @@ def split_release_notes(doctree):
             raise RuntimeError("top-level section without title")
 
         raw_version = title.split(" ")[1]
+        # Needed if version is not SemVer compatible
+        if len(raw_version.split(".")) == 2:
+            raw_version += ".0"
         try:
             version = Version.parse(raw_version)
         except ValueError as e:


### PR DESCRIPTION
We fixed this problem on [`stable`](https://app.circleci.com/pipelines/github/ferrocene/ferrocene/5702/workflows/e01f0678-fe43-43f2-8619-7c19a76f3ce4/jobs/30201?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) when the SemVer version is not correct.
Same fix for main.