### PR TITLE
Allow building ferrocene docs on windows

### DIFF
--- a/ferrocene/doc/document-list/exts/ferrocene_document_list.py
+++ b/ferrocene/doc/document-list/exts/ferrocene_document_list.py
@@ -18,7 +18,7 @@ class DocumentId(SphinxRole):
             return [], [self.error(self.text)]
         if not os.path.exists(path):
             return [], [self.error(path)]
-        with open(path) as file:
+        with open(path, "r", encoding="utf-8") as file:
             id = file.read()
         node = nodes.literal(text=id)
         return [node], []

--- a/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/outcomes.py
+++ b/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/outcomes.py
@@ -80,7 +80,7 @@ class Outcomes:
     platforms: OrderedDict[(str, str), Platform] = field(default_factory=OrderedDict)
 
     def load_file(self, file):
-        with open(file) as f:
+        with open(file, "r", encoding="utf-8") as f:
             contents = json.load(f)
 
         if "format_version" not in contents:

--- a/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/render_template.py
+++ b/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/render_template.py
@@ -61,7 +61,7 @@ class RenderOutcomesTemplate(SphinxDirective):
 
 def render_template(directive, template, context):
     path = f"{directive.env.srcdir}/{template}"
-    with open(path) as f:
+    with open(path, "r", encoding="utf-8") as f:
         content = f.read()
     directive.env.note_dependency(path)
 

--- a/ferrocene/doc/release-notes/exts/ferrocene_relnotes/rust_changelog.py
+++ b/ferrocene/doc/release-notes/exts/ferrocene_relnotes/rust_changelog.py
@@ -47,7 +47,7 @@ def load_release_notes(app):
 
 
 def read_release_notes(path):
-    with open(path) as f:
+    with open(path, "r", encoding="utf-8") as f:
         content = f.read()
 
     parsed = docutils.core.publish_doctree(

--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/signature_page.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_qualification/signature_page.py
@@ -58,7 +58,7 @@ class SignatureStatus:
         self.loaded_files.append(path)
         if copy:
             self.copiable_files[name] = path
-        with open(path) as f:
+        with open(path, "r", encoding="utf-8") as f:
             return f.read()
 
     def load_private_file(self, name, *, copy=False):
@@ -69,7 +69,7 @@ class SignatureStatus:
         path = f"{self.app.config.ferrocene_private_signature_files_dir}/{uuid}"
         if copy:
             self.copiable_files[name] = path
-        with open(path) as f:
+        with open(path, "r", encoding="utf-8") as f:
             return f.read()
 
 

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -9,7 +9,7 @@ use crate::utils::exec::BootstrapCommand;
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{absolute, Path, PathBuf};
 
 pub(crate) trait IsSphinxBook {
     const SOURCE: &'static str;
@@ -871,10 +871,10 @@ impl Step for Index {
 }
 
 // Note: this function is correct for the use made in this module, but it will not work correctly
-// if paths don't exists or the paths do not have any segments in common.
+// if the paths do not have any segments in common.
 fn relative_path(base: &Path, path: &Path) -> PathBuf {
-    let base = fs::canonicalize(base).unwrap_or_else(|_| base.to_path_buf());
-    let path = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let base = absolute(base).unwrap_or_else(|_| base.to_owned());
+    let path = absolute(path).unwrap_or_else(|_| path.to_owned());
 
     let common = base
         .components()


### PR DESCRIPTION
Canonicalizing paths yields [extended length paths](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file) on windows causing the paths to differ significantly if one of the two doesn't exist. From what I can tell we mainly want to get rid of any potential `..` and `.` segments from the paths though (and make them absolute), not resolve symlinks, so absolutizing should suffice.

Additionally this sets the encoding for text file `open` calls to `utf8` as that defaults to `cp1252` on windows.