### PR TITLE
[try] qnx: unignore failing `std::process` tests

### DIFF
--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -21,7 +21,6 @@ fn shell_cmd() -> Command {
 
 #[test]
 #[cfg_attr(any(target_os = "vxworks"), ignore)]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn smoke() {
     let p = if cfg!(target_os = "windows") {
         Command::new("cmd").args(&["/C", "exit 0"]).spawn()
@@ -44,7 +43,6 @@ fn smoke_failure() {
 
 #[test]
 #[cfg_attr(any(target_os = "vxworks"), ignore)]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn exit_reported_right() {
     let p = if cfg!(target_os = "windows") {
         Command::new("cmd").args(&["/C", "exit 1"]).spawn()
@@ -60,7 +58,6 @@ fn exit_reported_right() {
 #[test]
 #[cfg(unix)]
 #[cfg_attr(any(target_os = "vxworks"), ignore)]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn signal_reported_right() {
     use crate::os::unix::process::ExitStatusExt;
 
@@ -85,7 +82,6 @@ pub fn run_output(mut cmd: Command) -> String {
 
 #[test]
 #[cfg_attr(any(target_os = "vxworks"), ignore)]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn stdout_works() {
     if cfg!(target_os = "windows") {
         let mut cmd = Command::new("cmd");
@@ -108,7 +104,6 @@ fn set_current_dir_works() {
 
 #[test]
 #[cfg_attr(any(windows, target_os = "vxworks"), ignore)]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn stdin_works() {
     let mut p = shell_cmd()
         .arg("-c")
@@ -127,7 +122,6 @@ fn stdin_works() {
 
 #[test]
 #[cfg_attr(any(target_os = "vxworks"), ignore)]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn child_stdout_read_buf() {
     let mut cmd = if cfg!(target_os = "windows") {
         let mut cmd = Command::new("cmd");
@@ -159,7 +153,6 @@ fn child_stdout_read_buf() {
 
 #[test]
 #[cfg_attr(any(target_os = "vxworks"), ignore)]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn test_process_status() {
     let mut status = if cfg!(target_os = "windows") {
         Command::new("cmd").args(&["/C", "exit 1"]).status().unwrap()
@@ -177,7 +170,6 @@ fn test_process_status() {
 }
 
 #[test]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn test_process_output_fail_to_start() {
     match Command::new("/no-binary-by-this-name-should-exist").output() {
         Err(e) => assert_eq!(e.kind(), ErrorKind::NotFound),
@@ -187,7 +179,6 @@ fn test_process_output_fail_to_start() {
 
 #[test]
 #[cfg_attr(any(target_os = "vxworks"), ignore)]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn test_process_output_output() {
     let Output { status, stdout, stderr } = if cfg!(target_os = "windows") {
         Command::new("cmd").args(&["/C", "echo hello"]).output().unwrap()
@@ -203,7 +194,6 @@ fn test_process_output_output() {
 
 #[test]
 #[cfg_attr(any(target_os = "vxworks"), ignore)]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn test_process_output_error() {
     let Output { status, stdout, stderr } = if cfg!(target_os = "windows") {
         Command::new("cmd").args(&["/C", "mkdir ."]).output().unwrap()
@@ -219,7 +209,6 @@ fn test_process_output_error() {
 
 #[test]
 #[cfg_attr(any(target_os = "vxworks"), ignore)]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn test_finish_once() {
     let mut prog = if cfg!(target_os = "windows") {
         Command::new("cmd").args(&["/C", "exit 1"]).spawn().unwrap()
@@ -231,7 +220,6 @@ fn test_finish_once() {
 
 #[test]
 #[cfg_attr(any(target_os = "vxworks"), ignore)]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn test_finish_twice() {
     let mut prog = if cfg!(target_os = "windows") {
         Command::new("cmd").args(&["/C", "exit 1"]).spawn().unwrap()
@@ -244,7 +232,6 @@ fn test_finish_twice() {
 
 #[test]
 #[cfg_attr(any(target_os = "vxworks"), ignore)]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn test_wait_with_output_once() {
     let prog = if cfg!(target_os = "windows") {
         Command::new("cmd").args(&["/C", "echo hello"]).stdout(Stdio::piped()).spawn().unwrap()
@@ -303,7 +290,6 @@ fn test_override_env() {
 
 #[test]
 #[cfg_attr(target_os = "vxworks", ignore)]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn test_add_to_env() {
     let result = env_cmd().env("RUN_TEST_NEW_ENV", "123").output().unwrap();
     let output = String::from_utf8_lossy(&result.stdout).to_string();
@@ -316,7 +302,6 @@ fn test_add_to_env() {
 
 #[test]
 #[cfg_attr(target_os = "vxworks", ignore)]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn test_capture_env_at_spawn() {
     use crate::env;
 
@@ -725,7 +710,6 @@ fn run_canonical_bat_script() {
 }
 
 #[test]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn terminate_exited_process() {
     let mut cmd = if cfg!(target_os = "android") {
         let mut p = shell_cmd();

--- a/library/std/src/sys/pal/unix/process/process_common/tests.rs
+++ b/library/std/src/sys/pal/unix/process/process_common/tests.rs
@@ -30,7 +30,6 @@ macro_rules! t {
     ),
     ignore
 )]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn test_process_mask() {
     // Test to make sure that a signal mask *does* get inherited.
     fn test_inner(mut cmd: Command) {
@@ -93,7 +92,6 @@ fn test_process_mask() {
     ),
     ignore
 )]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn test_process_group_posix_spawn() {
     unsafe {
         // Spawn a cat subprocess that's just going to hang since there is no I/O.


### PR DESCRIPTION
I have been unable to get these to fail locally after rebasing. Let's see if that's the case in CI