### PR TITLE
add rust-lang/backtrace-rs subtree

### DIFF
--- a/ferrocene/tools/pull-subtrees/subtrees.yml
+++ b/ferrocene/tools/pull-subtrees/subtrees.yml
@@ -27,3 +27,9 @@
   ref: libc-0.2
   after:
     - update-cargo-lock
+
+- path: ferrocene/library/backtrace-rs
+  repo: rust-lang/backtrace-rs
+  ref: master
+  after:
+    - update-cargo-lock


### PR DESCRIPTION
in the next automation run

the latest version of backtrace-rs fixes backtrace related UI tests for the QNX targets