### PR TITLE
Remove stale exceptions from requirements-traceability

### DIFF
--- a/ferrocene/doc/qualification-report/src/requirements-traceability.rst
+++ b/ferrocene/doc/qualification-report/src/requirements-traceability.rst
@@ -13,24 +13,3 @@ this page.
 Note that the reporting tool only considers tests that were actually executed
 as part of the :doc:`test results <tests/index>`. Ignored tests are not
 considered when determining the traceability.
-
-Exceptions
-----------
-
-Some requirements are marked as not covered in the traceability report linked
-above:
-
-.. list-table::
-   :header-rows: 1
-
-   * - ID
-     - Targets
-     - Reasoning
-
-   * - ``fls_2d6bqnpy6tvs``
-     - :target-with-triple:`aarch64-unknown-none`
-     - Procedural macros are only available on host platforms, while this is a cross-compilation target
-
-   * - ``fls_4vjbkm4ceymk``
-     - :target-with-triple:`aarch64-unknown-none`
-     - Procedural macros are only available on host platforms, while this is a cross-compilation target


### PR DESCRIPTION
If https://github.com/ferrocene/ferrocene/pull/842 lands, the two tests are in fact green in the matrix