### PR TITLE
keep library/ lockfile fresh

### DIFF
--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -7,7 +7,7 @@ IFS=$'\n\t'
 
 UPSTREAM_REPO="https://github.com/rust-lang/rust"
 TEMP_BRANCH="pull-upstream-temp--do-not-use-for-real-code"
-DIRECTORIES_CONTAINING_LOCKFILES=("" "src/bootstrap/")
+DIRECTORIES_CONTAINING_LOCKFILES=("" "library" "src/bootstrap/")
 GENERATED_COMPLETIONS_DIR="src/etc/completions/"
 
 # Set a default max of merges per PR to 30, if it was not overridden in the


### PR DESCRIPTION
library/ has been moved to a separate workspace, so it has its own lockfile that needs to be kept updated