### PR TITLE
Update release notes for 24.08.0

### DIFF
--- a/ferrocene/doc/release-notes/src/24.08.0.rst
+++ b/ferrocene/doc/release-notes/src/24.08.0.rst
@@ -1,8 +1,6 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-:upcoming-release:
-
 Ferrocene 24.08.0
 =================
 
@@ -15,7 +13,14 @@ cross-compilation targets.
 New features
 ------------
 
-* The Rust version has been updated to 1.79.0.
+* Updated the Rust version to include the changes in Rust 1.77.0, 1.77.1,
+  1.77.2, 1.78.0 and 1.79.0. Backports of `Rust PR #128271`_, `Rust PR
+  #127364`_ and `Rust PR #126154`_ are also included to fix bugs introduced in
+  Rust 1.78.0.
+
+.. _Rust PR #128271: https://github.com/rust-lang/rust/pull/128271
+.. _Rust PR #127364: https://github.com/rust-lang/rust/pull/127364
+.. _Rust PR #126154: https://github.com/rust-lang/rust/pull/126154
 
 New experimental features
 -------------------------


### PR DESCRIPTION
Ran this command to copy all the changes we made to the 24.08.0 release notes:

```
git checkout origin/release/1.79 -- ferrocene/doc/release-notes/src/24.08.0.rst
```