### PR TITLE
Move `gha-app-auth.py` to scripts as `gha_app_auth.py`

### DIFF
--- a/.github/workflows/automation-backport.yml
+++ b/.github/workflows/automation-backport.yml
@@ -45,7 +45,7 @@ jobs:
       # them. To work around that we're using a fresh token from an ad-hoc
       # GitHub App with access to push new branches to this repo.
       - name: Authenticate with GitHub to create branches
-        run: ferrocene/ci/github-app-auth.py
+        run: ferrocene/ci/scripts/github_app_auth.py
         env:
           # https://github.com/organizations/ferrocene/settings/apps/ferrocene-backport
           APP_ID: 298770

--- a/.github/workflows/automation-pull-subtrees.yml
+++ b/.github/workflows/automation-pull-subtrees.yml
@@ -61,7 +61,7 @@ jobs:
       # GitHub App that has only read access to those repos, and we use that app to
       # generate a temporary token.
       - name: Authenticate with GitHub to fetch from repositories
-        run: ferrocene/ci/github-app-auth.py
+        run: ferrocene/ci/scripts/github_app_auth.py
         env:
           # https://github.com/organizations/ferrocene/settings/apps/ferrocene-pull-subtrees
           APP_ID: 200501

--- a/.github/workflows/automation-pull-upstream.yml
+++ b/.github/workflows/automation-pull-upstream.yml
@@ -59,7 +59,7 @@ jobs:
       # them. To work around that we're using a fresh token from an ad-hoc
       # GitHub App with access to push new branches to this repo.
       - name: Authenticate with GitHub to create branches
-        run: ferrocene/ci/github-app-auth.py
+        run: ferrocene/ci/scripts/github_app_auth.py
         env:
           # https://github.com/organizations/ferrocene/settings/apps/ferrocene-pull-upstream
           APP_ID: 211522

--- a/.github/workflows/mirror-sphinx-shared-resources.yml
+++ b/.github/workflows/mirror-sphinx-shared-resources.yml
@@ -33,7 +33,7 @@ jobs:
           path: ${{ env.ORIGIN_REPO_PATH }}
 
       - name: Authenticate with GitHub
-        run: ferrocene/ci/github-app-auth.py
+        run: ferrocene/ci/scripts/github_app_auth.py
         env:
           # https://github.com/organizations/ferrocene/settings/apps/ferrocene-mirror-shared-resources
           APP_ID: 852121


### PR DESCRIPTION
This kinda fell out of some work with #876 #867 and just brings the `gha-app-auth.py` script into the fold so other scripts can call it.