### PR TITLE
we use a method introduced in Python 3.12

### DIFF
--- a/.github/workflows/automation-pull-subtrees.yml
+++ b/.github/workflows/automation-pull-subtrees.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   run:
     name: ${{ matrix.branch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/runner/work/ferrocene/ferrocene/ferrocene/tools/pull-subtrees/pull.py", line 442, in <module>
    PullSubtreePR(subtree, args.target).create()
  File "/home/runner/work/ferrocene/ferrocene/ferrocene/tools/pull-subtrees/../common/automated_prs.py", line 62, in create
    result = self.run()
  File "/home/runner/work/ferrocene/ferrocene/ferrocene/tools/pull-subtrees/pull.py", line 322, in run
    self.diff = update_subtree(self.repo_root, self.subtree)
  File "/home/runner/work/ferrocene/ferrocene/ferrocene/tools/pull-subtrees/pull.py", line 252, in update_subtree
    AFTER_ACTIONS[action[0]](subtree, repo_root, action[1:])
  File "/home/runner/work/ferrocene/ferrocene/ferrocene/tools/pull-subtrees/pull.py", line 275, in action_update_cargo_lock
    for [package_name, workspace] in itertools.batched(params, 2):
AttributeError: module 'itertools' has no attribute 'batched'