### PR TITLE
Fix automation commits not triggering CI

### DIFF
--- a/.github/workflows/automation-backport.yml
+++ b/.github/workflows/automation-backport.yml
@@ -21,8 +21,6 @@ jobs:
     name: Create PR
     runs-on: ubuntu-latest
 
-    environment: automation-backport
-
     steps:
       - name: Checkout the Ferrocene repository
         uses: actions/checkout@v4
@@ -39,18 +37,6 @@ jobs:
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-
-      # The builtin GitHub token doesn't have the "workflows" permissions, and
-      # so it can't create new branches with the .github/workflows directory in
-      # them. To work around that we're using a fresh token from an ad-hoc
-      # GitHub App with access to push new branches to this repo.
-      - name: Authenticate with GitHub to create branches
-        run: ferrocene/ci/scripts/github_app_auth.py
-        env:
-          # https://github.com/organizations/ferrocene/settings/apps/ferrocene-backport
-          APP_ID: 298770
-          APP_PRIVATE_KEY: "${{ secrets.BACKPORT_APP_PRIVATE_KEY }}"
-        id: github_app_auth
 
       - name: Run the backport automation
         run: python3 ferrocene/tools/backport/all.py

--- a/.github/workflows/automation-backport.yml
+++ b/.github/workflows/automation-backport.yml
@@ -12,9 +12,12 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
   pull-requests: write
   issues: write
+  # Pushes are done by the GitHub app, to be able to trigger workflows.
+  # Marking this as `read` rather than `write` so that pushes accidentally
+  # using the builtin token rather than the app will fail loudly.
+  contents: read
 
 jobs:
   run:
@@ -37,6 +40,23 @@ jobs:
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
+
+      # The builtin GitHub token doesn't have the "workflows" permissions, and
+      # so it can't create new branches with the .github/workflows directory in
+      # them, or push commits changing files in that directory.
+      #
+      # Another limitation of the builtin GitHub token is that commits pushed
+      # through it don't start other GitHub Actions workflows, to prevent
+      # accidental infinte loops. Still, that's not acceptable for us, as we
+      # need to run CI on commits produced by this automation.
+      #
+      # To work around both problems we're using a fresh token from an ad-hoc
+      # GitHub App with access to push content to this repo.
+      - name: Authenticate with GitHub to create branches
+        run: ferrocene/ci/scripts/github_app_auth.py --set-git-credentials
+        env:
+          APP_ID: "${{ vars.AUTOMATIONS_APP_ID }}"
+          APP_PRIVATE_KEY: "${{ secrets.AUTOMATIONS_APP_PRIVATE_KEY }}"
 
       - name: Run the backport automation
         run: python3 ferrocene/tools/backport/all.py

--- a/.github/workflows/automation-pull-subtrees.yml
+++ b/.github/workflows/automation-pull-subtrees.yml
@@ -12,14 +12,18 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
   pull-requests: write
   issues: write
+  # Pushes are done by the GitHub app, to be able to trigger workflows.
+  # Marking this as `read` rather than `write` so that pushes accidentally
+  # using the builtin token rather than the app will fail loudly.
+  contents: read
 
 jobs:
   run:
     name: ${{ matrix.branch }}
     runs-on: ubuntu-24.04
+    environment: automations
 
     strategy:
       fail-fast: false
@@ -46,6 +50,23 @@ jobs:
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
+
+      # The builtin GitHub token doesn't have the "workflows" permissions, and
+      # so it can't create new branches with the .github/workflows directory in
+      # them, or push commits changing files in that directory.
+      #
+      # Another limitation of the builtin GitHub token is that commits pushed
+      # through it don't start other GitHub Actions workflows, to prevent
+      # accidental infinte loops. Still, that's not acceptable for us, as we
+      # need to run CI on commits produced by this automation.
+      #
+      # To work around both problems we're using a fresh token from an ad-hoc
+      # GitHub App with access to push content to this repo.
+      - name: Authenticate with GitHub to create branches
+        run: ferrocene/ci/scripts/github_app_auth.py --set-git-credentials
+        env:
+          APP_ID: "${{ vars.AUTOMATIONS_APP_ID }}"
+          APP_PRIVATE_KEY: "${{ secrets.AUTOMATIONS_APP_PRIVATE_KEY }}"
 
       # Some subtrees require updating the Cargo.lock once they're updated, and
       # updating the Cargo.lock requires subtrees to be present.

--- a/.github/workflows/automation-pull-subtrees.yml
+++ b/.github/workflows/automation-pull-subtrees.yml
@@ -27,7 +27,6 @@ jobs:
         branch:
           - main
 
-    environment: automation-pull-subtrees
     steps:
       - name: Checkout the Ferrocene repository
         uses: actions/checkout@v4
@@ -48,26 +47,6 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-      # The pull-subtrees automation needs to fetch from the repositories the
-      # subtrees are based on, but since those repositories are private we need to
-      # authenticate on GitHub Actions with some kind of credentials.
-      #
-      # Unfortunately deploy keys are not feasible, as a single deploy key can only
-      # clone one repository, and git doesn't make it easy to use multiple keys for
-      # different repositories. Personal access tokens are also not adequate as
-      # there's no way to scope the repositories a token has access to.
-      #
-      # To limit the permissions as much as possible, we then decided to create a
-      # GitHub App that has only read access to those repos, and we use that app to
-      # generate a temporary token.
-      - name: Authenticate with GitHub to fetch from repositories
-        run: ferrocene/ci/scripts/github_app_auth.py
-        env:
-          # https://github.com/organizations/ferrocene/settings/apps/ferrocene-pull-subtrees
-          APP_ID: 200501
-          APP_PRIVATE_KEY: "${{ secrets.PULL_SUBTREES_APP_PRIVATE_KEY }}"
-        id: github_app_auth
-
       # Some subtrees require updating the Cargo.lock once they're updated, and
       # updating the Cargo.lock requires subtrees to be present.
       - name: Fetch submodules
@@ -77,4 +56,3 @@ jobs:
         run: python3 ferrocene/tools/pull-subtrees/pull.py --automation --target ${{ matrix.branch }}
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          HTTP_CLONE_TOKEN: "${{ steps.github_app_auth.outputs.token }}"

--- a/.github/workflows/automation-pull-upstream.yml
+++ b/.github/workflows/automation-pull-upstream.yml
@@ -18,14 +18,18 @@ on:
         required: true
 
 permissions:
-  contents: write
   pull-requests: write
   issues: write
+  # Pushes are done by the GitHub app, to be able to trigger workflows.
+  # Marking this as `read` rather than `write` so that pushes accidentally
+  # using the builtin token rather than the app will fail loudly.
+  contents: read
 
 jobs:
   run:
     name: ${{ matrix.branch }}
     runs-on: ubuntu-latest
+    environment: automations
 
     strategy:
       fail-fast: false
@@ -34,8 +38,6 @@ jobs:
           - master # be sure to change the name in ferrocene/tools/pull-upstream/pull.sh if this changes
           - beta
           - stable
-
-    environment: automation-pull-upstream
 
     steps:
       - name: Checkout the Ferrocene repository
@@ -56,20 +58,23 @@ jobs:
 
       # The builtin GitHub token doesn't have the "workflows" permissions, and
       # so it can't create new branches with the .github/workflows directory in
-      # them. To work around that we're using a fresh token from an ad-hoc
-      # GitHub App with access to push new branches to this repo.
+      # them, or push commits changing files in that directory.
+      #
+      # Another limitation of the builtin GitHub token is that commits pushed
+      # through it don't start other GitHub Actions workflows, to prevent
+      # accidental infinte loops. Still, that's not acceptable for us, as we
+      # need to run CI on commits produced by this automation.
+      #
+      # To work around both problems we're using a fresh token from an ad-hoc
+      # GitHub App with access to push content to this repo.
       - name: Authenticate with GitHub to create branches
-        run: ferrocene/ci/scripts/github_app_auth.py
+        run: ferrocene/ci/scripts/github_app_auth.py --set-git-credentials
         env:
-          # https://github.com/organizations/ferrocene/settings/apps/ferrocene-pull-upstream
-          APP_ID: 211522
-          APP_PRIVATE_KEY: "${{ secrets.PULL_UPSTREAM_APP_PRIVATE_KEY }}"
-        id: github_app_auth
+          APP_ID: "${{ vars.AUTOMATIONS_APP_ID }}"
+          APP_PRIVATE_KEY: "${{ secrets.AUTOMATIONS_APP_PRIVATE_KEY }}"
 
       - name: Create the release branch if missing
         run: ferrocene/tools/pull-upstream/create-release-branch.sh ${{ matrix.branch }}
-        env:
-          HTTP_PUSH_TOKEN: "${{ steps.github_app_auth.outputs.token }}"
         if: matrix.branch != 'master'
         id: create_branch
 

--- a/ferrocene/ci/scripts/github_app_auth.py
+++ b/ferrocene/ci/scripts/github_app_auth.py
@@ -2,9 +2,12 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: The Ferrocene Developers
 
+import argparse
+import base64
 import jwt
 import os
 import requests
+import subprocess
 import time
 
 
@@ -46,11 +49,35 @@ def get_token(app_id, private_key):
 
     token = req(http, "POST", installations[0]["access_tokens_url"])["token"]
 
-    # We never want to print this on GHA, ensure the caller doesn't forget.
-    if 'GITHUB_ACTIONS' in os.environ and os.environ['GITHUB_ACTIONS'] == True:
-        print(f"::add-mask::{token}")
-    
+    mask_secret(token)
     return token
+
+
+def set_git_credentials(origin, token):
+    if not origin.startswith("https://") or not origin.endswith("/"):
+        print("error: origin must be an https URL with a trailing slash")
+        exit(1)
+
+    basic = base64.b64encode(f"x-access-token:{token}".encode("utf-8")).decode("utf-8")
+    mask_secret(basic)
+
+    # Configure git to use the token for HTTPS requests to GitHub in this repository.
+    subprocess.run(
+        [
+            "git",
+            "config",
+            "--local",
+            f"http.{origin}.extraheader",
+            f"Authorization: basic {basic}",
+        ],
+        check=True,
+    )
+
+
+def mask_secret(value):
+    if "GITHUB_ACTIONS" in os.environ and os.environ["GITHUB_ACTIONS"] == True:
+        print(f"::add-mask::{value}")
+
 
 if __name__ == "__main__":
     for var in ["APP_PRIVATE_KEY", "APP_ID"]:
@@ -58,11 +85,16 @@ if __name__ == "__main__":
             print(f"error: missing environment variable {var}")
             exit(1)
 
+    cli = argparse.ArgumentParser()
+    cli.add_argument("--set-git-credentials", action="store_true")
+    args = cli.parse_args()
+
     app_id = os.environ["APP_ID"]
     private_key = os.environ["APP_PRIVATE_KEY"]
 
     token = get_token(app_id, private_key)
-
-    print(f"::add-mask::{token}")
     with open(os.environ["GITHUB_OUTPUT"], "a") as f:
         f.write(f"token={token}\n")
+
+    if args.set_git_credentials:
+        set_git_credentials("https://github.com/", token)

--- a/ferrocene/tools/pull-subtrees/pull.py
+++ b/ferrocene/tools/pull-subtrees/pull.py
@@ -12,9 +12,6 @@
 # Required enviroment variables for the --automation flag:
 # - `GITHUB_TOKEN`: API token with access to the repo contents, issues and RPs
 # - `GITHUB_REPOSITORY`: name of the GitHub repository to run this script on
-#
-# If the `HTTP_CLONE_TOKEN` environment variable is provided, that token will
-# be used for HTTP cloning, rather than using SSH for cloning.
 
 from dataclasses import dataclass
 from pathlib import Path
@@ -87,12 +84,6 @@ def resolve_commit(ref):
 
 
 def fetch_latest_commit(subtree):
-    if "HTTP_CLONE_TOKEN" in os.environ:
-        token = os.environ["HTTP_CLONE_TOKEN"]
-        pull_url = f"https://ghost:{token}@github.com/{subtree.repo}"
-    else:
-        pull_url = f"git@github.com:{subtree.repo}"
-
     print(f"fetching latest commit from {subtree.repo} {subtree.ref}")
     run(
         [
@@ -103,7 +94,7 @@ def fetch_latest_commit(subtree):
             "http.https://github.com.extraheader=",
             # Fetch the latest commit in the subtree's ref
             "fetch",
-            pull_url,
+            "https://github.com/{subtree.repo}",
             subtree.ref,
         ]
     )

--- a/ferrocene/tools/pull-upstream/create-release-branch.sh
+++ b/ferrocene/tools/pull-upstream/create-release-branch.sh
@@ -98,15 +98,7 @@ else
     fi
     git branch "${branch_name}" "${last_commit}"
 
-    # On GitHub Actions we have to use a different token to push than the
-    # included one. This allows switching to that token.
-    origin="${FERROCENE_ORIGIN}"
-    if [[ -v HTTP_PUSH_TOKEN ]]; then
-        origin="https://ghost:${HTTP_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}"
-    fi
-    # The "-c http.https://github.com.extraheader=" ignores the authentication
-    # token set by the actions/checkout action, in case we push over HTTP.
-    git -c "http.https://github.com.extraheader=" push "${origin}" "${branch_name}"
+    git push "${FERROCENE_ORIGIN}" "${branch_name}"
 fi
 
 # Let other parts of the GitHub Actions workflow know what the branch name is.


### PR DESCRIPTION
After migrating CI checks to GitHub Actions, it was discovered that automated PRs do not trigger CI anymore. This is because GitHub Actions refuses to start any workflow on commits pushed by a GitHub Action's `$GITHUB_TOKEN`, to prevent infinite loops. Still, we do want CI to run on those commits, so we have to resort to using our own GitHub App token.

This PR does that by creating a new `automations` environment containing a GitHub App with write access to this repository's contents, and adding a `--set-git-credentials` flag to `github_app_auth.py` to configure git to use the newly created token.

It also cleans up the existing separate GitHub apps that automations had:

* The app for `automation-backport` didn't seem to be used anywhere.
* The app for `automation-pull-subtrees` was only used to fetch private repositories for subtrees, but we don't have any private subtree anymore.
* The app for `automation-pull-upstream` was used to create new branches (due to the builtin workflow not being able to push commits containing the `.github/workflows` directory), but that has been superseded by the new app.

This PR is best reviewed commit-by-commit.