### PR TITLE
Split tasks and run.sh output what they're running

### DIFF
--- a/ferrocene/ci/run.sh
+++ b/ferrocene/ci/run.sh
@@ -27,6 +27,7 @@ if [[ -f config.toml ]]; then
     echo
 fi
 
+echo "Configuring"
 # Generate `config.toml`.
 ferrocene/ci/configure.sh
 
@@ -43,6 +44,9 @@ ferrocene/ci/configure.sh
 #   preventing spurious rebuilds if a build script uses `rerun-if-changed`
 #   inside the sources directory.
 export CARGO_HOME="$(pwd)/build/cargo-home"
+
+echo "Running:"
+echo "${SCRIPT}"
 
 # Give control to the actual CI script. $SCRIPT
 exec bash -euo pipefail -c "${SCRIPT}"

--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -210,7 +210,9 @@ def cli():
     else:
         flags += get_flags_for_default_job(JOBS_DEFINITION, split[0])
 
-    print(" ".join(flags))
+    flag_arg = " ".join(flags)
+    print(f"Split tasks: {flag_arg}", file=sys.stderr)
+    print(flag_arg)
 
 
 def err(message):


### PR DESCRIPTION
After chatting with the team some folks expressed desire to improve the insight into what exactly the CI is running when `run.sh` or `split-tasks.py` is run.

This adds a bit of echo (like `set -x` but more limited) so folks can know what's going on.