### PR TITLE
Use Github token from app_auth

### DIFF
--- a/.github/workflows/automation-backport.yml
+++ b/.github/workflows/automation-backport.yml
@@ -54,6 +54,7 @@ jobs:
       # To work around both problems we're using a fresh token from an ad-hoc
       # GitHub App with access to push content to this repo.
       - name: Authenticate with GitHub to create branches
+        id: auth # The script sets the output `token`
         run: ferrocene/ci/scripts/github_app_auth.py --set-git-credentials
         env:
           APP_ID: "${{ vars.AUTOMATIONS_APP_ID }}"
@@ -62,5 +63,5 @@ jobs:
       - name: Run the backport automation
         run: python3 ferrocene/tools/backport/all.py
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ steps.auth.outputs.token }}"
           PYTHONUNBUFFERED: "true"

--- a/.github/workflows/automation-pull-subtrees.yml
+++ b/.github/workflows/automation-pull-subtrees.yml
@@ -63,6 +63,7 @@ jobs:
       # To work around both problems we're using a fresh token from an ad-hoc
       # GitHub App with access to push content to this repo.
       - name: Authenticate with GitHub to create branches
+        id: auth # The script sets the output `token`
         run: ferrocene/ci/scripts/github_app_auth.py --set-git-credentials
         env:
           APP_ID: "${{ vars.AUTOMATIONS_APP_ID }}"
@@ -76,4 +77,4 @@ jobs:
       - name: Run the manage-subtrees automation
         run: python3 ferrocene/tools/pull-subtrees/pull.py --automation --target ${{ matrix.branch }}
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ steps.auth.outputs.token }}"

--- a/.github/workflows/automation-pull-upstream.yml
+++ b/.github/workflows/automation-pull-upstream.yml
@@ -68,6 +68,7 @@ jobs:
       # To work around both problems we're using a fresh token from an ad-hoc
       # GitHub App with access to push content to this repo.
       - name: Authenticate with GitHub to create branches
+        id: auth # The script sets the output `token`
         run: ferrocene/ci/scripts/github_app_auth.py --set-git-credentials
         env:
           APP_ID: "${{ vars.AUTOMATIONS_APP_ID }}"
@@ -84,5 +85,5 @@ jobs:
       - name: Run the pull-upstream automation
         run: python3 ferrocene/tools/pull-upstream/automation.py ${{ matrix.branch }} ${{ steps.create_branch.outputs.name || 'main' }}
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ steps.auth.outputs.token }}"
           MAX_MERGES_PER_PR: "${{ github.event_name == 'workflow_dispatch' && inputs.max_merges_per_pr || 30 }}"


### PR DESCRIPTION
I noticed some of our automations aren't having their PRs triggered on pushes. This makes those scripts use the app token instead of the normal Github token context.