### PR TITLE
Add QNX to qualification report

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -362,7 +362,7 @@ jobs:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       FERROCENE_TARGETS: x86_64-pc-nto-qnx710
       SCRIPT: |
-        set +u; source ./qnx710/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.11:12345 ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call
+        set +u; source ./qnx710-472/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.11:12345 ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call
     steps:
       - aws-oidc-auth
       - ferrocene-checkout
@@ -374,7 +374,7 @@ jobs:
           docker-image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
           run-emulator-docker-image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-24 >>
           restore-from-job: x86_64-linux-build
-          emulator-script: "set +u; source ./qnx710/qnxsdp-env.sh; set -u; ./ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh"
+          emulator-script: "set +u; source ./qnx710-472/qnxsdp-env.sh; set -u; ./ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh"
 
   aarch64-qnx-generic-test-vm:
     executor: linux-vm
@@ -388,7 +388,7 @@ jobs:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       FERROCENE_TARGETS: aarch64-unknown-nto-qnx710
       SCRIPT: |
-        set +u; source ./qnx710/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.105:12345 ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call
+        set +u; source ./qnx710-472/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.105:12345 ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call
     steps:
       - aws-oidc-auth
       - ferrocene-checkout
@@ -400,7 +400,7 @@ jobs:
           docker-image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
           run-emulator-docker-image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-24 >>
           restore-from-job: x86_64-linux-build
-          emulator-script: "set +u; source ./qnx710/qnxsdp-env.sh; set -u; ./ferrocene/ci/scripts/emulated-aarch64-qnx-test-runner.sh"
+          emulator-script: "set +u; source ./qnx710-472/qnxsdp-env.sh; set -u; ./ferrocene/ci/scripts/emulated-aarch64-qnx-test-runner.sh"
 
   # aarch64-unknown-linux-gnu jobs
 
@@ -1353,13 +1353,13 @@ commands:
             else
                 source $HOME/.venv/bin/activate
             fi
-            python ferrocene/ci/scripts/cache.py retrieve s3://ferrocene-ci-mirrors/manual/qnx/qnx710-deployment.tar.zst .
+            python ferrocene/ci/scripts/cache.py retrieve s3://ferrocene-ci-mirrors/manual/qnx/qnx710-472-deployment.tar.zst .
       - when:
           condition: << parameters.source-env-script >>
           steps:
             - run:
                 name: Set PATH to include QNX710 tools
-                command: echo 'source $(pwd)/qnx710/qnxsdp-env.sh' >> "$BASH_ENV"
+                command: echo 'source $(pwd)/qnx710-472/qnxsdp-env.sh' >> "$BASH_ENV"
       - run:
           name: Test qcc
           command: qcc -v || true

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -814,6 +814,12 @@ workflows:
             - x86_64-linux-test-library
             - x86_64-linux-test-library-std
             - x86_64-linux-compiletest
+            - x86_64-qnx-test-library
+            - x86_64-qnx-test-library-std
+            - x86_64-qnx-test-compiletest
+            - aarch64-qnx-test-library
+            - aarch64-qnx-test-library-std
+            - aarch64-qnx-test-compiletest
             - aarch64-linux-test-library
             - aarch64-linux-compiletest
       - x86_64-linux-traceability-matrix:
@@ -993,12 +999,6 @@ workflows:
             - x86_64-linux-traceability-matrix
             - x86_64-linux-self-test
             - x86_64-windows-self-test
-            - x86_64-qnx-test-library
-            - x86_64-qnx-test-library-std
-            - x86_64-qnx-test-compiletest
-            - aarch64-qnx-test-library
-            - aarch64-qnx-test-library-std
-            - aarch64-qnx-test-compiletest
             - wasm-dist-oxidos
             - aarch64-linux-self-test
             - aarch64-darwin-self-test

--- a/ferrocene/doc/internal-procedures/src/partners/qnx.rst
+++ b/ferrocene/doc/internal-procedures/src/partners/qnx.rst
@@ -49,7 +49,9 @@ Select "Add Installation...".
 
 Expand the "QNX® Software Development Platform 7.1" section.
 
-Select "QNX® Software Development Platform 7.1":
+Select "QNX® Software Development Platform 7.1" and ensure the version is
+"Stable (7.1 BuildID 472)", you may need to uncheck "Show Only Latest Version"
+at the bottom of the window:
 
 .. figure:: ../figures/qnx.png
 
@@ -100,13 +102,14 @@ below example, the downloaded ``.run`` file has been saved as
     follow the Windows instructions above, starting from "Log in, if
     prompted" now.
 
-Then, install QNX 7.1.0:
+Then, install QNX 7.1.0 BuildID 472:
 
 .. code-block::
     
     LICENSE_KEY="FILL_ME_IN"
     QNX_USER="FILL_ME_IN"
     QNX_PASSWORD="FILL_ME_IN"
+    QNX_VERSION="7.1.0.00472T202006132107S"
 
     cd $HOME/
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
@@ -114,11 +117,11 @@ Then, install QNX 7.1.0:
         -activateLicenseKey $LICENSE_KEY
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
         -myqnx.user $QNX_USER -myqnx.password $QNX_PASSWORD \
-        -mirrorBaseline qnx710
+        -mirrorBaseline qnx710-472
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
         -myqnx.user $QNX_USER -myqnx.password $QNX_PASSWORD \
-        -installBaseline com.qnx.qnx710 \
-        -destination qnx/qnx710 \
+        -installBaseline com.qnx.qnx710/$QNX_VERSION \
+        -destination qnx/qnx710-472 \
         -cleanInstall
 
 Finally, you can source your QNX toolchain in ``bash``:
@@ -181,42 +184,42 @@ Create a deployment containing Linux and Windows toolchains:
     LICENSE_KEY="FILL_ME_IN"
     QNX_USER="FILL_ME_IN"
     QNX_PASSWORD="FILL_ME_IN"
+    QNX_VERSION="7.1.0.00472T202006132107S"
+    QNX_HOST_VERSION="0.0.2.00472T202006132107S"
+    QNX_BSP_VERSION="0.0.3.00010T202012081457E"
 
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
         -myqnx.user $QNX_USER -myqnx.password $QNX_PASSWORD \
         -activateLicenseKey $LICENSE_KEY
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
-        -myqnx.user $QNX_USER -myqnx.password $QNX_PASSWORD \
         -mirrorBaseline qnx710
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
-        -myqnx.user $QNX_USER -myqnx.password $QNX_PASSWORD \
-        -installBaseline com.qnx.qnx710 \
-        -installPackage com.qnx.qnx710.host.win.x86_64 \
-        -installPackage com.qnx.qnx710.host.linux.x86_64 \
-        -installPackage com.qnx.qnx710.bsp.xilinx_xzynq_zcu102 \
-        -destination qnx/qnx710 \
+        -installBaseline com.qnx.qnx710/$QNX_VERSION \
+        -installPackage com.qnx.qnx710.host.win.x86_64/$QNX_HOST_VERSION \
+        -installPackage com.qnx.qnx710.host.linux.x86_64/$QNX_HOST_VERSION \
+        -installPackage com.qnx.qnx710.bsp.xilinx_xzynq_zcu102/$QNX_BSP_VERSION \
+        -destination qnx/qnx710-472 \
         -cleanInstall
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
-        -myqnx.user $QNX_USER -myqnx.password $QNX_PASSWORD \
-        -deploySdpInstallation qnx/qnx710 \
+        -deploySdpInstallation qnx/qnx710-472 \
         -deployLicense $LICENSE_KEY \
-        -installationDeployAs qnx/qnx710-deployment
+        -installationDeployAs qnx/qnx710-472-deployment
 
 Finally, create an archive of the deployment (with dereferenced symlinks) and upload it to the S3 URL which the CI attempts to pull from:
 
 .. code-block::
 
     cd $HOME
-    tar -cv --dereference -I 'zstd -T0' -f qnx/qnx710-deployment.tar.xz -C qnx/qnx710-deployment/ qnx710
-    aws s3 cp qnx/qnx710-deployment.tar.xz s3://ferrocene-ci-mirrors/manual/qnx/qnx710-deployment.tar.xz
+    tar -cv --dereference -I 'zstd -T0' -f qnx/qnx710-472-deployment.tar.zst -C qnx/qnx710-472-deployment/ qnx710-472
+    aws s3 cp qnx/qnx710-472-deployment.tar.zst s3://ferrocene-ci-mirrors/manual/qnx/qnx710-472-deployment.tar.zst
 
 On CI/CD hosts we use a Python script to setup the toolchain:
 
 .. code-block::
 
     cd $HOME
-    git/ferrocene/ferrocene/ferrocene/ci/scripts/setup-qnx-toolchain.py
-    source qnx/qnx710/qnxsdp-env.sh
+    ferrocene/ci/scripts/cache.py retrieve s3://ferrocene-ci-mirrors/manual/qnx/qnx710-472-deployment.tar.zst .
+    source qnx/qnx710-472/qnxsdp-env.sh
     qcc -v
 
 It's also possible to use ``tar`` directly, but it can be problematic on Windows hosts.
@@ -224,6 +227,6 @@ It's also possible to use ``tar`` directly, but it can be problematic on Windows
 .. code-block::
 
     cd $HOME
-    aws s3 cp s3://ferrocene-ci-mirrors/manual/qnx/qnx710-deployment.tar.xz - | tar -x --zstd -f-
-    source qnx/qnx710/qnxsdp-env.sh
+    aws s3 cp s3://ferrocene-ci-mirrors/manual/qnx/qnx710-472-deployment.tar.zst - | tar -x --zstd -f-
+    source qnx/qnx710-472/qnxsdp-env.sh
     qcc -v

--- a/ferrocene/doc/qualification-report/src/index.rst
+++ b/ferrocene/doc/qualification-report/src/index.rst
@@ -23,7 +23,9 @@ qualification, in accordance to the standards above.
 
    rustc/index
    rustc/aarch64-unknown-none
+   rustc/aarch64-unknown-nto-qnx710
    rustc/x86_64-unknown-linux-gnu
+   rustc/x86_64-pc-nto-qnx710
 
 .. appendices::
    :caption: Appendices:

--- a/ferrocene/doc/qualification-report/src/rustc/aarch64-unknown-nto-qnx710.rst
+++ b/ferrocene/doc/qualification-report/src/rustc/aarch64-unknown-nto-qnx710.rst
@@ -1,0 +1,6 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+.. render-outcomes-template:: templates/tests.jinja2
+   :host: x86_64-unknown-linux-gnu
+   :target: aarch64-unknown-nto-qnx710

--- a/ferrocene/doc/qualification-report/src/rustc/x86_64-pc-nto-qnx710.rst
+++ b/ferrocene/doc/qualification-report/src/rustc/x86_64-pc-nto-qnx710.rst
@@ -1,0 +1,6 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+.. render-outcomes-template:: templates/tests.jinja2
+   :host: x86_64-unknown-linux-gnu
+   :target: x86_64-pc-nto-qnx710

--- a/ferrocene/doc/release-notes/src/next.rst
+++ b/ferrocene/doc/release-notes/src/next.rst
@@ -14,6 +14,10 @@ New features
 
 * The ``rustfmt`` code formatter version |rustfmt_version| is now supported and
   qualified for safety critical use.
+* Two new qualified targets have been added.
+  
+  * :target-with-triple:`aarch64-unknown-nto-qnx710`
+  * :target-with-triple:`x86_64-pc-nto-qnx710`
 
 New experimental features
 -------------------------

--- a/ferrocene/doc/safety-manual/src/scope.rst
+++ b/ferrocene/doc/safety-manual/src/scope.rst
@@ -31,6 +31,14 @@ This qualification is restricted to the following environment:
      - :target:`x86_64-unknown-linux-gnu`
      - ``core``, ``alloc``, ``std``, ``proc_macro``, ``test``
 
+   * - :target:`x86_64-unknown-linux-gnu`
+     - :target:`x86_64-pc-nto-qnx710`
+     - ``core``, ``alloc``
+
+   * - :target:`x86_64-unknown-linux-gnu`
+     - :target:`aarch64-unknown-nto-qnx710`
+     - ``core``, ``alloc``
+
 The libraries provided are evaluated and tested within the scope of
 Ferrocene qualification for compiler use only. The use of these libraries by
 end-use code is outside the scope of the current Ferrocene qualification. It

--- a/ferrocene/doc/safety-manual/src/scope.rst
+++ b/ferrocene/doc/safety-manual/src/scope.rst
@@ -33,11 +33,11 @@ This qualification is restricted to the following environment:
 
    * - :target:`x86_64-unknown-linux-gnu`
      - :target:`x86_64-pc-nto-qnx710`
-     - ``core``, ``alloc``
+     - ``core``, ``alloc``, ``std``, ``proc_macro``, ``test``
 
    * - :target:`x86_64-unknown-linux-gnu`
      - :target:`aarch64-unknown-nto-qnx710`
-     - ``core``, ``alloc``
+     - ``core``, ``alloc``, ``std``, ``proc_macro``, ``test``
 
 The libraries provided are evaluated and tested within the scope of
 Ferrocene qualification for compiler use only. The use of these libraries by

--- a/ferrocene/doc/user-manual/src/targets/aarch64-unknown-nto-qnx710.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-unknown-nto-qnx710.rst
@@ -30,6 +30,22 @@ to be installed.
 Typically this is done through `QNX Software Center
 <https://www.qnx.com/download/group.html?programid=29178>`_.
 
+Ferrocene is qualified using a specific version QNX SDP version. In safety
+critical contexts you must ensure 7.1.0.00472T202006132107S (also known as
+7.1 BuildID 472) is used.
+
+.. code-block::
+
+    QNX_VERSION="7.1.0.00472T202006132107S"
+
+    qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
+        -installBaseline com.qnx.qnx710/$QNX_VERSION \
+        -destination qnx/qnx710-472 \
+        -cleanInstall
+
+In an existing QNX 7.1.0 install you can check for the presence of the
+``.packages/metadata/com.qnx.qnx710/7.1.0.00472T202006132107S/`` directory.
+
 Ferrocene documents how our internal QNX toolchains are installed and
 configured in :doc:`internal procedures (QNX) <internal-procedures:partners/qnx>`.
 Your organizational and licensing needs may differ.
@@ -48,16 +64,13 @@ Required shell environment
 To use the target, the following procedures must be undertaken in the shell
 running the build.
 
-You must source ``qnxsdp-env.sh`` from your QNX SDP 7.1.0 installation:
+You must ensure ``$HOME`` is set to a valid path, then source ``qnxsdp-env.sh``
+from your QNX SDP 7.1.0 installation:
 
 .. code-block::
 
     source $QNX_SDP_710_INSTALL/qnxsdp-env.sh
 
-    CC_aarch64-unknown-nto-qnx710=qcc
-    CFLAGS_aarch64-unknown-nto-qnx710=-Vgcc_ntoaarch64le_cxx
-    CXX_aarch64-unknown-nto-qnx710=qcc
-    AR_aarch64_unknown_nto_qnx710=ntoaarch64-ar
 
 On :ref:`x86_64-pc-windows-msvc`, there exists a ``qnxsdp-env.bat`` if
 required. Ferrocene is internally tested using ``bash.exe`` provided by

--- a/ferrocene/doc/user-manual/src/targets/aarch64-unknown-nto-qnx710.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-unknown-nto-qnx710.rst
@@ -11,12 +11,11 @@ ARMv8-A processors operating in Aarch64 mode.
 
 .. note::
     
-   QNX SDP only supports :ref:`x86_64-unknown-linux-gnu` and
-    :ref:`x86_64-pc-windows-msvc` as host platforms.
+    QNX SDP only supports :ref:`x86_64-unknown-linux-gnu` and :ref:`x86_64-pc-windows-msvc` as host platforms.
 
     Currently, Ferrocene only tests cross compiling from :ref:`x86_64-unknown-linux-gnu`
     to :target:`aarch64-unknown-nto-qnx710`. Compiling from :ref:`x86_64-pc-windows-msvc`
-    will be supported in the future.
+    will be tested in the future.
     
     QNX does not support :ref:`aarch64-apple-darwin` as a host platform. QNX is
     deprecating support for :target:`x86_64-apple-darwin` as a host platform.

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -59,6 +59,19 @@ qualified upon request.
      - Bare-metal
      - \-
 
+
+   * - :ref:`aarch64-unknown-nto-qnx710`
+     - ``aarch64-unknown-nto-qnx710``
+     - Cross-compilation
+     - Full
+     - Can only be cross-compiled from :ref:`x86_64-unknown-linux-gnu` and :ref:`x86_64-pc-windows-msvc`.
+
+   * - :ref:`x86_64-pc-nto-qnx710`
+     - ``x86_64-pc-nto-qnx710``
+     - Cross-compilation
+     - Full
+     - Can only be cross-compiled from :ref:`x86_64-unknown-linux-gnu` and :ref:`x86_64-pc-windows-msvc`.
+
 Quality managed targets
 -----------------------
 
@@ -135,18 +148,6 @@ should not be used in production.
      - Cross-compilation
      - Bare-metal
      - \-
-
-   * - :ref:`aarch64-unknown-nto-qnx710`
-     - ``aarch64-unknown-nto-qnx710``
-     - Cross-compilation
-     - Full
-     - Can only be cross-compiled from :ref:`x86_64-unknown-linux-gnu`.
-
-   * - :ref:`x86_64-pc-nto-qnx710`
-     - ``x86_64-pc-nto-qnx710``
-     - Cross-compilation
-     - Full
-     - Can only be cross-compiled from :ref:`x86_64-unknown-linux-gnu`.
 
    * - :target:`wasm32-unknown-unknown`
      - ``wasm32-unknown-unknown``

--- a/ferrocene/doc/user-manual/src/targets/x86_64-pc-nto-qnx710.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-pc-nto-qnx710.rst
@@ -30,6 +30,22 @@ to be installed.
 Typically this is done through `QNX Software Center
 <https://www.qnx.com/download/group.html?programid=29178>`_.
 
+Ferrocene is qualified using a specific version QNX SDP version. In safety
+critical contexts you must ensure 7.1.0.00472T202006132107S (also known as
+7.1 BuildID 472) is used.
+
+.. code-block::
+
+    QNX_VERSION="7.1.0.00472T202006132107S"
+
+    qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
+        -installBaseline com.qnx.qnx710/$QNX_VERSION \
+        -destination qnx/qnx710-472 \
+        -cleanInstall
+
+In an existing QNX 7.1.0 install you can check for the presence of the
+``.packages/metadata/com.qnx.qnx710/7.1.0.00472T202006132107S/`` directory.
+
 Ferrocene documents how our internal QNX toolchains are installed and
 configured in :doc:`internal procedures (QNX) <internal-procedures:partners/qnx>`.
 Your organizational and licensing needs may differ.
@@ -48,16 +64,13 @@ Required shell environment
 To use the target, the following procedures must be undertaken in the shell
 running the build.
 
-You must source ``qnxsdp-env.sh`` from your QNX SDP 7.1.0 installation:
+You must ensure ``$HOME`` is set to a valid path, then source ``qnxsdp-env.sh``
+from your QNX SDP 7.1.0 installation:
 
 .. code-block::
 
     source $QNX_SDP_710_INSTALL/qnxsdp-env.sh
 
-    CC_x86_64-pc-nto-qnx710=qcc
-    CFLAGS_x86_64-pc-nto-qnx710=-Vgcc_ntox86_64_cxx
-    CXX_x86_64-pc-nto-qnx710=qcc
-    AR_x86_64_pc_nto_qnx710=ntox86_64-ar
 
 On :ref:`x86_64-pc-windows-msvc`, there exists a ``qnxsdp-env.bat`` if
 required. Ferrocene is internally tested using ``bash.exe`` provided by

--- a/ferrocene/doc/user-manual/src/targets/x86_64-pc-nto-qnx710.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-pc-nto-qnx710.rst
@@ -11,12 +11,11 @@ x86-64 processors.
 
 .. note::
     
-    QNX SDP only supports :ref:`x86_64-unknown-linux-gnu` and
-    :ref:`x86_64-pc-windows-msvc` as host platforms.
+    QNX SDP only supports :ref:`x86_64-unknown-linux-gnu` and :ref:`x86_64-pc-windows-msvc` as host platforms.
 
     Currently, Ferrocene only tests cross compiling from :ref:`x86_64-unknown-linux-gnu`
     to :target:`x86_64-pc-nto-qnx710`. Compiling from :ref:`x86_64-pc-windows-msvc`
-    will be supported in the future.
+    will be tested in the future.
     
     QNX does not support :ref:`aarch64-apple-darwin` as a host platform. QNX is
     deprecating support for :target:`x86_64-apple-darwin` as a host platform.


### PR DESCRIPTION
Write the qualification docs for QNX. We only qualify with a specific QNX version for now.

Review:

```bash
./x.py doc ferrocene/doc/qualification-report --fresh
./x.py doc ferrocene/doc/safety-manual --fresh
./x.py doc ferrocene/doc/user-manual --fresh
```
