### PR TITLE
qnx: remove leftover `ignore` attributes

### DIFF
--- a/library/std/src/sys/pal/unix/process/process_common/tests.rs
+++ b/library/std/src/sys/pal/unix/process/process_common/tests.rs
@@ -28,7 +28,6 @@ macro_rules! t {
     ),
     ignore
 )]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn test_process_mask() {
     // Test to make sure that a signal mask *does* get inherited.
     fn test_inner(mut cmd: Command) {
@@ -91,7 +90,6 @@ fn test_process_mask() {
     ),
     ignore
 )]
-#[cfg_attr(all(target_arch = "x86_64", target_os = "nto"), ignore)]
 fn test_process_group_posix_spawn() {
     unsafe {
         // Spawn a cat subprocess that's just going to hang since there is no I/O.


### PR DESCRIPTION
these probably were left behind after some rebase went amiss