### PR TITLE
Annotate tests for spec changes

### DIFF
--- a/tests/ui/lint/rfc-2383-lint-reason/lint-attribute-only-with-reason.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/lint-attribute-only-with-reason.rs
@@ -10,3 +10,6 @@
 #[warn(dead_code, reason = "This is also reasonable")]
 
 fn main() {}
+
+// ferrocene-annotations: fls_ahmnqhm8anlb
+// Built-in Attributes

--- a/tests/ui/self/elision/ignore-non-reference-lifetimes.rs
+++ b/tests/ui/self/elision/ignore-non-reference-lifetimes.rs
@@ -22,3 +22,6 @@ impl<'a> Foo2<'a> {
 }
 
 fn main() {}
+
+// ferrocene-annotations: fls_hethxxbcg7ja
+// Function Lifetime Elision

--- a/tests/ui/self/elision/multiple-ref-self-async.rs
+++ b/tests/ui/self/elision/multiple-ref-self-async.rs
@@ -118,3 +118,6 @@ fn main() { }
 //
 // ferrocene-annotations: fls_1h0olpc7vbui
 // Type Path Resolution
+//
+// ferrocene-annotations: fls_hethxxbcg7ja
+// Function Lifetime Elision

--- a/tests/ui/self/elision/multiple-ref-self.rs
+++ b/tests/ui/self/elision/multiple-ref-self.rs
@@ -116,3 +116,6 @@ fn main() { }
 //
 // ferrocene-annotations: fls_1h0olpc7vbui
 // Type Path Resolution
+//
+// ferrocene-annotations: fls_hethxxbcg7ja
+// Function Lifetime Elision

--- a/tests/ui/self/elision/no-shadow-pin-self.rs
+++ b/tests/ui/self/elision/no-shadow-pin-self.rs
@@ -15,3 +15,6 @@ impl<P> Trait for Pin<P> {
 }
 
 fn main() {}
+
+// ferrocene-annotations: fls_hethxxbcg7ja
+// Function Lifetime Elision

--- a/tests/ui/self/elision/ref-assoc-async.rs
+++ b/tests/ui/self/elision/ref-assoc-async.rs
@@ -105,3 +105,6 @@ fn main() { }
 //
 // ferrocene-annotations: fls_1h0olpc7vbui
 // Type Path Resolution
+//
+// ferrocene-annotations: fls_hethxxbcg7ja
+// Function Lifetime Elision

--- a/tests/ui/self/elision/ref-assoc.rs
+++ b/tests/ui/self/elision/ref-assoc.rs
@@ -103,3 +103,6 @@ fn main() { }
 //
 // ferrocene-annotations: fls_1h0olpc7vbui
 // Type Path Resolution
+//
+// ferrocene-annotations: fls_hethxxbcg7ja
+// Function Lifetime Elision

--- a/tests/ui/self/elision/ref-self-async.rs
+++ b/tests/ui/self/elision/ref-self-async.rs
@@ -124,3 +124,6 @@ fn main() { }
 //
 // ferrocene-annotations: fls_1h0olpc7vbui
 // Type Path Resolution
+//
+// ferrocene-annotations: fls_hethxxbcg7ja
+// Function Lifetime Elision

--- a/tests/ui/self/elision/ref-self-multi.rs
+++ b/tests/ui/self/elision/ref-self-multi.rs
@@ -27,3 +27,6 @@ impl Struct {
 }
 
 fn main() { }
+
+// ferrocene-annotations: fls_hethxxbcg7ja
+// Function Lifetime Elision

--- a/tests/ui/self/elision/ref-self.fixed
+++ b/tests/ui/self/elision/ref-self.fixed
@@ -132,3 +132,6 @@ fn main() {}
 //
 // ferrocene-annotations: fls_1h0olpc7vbui
 // Type Path Resolution
+//
+// ferrocene-annotations: fls_hethxxbcg7ja
+// Function Lifetime Elision

--- a/tests/ui/self/elision/ref-self.rs
+++ b/tests/ui/self/elision/ref-self.rs
@@ -132,3 +132,6 @@ fn main() {}
 //
 // ferrocene-annotations: fls_1h0olpc7vbui
 // Type Path Resolution
+//
+// ferrocene-annotations: fls_hethxxbcg7ja
+// Function Lifetime Elision


### PR DESCRIPTION
To note: 
- New paragraphs: [7:2](https://spec.ferrocene.dev/values.html#fls_CUJyMj0Sj8NS), [7:3](https://spec.ferrocene.dev/values.html#fls_kaomYy0Ml4Nh), [7:4](https://spec.ferrocene.dev/values.html#fls_B5cmkWfD5GNt), [7:11](https://spec.ferrocene.dev/values.html#fls_oqhQ62mDLckN), [7:12](https://spec.ferrocene.dev/values.html#fls_uhwpuv6cx4ip), [7:13](https://spec.ferrocene.dev/values.html#fls_xuuFKmm181bs)
  - These have no changes in here as they are either term definitions for the spec or undefined behavior descriptions
- The following pattern changes are already correctly annotated, this is due to their tests having been added to `tests\ui\half-open-range-patterns` which hosts a `tests\ui\half-open-range-patterns\ferrocene-annotations` file with the correct annotations:
  - Changed syntax: RangePattern
  - New syntax: ExclusiveRangePattern
  - Changed paragraph: 5.1.5:16
  - New paragraphs: 5.1.5:4, 5.1.5:11, 5.4.5:4
