### PR TITLE
Mention IEC 62304 in more places

### DIFF
--- a/ferrocene/doc/index/index.html
+++ b/ferrocene/doc/index/index.html
@@ -90,7 +90,7 @@
                     </a>
                     <a href="qualification/plan/index.html">
                         <h3>Qualification Plan</h3>
-                        <p>Phases and activities that describe the qualification of the Ferrocene toolchain with the TCL 3/ASIL D level in accordance with ISO-26262 standard and the class T3 in accordance with the IEC-61508 standard.</p>
+                        <p>Phases and activities that describe the qualification of the Ferrocene toolchain with the TCL 3/ASIL D level in accordance with ISO-26262 standard, the class T3 in accordance with the IEC-61508 standard, and in accordance with the IEC-62304 standard.</p>
                     </a>
                     <a href="qualification/report/index.html">
                         <h3>Qualification Report</h3>

--- a/ferrocene/doc/user-manual/src/overview.rst
+++ b/ferrocene/doc/user-manual/src/overview.rst
@@ -4,8 +4,8 @@
 Overview
 ========
 
-This Manual describes the use of Ferrocene |ferrocene_version|, the |iso_ref|
-and |iec_ref| qualified version of the Rust toolchain.
+This Manual describes the use of Ferrocene |ferrocene_version|, the |iso_ref|,
+|iec_ref|, and |iec_med_ref| qualified version of the Rust toolchain.
 Ferrocene is based on ``rustc`` version |rust_version|.
 
 This Manual assumes familiarity with rustc and the Rust language, and outlines


### PR DESCRIPTION
While #874 added the IEC 62304 bits in a bunch of places, we seem to have missed a couple spots.

I'm not sure if the wording is right since I understand Medical is more certification than qualification?
