### PR TITLE
Minor fixes coming out of 24.11 review

### DIFF
--- a/ferrocene/doc/evaluation-plan/src/link-with-iec-62304-requirements.rst
+++ b/ferrocene/doc/evaluation-plan/src/link-with-iec-62304-requirements.rst
@@ -16,7 +16,7 @@ application of tool classification and qualification according to [|iec_ref|] is
 
 In addition, Ferrocene follows an open source development model.
 Nevertheless, Ferrocene is the qualified version of the open source Rust
-toolchain, and will therefore follow a develoment process in accordance to
+toolchain, and will therefore follow a development process in accordance to
 [|iso_ref|] Clause 11.4.8, as well as classification accordance to [|iec_ref|].
 
 In order to respect these three steps, we'll manage five documents:

--- a/ferrocene/doc/evaluation-plan/src/link-with-iso-requirements.rst
+++ b/ferrocene/doc/evaluation-plan/src/link-with-iso-requirements.rst
@@ -17,7 +17,7 @@ as there is no data collected of its use.
 
 In addition, Ferrocene follows an open source development model.
 Nevertheless, Ferrocene is the qualified version of the open source Rust
-toolchain, and will therefore follow a develoment process in accordance to
+toolchain, and will therefore follow a development process in accordance to
 11.4.8.
 
 In order to respect these three steps, we'll manage five documents:

--- a/ferrocene/doc/evaluation-report/src/hazop-words.rst
+++ b/ferrocene/doc/evaluation-report/src/hazop-words.rst
@@ -7,7 +7,7 @@ HazOp Guide Words
 Guide words must be in accordance with the software tool use domains. For the
 need of Ferrocene qualification, we have selected the following guide words:
 
-* **INVALID**: One of the parameter violates its semantics.
+* **INVALID**: One of the parameters violates its semantics.
 * **CHANGED**: A change occurs during processing.
 * **MORE INFO**: An input or an output contains more information than expected.
 * **LESS INFO**: An input or an output contains less information than expected.

--- a/ferrocene/doc/internal-procedures/src/external-contributions.rst
+++ b/ferrocene/doc/internal-procedures/src/external-contributions.rst
@@ -10,7 +10,7 @@ from forks. Before executing, confidence in the code needs to be established.
 To establish confidence, the code must be reviewed by a Ferrocene Developer and
 marked as trusted.
 
-The worflow to establish confidence is as follows:
+The workflow to establish confidence is as follows:
 
 1. Review the changes. The main threats are leaking credentials and arbitrary
    code execution. If the PR includes any suspicious changes, talk to the PR

--- a/ferrocene/tools/document-signatures/src/sign.rs
+++ b/ferrocene/tools/document-signatures/src/sign.rs
@@ -49,6 +49,7 @@ pub(crate) fn sign(
         .arg(pinned_temp.path())
         .arg("--bundle")
         .arg(bundle_temp.path())
+        .arg("--yes")
         .status()?;
     if !status.success() {
         anyhow::bail!("failed to invoke cosign (exited with status {status})");


### PR DESCRIPTION
Two patches that

a) fix minor typos that don't merit a whole review round

and

b) always confirm that we want to publish our data at cosign, increasing script resilience and signing ease