### PR TITLE
Exclude rustc-perf site from . workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ exclude = [
   # not all `Cargo.toml` files are available, so we exclude the `x` binary,
   # so it can be invoked before the current checkout is set up.
   "src/tools/x",
+  "src/tools/rustc-perf/site",
 ]
 
 [profile.release.package.rustc-rayon-core]

--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -123,6 +123,7 @@ impl Step for SourceTarball {
             "src/bootstrap/Cargo.toml",
             "src/tools/cargo/Cargo.toml",
             "src/tools/rust-analyzer/Cargo.toml",
+            "src/tools/rustc-perf/site/Cargo.toml",
         ];
 
         let mut subsetter = Subsetter::new(builder, "ferrocene-src", "");


### PR DESCRIPTION
While trying to build ferrocene inside of a network-less sandbox, a user reported the following error while running `x.py test`:

```
tidy check
thread 'deps (.)' panicked at src/tools/tidy/src/deps.rs:575:24:
cmd.exec() failed with `cargo metadata` exited with an error:     Updating git repository `https://github.com/rust-lang/team`
warning: spurious network error (3 tries remaining): failed to resolve address for github.com: Temporary failure in name resolution; class=Net (12)
warning: spurious network error (2 tries remaining): failed to resolve address for github.com: Temporary failure in name resolution; class=Net (12)
warning: spurious network error (1 tries remaining): failed to resolve address for github.com: Temporary failure in name resolution; class=Net (12)
error: failed to get `rust_team_data` as a dependency of package `site v0.1.0 (/ferrocene/src/tools/rustc-perf/site)`
```

This PR adds that crate to the workspace exclusion so that it gets vendored properly.