### PR TITLE
Repair rmake annotation detection

### DIFF
--- a/ferrocene/tools/traceability-matrix/src/annotations.rs
+++ b/ferrocene/tools/traceability-matrix/src/annotations.rs
@@ -18,6 +18,7 @@ impl std::fmt::Display for AnnotatedFile {
         match &self.source {
             AnnotationSource::TestItself => write!(f, "{}", self.test.display()),
             AnnotationSource::Makefile => write!(f, "{} (from its Makefile)", self.test.display()),
+            AnnotationSource::Rmake => write!(f, "{} (from its rmake.rs)", self.test.display()),
             AnnotationSource::ParentDirectory { .. } => {
                 write!(f, "{} (from its parent directory)", self.test.display())
             }
@@ -47,6 +48,7 @@ pub(crate) enum AnnotationSource {
     TestItself,
     ParentDirectory { bulk_file: PathBuf },
     Makefile,
+    Rmake,
 }
 
 #[derive(Debug)]
@@ -156,6 +158,8 @@ impl Annotations {
                     AnnotationSource::ParentDirectory { bulk_file: shrink_path(&annotation.file) }
                 } else if annotation.file == file.file.join("Makefile") {
                     AnnotationSource::Makefile
+                } else if annotation.file == file.file.join("rmake.rs") {
+                    AnnotationSource::Rmake
                 } else {
                     anyhow::bail!(
                         "bug: annotation {annotation:?} doesn't come from the file itself, \

--- a/ferrocene/tools/traceability-matrix/templates/report.html
+++ b/ferrocene/tools/traceability-matrix/templates/report.html
@@ -218,6 +218,8 @@
     {% when AnnotationSource::TestItself %}
     {% when AnnotationSource::Makefile %}
     (annotated in its <a href="{{ urls.src }}/{{ file.test.display() }}/Makefile">Makefile</a>)
+    {% when AnnotationSource::Rmake %}
+    (annotated in its <a href="{{ urls.src }}/{{ file.test.display() }}/rmake.rs">rmake.rs</a>)
     {% when AnnotationSource::ParentDirectory with { bulk_file } %}
     (annotated in its <a href="{{ urls.src }}/{{ bulk_file.display() }}">parent directory</a>)
 {% endmatch %}

--- a/src/tools/compiletest/src/ferrocene_annotations.rs
+++ b/src/tools/compiletest/src/ferrocene_annotations.rs
@@ -116,9 +116,7 @@ impl Collector {
     fn collect_annotations(&self, path: &Path, contents: &str) -> Vec<Annotation> {
         let mut found = Vec::new();
         for line in contents.lines() {
-            let prefix = if path.file_name() == Some(OsStr::new("Makefile"))
-                || path.file_name() == Some(OsStr::new("rmake.rs"))
-            {
+            let prefix = if path.file_name() == Some(OsStr::new("Makefile")) {
                 "# "
             } else if path.extension() == Some(OsStr::new("rs"))
                 || path.file_name() == Some(OsStr::new(BULK_ANNOTATIONS_FILE_NAME))


### PR DESCRIPTION
To test:

```bash
./x.py run traceability-matrix
```

Review `build/x86_64-unknown-linux-gnu/doc/qualification/traceability-matrix.html` in your browser.

Search `um_rustc_C_codegen_units` and hit "Show linked tests", observe the `rmake.rs` note:
![image](https://github.com/user-attachments/assets/d9a7f122-0c2a-4e96-aeb7-5739df343ac6)

