### PR TITLE
Dockerfiles version lock uv as well

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -111,12 +111,13 @@ jobs:
       - aws-oidc-auth
       - ferrocene-checkout:
           llvm-subset: true
+      - setup-venv
       - run:
           name: Check whether git conflict markers are present
           command: ferrocene/ci/scripts/detect-conflict-markers.py
       - run:
           name: Perform licensing checks
-          command: reuse --include-submodules lint
+          command: uv run reuse --include-submodules lint
       - ferrocene-ci
 
   # Container dedicated to running ad-hoc tests that don't depend on an
@@ -133,9 +134,10 @@ jobs:
       - aws-oidc-auth
       - ferrocene-checkout:
           llvm-subset: true
+      - setup-venv
       - run:
           name: Perform licensing checks
-          command: reuse --include-submodules lint
+          command: uv run reuse --include-submodules lint
       - ferrocene-ci
 
   # x86_64-unknown-linux-gnu jobs
@@ -330,6 +332,7 @@ jobs:
           steps:
             - aws-oidc-auth
             - ferrocene-checkout
+            - setup-venv
             - ferrocene-ci
       - run:
           name: Empty step to make sure the job always has steps
@@ -344,6 +347,7 @@ jobs:
     steps:
       - ferrocene-git-shallow-clone:
           depth: 1
+      - setup-venv
       - aws-oidc-auth
       - setup-qnx-toolchain: {}
       - run:
@@ -420,6 +424,7 @@ jobs:
           steps:
             - aws-oidc-auth
             - ferrocene-checkout
+            - setup-venv
             - ferrocene-ci
       - run:
           name: Empty step to make sure the job always has steps
@@ -468,6 +473,7 @@ jobs:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
       FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-unknown-linux-gnu--self-test >>
     steps:
+      - setup-venv
       - aws-oidc-auth
       - ferrocene-git-shallow-clone:
           depth: 1
@@ -559,6 +565,7 @@ jobs:
       - ferrocene-git-shallow-clone:
           depth: 1
       - ferrocene-setup-darwin # Darwin does not come with awscli, setup it before aws steps
+      - setup-venv
       - aws-oidc-auth
       - run:
           name: Download dist artifacts and run the self-test tool
@@ -1047,13 +1054,12 @@ commands:
             equal: [<<parameters.os>>, "darwin"]
           steps:
             - ferrocene-setup-darwin
-            - setup-venv
       - when:
           condition:
             equal: [<<parameters.os>>, "windows"]
           steps:
             - ferrocene-setup-windows
-            - setup-venv
+      - setup-venv
       - aws-oidc-auth
       - ferrocene-ci
       # Persist the build artifacts so following jobs don't have to start from
@@ -1089,13 +1095,12 @@ commands:
             equal: [<<parameters.os>>, "darwin"]
           steps:
             - ferrocene-setup-darwin
-            - setup-venv
       - when:
           condition:
             equal: [<<parameters.os>>, "windows"]
           steps:
             - ferrocene-setup-windows
-            - setup-venv
+      - setup-venv
       - aws-oidc-auth
       - when:
           condition:  <<parameters.restore-from-job>>
@@ -1126,6 +1131,7 @@ commands:
             equal: [<<parameters.os>>, "darwin"]
           steps:
             - ferrocene-setup-darwin  # Darwin does not come with awscli, setup it before aws steps
+      - setup-venv
       - aws-oidc-auth
       - run:
           name: Restore files from the << parameters.restore-from-job >> job

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -473,10 +473,10 @@ jobs:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
       FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-unknown-linux-gnu--self-test >>
     steps:
-      - setup-venv
-      - aws-oidc-auth
       - ferrocene-git-shallow-clone:
           depth: 1
+      - setup-venv
+      - aws-oidc-auth
       - run:
           name: Download dist artifacts and run the self-test tool
           command: ferrocene/ci/scripts/run-self-test.sh

--- a/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
@@ -246,12 +246,6 @@ USER ci
 WORKDIR /home/ci
 
 # We prefer uv over other solutions, it's in Rust and fast
-ENV PATH="/home/ci/.venv/bin:/home/ci/.cargo/bin:$PATH"
-# Setup the venv
-COPY requirements.txt /tmp/requirements.txt
-RUN <<-EOF
-    set -xe
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    uv venv
-    uv pip sync /tmp/requirements.txt
-EOF
+ENV PATH="/home/ci/.venv/bin:/home/ci/.local/bin:$PATH"
+RUN curl -LsSf https://astral.sh/uv/0.5.0/install.sh | sh
+

--- a/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
@@ -103,12 +103,5 @@ USER ci
 WORKDIR /home/ci
 
 # We prefer uv over other solutions, it's in Rust and fast
-ENV PATH="/home/ci/.venv/bin:/home/ci/.cargo/bin:$PATH"
-# Setup the venv
-COPY requirements.txt /tmp/requirements.txt
-RUN <<-EOF
-    set -xe
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    uv venv
-    uv pip sync /tmp/requirements.txt
-EOF
+ENV PATH="/home/ci/.venv/bin:/home/ci/.local/bin:$PATH"
+RUN curl -LsSf https://astral.sh/uv/0.5.0/install.sh | sh


### PR DESCRIPTION
In #1050 I missed the dockerfiles.

This means the dockerfiles no longer setup the venv/python pin, however since most uses mount the local directory in, if it's setup there, it'll still work.