### PR TITLE
Revert "Signatures for Ferrocene 24.11"

### DIFF
--- a/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
@@ -225,7 +225,7 @@ ENV PATH="/home/ci/.venv/bin:/home/ci/.cargo/bin:$PATH"
 COPY requirements.txt /tmp/requirements.txt
 RUN <<-EOF
     set -xe
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    curl -LsSf https://astral.sh/uv/0.4.3/install.sh | sh
     uv venv
     uv pip sync /tmp/requirements.txt
 EOF

--- a/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
@@ -108,7 +108,7 @@ ENV PATH="/home/ci/.venv/bin:/home/ci/.cargo/bin:$PATH"
 COPY requirements.txt /tmp/requirements.txt
 RUN <<-EOF
     set -xe
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    curl -LsSf https://astral.sh/uv/0.4.3/install.sh | sh
     uv venv
     uv pip sync /tmp/requirements.txt
 EOF

--- a/ferrocene/ci/scripts/setup-venv.sh
+++ b/ferrocene/ci/scripts/setup-venv.sh
@@ -9,7 +9,7 @@ if command -v uv &> /dev/null; then
     exit 0
 fi
 
-curl -LsSf https://astral.sh/uv/install.sh | sh
+curl -LsSf https://astral.sh/uv/0.4.3/install.sh | sh
 
 source $HOME/.cargo/env
 echo "source $HOME/.cargo/env" >> $BASH_ENV

--- a/ferrocene/doc/document-list/signature/signature.toml
+++ b/ferrocene/doc/document-list/signature/signature.toml
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: The Ferrocene Developers
-
-[files]
-"pinned.toml" = "841920c5-1dd9-42f4-9b03-e97ca2c2999a"
-"safety-manager.cosign-bundle" = "8ca73aea-5fef-481e-a255-e251e83bd4f7"

--- a/ferrocene/doc/evaluation-plan/signature/signature.toml
+++ b/ferrocene/doc/evaluation-plan/signature/signature.toml
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: The Ferrocene Developers
-
-[files]
-"pinned.toml" = "0dbc4791-3082-41c1-84a6-35eadc4dd262"
-"safety-manager.cosign-bundle" = "f89fc0e7-069e-4307-803a-131448d8c67c"

--- a/ferrocene/doc/evaluation-report/signature/signature.toml
+++ b/ferrocene/doc/evaluation-report/signature/signature.toml
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: The Ferrocene Developers
-
-[files]
-"pinned.toml" = "bdd311a9-c5a0-4b22-adb5-0f042017eb44"
-"safety-manager.cosign-bundle" = "22921b69-d40d-4c3b-a9d5-b69a7e26cbc2"

--- a/ferrocene/doc/internal-procedures/signature/signature.toml
+++ b/ferrocene/doc/internal-procedures/signature/signature.toml
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: The Ferrocene Developers
-
-[files]
-"pinned.toml" = "8caf80dd-61f0-47f2-818c-087f481c5e73"
-"safety-manager.cosign-bundle" = "2285879c-8c4a-468f-87e9-dcbcd2049ed0"

--- a/ferrocene/doc/qualification-plan/signature/signature.toml
+++ b/ferrocene/doc/qualification-plan/signature/signature.toml
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: The Ferrocene Developers
-
-[files]
-"pinned.toml" = "0b0a403e-0b91-4251-9962-99540afa14ff"
-"safety-manager.cosign-bundle" = "04c514e7-cfca-4dd3-9de7-d8e099e3d93a"

--- a/ferrocene/doc/qualification-report/signature/signature.toml
+++ b/ferrocene/doc/qualification-report/signature/signature.toml
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: The Ferrocene Developers
-
-[files]
-"pinned.toml" = "05b2c6ec-6d65-4aaa-b617-b13092aabbce"
-"safety-manager.cosign-bundle" = "74857d55-dfb0-47c8-a662-eb67f6b7689d"

--- a/ferrocene/doc/safety-manual/signature/signature.toml
+++ b/ferrocene/doc/safety-manual/signature/signature.toml
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: The Ferrocene Developers
-
-[files]
-"pinned.toml" = "4bce26d8-a137-4737-a8bf-ae933fb8e2c5"
-"safety-manager.cosign-bundle" = "c1bb6c1b-7030-4e42-8f99-09bdef38fa5c"

--- a/ferrocene/tools/traceability-matrix/src/annotations.rs
+++ b/ferrocene/tools/traceability-matrix/src/annotations.rs
@@ -18,6 +18,7 @@ impl std::fmt::Display for AnnotatedFile {
         match &self.source {
             AnnotationSource::TestItself => write!(f, "{}", self.test.display()),
             AnnotationSource::Makefile => write!(f, "{} (from its Makefile)", self.test.display()),
+            AnnotationSource::Rmake => write!(f, "{} (from its rmake.rs)", self.test.display()),
             AnnotationSource::ParentDirectory { .. } => {
                 write!(f, "{} (from its parent directory)", self.test.display())
             }
@@ -47,6 +48,7 @@ pub(crate) enum AnnotationSource {
     TestItself,
     ParentDirectory { bulk_file: PathBuf },
     Makefile,
+    Rmake,
 }
 
 #[derive(Debug)]
@@ -156,6 +158,8 @@ impl Annotations {
                     AnnotationSource::ParentDirectory { bulk_file: shrink_path(&annotation.file) }
                 } else if annotation.file == file.file.join("Makefile") {
                     AnnotationSource::Makefile
+                } else if annotation.file == file.file.join("rmake.rs") {
+                    AnnotationSource::Rmake
                 } else {
                     anyhow::bail!(
                         "bug: annotation {annotation:?} doesn't come from the file itself, \

--- a/ferrocene/tools/traceability-matrix/templates/report.html
+++ b/ferrocene/tools/traceability-matrix/templates/report.html
@@ -218,6 +218,8 @@
     {% when AnnotationSource::TestItself %}
     {% when AnnotationSource::Makefile %}
     (annotated in its <a href="{{ urls.src }}/{{ file.test.display() }}/Makefile">Makefile</a>)
+    {% when AnnotationSource::Rmake %}
+    (annotated in its <a href="{{ urls.src }}/{{ file.test.display() }}/rmake.rs">rmake.rs</a>)
     {% when AnnotationSource::ParentDirectory with { bulk_file } %}
     (annotated in its <a href="{{ urls.src }}/{{ bulk_file.display() }}">parent directory</a>)
 {% endmatch %}

--- a/src/tools/compiletest/src/ferrocene_annotations.rs
+++ b/src/tools/compiletest/src/ferrocene_annotations.rs
@@ -116,9 +116,7 @@ impl Collector {
     fn collect_annotations(&self, path: &Path, contents: &str) -> Vec<Annotation> {
         let mut found = Vec::new();
         for line in contents.lines() {
-            let prefix = if path.file_name() == Some(OsStr::new("Makefile"))
-                || path.file_name() == Some(OsStr::new("rmake.rs"))
-            {
+            let prefix = if path.file_name() == Some(OsStr::new("Makefile")) {
                 "# "
             } else if path.extension() == Some(OsStr::new("rs"))
                 || path.file_name() == Some(OsStr::new(BULK_ANNOTATIONS_FILE_NAME))


### PR DESCRIPTION
This reverts commit e704946394d2daf896d65e6c94df1734f63aeefb and prepares this branch for re-signing.

This also rolls up #1059, which are a fix for our Dockerfiles to make CI run again.