### PR TITLE
Repair `download-ci-llvm` via including overlay in `rust-dev` component

### DIFF
--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -275,7 +275,7 @@ add --enable-extended
 #
 # NOTE: If you add a new tool here, make sure to also change
 # `ferrocene/packages.toml` to include it in new releases.
-add --tools=rustdoc,cargo,llvm-tools,rustfmt,rust-analyzer,clippy
+add --tools=rust-dev,rustdoc,cargo,llvm-tools,rustfmt,rust-analyzer,clippy
 
 # Build and enable the profiler runtime.
 #

--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -275,7 +275,7 @@ add --enable-extended
 #
 # NOTE: If you add a new tool here, make sure to also change
 # `ferrocene/packages.toml` to include it in new releases.
-add --tools=rust-dev,rustdoc,cargo,llvm-tools,rustfmt,rust-analyzer,clippy
+add --tools=rustdoc,cargo,llvm-tools,rustfmt,rust-analyzer,clippy
 
 # Build and enable the profiler runtime.
 #

--- a/ferrocene/tools/generate-tarball/src/generator.rs
+++ b/ferrocene/tools/generate-tarball/src/generator.rs
@@ -98,7 +98,6 @@ impl Generator {
             rel_manifest_dir: _,
             success_message: _,
             legacy_manifest_dirs: _,
-            non_installed_overlay: _,
             bulk_dirs: _,
             component_name: _,
             //
@@ -108,6 +107,7 @@ impl Generator {
             output_dir,
             compression_profile,
             compression_formats,
+            non_installed_overlay,
             override_file_mtime,
             ferrocene_commit_sha,
             ferrocene_signing_kms_key_arn,
@@ -125,6 +125,11 @@ impl Generator {
 
         // copy over the image to the working directory
         copy_recursive(image_dir.as_ref(), &package_dir)?;
+
+        // Copy the overlay.
+        if !non_installed_overlay.is_empty() {
+            copy_recursive(non_installed_overlay.as_ref(), &package_dir)?;
+        }
 
         if let Some(key_arn) = ferrocene_signing_kms_key_arn {
             let Some(commit_sha) = ferrocene_commit_sha else {

--- a/ferrocene/tools/generate-tarball/src/generator.rs
+++ b/ferrocene/tools/generate-tarball/src/generator.rs
@@ -99,7 +99,7 @@ impl Generator {
             success_message: _,
             legacy_manifest_dirs: _,
             bulk_dirs: _,
-            component_name: _,
+            component_name,
             //
             package_name,
             image_dir,
@@ -127,8 +127,12 @@ impl Generator {
         copy_recursive(image_dir.as_ref(), &package_dir)?;
 
         // Copy the overlay.
-        if !non_installed_overlay.is_empty() {
-            copy_recursive(non_installed_overlay.as_ref(), &package_dir)?;
+        // We only preserve the `non_installed_overlay` on the `rust-dev` component.
+        // The `builder-config` file present is required for the `download-ci-llvm` flag.
+        if component_name == "rust-dev" {
+            if !non_installed_overlay.is_empty() {
+                copy_recursive(non_installed_overlay.as_ref(), &package_dir)?;
+            }
         }
 
         if let Some(key_arn) = ferrocene_signing_kms_key_arn {


### PR DESCRIPTION
The `download-ci-llvm` config option is currently not working

```toml
# config.toml
[llvm]
download-ci-llvm = true
```

If a user tries to use it they'll get something like

```
download: s3://ferrocene-ci-artifacts/ferrocene/dist/fb8e927c45ed5d7861fb9ff4b9e55ece779a4382/rust-dev-aarch64-unknown-linux-gnu-fb8e927c4.tar.xz to build/tmp/rust-dev-aarch64-unknown-linux-gnu-fb8e927c4.tar.xz
extracting /home/ana.linux/git/ferrocene/ferrocene/build/cache/llvm-fb8e927c45ed5d7861fb9ff4b9e55ece779a4382-false/rust-dev-aarch64-unknown-linux-gnu-fb8e927c4.tar.xz to /home/ana.linux/git/ferrocene/ferrocene/build/aarch64-unknown-linux-gnu/ci-llvm
thread 'main' panicked at src/core/config/config.rs:1336:13:
fs::read_to_string(file) failed with No such file or directory (os error 2) ("config file /home/ana.linux/git/ferrocene/ferrocene/build/aarch64-unknown-linux-gnu/ci-llvm/builder-config not found")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Build completed unsuccessfully in 0:00:37
```

Which, is a huge bummer!

It turns out our `rust-dev` component doesn't have the `builder-config` present, so the cache doesn't work. This is built as part of our `dist` jobs.

I consulted some folks I know and it seems that sometimes other components can cause problems, or the fact that this is not depended upon directly may be the cause.

This PR is so we can `bors try` and see if we get a working cache from CI.