### PR TITLE
Add `pkg-config` to the CI docker images

### DIFF
--- a/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
@@ -53,12 +53,13 @@ RUN <<-EOF
         zlib1g-dev \
         moreutils \
         zstd \
-        sudo
+        sudo \
+        pkg-config
 
     # Needed to support the QEMU copied over from Ubuntu 24.04 (see above).
     # Replace this with qemu-user-static once we're not on Ubuntu 20.04.
     apt-install binfmt-support
-    
+
     if [ "$TARGETPLATFORM" = "linux/amd64" ]; then
         # Needed for aarch64-unknown-linux-gnu cross-compilation
         apt-install \
@@ -74,7 +75,7 @@ RUN <<-EOF
             binutils-x86-64-linux-gnu \
             libc6-dev-amd64-cross
     fi
-    
+
     # Needed for thumbv7em-none-eabihf & armv8r-none-eabihf cross-compilation
     apt-install gcc-arm-none-eabi
 
@@ -82,7 +83,7 @@ RUN <<-EOF
     apt-install clang
     # Needed to install AWS CLI during the build:
     apt-install unzip
-    
+
     # Needed to install git during the build:
     apt-install \
         dh-autoreconf \

--- a/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
@@ -35,7 +35,8 @@ RUN <<-EOF
         moreutils \
         cmake \
         python-is-python3 \
-        pipx
+        pipx \
+        pkg-config
 
     # On x86_64, gcc-multilib lets us compile to aarch64
     if [ "$TARGETPLATFORM" = "linux/amd64" ]; then


### PR DESCRIPTION
`pkg-config` is required by `openssl-sys` so it can find openssl's directory. This
means that without `pkg-config`, you won't be able to run `./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist)` 
