### PR TITLE
Fix flake8 warning in sphinx-shared-resources

### DIFF
--- a/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_domain_cli/domain.py
+++ b/ferrocene/doc/sphinx-shared-resources/exts/ferrocene_domain_cli/domain.py
@@ -38,7 +38,8 @@ class ProgramDirective(SphinxDirective):
             "no_traceability_matrix" in self.options,
         )
 
-        # parse and process content of `ProgramDirective`` (one or more `OptionDirective`s)
+        # parse and process content of `ProgramDirective`` 
+        # (one or more `OptionDirective`s)
         node = nodes.container()
         self.state.nested_parse(self.content, self.content_offset, node)
 


### PR DESCRIPTION
Fixes the flake8 warning in sphinx-shared-resources (line was too long)