### PR TITLE
PR rotation uses a bigger runner

### DIFF
--- a/.github/workflows/automation-pull-upstream.yml
+++ b/.github/workflows/automation-pull-upstream.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   run:
     name: ${{ matrix.branch }}
-    runs-on: ubuntu-latest
+    runs-on: 8core-x86_64-unknown-linux-gnu
     environment: automations
 
     strategy:


### PR DESCRIPTION
We were having problems with checkout on the automation, this solves it by literally just throwing more power at it. We'll likely want to take a slightly smaller runner later.

Note: This runner only works for certain branches/workflows, you can't just use it willy nilly.