### PR TITLE
use Python syntax known by Ubuntu 22.04

### DIFF
--- a/ferrocene/tools/backport/utils/update-last-message.py
+++ b/ferrocene/tools/backport/utils/update-last-message.py
@@ -32,7 +32,8 @@ def amend_commit_message(new_message):
 
 def main(pr_number):
     current_message = get_current_commit_message()
-    fixed_message = current_message + f"\n{TRAILER_NAME}: {os.environ.get("GITHUB_REPOSITORY", "")}#{pr_number}\n"
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    fixed_message = current_message + f"\n{TRAILER_NAME}: {repo}#{pr_number}\n"
     amend_commit_message(fixed_message)
 
 


### PR DESCRIPTION
Backport CI runner has Python 3.10, but this syntax was only introduced in Python 3.12. This resulted in backports failing.