### PR TITLE
[1.81] add technical report

### DIFF
--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -337,9 +337,9 @@ fi
 #
 # If this is not provided, the report will not be included in the generated
 # documentation. This should only be set in stable, qualified releases.
-#if is_internal; then
-#    add --set ferrocene.technical-report-url="s3://ferrocene-ci-mirrors/manual/tuv-technical-reports/YYYY-MM-DD-ferrocene-YY.MM.N-technical-report.pdf"
-#fi
+if is_internal; then
+   add --set ferrocene.technical-report-url="s3://ferrocene-ci-mirrors/manual/tuv-technical-reports/2024-11-22-ferrocene-24.11-technical-report.pdf"
+fi
 
 # When building Ferrocene outside of Ferrous Systems, folks will not have
 # access to the document signature files stored in AWS. In that case, configure


### PR DESCRIPTION
As detailed in https://public-docs.ferrocene.dev/main/qualification/internal-procedures/release/stable.html#uploading-the-qualification-technical-report, this sets the technical report URL for the upcoming, qualified, 24.11 release.

An example of this change in 24.08: https://github.com/ferrocene/ferrocene/blob/0b9a49099034657140d565f8129e4990881ff296/ferrocene/ci/configure.sh#L336-L343

Please review the linked document and ensure that this lists a file:

```
aws --profile ferrocene-ci s3 ls s3://ferrocene-ci-mirrors/manual/tuv-technical-reports/2024-11-22-ferrocene-24.11-technical-report.pdf
```

You should also download it and confirm the the file appears the same format of [24.05](https://docs.ferrocene.dev/stable-24.05/qualification/technical-report.pdf) and [24.08](https://docs.ferrocene.dev/stable-24.08/qualification/technical-report.pdf).

```
aws --profile ferrocene-ci s3 cp s3://ferrocene-ci-mirrors/manual/tuv-technical-reports/2024-11-22-ferrocene-24.11-technical-report.pdf technical-report.pdf
```

You should confirm the report contains a section about 24.11. You do not need to read the document or check it's contents -- It's provided by the assessors. Just confirm this is the one for 24.11.

**Please make sure you delete the technical report after, do not accidently commit it to the repo (like I almost did)**

You can ensure the technical report ends up in the docs with:

```bash
FERROCENE_HOST=x86_64-unknown-linux-gnu CI=1 ./ferrocene/ci/configure.sh
AWS_DEFAULT_PROFILE=ferrocene-ci  ./x.py doc ferrocene/doc
AWS_DEFAULT_PROFILE=ferrocene-ci ./x.py doc ferrocene-technical-report
``` 

Then opening the index and checking.

(Note: You may want to back up your existing `config.toml` since the CI has a rather specific one)
