### PR TITLE
Move 24.11/1.81 to stable for release

### DIFF
--- a/ferrocene/ci/channel
+++ b/ferrocene/ci/channel
@@ -1,1 +1,1 @@
-beta
+stable


### PR DESCRIPTION
Follows the release process as detailed in https://public-docs.ferrocene.dev/main/qualification/internal-procedures/release/stable.html#publishing-a-stable-release.

No special review steps, just normal.