### PR TITLE
unbreak subtree pulls

### DIFF
--- a/ferrocene/tools/pull-subtrees/pull.py
+++ b/ferrocene/tools/pull-subtrees/pull.py
@@ -351,7 +351,7 @@ class PullSubtreePR(AutomatedPR):
         return self.into
 
     def automation_name(self):
-        return f"pull-subtree-{self.subtree}"
+        return f"pull-subtree"
 
     def pr_title(self):
         if len(self.subtree.into) > 1:


### PR DESCRIPTION
self.subtree includes a lot more than just a branch name

in addition, we don't even need a branch name (to be part of the automated pr branch name), for we never pull more than one branch at all for any of the subtrees

that is, this is enough: automation/pull-subtree-jkc4w0dm
we don't need it to be: automation/pull-subtree-main-jkc4w0dm