### PR TITLE
Fix misc typos

### DIFF
--- a/src/doc/rustc/src/platform-support/android.md
+++ b/src/doc/rustc/src/platform-support/android.md
@@ -65,4 +65,4 @@ Currently the `riscv64-linux-android` target requires the following architecture
 ### aarch64-linux-android on Nightly compilers
 
 As soon as `-Zfixed-x18` compiler flag is supplied, the [`ShadowCallStack` sanitizer](https://releases.llvm.org/7.0.1/tools/clang/docs/ShadowCallStack.html)
-instrumentation is also made avaiable by supplying the second compiler flag `-Zsanitizer=shadow-call-stack`.
+instrumentation is also made available by supplying the second compiler flag `-Zsanitizer=shadow-call-stack`.

--- a/src/doc/rustc/src/platform-support/riscv64gc-unknown-linux-gnu.md
+++ b/src/doc/rustc/src/platform-support/riscv64gc-unknown-linux-gnu.md
@@ -65,7 +65,7 @@ section below.
 
 A RISC-V toolchain can be obtained for Windows/Mac/Linux from the
 [`riscv-gnu-toolchain`](https://github.com/riscv-collab/riscv-gnu-toolchain)
-repostory. Binaries are available via
+repository. Binaries are available via
 [embecosm](https://www.embecosm.com/resources/tool-chain-downloads/#riscv-linux),
 and may also be available from your OS's package manager.
 
@@ -122,7 +122,7 @@ limactl shell riscv
 
 Using [Docker (with BuildKit)](https://docs.docker.com/build/buildkit/) the
 [`riscv64/ubuntu`](https://hub.docker.com/r/riscv64/ubuntu) image can be used
-to buiild or run `riscv64gc-unknown-linux-gnu` binaries.
+to build or run `riscv64gc-unknown-linux-gnu` binaries.
 
 ```bash
 docker run --platform linux/riscv64 -ti --rm --mount "type=bind,src=$(pwd),dst=/checkout" riscv64/ubuntu bash

--- a/src/doc/rustc/src/targets/custom.md
+++ b/src/doc/rustc/src/targets/custom.md
@@ -21,10 +21,10 @@ To use a custom target, see the (unstable) [`build-std` feature](../../cargo/ref
 When `rustc` is given an option `--target=TARGET` (where `TARGET` is any string), it uses the following logic:
 1. if `TARGET` is the name of a built-in target, use that
 2. if `TARGET` is a path to a file, read that file as a json target
-3. otherwise, search the colon-seperated list of directories found
+3. otherwise, search the colon-separated list of directories found
    in the `RUST_TARGET_PATH` environment variable from left to right
    for a file named `TARGET.json`.
 
-These steps are tried in order, so if there are multple potentially valid
+These steps are tried in order, so if there are multiple potentially valid
 interpretations for a target, whichever is found first will take priority.
 If none of these methods find a target, an error is thrown.

--- a/src/doc/rustdoc/src/write-documentation/documentation-tests.md
+++ b/src/doc/rustdoc/src/write-documentation/documentation-tests.md
@@ -412,7 +412,7 @@ In some cases, doctests cannot be merged. For example, if you have:
 ```
 
 The problem with this code is that, if you change any other doctests, it'll likely break when
-runing `rustdoc --test`, making it tricky to maintain.
+running `rustdoc --test`, making it tricky to maintain.
 
 This is where the `standalone_crate` attribute comes in: it tells `rustdoc` that a doctest
 should not be merged with the others. So the previous code should use it:

--- a/src/doc/unstable-book/src/compiler-flags/default-visibility.md
+++ b/src/doc/unstable-book/src/compiler-flags/default-visibility.md
@@ -41,4 +41,4 @@ building for Linux. Other linkers such as LLD are not affected.
 Using `-Zdefault-visibility=interposable` will cause symbols to be emitted with "default"
 visibility. On platforms that support it, this makes it so that symbols can be interposed, which
 means that they can be overridden by symbols with the same name from the executable or by other
-shared objects earier in the load order.
+shared objects earlier in the load order.

--- a/src/doc/unstable-book/src/compiler-flags/randomize-layout.md
+++ b/src/doc/unstable-book/src/compiler-flags/randomize-layout.md
@@ -7,7 +7,7 @@ The tracking issue for this feature is: [#106764](https://github.com/rust-lang/r
 The `-Zrandomize-layout` flag changes the layout algorithm for `repr(Rust)` types defined in the current crate from its normal
 optimization goals to pseudorandomly rearranging fields within the degrees of freedom provided by the largely unspecified
 default representation. This also affects type sizes and padding.
-Downstream intantiations of generic types defined in a crate with randomization enabled will also be randomized.
+Downstream instantiations of generic types defined in a crate with randomization enabled will also be randomized.
 
 It can be used to find unsafe code that accidentally relies on unspecified behavior.
 

--- a/src/doc/unstable-book/src/compiler-flags/remap-path-scope.md
+++ b/src/doc/unstable-book/src/compiler-flags/remap-path-scope.md
@@ -10,7 +10,7 @@ This flag accepts a comma-separated list of values and may be specified multiple
 
 - `macro` - apply remappings to the expansion of `std::file!()` macro. This is where paths in embedded panic messages come from
 - `diagnostics` - apply remappings to printed compiler diagnostics
-- `debuginfo` - apply remappings to debug informations
+- `debuginfo` - apply remappings to debug information
 - `object` - apply remappings to all paths in compiled executables or libraries, but not elsewhere. Currently an alias for `macro,debuginfo`.
 - `all` - an alias for all of the above, also equivalent to supplying only `--remap-path-prefix` without `--remap-path-scope`.
 


### PR DESCRIPTION
Found with `codespell -L crate -i 3 -w`.