### PR TITLE
Show pull upstream warnings in the generated PRs

### DIFF
--- a/ferrocene/tools/pull-upstream/generate_pr_body.py
+++ b/ferrocene/tools/pull-upstream/generate_pr_body.py
@@ -96,14 +96,6 @@ def render_changes(origin, base_branch, new_branch):
         if last not in commits:
             return "**Nothing**"
 
-    merge_message = commits[last].message
-    if merge_message == "pull new changes from upstream (partial)":
-        partial_pull = True
-    elif merge_message == "pull new changes from upstream":
-        partial_pull = False
-    else:
-        raise RuntimeError(f"unsupported merge commit message: {merge_message}")
-
     # Parse the commit graph and generate the list of changes
     changes = ""
     cursor = commits[last].merge
@@ -126,11 +118,6 @@ def render_changes(origin, base_branch, new_branch):
                 if rollup_pr is None:
                     break
                 changes += f"  * {linker.link(UPSTREAM_REPO, rollup_pr)}\n"
-
-    if partial_pull:
-        changes += "\n"
-        changes += ":warning: Not all changes were pulled, as there were too many "
-        changes += "PRs to pull. Run the automation again to pull the rest.\n"
 
     return changes
 


### PR DESCRIPTION
Right now the pull upstream automation displays some warnings in its output when it does something requiring manual action from the members of the PR rotation. This is far from ideal: if the person reviewing the PR wants to look at them, they'd have to find the GitHub Actions workflow that created the PR and sift through tons of log messages to find them.

This PR improves the situation by adding a new function to `pull.sh`: `automation_warning`. When the function is called, the warning will be displayed with emphasis in the logs and it will be recorded in a separate file. The automation will then include all of those warnings at the top of the description of the created PR, highlighting them for the reviewers.

Right now I only converted to this system the warnings that require explicit action (this is a partial pull, there are committed conflict markers, and the completions have to be regenerated) to keep the noise low. In the future it'll be up to the PR rotation team to figure out what warnings could be useful for them, and extend the pull script to include them.

https://app.clickup.com/t/8697gmju8