### PR TITLE
Add workflow to automatically add the "merged-in:*" label

### DIFF
--- a/.github/workflows/merged-in-labels.yml
+++ b/.github/workflows/merged-in-labels.yml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+# Add a "merged-in:1.NN" label to all PRs, to glance in which release the PR was merged.
+
+---
+
+name: merged-in labels
+run-name: "Set merge-in label for PR #${{ github.event.pull_request.number }}"
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  add-label:
+    name: Add label
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Clone the source code
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        run: ferrocene/ci/scripts/setup-uv.sh
+
+      - name: Add the label
+        run: "ferrocene/ci/scripts/add-merged-in-label.py ${{ github.event.pull_request.number }}"

--- a/ferrocene/ci/scripts/add-merged-in-label.py
+++ b/ferrocene/ci/scripts/add-merged-in-label.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env -S uv run
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["requests ~= 2.32"]
+# ///
+
+import argparse
+import base64
+import os
+import requests
+import sys
+
+
+LABEL_PREFIX = "merged-in:"
+LABEL_COLOR = "c5def5"  # light blue
+
+
+http = requests.Session()
+http.headers["Authorization"] = f"token {os.environ['GITHUB_TOKEN']}"
+
+repo = os.environ["GITHUB_REPOSITORY"]
+
+
+def main(pr_number):
+    pr = get(f"pulls/{pr_number}", check=False)
+
+    if pr is None:
+        error(f"PR {pr_number} doesn't exist")
+    if pr["merged_at"] is None:
+        error(f"PR {pr_number} has not been merged")
+
+    # Determine the expected label.
+    src_version_resp = get(f"contents/src/version?ref={pr['merge_commit_sha']}")
+    major, minor, _patch = (
+        base64.b64decode(src_version_resp["content"]).decode("utf-8").strip().split(".")
+    )
+    new_label = f"{LABEL_PREFIX}{major}.{minor}"
+
+    # Create the label if it doesn't exist.
+    if get(f"labels/{new_label}", check=False) is None:
+        post("labels", json={"name": new_label, "color": LABEL_COLOR})
+
+    # Add the label to the PR. This uses the "issues" API because the GitHub API treats issues and
+    # PRs the same way (PRs have an extra set of APIs specific to them though).
+    post(f"issues/{pr_number}/labels", json=[new_label])
+
+
+def get(path, *, check=True):
+    resp = http.get(f"https://api.github.com/repos/{repo}/{path}")
+    if not check and resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    return resp.json()
+
+
+def post(path, *, json=None):
+    resp = http.post(f"https://api.github.com/repos/{repo}/{path}", json=json)
+    resp.raise_for_status()
+
+
+def error(message):
+    print(f"error: {message}", file=sys.stderr)
+    exit(1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("pr_number")
+    cli = parser.parse_args()
+
+    main(cli.pr_number)


### PR DESCRIPTION
I recently labeled every PR in the repository with the new `merged-in:*` label, which indicates which Rust release was the PR merged in. This will be of great help when deciding what to backport. This PR adds a workflow that automatically applies the label to all merged PRs.

While the workflow is untested (of course), I tested the script locally.