### PR TITLE
Pass the github token to the merge label automation

### DIFF
--- a/.github/workflows/merged-in-labels.yml
+++ b/.github/workflows/merged-in-labels.yml
@@ -27,3 +27,5 @@ jobs:
 
       - name: Add the label
         run: "ferrocene/ci/scripts/add-merged-in-label.py ${{ github.event.pull_request.number }}"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Forgot to add it, and it's causing the workflow to fail.