### PR TITLE
Rename experimental targets to untested targets

### DIFF
--- a/ferrocene/doc/user-manual/src/targets/aarch64-apple-darwin.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-apple-darwin.rst
@@ -8,7 +8,7 @@
 
 .. warning::
    
-   Experimental targets cannot be used in safety-critical contexts, and there is
+   Untested targets cannot be used in safety-critical contexts, and there is
    no guarantee that the Ferrocene test suite is successfully executed on the
    target. They are provided as a preview, with limited support available. They
    should not be used in production.

--- a/ferrocene/doc/user-manual/src/targets/aarch64-unknown-nto-qnx710.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-unknown-nto-qnx710.rst
@@ -16,7 +16,7 @@ ARMv8-A processors operating in Aarch64 mode.
 
     Currently, Ferrocene only qualifies cross compilation to this target from
     :ref:`x86_64-unknown-linux-gnu`. Cross-compilation from 
-    :ref:`x86_64-pc-windows-msvc` is experimental and cross-compilation from
+    :ref:`x86_64-pc-windows-msvc` is untested and cross-compilation from
     :ref:`aarch64-apple-darwin` is unsupported.
 
 Prerequisites

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -94,9 +94,11 @@ available.
 For any of the following reasons, the target is not qualified:
 
 * The target is deemed unlikely to be used in a safety critical context.
-* The target is in the process of qualification, but is not completed yet.
+* The target is in the process of qualification, but the work has not
+  been completed yet.
 
-Quality managed targets are not qualified, but can usually be qualified on request.
+Quality managed targets are not qualified, but can usually become qualified on
+request.
 
 .. list-table::
    :header-rows: 1
@@ -114,12 +116,22 @@ Quality managed targets are not qualified, but can usually be qualified on reque
      - \-
 
 Untested targets
---------------------
+----------------
 
 Untested targets cannot be used in safety-critical contexts, and there is
 no guarantee that the Ferrocene test suite is successfully executed on the
 target. They are provided as a preview, with limited support available. They
 should not be used in production.
+
+For any of the following reasons, the target is not quality managed or qualified:
+
+* The Ferrocene test suite may not successfully execute on the target.
+* Some or all of the Ferrocene test suite does not yet execute on the target.
+* An appropriate virtualization target for testing has not been identified.
+* Improved support for the target has not been requested.
+
+Untested managed targets are not quality managed or qualified, but can usually
+become quality managed or qualified on request.
 
 .. list-table::
    :header-rows: 1
@@ -184,6 +196,27 @@ should not be used in production.
      - Bare-metal
      - \-
 
+   * - :ref:`x86_64-pc-windows-msvc`
+     - ``x86_64-pc-windows-msvc``
+     - Host platform
+     - Full
+     - \-
+
+Experimental Targets
+--------------------
+
+Experimental targets cannot be used in safety-critical contexts, the Ferrocene test suite
+was not executed on the target. No support is available for these targets, artifacts are
+provided as-is and the targets be removed from future versions without notice.
+
+For any of the following reasons, the target is experimental:
+
+* The target is deprecated and no longer produced.
+* The target has an unstable API.
+
+If your project needs support for one of these targets, consider reaching out the Ferrocene
+support team to discuss custom support contracts.
+
    * - :target:`wasm32-unknown-unknown`
      - ``wasm32-unknown-unknown``
      - Cross-compilation
@@ -195,16 +228,6 @@ should not be used in production.
      - Cross-compilation
      - Full
      - Available as a cross-compile target on :ref:`aarch64-apple-darwin`.
-
-   * - :ref:`x86_64-pc-windows-msvc`
-     - ``x86_64-pc-windows-msvc``
-     - Host platform
-     - Full
-     - \-
-
-
-If your project needs support for one of these targets, please reach out to the
-Ferrocene support team.
 
 Unsupported targets
 -------------------

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -207,7 +207,7 @@ Experimental Targets
 
 Experimental targets cannot be used in safety-critical contexts, the Ferrocene test suite
 was not executed on the target. No support is available for these targets, artifacts are
-provided as-is and the targets be could removed from future versions without notice.
+provided as-is and the targets could be removed from future versions without notice.
 
 For any of the following reasons, the target is experimental:
 

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -5,10 +5,10 @@ Compilation targets overview
 ============================
 
 Ferrocene has support for multiple compilation targets and host platforms.
-Targets are categorized as either "supported" or "untested" depending on
-the level of support. This page lists the current support status for all
-targets, and individual pages with more details are provided for supported
-targets.
+Targets are categorized as either "qualified", "quality managed", "untested",
+or "experimental" depending on the level of support. This page lists the
+current support status for all targets, and individual pages with more details
+are provided for supported targets, as well as some other targets.
 
 There are two kinds of targets available:
 
@@ -207,15 +207,25 @@ Experimental Targets
 
 Experimental targets cannot be used in safety-critical contexts, the Ferrocene test suite
 was not executed on the target. No support is available for these targets, artifacts are
-provided as-is and the targets be removed from future versions without notice.
+provided as-is and the targets be could removed from future versions without notice.
 
 For any of the following reasons, the target is experimental:
 
 * The target is deprecated and no longer produced.
 * The target has an unstable API.
+* The target is a proof of concept.
 
 If your project needs support for one of these targets, consider reaching out the Ferrocene
 support team to discuss custom support contracts.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Target
+     - Triple
+     - Kind
+     - Standard library
+     - Notes
 
    * - :target:`wasm32-unknown-unknown`
      - ``wasm32-unknown-unknown``

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -237,7 +237,8 @@ support team to discuss custom support contracts.
      - ``x86_64-apple-darwin``
      - Cross-compilation
      - Full
-     - Available as a cross-compile target on :ref:`aarch64-apple-darwin`.
+     - Apple is no longer producing x86 machines.
+
 
 Unsupported targets
 -------------------

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -125,7 +125,7 @@ should not be used in production.
 
 For any of the following reasons, the target is not quality managed or qualified:
 
-* The Ferrocene test suite may not successfully execute on the target.
+* Some tests present within the Ferrocene test suite may not pass on the target.
 * Some or all of the Ferrocene test suite does not yet execute on the target.
 * An appropriate virtualization target for testing has not been identified.
 * Improved support for the target has not been requested.

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -5,7 +5,7 @@ Compilation targets overview
 ============================
 
 Ferrocene has support for multiple compilation targets and host platforms.
-Targets are categorized as either "supported" or "experimental" depending on
+Targets are categorized as either "supported" or "untested" depending on
 the level of support. This page lists the current support status for all
 targets, and individual pages with more details are provided for supported
 targets.
@@ -113,11 +113,10 @@ Quality managed targets are not qualified, but can usually be qualified on reque
      - Full
      - \-
 
-
-Experimental targets
+Untested targets
 --------------------
 
-Experimental targets cannot be used in safety-critical contexts, and there is
+Untested targets cannot be used in safety-critical contexts, and there is
 no guarantee that the Ferrocene test suite is successfully executed on the
 target. They are provided as a preview, with limited support available. They
 should not be used in production.

--- a/ferrocene/doc/user-manual/src/targets/x86_64-pc-nto-qnx710.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-pc-nto-qnx710.rst
@@ -16,7 +16,7 @@ x86-64 processors.
 
     Currently, Ferrocene only qualifies cross compilation to this target from
     :ref:`x86_64-unknown-linux-gnu`. Cross-compilation from 
-    :ref:`x86_64-pc-windows-msvc` is experimental and cross-compilation from
+    :ref:`x86_64-pc-windows-msvc` is untested and cross-compilation from
     :ref:`aarch64-apple-darwin` is unsupported.
 
 Prerequisites

--- a/ferrocene/doc/user-manual/src/targets/x86_64-pc-windows-msvc.rst
+++ b/ferrocene/doc/user-manual/src/targets/x86_64-pc-windows-msvc.rst
@@ -8,7 +8,7 @@
 
 .. warning::
    
-   Experimental targets cannot be used in safety-critical contexts, and there is
+   Untested targets cannot be used in safety-critical contexts, and there is
    no guarantee that the Ferrocene test suite is successfully executed on the
    target. They are provided as a preview, with limited support available. They
    should not be used in production.


### PR DESCRIPTION
We discussed if "Untested" is a better name than "Experimental", this PR does the needful in case we commit.