### PR TITLE
Add page documenting how to test other targets

### DIFF
--- a/ferrocene/doc/internal-procedures/src/index.rst
+++ b/ferrocene/doc/internal-procedures/src/index.rst
@@ -16,6 +16,7 @@ based on software engineering best practices.
    onboarding
    setup-local-env
    working-with-the-ci
+   testing-other-targets
    upstream-pulls
    subtree-pulls
    known-problems

--- a/ferrocene/doc/internal-procedures/src/setup-local-env.rst
+++ b/ferrocene/doc/internal-procedures/src/setup-local-env.rst
@@ -21,6 +21,7 @@ installed:
   account. Note that most Linux distributions only include version 1 of the AWS
   CLI, while we explicitly require version 2.
 
+
 Configuring git
 ---------------
 

--- a/ferrocene/doc/internal-procedures/src/setup-local-env.rst
+++ b/ferrocene/doc/internal-procedures/src/setup-local-env.rst
@@ -7,12 +7,10 @@ Setting up a local development environment
 Required software
 -----------------
 
-To develop Ferrocene locally, you’ll need to have the following software
-installed:
+To develop Ferrocene locally, you’ll need to have the software required to build
+Rust, as well as the following:
 
 * ``git``, as the version control system used by Ferrocene.
-
-* ``Python 3``, needed for the entry point of Rust’s build system.
 
 * ``uv``, to manage the environment used to build the documentation. `Installation
   instructions. <https://docs.astral.sh/uv/getting-started/installation/>`_
@@ -20,6 +18,71 @@ installed:
 * ``AWS CLI v2``, version **2.9.0 or greater**, needed to interact with our AWS
   account. Note that most Linux distributions only include version 1 of the AWS
   CLI, while we explicitly require version 2.
+
+
+:ref:`x86_64-unknown-linux-gnu`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On Ubuntu 24.10, the following commands can be used:
+
+.. code-block:: bash
+
+   sudo apt install ninja-build bzip2 cmake gcc g++ awscli
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+
+.. note::
+
+   On versions earlier than Ubuntu 24.10 the ``awscli`` package is not newer than
+   2.9.0, and should not be used.
+
+On other distributions, you will likely need to adapt the command for the
+relevant package manager and any modified package names.
+
+For example, on Arch Linux ``awscli`` can be obtained from the
+`AUR <https://aur.archlinux.org/packages/aws-cli-v2>`_, and the remaining packages
+from the official repositories:
+
+.. code-block:: bash
+
+   sudo pacman -S ninja bzip2 cmake gcc uv
+
+:ref:`aarch64-apple-darwin`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you don't already have XCode set up, get the XCode command line tools as
+guided in :doc:`user-manual:targets/aarch64-apple-darwin`, then use
+`Homebrew <https://brew.sh/>`_ to install the remaining dependencies.
+
+
+To install Homebrew:
+
+.. code-block:: bash
+
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+Then use Homebrew to install the remaining packages:
+
+.. code-block:: bash
+
+   brew install ninja bzip2 cmake awscli uv
+
+
+:ref:`x86_64-pc-windows-msvc`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note::
+
+   Ferrocene development is only supported on Windows 11 Pro with 
+   `"Developer Mode" <https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development#activate-developer-mode>`_
+   enabled.
+
+If you don't already have Visual Studio installed, get the build tools as guided
+in :doc:`user-manual:targets/x86_64-pc-windows-msvc`, then use ``winget`` to
+install the remaining dependencies:
+
+.. code-block:: bash
+
+   winget install astral-sh.uv Kitware.CMake Ninja-build.Ninja Amazon.AWSCLI
 
 
 Configuring git

--- a/ferrocene/doc/internal-procedures/src/setup-local-env.rst
+++ b/ferrocene/doc/internal-procedures/src/setup-local-env.rst
@@ -20,10 +20,10 @@ Rust, as well as the following:
   CLI, while we explicitly require version 2.
 
 
-:ref:`x86_64-unknown-linux-gnu`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:target-with-triple:`x86_64-unknown-linux-gnu`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-On Ubuntu 24.10, the following commands can be used:
+On Ubuntu 24.10, install the software requirements by running:
 
 .. code-block:: bash
 
@@ -35,8 +35,7 @@ On Ubuntu 24.10, the following commands can be used:
    On versions earlier than Ubuntu 24.10 the ``awscli`` package is not newer than
    2.9.0, and should not be used.
 
-On other distributions, you will likely need to adapt the command for the
-relevant package manager and any modified package names.
+To install the requirements on other distributions, adapt the command for the relevant package manager and any modified package names.
 
 For example, on Arch Linux ``awscli`` can be obtained from the
 `AUR <https://aur.archlinux.org/packages/aws-cli-v2>`_, and the remaining packages
@@ -46,11 +45,11 @@ from the official repositories:
 
    sudo pacman -S ninja bzip2 cmake gcc uv
 
-:ref:`aarch64-apple-darwin`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:target-with-triple:`aarch64-apple-darwin`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you don't already have XCode set up, get the XCode command line tools as
-guided in :doc:`user-manual:targets/aarch64-apple-darwin`, then use
+described in :doc:`user-manual:targets/aarch64-apple-darwin`, then use
 `Homebrew <https://brew.sh/>`_ to install the remaining dependencies.
 
 
@@ -67,8 +66,8 @@ Then use Homebrew to install the remaining packages:
    brew install ninja bzip2 cmake awscli uv
 
 
-:ref:`x86_64-pc-windows-msvc`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:target-with-triple:`x86_64-pc-windows-msvc`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
 

--- a/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
+++ b/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
@@ -189,7 +189,7 @@ Then make sure it's imported:
     
     Currently, this target uses our *secret sauce*. Eventually this will be an open source component of Ferrocene, but for now, it's our little bit of arcane magic.
 
-First, set the target:
+Now set the target:
 
 .. code-block:: bash
 

--- a/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
+++ b/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
@@ -1,0 +1,193 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Testing Other Targets 
+=====================
+
+It's often possible to test targets other than your host tuple. Windows and macOS hosts can target
+Linux using `Lima <https://lima-vm.io/>`_ (Mac/Linux) or
+`WSL2 <https://learn.microsoft.com/en-us/windows/wsl/install>`_ (Windows). Lima can be used to test
+other architectures such as :ref:`x86_64-unknown-linux-gnu`, :target:`aarch64-unknown-linux-gnu`, or
+:target:`riscv64gc-unknown-linux-gnu`, while WSL2 can do similar with `QEMU <https://www.qemu.org/>`_.
+
+Additionally, Ferrocene supports testing a number of targets which are not supported by upstream.
+When testing locally, special tools or configuration may be required.
+
+In general, any "bare-metal" target listed in :doc:`user-manual:targets/index` requires special
+setup inside a Linux based environment.
+
+Host Setup
+----------
+
+Unless otherwise noted, all bare-metal targets are tested in QEMU on a Linux host.
+On macOS, a tool like Lima or Docker must be used. On Windows, WSL2 must be used.
+
+Please refer to the relevant per-host setup instructions below.
+
+:ref:`x86_64-unknown-linux-gnu`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You need to have all the normal prerequisites for testing Rust installed, as well as a few extras:
+
+.. code-block:: bash
+
+   sudo apt install awscli ninja-build bzip2 cmake gcc g++ qemu-user-static binfmt-support
+
+
+:ref:`aarch64-apple-darwin`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You need to use Lima. It's recommended to use the 'default' template and modify it as shown below.
+
+.. note::
+
+   The guest needs to have at more than the default of 4GiB of memory to not trigger the OOM
+   killer during build. 8GiB is recommended.
+
+Here is an sample config for your ``~/.lima/default/lima.yaml``:
+
+.. code-block:: yaml
+
+    minimumLimaVersion: "1.0.0"
+    images:
+    - location: "https://cloud-images.ubuntu.com/releases/24.10/release-20241212/ubuntu-24.10-server-cloudimg-arm64.img"
+      arch: "aarch64"
+      digest: "sha256:fb39312ffd2b47b97eaef6ff197912eaa3e0a215eb3eecfbf2a24acd96ee1125"
+    - location: "https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-arm64.img"
+      arch: "aarch64"
+    mounts:
+    - location: "~"
+    - location: "/tmp/lima"
+      writable: true
+    ssh:
+      forwardAgent: true
+    cpus: 8
+    memory: "8GiB"
+    mountTypesUnsupported: ["9p"]
+
+If you changed your configuration, make sure to restart the environment with ``limactl stop default`` then ``limactl start default``.
+
+Enter the shell with ``limactl shell default``.
+
+:ref:`x86_64-pc-windows-msvc`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You need to use WSL2. It's recommended to use the latest stable Ubuntu.
+
+Here is a sample configuration for your ``/etc/wsl.conf`` (in the guest):
+
+.. code-block::
+
+    [user]
+    default=ana
+
+    [boot]
+    systemd=true
+
+    [wsl2]
+    nestedVirtualization=true
+    
+If you changed your configuration, make sure to restart the environment with ``wsl --shutdown``.
+
+Enter the shell with ``wsl``, or `point Visual Studio Code <https://code.visualstudio.com/docs/remote/wsl-tutorial>`_ at it.
+
+Target Procedures
+-----------------
+
+In general, bare-metal targets follow a similar strategy: Use `binfmt_misc` to run the
+test target binaries.
+
+:ref:`aarch64-unknown-none`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. Note::
+    
+    In a ``aarch64-unknown-linux-gnu`` environment you may simply skip to the final step,
+    no QEMU is needed.
+
+Install the necessary packages:
+
+.. code-block:: bash
+
+    sudo apt install gcc-aarch64-linux-gnu qemu-system-aarch64
+
+If you don't already have a ``/usr/share/binfmts/qemu-aarch64`` file, create one:
+
+.. code-block:: bash
+
+    package qemu-aarch64
+    interpreter /usr/bin/qemu-aarch64-static
+    magic \x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7\x00
+    mask \xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff
+    credentials no
+    preserve no
+    fix_binary no
+    
+Then make sure it's imported:
+
+.. code-block:: bash
+    
+   sudo update-binfmts --import qemu-aarch64
+
+You can now run the tests:
+
+.. code-block:: bash
+
+    ./x test --stage 1 --target aarch64-unknown-ferrocenecoretest library/core
+
+:target:`thumbv7em-none-eabihf` & :target:`thumbv7em-none-eabi`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Install the necessary packages:
+
+.. code-block:: bash
+
+    sudo apt install gcc-arm-none-eabi qemu-system-arm
+
+If you don't already have a ``/usr/share/binfmts/qemu-arm`` file, create one:
+
+.. code-block:: bash
+
+    package qemu-arm
+    interpreter /usr/bin/qemu-arm-static
+    magic \x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00
+    mask \xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff
+    credentials no
+    preserve no
+    fix_binary no
+    
+Then make sure it's imported:
+
+.. code-block:: bash
+    
+   sudo update-binfmts --import qemu-arm
+
+Currently, this target uses our *secret sauce*. Eventually this will be an open source component of Ferrocene, but for now, it's our little bit of arcane magic.
+
+First, set the target:
+
+.. code-block:: bash
+
+    export TARGET="thumbv7em-ferrocenecoretest-eabihf"
+    # or 
+    export TARGET="thumbv7em-ferrocenecoretest-eabi"
+
+Next, it's possible to build the *secret sauce*, or to download it. Generally, it's easier to download it, but if necessary you can find the repository in the `Ferrocene <https://github.com/ferrocene>`_ organization.
+
+Refer to the ``.circleci/workflows.yml`` file on the ``setup-secret-sauce`` command to see which date/hash of the sauce to download.
+
+.. code-block:: bash
+
+    export SAUCE_DATE=20250121
+    export SAUCE_HASH=1671dac
+    
+    mkdir -p /tmp/ferrocene/$TARGET
+    aws s3 cp s3://ferrocene-ci-mirrors/coretest-secret-sauce/$SAUCE_DATE/$SAUCE_HASH/$TARGET.tar.gz /tmp/ferrocene/
+    tar xf /tmp/ferrocene/$TARGET.tar.gz --directory=/tmp/ferrocene/$TARGET
+
+You can now run the tests:
+
+.. code-block:: bash
+
+    export QEMU_CPU=cortex-m4
+    ./x test --stage 1 --target $TARGET library/core

--- a/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
+++ b/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
@@ -189,7 +189,7 @@ After, you can run the tests:
 .. code-block:: bash
 
     export QEMU_LD_PREFIX="/usr/aarch64-linux-gnu"
-    ./x test --stage 1 --target aarch64-unknown-ferrocenecoretest library/core
+    ./x test --stage 1 --target aarch64-unknown-ferrocenecoretest library/coretests
 
 :target-with-triple:`thumbv7em-none-eabihf` & :target-with-triple:`thumbv7em-none-eabi`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -251,4 +251,4 @@ You can now run the tests:
 .. code-block:: bash
 
     export QEMU_CPU=cortex-m4
-    ./x test --stage 1 --target $TARGET library/core
+    ./x test --stage 1 --target $TARGET library/coretests

--- a/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
+++ b/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
@@ -146,7 +146,7 @@ Currently bare metal targets have a similar procedure for testing.
     In a :target:`aarch64-unknown-linux-gnu` environment -- such as a guest on
     :target:`aarch64-apple-darwin` or :target:`x86_64-pc-windows-msvc` -- you **must** skip to the final step, running the tests using::
     
-        ./x test --stage 1 --target aarch64-unknown-ferrocenecoretest library/core
+        ./x test --stage 1 --target aarch64-unknown-ferrocenecoretest library/coretests
 
     Incorrectly configuring your :target:`aarch64-unknown-linux-gnu` environment using the other steps 
     will damage to the environment and result in "Too many levels of symbolic links" errors.
@@ -188,7 +188,6 @@ After, you can run the tests:
 
 .. code-block:: bash
 
-    export QEMU_LD_PREFIX="/usr/aarch64-linux-gnu"
     ./x test --stage 1 --target aarch64-unknown-ferrocenecoretest library/coretests
 
 :target-with-triple:`thumbv7em-none-eabihf` & :target-with-triple:`thumbv7em-none-eabi`

--- a/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
+++ b/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
@@ -89,7 +89,7 @@ Setup WSL2, if you don't have it:
 
 .. code-block:: bash
 
-    wsl --install --distribution Ubuntu-24.10
+    wsl --install --distribution Ubuntu-24.04
 
 Ensure `nestedVirtualization` is set in the guest ``/etc/wsl.conf``, here is an example
 configuration:

--- a/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
+++ b/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
@@ -186,6 +186,7 @@ After, you can run the tests:
 
 .. code-block:: bash
 
+    export QEMU_LD_PREFIX="/usr/aarch64-linux-gnu"
     ./x test --stage 1 --target aarch64-unknown-ferrocenecoretest library/core
 
 :target:`thumbv7em-none-eabihf` & :target:`thumbv7em-none-eabi`


### PR DESCRIPTION
A first brush at a page describing how to replicate our bare-metal testing locally.

I'd like to circle back and add QNX later, as the steps are a bit different and require licensing notes. For now, the people with QNX licenses already know how to run the tests.