### PR TITLE
[1.83] Backport KP docs, release notes fix

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -456,6 +456,7 @@ Libraries
 - [Replace sort implementations with stable `driftsort` and unstable `ipnsort`.](https://github.com/rust-lang/rust/pull/124032/) All `slice::sort*` and `slice::select_nth*` methods are expected to see significant performance improvements. See the [research project](https://github.com/Voultapher/sort-research-rs) for more details.
 - [Document behavior of `create_dir_all` with respect to empty paths.](https://github.com/rust-lang/rust/pull/125112/)
 - [Fix interleaved output in the default panic hook when multiple threads panic simultaneously.](https://github.com/rust-lang/rust/pull/127397/)
+- Fix `Command`'s batch files argument escaping not working when file name has trailing whitespace or periods (CVE-2024-43402).
 
 <a id="1.81.0-Stabilized-APIs"></a>
 

--- a/ferrocene/doc/safety-manual/src/customer-interactions.rst
+++ b/ferrocene/doc/safety-manual/src/customer-interactions.rst
@@ -32,9 +32,9 @@ customer portal account), or can be downloaded along with the Ferrocene release
 Consulting Known Problems
 -------------------------
 
-Whenever a noticeable defect is discovered in Ferrocene, a new known problem is
-recorded in the :doc:`/known-problems`. Customers are alerted of new known
-problems via email.
+Whenever a noticeable defect is discovered in Ferrocene, it is analyzed and
+recorded into a database. The :doc:`known-problems` page describes how to access
+the database and how to keep up with newly discovered problems.
 
 .. _customer portal: https://customers.ferrocene.dev
 .. _docs.ferrocene.dev: https://docs.ferrocene.dev

--- a/ferrocene/doc/safety-manual/src/known-problems.rst
+++ b/ferrocene/doc/safety-manual/src/known-problems.rst
@@ -4,6 +4,35 @@
 Known Problems
 ==============
 
-The description of KPs, along with their workarounds, detection, and mitigation
-strategies, are available for customers on `problems.ferrocene.dev
-<https://problems.ferrocene.dev>`_.
+Ferrocene's defects are categorized into the Known Problems (KP) database. Each
+KP is described along with its workaround, detection and mitigation strategies.
+Access to the database is only available to Ferrocene customers with an active
+subscription.
+
+Consulting Known Problems
+-------------------------
+
+The up-to-date version of the Known Problems database is available at
+`problems.ferrocene.dev`_. The contents of the database are regularly updated,
+as new problems are discovered or fixed.
+
+An offline copy of the database can be downloaded by following the instructions
+at `problems.ferrocene.dev`_. When consulting an offline copy, make sure it is
+up to date.
+
+Notification of newly discovered problems
+-----------------------------------------
+
+All customers with an active subscription that includes known problems
+notifications can receive emails when new problems are discovered. The
+customer's employees in charge of triaging new Known Problems must enable
+"Functional Safety notifications" in the `notification settings`_ to receive
+them.
+
+It is the responsibility of the customer to be aware of new problems being
+discovered (for example by subscribing to the notifications, or by periodically
+monitoring `problems.ferrocene.dev`_) and apply the procedures described in new
+database entries.
+
+.. _problems.ferrocene.dev: https://problems.ferrocene.dev
+.. _notification settings: https://customers.ferrocene.dev/users/notifications/preference


### PR DESCRIPTION
Backports

* #1244 

Also backports https://github.com/rust-lang/rust/pull/129960/commits/24906b593066da249b07a409af323f17a2840ca5 which which upstream is also doing: https://github.com/rust-lang/rust/pull/135934

In the case of 24906b593066da249b07a409af323f17a2840ca5, this is somewhat of a special circumstance. We noticed during our own release process that our 1.81 (so 24.11) release notes had changed and this change (along with https://github.com/rust-lang/rust/pull/126967 which was removed with https://github.com/rust-lang/rust/pull/129995) had disappeared. We confirmed the fix for https://github.com/rust-lang/rust/pull/129960/ is indeed in tree, but upstream never ported the release note update to their main branch. This port is being done in https://github.com/rust-lang/rust/pull/135934.

