### PR TITLE
Fix pull automation not working

### DIFF
--- a/.github/workflows/automation-pull-upstream.yml
+++ b/.github/workflows/automation-pull-upstream.yml
@@ -124,6 +124,12 @@ jobs:
       - name: Clone a subset of the LLVM submodule rather than the whole thing
         run: ferrocene/ci/scripts/clone-llvm-subset.sh
 
+      - name: Clone an empty GCC submodule
+        run: ferrocene/ci/scripts/clone-empty-submodule.sh src/gcc
+
+      - name: Clone an empty Enzyme submodule
+        run: ferrocene/ci/scripts/clone-empty-submodule.sh src/tools/enzyme
+
       - name: Run the pull-upstream automation
         run: ferrocene/tools/pull-upstream/automation.py ${{ matrix.branch }} ${{ steps.create_branch.outputs.name || 'main' }}
         env:

--- a/ferrocene/ci/scripts/clone-empty-submodule.sh
+++ b/ferrocene/ci/scripts/clone-empty-submodule.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+# Some submodules (like gcc and enzyme) are really big, but we don't need them in some jobs (like
+# automations). This script uses partial clones and sparse checkouts to clone an empty version of
+# the submodule, without breaking external tools relying on the submodule's presence.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <path>"
+    exit 1
+fi
+path="$1"
+
+git_submodule() {
+    git -C "${path}" $@
+}
+
+git submodule init "${path}"
+submodule_commit="$(git ls-tree HEAD "${path}" | awk '{print($3)}')"
+submodule_url="$(git config --file .gitmodules --get-regexp '\.url$' | grep "submodule.${path}.url" | awk '{print($2)}')"
+
+git init "${path}"
+git_submodule remote add origin "${submodule_url}"
+
+# Configure partial clone not to download any blob.
+git_submodule config remote.origin.promisor true
+git_submodule config remote.origin.partialCloneFilter blob:none
+
+# Configure sparse checkout to only checkout the paths we need.
+#
+# The --cone flag is an optimization when you need to checkout whole
+# directories, not arbitrary patterns, which speeds up later checkouts.
+#
+# We are not actually adding paths because we don't really care about this submodule.
+git_submodule sparse-checkout init --cone
+
+git_submodule fetch --depth=1 origin "${submodule_commit}"
+git_submodule checkout "${submodule_commit}"
+
+# Load the git repository we created in src/gcc as the submodule.
+git submodule absorbgitdirs

--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -73,7 +73,11 @@ cd "$(git rev-parse --show-toplevel)"
 # Safety check to avoid messing with uncommitted changes.
 # Submodules are updated before that, as submodules needing an update should
 # not block merging changes from upstream.
+#
+# The update-index command ensures diff-index doesn't spuriously fail.
+# https://stackoverflow.com/questions/3878624#comment108071431_3879077
 git submodule update --init
+git update-index --refresh
 if ! git diff-index --quiet HEAD; then
     echo "pull-upstream: the current branch contains uncommitted changes!"
     echo "pull-upstream: make sure all changes are committed before running this script."


### PR DESCRIPTION
This PR fixes the pull automation failing because `git diff-index --quiet HEAD` misreported the state of the index. While I was at it, I also shaved 8 minutes off the CI job by avoiding to clone GCC and Enzyme, using a script inspired by the existing `clone-llvm-subset.sh` script.