### PR TITLE
[1.83] Fix downloading from CI on the `release/1.83` branch

### DIFF
--- a/src/stage0
+++ b/src/stage0
@@ -3,7 +3,7 @@ artifacts_server=s3://ferrocene-ci-artifacts/ferrocene/dist
 artifacts_with_llvm_assertions_server=s3://ferrocene-ci-artifacts/ferrocene/dist
 git_merge_commit_email=87868125+bors-ferrocene\[bot\]@users.noreply.github.com
 git_repository=ferrocene/ferrocene
-nightly_branch=main
+nightly_branch=release/1.83
 
 # The configuration above this comment is editable, and can be changed
 # by forks of the repository if they have alternate values.


### PR DESCRIPTION
This will allow the build system to automatically retrieve the correct test outcomes without having to manually inject them on the 1.83 branch. I will also make a followup PR later to automatically do this for all of our branches.