### PR TITLE
Fix download from CI in release branches by updating `src/stage0`

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Check whether any of our Cargo patches are unused
         run: ferrocene/ci/scripts/detect-unused-cargo-patches.py
 
+      - name: Check whether src/stage0 is up to date
+        run: ferrocene/ci/scripts/fix-stage0-branch.py --check
+
       - name: Perform licensing checks
         run: uv run reuse --include-submodules lint
 

--- a/ferrocene/ci/scripts/fix-stage0-branch.py
+++ b/ferrocene/ci/scripts/fix-stage0-branch.py
@@ -68,6 +68,8 @@ def check():
 
     if current != expected:
         print(f"error: {BRANCH_KEY} is '{current}' but must be '{expected}' in {STAGE0_PATH}")
+        print("note: the pull from upstream automation is supposed to fix this, you should check")
+        print("      why it didn't update the key in the pull from beta.")
         exit(1)
 
 

--- a/ferrocene/ci/scripts/fix-stage0-branch.py
+++ b/ferrocene/ci/scripts/fix-stage0-branch.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env -S uv run
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+
+# The `src/stage0` file not only describe which compiler to use as the first bootstrap stage, but it
+# also serves as a generic "configuration file" for the repository.
+#
+# One of its fields is `nightly_branch`, configuring the name of the branch PRs will be sent to. For
+# us that is not just `main`, but also `release/1.NN` if we are in a release branch. Having the
+# wrong value in the field breaks bootstrap's download from CI feature, as bootstrap won't be able
+# to determine the commit to download from.
+#
+# This script updates `src/stage0` to always point to the correct branch, and it's executed as part
+# of upstream pulls. It also provides a --check flag to ensure the branch name is correct, for CI.
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+import argparse
+
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+STAGE0_PATH = ROOT / "src" / "stage0"
+BRANCH_KEY = "nightly_branch"
+
+
+def expected_branch():
+    rust_channel = (ROOT / "src" / "ci" / "channel").read_text().strip()
+    rust_version = (ROOT / "src" / "version").read_text().strip()
+
+    if rust_channel == "nightly":
+        return "main"
+    else:
+        major, minor, _patch = rust_version.split(".")
+        return f"release/{major}.{minor}"
+
+
+def parse_stage0():
+    stage0 = Stage0()
+    raw = STAGE0_PATH.read_text()
+
+    for line in raw.split("\n"):
+        if line.startswith(f"{BRANCH_KEY}="):
+            if stage0.branch is None:
+                stage0.branch = line.removeprefix(f"{BRANCH_KEY}=")
+            else:
+                raise RuntimeError(f"duplicate {BRANCH_KEY} in stage0")
+        else:
+            if stage0.branch is None:
+                stage0.before_raw += f"{line}\n"
+            else:
+                stage0.after_raw += f"\n{line}"
+
+    if stage0.branch is None:
+        raise RuntimeError(f"missing {BRANCH_KEY} in stage0")
+
+    return stage0
+
+
+def check():
+    current = parse_stage0().branch
+    expected = expected_branch()
+
+    if current != expected:
+        print(f"error: {BRANCH_KEY} is '{current}' but must be '{expected}' in {STAGE0_PATH}")
+        exit(1)
+
+
+def fix():
+    stage0 = parse_stage0()
+    expected = expected_branch()
+
+    STAGE0_PATH.open("w").write(f"{stage0.before_raw}{BRANCH_KEY}={expected}{stage0.after_raw}")
+
+
+@dataclass
+class Stage0:
+    before_raw: str = ""
+    branch: Optional[str] = None
+    after_raw: str = ""
+
+
+if __name__ == "__main__":
+    cli = argparse.ArgumentParser()
+    cli.add_argument("--check", action="store_true")
+    args = cli.parse_args()
+
+    if args.check:
+        check()
+    else:
+        fix()

--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -323,6 +323,15 @@ else
     automation_warning "Couldn't regenerate the \`x.py\` completions. Please run \`./x run generate-completions\` after fixing the merge conflicts."
 fi
 
+# Some parts of src/stage0 need to be updated when we branch off from main to a release branch.
+# Running the fixup script here ensures the fix is always applied.
+echo "pull-upstream: trying to fix src/stage0"
+ferrocene/ci/scripts/fix-stage0-branch.py
+if git status --porcelain=v1 | grep "^ M src/stage0$" >/dev/null; then
+    git add src/stage0
+    git commit -m "update src/stage0"
+fi
+
 git branch -D "${TEMP_BRANCH}"
 
 echo


### PR DESCRIPTION
Downloads from CI work transparently on the main branch, both for LLVM and the test outcomes. They were historically broken on release branches though, due to bootstrap not being able to identify the correct parent commit.

The general fix for the issue is to update `nightly_branch` in `src/stage0` with the name of the base branch, which is `release/1.NN` for release branches. Since the branch name needs to be updated as soon as we branch off from `main`, this PR changes the upstream pull script to ensure the branch name is correct.

This also adds a CI check to ensure the branch name is correct, in case the automation fails to update it for whatever reason.

:warning: Merging this PR will break pulls from upstream beta and stable until the PR is backported to the relevant branches. The backport PR can be created with the automation, bu tit will require a manual commit updating `src/stage0`. :warning: 