### PR TITLE
Improve the document signing UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,6 +1626,7 @@ dependencies = [
  "anyhow",
  "asn1-rs",
  "base64 0.21.7",
+ "clap",
  "getrandom",
  "hex",
  "serde",

--- a/ferrocene/tools/document-signatures/Cargo.toml
+++ b/ferrocene/tools/document-signatures/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 anyhow = "1.0.65"
 asn1-rs = "0.5.1"
 base64 = "0.21.0"
+clap = { version = "4.5.27", features = ["derive"] }
 getrandom = { version = "0.2.10", features = ["std"] }
 hex = "0.4.2"
 serde = { version = "1.0.147", features = ["derive"] }

--- a/ferrocene/tools/document-signatures/src/main.rs
+++ b/ferrocene/tools/document-signatures/src/main.rs
@@ -26,6 +26,8 @@ enum CliCommand {
     Sign {
         source_dir: PathBuf,
         output_dir: PathBuf,
+        #[arg(long)]
+        force: bool,
     },
     Verify {
         source_dir: PathBuf,
@@ -45,8 +47,8 @@ fn main() -> Result<(), Error> {
     let env = Env::load()?;
 
     match cli.cmd {
-        CliCommand::Sign { source_dir, output_dir } => {
-            sign::sign(&source_dir, &output_dir, &env)?;
+        CliCommand::Sign { source_dir, output_dir, force } => {
+            sign::sign(&source_dir, &output_dir, force, &env)?;
         }
         CliCommand::Verify { source_dir, output_dir } => {
             verify::verify(&source_dir, &output_dir, &env)?;

--- a/ferrocene/tools/document-signatures/src/signature_files.rs
+++ b/ferrocene/tools/document-signatures/src/signature_files.rs
@@ -15,16 +15,16 @@ use anyhow::{Context, Error, bail};
 use tempfile::NamedTempFile;
 use uuid::Uuid;
 
-use crate::{CliOptions, TOML_HEADER_COMMENTS};
+use crate::{Env, TOML_HEADER_COMMENTS};
 
-pub(crate) struct SignatureFiles<'opts> {
+pub(crate) struct SignatureFiles<'env> {
     signature_toml: Signature,
     signature_toml_path: PathBuf,
-    options: &'opts CliOptions,
+    env: &'env Env,
 }
 
-impl<'opts> SignatureFiles<'opts> {
-    pub(crate) fn load(document: &Path, options: &'opts CliOptions) -> Result<Self, Error> {
+impl<'env> SignatureFiles<'env> {
+    pub(crate) fn load(document: &Path, options: &'env Env) -> Result<Self, Error> {
         let signature_toml_path = document.join("signature").join("signature.toml");
 
         let signature_toml = if signature_toml_path.exists() {
@@ -33,7 +33,7 @@ impl<'opts> SignatureFiles<'opts> {
             Signature { files: BTreeMap::new() }
         };
 
-        Ok(Self { signature_toml, signature_toml_path, options })
+        Ok(Self { signature_toml, signature_toml_path, env: options })
     }
 
     pub(crate) fn read(&self, name: &str) -> Result<Option<Vec<u8>>, Error> {
@@ -43,7 +43,7 @@ impl<'opts> SignatureFiles<'opts> {
         };
 
         Ok(Some(
-            std::fs::read(self.options.s3_cache_dir.join(uuid.to_string()))
+            std::fs::read(self.env.s3_cache_dir.join(uuid.to_string()))
                 // Assume that if a file is in `signature.toml` it must exist in S3.
                 .context("this is a bootstrap bug (file is supposed to be cached)")
                 .with_context(|| {
@@ -63,7 +63,7 @@ impl<'opts> SignatureFiles<'opts> {
             return Ok(None);
         };
 
-        let mut cache = File::open(self.options.s3_cache_dir.join(uuid.to_string()))
+        let mut cache = File::open(self.env.s3_cache_dir.join(uuid.to_string()))
             .context("this is a bootstrap bug (the file is supposed to be cached)")
             .with_context(|| {
                 format!("failed to retrieve signature file {name} (with UUID {uuid})")
@@ -77,7 +77,7 @@ impl<'opts> SignatureFiles<'opts> {
     }
 
     pub(crate) fn write(&mut self, name: &str, contents: &[u8]) -> Result<(), Error> {
-        let Some(s3_bucket) = &self.options.s3_bucket else {
+        let Some(s3_bucket) = &self.env.s3_bucket else {
             panic!("uploading signatures is only supported with the s3 backend");
         };
         let uuid = Uuid::new_v4();
@@ -103,7 +103,7 @@ impl<'opts> SignatureFiles<'opts> {
 
         // Then we write the file in the local cache, to avoid having bootstrap read it from S3
         // the next time it's invoked.
-        std::fs::write(self.options.s3_cache_dir.join(uuid.to_string()), contents)?;
+        std::fs::write(self.env.s3_cache_dir.join(uuid.to_string()), contents)?;
 
         // And finally we update `signature.toml` to record the UUID of the file.
         self.signature_toml.files.insert(name.into(), uuid);

--- a/ferrocene/tools/document-signatures/src/signature_files.rs
+++ b/ferrocene/tools/document-signatures/src/signature_files.rs
@@ -36,6 +36,10 @@ impl<'env> SignatureFiles<'env> {
         Ok(Self { signature_toml, signature_toml_path, env: options })
     }
 
+    pub(crate) fn file_exists(&self, name: &str) -> bool {
+        self.signature_toml.files.contains_key(name)
+    }
+
     pub(crate) fn read(&self, name: &str) -> Result<Option<Vec<u8>>, Error> {
         // Treat files not mentioned in `signature.toml` as missing.
         let Some(uuid) = self.signature_toml.files.get(name) else {

--- a/ferrocene/tools/document-signatures/src/verify.rs
+++ b/ferrocene/tools/document-signatures/src/verify.rs
@@ -7,17 +7,13 @@ use std::process::Command;
 
 use anyhow::{Context, Error, anyhow};
 
-use crate::CliOptions;
+use crate::Env;
 use crate::config::Config;
 use crate::pinned::Pinned;
 use crate::signature_files::SignatureFiles;
 
-pub(crate) fn verify(
-    source_dir: &Path,
-    output_dir: &Path,
-    options: &CliOptions,
-) -> Result<(), Error> {
-    let signature_files = SignatureFiles::load(source_dir, options)?;
+pub(crate) fn verify(source_dir: &Path, output_dir: &Path, env: &Env) -> Result<(), Error> {
+    let signature_files = SignatureFiles::load(source_dir, env)?;
 
     let pinned_toml = if let Some(mut file) = signature_files.on_disk_as_tempfile("pinned.toml")? {
         let mut contents = Vec::new();
@@ -52,7 +48,7 @@ pub(crate) fn verify(
             .ok_or_else(|| anyhow!("missing signature file for role {role_name}"))?;
 
         eprintln!("checking role {role_name}");
-        let status = Command::new(&options.cosign_binary)
+        let status = Command::new(&env.cosign_binary)
             .arg("verify-blob")
             .arg(pinned_toml.path())
             .arg("--bundle")

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1239,7 +1239,7 @@ impl<'a> Builder<'a> {
             ),
             Subcommand::Vendor { .. } => (Kind::Vendor, &paths[..]),
             Subcommand::Perf { .. } => (Kind::Perf, &paths[..]),
-            Subcommand::Sign => (Kind::Sign, &paths[..]), // for Ferrocene
+            Subcommand::Sign { .. } => (Kind::Sign, &paths[..]), // for Ferrocene
         };
 
         Self::new_internal(build, kind, paths.to_owned())

--- a/src/bootstrap/src/core/config/flags.rs
+++ b/src/bootstrap/src/core/config/flags.rs
@@ -507,7 +507,11 @@ Arguments:
     Perf {},
     /// Sign Ferrocene qualification documents
     #[clap(long_about = "\n")]
-    Sign,
+    Sign {
+        /// Force re-signing the document even if its latest version is signed
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 impl Subcommand {

--- a/src/bootstrap/src/ferrocene/sign/mod.rs
+++ b/src/bootstrap/src/ferrocene/sign/mod.rs
@@ -62,11 +62,11 @@ macro_rules! documents {
 
             impl Step for $name {
                 type Output = ();
-                const DEFAULT: bool = false;
+                const DEFAULT: bool = true;
                 const ONLY_HOSTS: bool = true;
 
                 fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-                    crate::ferrocene::doc::$name::should_run(run)
+                    run.path(crate::ferrocene::doc::$name::SOURCE)
                 }
 
                 fn make_run(run: RunConfig<'_>) {

--- a/src/etc/completions/x.fish
+++ b/src/etc/completions/x.fish
@@ -776,6 +776,7 @@ complete -c x -n "__fish_x_using_subcommand sign" -l rust-profile-use -d 'use PG
 complete -c x -n "__fish_x_using_subcommand sign" -l llvm-profile-use -d 'use PGO profile for LLVM build' -r -F
 complete -c x -n "__fish_x_using_subcommand sign" -l reproducible-artifact -d 'Additional reproducible artifacts that should be added to the reproducible artifacts archive' -r
 complete -c x -n "__fish_x_using_subcommand sign" -l set -d 'override options in config.toml' -r -f
+complete -c x -n "__fish_x_using_subcommand sign" -l force -d 'Force re-signing the document even if its latest version is signed'
 complete -c x -n "__fish_x_using_subcommand sign" -s v -l verbose -d 'use verbose output (-vv for very verbose)'
 complete -c x -n "__fish_x_using_subcommand sign" -s i -l incremental -d 'use incremental compilation'
 complete -c x -n "__fish_x_using_subcommand sign" -l include-default-paths -d 'include default paths in addition to the provided ones'

--- a/src/etc/completions/x.ps1
+++ b/src/etc/completions/x.ps1
@@ -824,6 +824,7 @@ Register-ArgumentCompleter -Native -CommandName 'x' -ScriptBlock {
             [CompletionResult]::new('--llvm-profile-use', '--llvm-profile-use', [CompletionResultType]::ParameterName, 'use PGO profile for LLVM build')
             [CompletionResult]::new('--reproducible-artifact', '--reproducible-artifact', [CompletionResultType]::ParameterName, 'Additional reproducible artifacts that should be added to the reproducible artifacts archive')
             [CompletionResult]::new('--set', '--set', [CompletionResultType]::ParameterName, 'override options in config.toml')
+            [CompletionResult]::new('--force', '--force', [CompletionResultType]::ParameterName, 'Force re-signing the document even if its latest version is signed')
             [CompletionResult]::new('-v', '-v', [CompletionResultType]::ParameterName, 'use verbose output (-vv for very verbose)')
             [CompletionResult]::new('--verbose', '--verbose', [CompletionResultType]::ParameterName, 'use verbose output (-vv for very verbose)')
             [CompletionResult]::new('-i', '-i', [CompletionResultType]::ParameterName, 'use incremental compilation')

--- a/src/etc/completions/x.py.fish
+++ b/src/etc/completions/x.py.fish
@@ -776,6 +776,7 @@ complete -c x.py -n "__fish_x.py_using_subcommand sign" -l rust-profile-use -d '
 complete -c x.py -n "__fish_x.py_using_subcommand sign" -l llvm-profile-use -d 'use PGO profile for LLVM build' -r -F
 complete -c x.py -n "__fish_x.py_using_subcommand sign" -l reproducible-artifact -d 'Additional reproducible artifacts that should be added to the reproducible artifacts archive' -r
 complete -c x.py -n "__fish_x.py_using_subcommand sign" -l set -d 'override options in config.toml' -r -f
+complete -c x.py -n "__fish_x.py_using_subcommand sign" -l force -d 'Force re-signing the document even if its latest version is signed'
 complete -c x.py -n "__fish_x.py_using_subcommand sign" -s v -l verbose -d 'use verbose output (-vv for very verbose)'
 complete -c x.py -n "__fish_x.py_using_subcommand sign" -s i -l incremental -d 'use incremental compilation'
 complete -c x.py -n "__fish_x.py_using_subcommand sign" -l include-default-paths -d 'include default paths in addition to the provided ones'

--- a/src/etc/completions/x.py.ps1
+++ b/src/etc/completions/x.py.ps1
@@ -824,6 +824,7 @@ Register-ArgumentCompleter -Native -CommandName 'x.py' -ScriptBlock {
             [CompletionResult]::new('--llvm-profile-use', '--llvm-profile-use', [CompletionResultType]::ParameterName, 'use PGO profile for LLVM build')
             [CompletionResult]::new('--reproducible-artifact', '--reproducible-artifact', [CompletionResultType]::ParameterName, 'Additional reproducible artifacts that should be added to the reproducible artifacts archive')
             [CompletionResult]::new('--set', '--set', [CompletionResultType]::ParameterName, 'override options in config.toml')
+            [CompletionResult]::new('--force', '--force', [CompletionResultType]::ParameterName, 'Force re-signing the document even if its latest version is signed')
             [CompletionResult]::new('-v', '-v', [CompletionResultType]::ParameterName, 'use verbose output (-vv for very verbose)')
             [CompletionResult]::new('--verbose', '--verbose', [CompletionResultType]::ParameterName, 'use verbose output (-vv for very verbose)')
             [CompletionResult]::new('-i', '-i', [CompletionResultType]::ParameterName, 'use incremental compilation')

--- a/src/etc/completions/x.py.sh
+++ b/src/etc/completions/x.py.sh
@@ -2933,7 +2933,7 @@ _x.py() {
             return 0
             ;;
         x.py__sign)
-            opts="-v -i -j -h --verbose --incremental --config --build-dir --build --host --target --exclude --skip --include-default-paths --rustc-error-format --on-fail --dry-run --dump-bootstrap-shims --stage --keep-stage --keep-stage-std --src --jobs --warnings --error-format --json-output --color --bypass-bootstrap-lock --rust-profile-generate --rust-profile-use --llvm-profile-use --llvm-profile-generate --enable-bolt-settings --skip-stage0-validation --reproducible-artifact --set --help [PATHS]... [ARGS]..."
+            opts="-v -i -j -h --force --verbose --incremental --config --build-dir --build --host --target --exclude --skip --include-default-paths --rustc-error-format --on-fail --dry-run --dump-bootstrap-shims --stage --keep-stage --keep-stage-std --src --jobs --warnings --error-format --json-output --color --bypass-bootstrap-lock --rust-profile-generate --rust-profile-use --llvm-profile-use --llvm-profile-generate --enable-bolt-settings --skip-stage0-validation --reproducible-artifact --set --help [PATHS]... [ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/src/etc/completions/x.py.zsh
+++ b/src/etc/completions/x.py.zsh
@@ -845,6 +845,7 @@ _arguments "${_arguments_options[@]}" : \
 '--llvm-profile-use=[use PGO profile for LLVM build]:PROFILE:_files' \
 '*--reproducible-artifact=[Additional reproducible artifacts that should be added to the reproducible artifacts archive]:REPRODUCIBLE_ARTIFACT:_default' \
 '*--set=[override options in config.toml]:section.option=value:' \
+'--force[Force re-signing the document even if its latest version is signed]' \
 '*-v[use verbose output (-vv for very verbose)]' \
 '*--verbose[use verbose output (-vv for very verbose)]' \
 '-i[use incremental compilation]' \

--- a/src/etc/completions/x.sh
+++ b/src/etc/completions/x.sh
@@ -2933,7 +2933,7 @@ _x() {
             return 0
             ;;
         x__sign)
-            opts="-v -i -j -h --verbose --incremental --config --build-dir --build --host --target --exclude --skip --include-default-paths --rustc-error-format --on-fail --dry-run --dump-bootstrap-shims --stage --keep-stage --keep-stage-std --src --jobs --warnings --error-format --json-output --color --bypass-bootstrap-lock --rust-profile-generate --rust-profile-use --llvm-profile-use --llvm-profile-generate --enable-bolt-settings --skip-stage0-validation --reproducible-artifact --set --help [PATHS]... [ARGS]..."
+            opts="-v -i -j -h --force --verbose --incremental --config --build-dir --build --host --target --exclude --skip --include-default-paths --rustc-error-format --on-fail --dry-run --dump-bootstrap-shims --stage --keep-stage --keep-stage-std --src --jobs --warnings --error-format --json-output --color --bypass-bootstrap-lock --rust-profile-generate --rust-profile-use --llvm-profile-use --llvm-profile-generate --enable-bolt-settings --skip-stage0-validation --reproducible-artifact --set --help [PATHS]... [ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/src/etc/completions/x.zsh
+++ b/src/etc/completions/x.zsh
@@ -845,6 +845,7 @@ _arguments "${_arguments_options[@]}" : \
 '--llvm-profile-use=[use PGO profile for LLVM build]:PROFILE:_files' \
 '*--reproducible-artifact=[Additional reproducible artifacts that should be added to the reproducible artifacts archive]:REPRODUCIBLE_ARTIFACT:_default' \
 '*--set=[override options in config.toml]:section.option=value:' \
+'--force[Force re-signing the document even if its latest version is signed]' \
 '*-v[use verbose output (-vv for very verbose)]' \
 '*--verbose[use verbose output (-vv for very verbose)]' \
 '-i[use incremental compilation]' \


### PR DESCRIPTION
This PR makes two changes to the `./x sign` command, learning from today's signing procedure:

* Signing a document will now do nothing if the document is already signed by all roles, and the signatures are up to date. This behavior can be overridden by passing `--force`.
* Running `./x sign` without any argument will attempt to sign all documents.

The result of these two changes is that Florian will now need to run only `./x sign`, both during the first signature of the release cycle, and during followup signatures of the same release. In the first case the command will sign all documents, and in the second it will only sign the changed documents.