### PR TITLE
Disable bootstrap's AWS access in commit checks

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -63,3 +63,6 @@ jobs:
             ./x.py test tidy
             ./x.py check library compiler/rustc
             ./x.py run ferrocene/tools/traceability-matrix
+          # Commit checks cannot authenticate with our AWS environment. Disable the parts of CI that
+          # rely on that (for example including document signatures).
+          OUTSIDE_FERROUS: 1


### PR DESCRIPTION
Forward port of the change in https://github.com/ferrocene/ferrocene/pull/1277.