### PR TITLE
Fix bors timeout (40h to 4h)

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -10,7 +10,7 @@ pr_status = ["Checks"]
 # Consider the build as failed if it takes more than four hours to finish
 # A normal build should take less, but there are slower parts of the build that
 # are only ran occasionally.
-timeout_sec = 144000
+timeout_sec = 14400
 
 # When someone queues a PR that has pending PR status checks, bors will wait
 # for those checks to be green before queueing the PR. This defines how long


### PR DESCRIPTION
Was a typo in https://github.com/ferrocene/ferrocene/pull/1116.