### PR TITLE
Show a warning banner on public-docs

### DIFF
--- a/ferrocene/ci/scripts/prepare-docs-to-github-pages.py
+++ b/ferrocene/ci/scripts/prepare-docs-to-github-pages.py
@@ -35,7 +35,7 @@ def run(branch, *, redirect_from_index=False):
     os.chmod(output, 0o755)
 
     with tempfile.TemporaryDirectory() as download_dir:
-        for tarball, directory_inside in get_docs_tarballs():
+        for tarball, directory_inside in get_docs_tarballs(branch):
             cmd(
                 "aws",
                 "s3",
@@ -84,11 +84,11 @@ def generate_redirect(output, src, dest):
         )
 
 
-def get_docs_tarballs():
+def get_docs_tarballs(branch):
     with open("ferrocene/packages.toml", "rb") as f:
         packages = tomllib.load(f)
 
-    commit_hash = cmd("git", "rev-parse", "--short=9", "HEAD", stdout=True).strip()
+    commit_hash = cmd("git", "rev-parse", "--short=9", branch, stdout=True).strip()
 
     for group in packages["groups"].values():
         for package in group["packages"]:

--- a/ferrocene/ci/scripts/prepare-docs-to-github-pages.py
+++ b/ferrocene/ci/scripts/prepare-docs-to-github-pages.py
@@ -13,6 +13,7 @@
 # small internal thing to help our developers view the current state of things.
 
 import os
+import shutil
 import subprocess
 import tempfile
 import tomllib
@@ -57,6 +58,12 @@ def run(branch, *, redirect_from_index=False):
         output,
         f"{branch}/traceability-matrix-x86_64-unknown-linux-gnu.html",
         f"/{branch}/qualification/traceability-matrix.html",
+    )
+
+    # Manually include the CSS file causing the public-docs warning to be shown.
+    shutil.copyfile(
+        "ferrocene/doc/public-docs-warning/public-docs-warning.css",
+        f"{output}/{branch}/public-docs-warning.css",
     )
 
     if redirect_from_index:

--- a/ferrocene/doc/breadcrumbs/ferrocene-breadcrumbs.css
+++ b/ferrocene/doc/breadcrumbs/ferrocene-breadcrumbs.css
@@ -2,13 +2,13 @@
 /* SPDX-FileCopyrightText: The Ferrocene Developers */
 
 :root {
-    --header-bar-2-height: 2.5rem;
+    --header-bar-1-height: 2.5rem;
 }
 
 div.breadcrumbs {
-    height: var(--header-bar-2-height);
+    height: var(--header-bar-1-height);
     position: fixed;
-    top: var(--header-bar-2-offset);
+    top: var(--header-bar-1-offset);
     left: 0;
     right: 0;
     z-index: 100;

--- a/ferrocene/doc/breadcrumbs/ferrocene-breadcrumbs.css
+++ b/ferrocene/doc/breadcrumbs/ferrocene-breadcrumbs.css
@@ -2,13 +2,13 @@
 /* SPDX-FileCopyrightText: The Ferrocene Developers */
 
 :root {
-    --header-offset: 2.5rem;
+    --header-bar-2-height: 2.5rem;
 }
 
 div.breadcrumbs {
-    height: var(--header-offset);
+    height: var(--header-bar-2-height);
     position: fixed;
-    top: 0;
+    top: var(--header-bar-2-offset);
     left: 0;
     right: 0;
     z-index: 100;

--- a/ferrocene/doc/index/index-assets/index.css
+++ b/ferrocene/doc/index/index-assets/index.css
@@ -33,8 +33,22 @@
     --body-bg: #f7f7f7;
     --note-fg: #5f5f5f;
     --header-fg: #194e80;
-    --header-offset: 0;
     --section-title-border: #bcbcbc;
+
+    /* Depending on where the theme is used, there might be one or more optional navigation bars
+     * present at the top of the page. To properly offset the theme based on the height of those
+     * navigation bars, we define a variable for each of them.
+     *
+     * When adding a new navigation bar, add a new variable for it, don't reuse an existing one. */
+    --header-bar-1-height: 0rem; /* Assigned to: public-docs warning banner */
+    --header-bar-1-offset: 0rem;
+    --header-bar-2-height: 0rem; /* Assigned to: breadcrumbs */
+    --header-bar-2-offset: var(--header-bar-1-height);
+    --header-offset: calc(var(--header-bar-1-height) + var(--header-bar-2-height));
+}
+
+.hidden {
+    display: none;
 }
 
 body {

--- a/ferrocene/doc/index/index.html
+++ b/ferrocene/doc/index/index.html
@@ -10,8 +10,10 @@
         <link rel="stylesheet" href="index-assets/index.css">
         <link rel="stylesheet" href="index-assets/subset-filters/signatures.css">
         <link rel="stylesheet" href="ferrocene-breadcrumbs.css">
+        <link rel="stylesheet" href="public-docs-warning.css">
     </head>
     <body>
+        <!-- FERROCENE-INCLUDE-PUBLIC-DOCS-WARNING -->
         <div class="breadcrumbs">
             <a href="#">
                 <svg width="179" height="204" viewBox="0 0 179 204" xmlns="http://www.w3.org/2000/svg" alt="Ferrocene logo">

--- a/ferrocene/doc/index/index.html
+++ b/ferrocene/doc/index/index.html
@@ -13,7 +13,6 @@
         <link rel="stylesheet" href="public-docs-warning.css">
     </head>
     <body>
-        <!-- FERROCENE-INCLUDE-PUBLIC-DOCS-WARNING -->
         <div class="breadcrumbs">
             <a href="#">
                 <svg width="179" height="204" viewBox="0 0 179 204" xmlns="http://www.w3.org/2000/svg" alt="Ferrocene logo">
@@ -24,6 +23,7 @@
                 Ferrocene Documentation
             </a>
         </div>
+        <!-- FERROCENE-INCLUDE-PUBLIC-DOCS-WARNING -->
 
         <header>
             <img src="index-assets/ferrocene.svg" alt="Ferrocene Logo">

--- a/ferrocene/doc/public-docs-warning/README.md
+++ b/ferrocene/doc/public-docs-warning/README.md
@@ -1,0 +1,20 @@
+# public-docs warning
+
+This directory contains the implementation of the warning banner we show in
+[public-docs.ferrocene.dev]. It is built with two components:
+
+* `header.html` is the template we include in all of our documentation (even
+  when building documentation not meant for public-docs!). Its content is hidden
+  with `display: none;`, so that it doesn't *actually* show up.
+
+* `public-docs-warning.css` is the styling of the warning, and crucially it is
+  only included when uploading the documentation to public-docs. This results in
+  the banner only being displayed there, even though we always include the HTML.
+
+To show the warning locally, run this command:
+
+```
+ln -s ../../../ferrocene/doc/public-docs-warning/public-docs-warning.css build/host/doc/
+```
+
+[public-docs.ferrocene.dev]: https://public-docs.ferrocene.dev

--- a/ferrocene/doc/public-docs-warning/README.md
+++ b/ferrocene/doc/public-docs-warning/README.md
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: The Ferrocene Developers -->
+
 # public-docs warning
 
 This directory contains the implementation of the warning banner we show in

--- a/ferrocene/doc/public-docs-warning/header.html
+++ b/ferrocene/doc/public-docs-warning/header.html
@@ -1,5 +1,5 @@
-{# SPDX-License-Identifier: MIT OR Apache-2.0 #}
-{# SPDX-FileCopyrightText: The Ferrocene Developers #}
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: The Ferrocene Developers -->
 
 <div class="ferrocene-public-docs-warning hidden">
     <div class="ferrocene-public-docs-warning-wrapper">

--- a/ferrocene/doc/public-docs-warning/header.html
+++ b/ferrocene/doc/public-docs-warning/header.html
@@ -1,0 +1,9 @@
+{# SPDX-License-Identifier: MIT OR Apache-2.0 #}
+{# SPDX-FileCopyrightText: The Ferrocene Developers #}
+
+<div class="ferrocene-public-docs-warning hidden">
+    <div class="ferrocene-public-docs-warning-wrapper">
+        <span>This is a preview from our development branch. It might be incomplete or inaccurate.</span>
+        <a href="https://docs.ferrocene.dev">Documentation access for customers &raquo;</a>
+    </div>
+</div>

--- a/ferrocene/doc/public-docs-warning/public-docs-warning.css
+++ b/ferrocene/doc/public-docs-warning/public-docs-warning.css
@@ -25,9 +25,10 @@
 
     display: flex;
     align-items: center;
-     justify-content: space-between;
+    justify-content: space-between;
 
     background: #f2bd0d;
+    font-size: 0.9em;
 }
 
 .ferrocene-public-docs-warning-wrapper a {

--- a/ferrocene/doc/public-docs-warning/public-docs-warning.css
+++ b/ferrocene/doc/public-docs-warning/public-docs-warning.css
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: MIT OR Apache-2.0 */
+/* SPDX-FileCopyrightText: The Ferrocene Developers */
+
+:root {
+    --header-bar-1-height: 2.5rem;
+}
+
+.ferrocene-public-docs-warning {
+    /* The HTML has class="hidden" applied to it, so we have to force the warning to be displayed if
+     * this CSS file is included. */
+    display: block !important;
+
+    position: fixed;
+    top: var(--header-bar-1-offset);
+    left: 0;
+    right: 0;
+    height: var(--header-bar-1-height);
+    z-index: 1000;
+}
+
+.ferrocene-public-docs-warning-wrapper {
+    height: var(--header-bar-1-height);
+    width: 100%;
+    padding: 0.5rem 1rem;
+
+    display: flex;
+    align-items: center;
+     justify-content: space-between;
+
+    background: #f2bd0d;
+}
+
+.ferrocene-public-docs-warning-wrapper a {
+    color: var(--text-fg);
+    text-decoration: underline;
+}
+
+@media (max-width: 65rem) {
+    :root {
+        --header-bar-1-height: 5rem;
+    }
+
+    .ferrocene-public-docs-warning-wrapper {
+        flex-direction: column;
+        justify-content: space-around;
+        text-align: center;
+    }
+}

--- a/ferrocene/doc/public-docs-warning/public-docs-warning.css
+++ b/ferrocene/doc/public-docs-warning/public-docs-warning.css
@@ -2,7 +2,7 @@
 /* SPDX-FileCopyrightText: The Ferrocene Developers */
 
 :root {
-    --header-bar-1-height: 2.5rem;
+    --header-bar-2-height: 2.5rem;
 }
 
 .ferrocene-public-docs-warning {
@@ -11,15 +11,15 @@
     display: block !important;
 
     position: fixed;
-    top: var(--header-bar-1-offset);
+    top: var(--header-bar-2-offset);
     left: 0;
     right: 0;
-    height: var(--header-bar-1-height);
+    height: var(--header-bar-2-height);
     z-index: 1000;
 }
 
 .ferrocene-public-docs-warning-wrapper {
-    height: var(--header-bar-1-height);
+    height: var(--header-bar-2-height);
     width: 100%;
     padding: 0.5rem 1rem;
 
@@ -37,7 +37,7 @@
 
 @media (max-width: 65rem) {
     :root {
-        --header-bar-1-height: 5rem;
+        --header-bar-2-height: 5rem;
     }
 
     .ferrocene-public-docs-warning-wrapper {

--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_theme/layout.html
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_theme/layout.html
@@ -10,9 +10,14 @@
 {% endblock %}
 
 {% block content %}
-{% if theme_include_in_header %}
-    {% include theme_include_in_header %}
-{% endif %}
+
+{% for to_include in theme_include_in_header.split(",") %}
+    {# The default value of include_in_header is "", avoid importing an empty string #}
+    {% if to_include %}
+        {% include to_include %}
+    {% endif %}
+{% endfor %}
+
 <div class="wrapper">
     <div class="sidebar">
         <header>

--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_theme/static/ferrocene.css
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_theme/static/ferrocene.css
@@ -109,9 +109,16 @@
     --spec-error-fg: #f00;
     --spec-syntax-literal-bg: #dbdbdb;
 
-    /* Vertical offset for the page. Defaults to 0, but can be set to an higher
-     * value by additional CSS files. */
-    --header-offset: 0rem;
+    /* Depending on where the theme is used, there might be one or more optional navigation bars
+     * present at the top of the page. To properly offset the theme based on the height of those
+     * navigation bars, we define a variable for each of them.
+     *
+     * When adding a new navigation bar, add a new variable for it, don't reuse an existing one. */
+    --header-bar-1-height: 0rem; /* Assigned to: public-docs warning banner */
+    --header-bar-1-offset: 0rem;
+    --header-bar-2-height: 0rem; /* Assigned to: breadcrumbs */
+    --header-bar-2-offset: var(--header-bar-1-height);
+    --header-offset: calc(var(--header-bar-1-height) + var(--header-bar-2-height));
 }
 
 * {

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -207,14 +207,14 @@ impl<P: Step + IsSphinxBook> Step for SphinxBook<P> {
                 builder.crates.get("rustfmt-nightly").unwrap().version,
             ));
 
-        // Include the public-docs warning message.
-        css_files.push(format!("{path_to_root}/../public-docs-warning.css"));
-        include_in_header.push(relative_path(&src, &public_docs_warning.join("header.html")));
-
         // Include the breadcrumbs in the generated documentation.
         css_files.push("ferrocene-breadcrumbs.css".into());
         include_in_header.push(relative_path(&src, &breadcrumbs.join("sphinx-template.html")));
         cmd.arg(format!("-Aferrocene_breadcrumbs_index={path_to_root}/index.html"));
+
+        // Include the public-docs warning message.
+        css_files.push(format!("{path_to_root}/../public-docs-warning.css"));
+        include_in_header.push(relative_path(&src, &public_docs_warning.join("header.html")));
 
         cmd.arg(path_define("html_css_files", comma_separated_paths(&css_files)));
         cmd.arg(path_define(

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -141,10 +141,10 @@ impl<P: Step + IsSphinxBook> Step for SphinxBook<P> {
                     format!("{}-doctrees-objectsinv", self.name)
                 }
             });
-        let substitutions =
-            builder.src.join("ferrocene").join("doc").join("sphinx-substitutions.toml");
-        let target_names = builder.src.join("ferrocene").join("doc").join("target-names.toml");
-        let breadcrumbs = builder.src.join("ferrocene").join("doc").join("breadcrumbs");
+        let ferrocene_doc = builder.src.join("ferrocene").join("doc");
+        let substitutions = ferrocene_doc.join("sphinx-substitutions.toml");
+        let target_names = ferrocene_doc.join("target-names.toml");
+        let breadcrumbs = ferrocene_doc.join("breadcrumbs");
 
         // In some cases we have to perform a fresh build to guarantee deterministic output (for
         // example to generate signatures). We want to purge the old build artifacts only when

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -189,35 +189,27 @@ impl<P: Step + IsSphinxBook> Step for SphinxBook<P> {
             .arg("-d")
             .arg(relative_path(&src, &doctrees))
             // Include the breadcrumbs
-            .arg("-D")
             .arg(path_define(
                 "html_theme_options.include_in_header",
                 &relative_path(&src, &breadcrumbs.join("sphinx-template.html")),
             ))
-            .arg("-A")
-            .arg(format!("ferrocene_breadcrumbs_index={path_to_root}/index.html"))
-            .arg("-D")
+            .arg(format!("-Aferrocene_breadcrumbs_index={path_to_root}/index.html"))
             .arg(format!(
-                "rustfmt_version={}",
+                "-Drustfmt_version={}",
                 builder.crates.get("rustfmt-nightly").unwrap().version,
             ))
             // Include the CSS for the breadcrumbs. Note that the path here is relative to the
             // _static directory in the rendered output. The directive works only because before
             // invoking Sphinx we copy the CSS file into _static manually.
-            .arg("-D")
-            .arg("html_css_files=ferrocene-breadcrumbs.css")
+            .arg("-Dhtml_css_files=ferrocene-breadcrumbs.css")
             // Provide the correct substitutions:
-            .arg("-D")
             .arg(path_define("ferrocene_substitutions_path", &relative_path(&src, &substitutions)))
             // Provide the correct target names:
-            .arg("-D")
             .arg(path_define("ferrocene_target_names_path", &relative_path(&src, &target_names)))
             // Toolchain versions
-            .arg("-D")
-            .arg(format!("ferrocene_version={ferrocene_version}"))
-            .arg("-D")
+            .arg(format!("-Dferrocene_version={ferrocene_version}"))
             .arg(format!(
-                "rust_version={}",
+                "-Drust_version={}",
                 fs::read_to_string(&builder.src.join("src").join("version")).unwrap().trim(),
             ));
 
@@ -232,7 +224,7 @@ impl<P: Step + IsSphinxBook> Step for SphinxBook<P> {
         }
 
         if self.require_relnotes {
-            cmd.arg("-D").arg(path_define(
+            cmd.arg(path_define(
                 "rust_release_notes",
                 &relative_path(&src, &builder.src.join("RELEASES.md")),
             ));
@@ -314,15 +306,15 @@ impl<P: Step + IsSphinxBook> Step for SphinxBook<P> {
             (_, SignatureStatus::Present) => {
                 let private_signature_files_dir = builder.ensure(CacheSignatureFiles::<P>::new());
 
-                cmd.args(["-D", "ferrocene_signature=present"]);
+                cmd.arg("-Dferrocene_signature=present");
                 // Provide the directory containing the cached private signature files:
-                cmd.arg("-D").arg(path_define(
+                cmd.arg(path_define(
                     "ferrocene_private_signature_files_dir",
                     &relative_path(&src, &private_signature_files_dir),
                 ));
             }
             (_, SignatureStatus::Missing) => {
-                cmd.args(["-D", "ferrocene_signature=missing"]);
+                cmd.arg("-Dferrocene_signature=missing");
             }
         }
 
@@ -410,7 +402,7 @@ fn add_intersphinx_arguments<P: Step + IsSphinxBook>(
     // configuration key we can set, that accepts the JSON representation of the mappings. The
     // extension then takes care of registering the mappings with InterSphinx.
     let serialized = serde_json::to_string(&inventories).unwrap();
-    cmd.arg("-D").arg(format!("ferrocene_intersphinx_mappings={serialized}"));
+    cmd.arg(format!("-Dferrocene_intersphinx_mappings={serialized}"));
 }
 
 fn add_external_sphinx_needs_argument<P: Step + IsSphinxBook>(
@@ -476,11 +468,12 @@ fn add_external_sphinx_needs_argument<P: Step + IsSphinxBook>(
     }
 
     let serialized = serde_json::to_string(&needs).unwrap();
-    cmd.arg("-D").arg(format!("ferrocene_external_needs={serialized}"));
+    cmd.arg(format!("-Dferrocene_external_needs={serialized}"));
 }
 
 fn path_define(key: &str, value: &Path) -> OsString {
     let mut string = OsString::new();
+    string.push("-D");
     string.push(key);
     string.push("=");
     string.push(value);

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -860,6 +860,7 @@ impl Step for Index {
         let index_dir = doc.join("index");
         let pdw_dir = doc.join("public-docs-warning");
         let out = builder.doc_out(self.target);
+        let assets_out = out.join("index-assets");
 
         if builder.config.dry_run() {
             return;
@@ -883,7 +884,8 @@ impl Step for Index {
         std::fs::write(out.join("index.html"), &template).expect("failed to write index.html");
 
         copy_breadcrumbs_assets(builder, &out);
-        builder.cp_link_r(&index_dir.join("index-assets"), &out.join("index-assets"));
+        builder.create_dir(&assets_out);
+        builder.cp_link_r(&index_dir.join("index-assets"), &assets_out);
     }
 }
 

--- a/src/bootstrap/src/ferrocene/doc.rs
+++ b/src/bootstrap/src/ferrocene/doc.rs
@@ -188,20 +188,6 @@ impl<P: Step + IsSphinxBook> Step for SphinxBook<P> {
             // Store doctrees outside the output directory:
             .arg("-d")
             .arg(relative_path(&src, &doctrees))
-            // Include the breadcrumbs
-            .arg(path_define(
-                "html_theme_options.include_in_header",
-                &relative_path(&src, &breadcrumbs.join("sphinx-template.html")),
-            ))
-            .arg(format!("-Aferrocene_breadcrumbs_index={path_to_root}/index.html"))
-            .arg(format!(
-                "-Drustfmt_version={}",
-                builder.crates.get("rustfmt-nightly").unwrap().version,
-            ))
-            // Include the CSS for the breadcrumbs. Note that the path here is relative to the
-            // _static directory in the rendered output. The directive works only because before
-            // invoking Sphinx we copy the CSS file into _static manually.
-            .arg("-Dhtml_css_files=ferrocene-breadcrumbs.css")
             // Provide the correct substitutions:
             .arg(path_define("ferrocene_substitutions_path", &relative_path(&src, &substitutions)))
             // Provide the correct target names:
@@ -211,7 +197,23 @@ impl<P: Step + IsSphinxBook> Step for SphinxBook<P> {
             .arg(format!(
                 "-Drust_version={}",
                 fs::read_to_string(&builder.src.join("src").join("version")).unwrap().trim(),
+            ))
+            .arg(format!(
+                "-Drustfmt_version={}",
+                builder.crates.get("rustfmt-nightly").unwrap().version,
             ));
+
+        // Include the breadcrumbs
+        cmd.arg(path_define(
+            "html_theme_options.include_in_header",
+            &relative_path(&src, &breadcrumbs.join("sphinx-template.html")),
+        ));
+        // Point the breadcrumbs to the root of the documentation.
+        cmd.arg(format!("-Aferrocene_breadcrumbs_index={path_to_root}/index.html"));
+        // Include the CSS for the breadcrumbs. Note that the path here is relative to the
+        // _static directory in the rendered output. The directive works only because before
+        // invoking Sphinx we copy the CSS file into _static manually.
+        cmd.arg("-Dhtml_css_files=ferrocene-breadcrumbs.css");
 
         if builder.config.cmd.fresh() {
             // The `-E` flag forces Sphinx to ignore any saved environment and build everything

--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -100,6 +100,15 @@ const INTRA_DOC_LINK_EXCEPTIONS: &[(&str, &[&str])] = &[
 
 ];
 
+// Ferrocene has some intentionally broken links present everywhere in our documentation. This list
+// will be checked for every link, regardless of the file it appears in.
+#[rustfmt::skip]
+const FERROCENE_GLOBAL_EXCEPTIONS: &[&str] = &[
+    // The CSS file is intentionally missing from the documentation we produce, as it is only
+    // injected in public-docs.ferrocene.dev.
+    "public-docs-warning.css",
+];
+
 macro_rules! static_regex {
     ($re:literal) => {{
         static RE: ::std::sync::OnceLock<::regex::Regex> = ::std::sync::OnceLock::new();
@@ -510,6 +519,9 @@ fn is_intra_doc_exception(file: &Path, link: &str) -> bool {
 }
 
 fn is_exception(file: &Path, link: &str) -> bool {
+    if FERROCENE_GLOBAL_EXCEPTIONS.contains(&link) {
+        return true;
+    }
     if let Some(entry) = LINKCHECK_EXCEPTIONS.iter().find(|&(f, _)| file.ends_with(f)) {
         entry.1.contains(&link)
     } else {


### PR DESCRIPTION
This PR adds a warning banner to https://public-docs.ferrocene.dev, to clarify the documentation comes from the main branch and might be inaccurate:

![image](https://github.com/user-attachments/assets/ccfa807b-0d31-4428-85bd-b8b37d36da73)

Feel free to review the code, but the messaging will need tweaking (we'll discuss this outside the PR). This PR is best reviewed commit-by-commit.

# Testing

To get the banner on a local build (eg `./x.py doc ferrocene/doc/internal-procedures --open`, perform the step that `prepare-docs-to-github-pages.py` would do:

```bash
cp ferrocene/doc/public-docs-warning/public-docs-warning.css build/host/doc/public-docs-warning.css
```