### PR TITLE
Add the `:upcoming:` Sphinx role

### DIFF
--- a/ferrocene/doc/internal-procedures/src/docs/sphinx-extensions.rst
+++ b/ferrocene/doc/internal-procedures/src/docs/sphinx-extensions.rst
@@ -165,6 +165,33 @@ the triple:
 The human-readable names are stored in ``ferrocene/doc/target-names.toml``, and
 referring to a target not defined in that file will emit a warning.
 
+Marking changes as upcoming
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When we add documentation about an upcoming feature to our documentation, the
+documentation will be immediately available on our `public documentation
+<https://public-docs.ferrocene.dev>`_. In those cases, you should mark those
+changes as "upcoming" by adding a note in the paragraph describing them:
+
+.. code-block:: rst
+
+   :upcoming:`25.02`
+
+The upcoming block must contain the version number in which the feature will be
+available. The badge will be shown in any branch not belonging to a specific
+release (like nightly or rolling) and in all releases with a version lower than
+the one you defined. It will automatically disappear from that version onwards.
+
+.. note::
+
+   You can include the ``:upcoming:`` role in page or section titles as well.
+   Doing so will result in the badge being displayed along the title:
+
+   .. code-block:: rst
+
+      New exciting feature :upcoming:`25.02`
+      ======================================
+
 .. _document-id:
 
 Document ID

--- a/ferrocene/doc/internal-procedures/src/release/stable.rst
+++ b/ferrocene/doc/internal-procedures/src/release/stable.rst
@@ -99,3 +99,14 @@ Finally, you need to send another PR targeting the ``release/1.NN`` branch,
 changing ``ferrocene/ci/channel`` back to ``beta`` and incrementing the point
 release version in ``ferrocene/version`` by 1. Note that you might need to
 remove some digital signatures when you increment the version number.
+
+Remove upcoming notes in the ``main`` branch
+--------------------------------------------
+
+After publishing the stable release, send a PR to the ``main`` branch to:
+
+* Remove the ``:upcoming-release:`` role at the top of the release notes page
+  for this release.
+
+* Remove all mentions of ``:upcoming:`YY.MM``` in the documentation, where
+  ``YY.MM`` is the current version number.

--- a/ferrocene/doc/release-notes/exts/ferrocene_relnotes/upcoming_release.py
+++ b/ferrocene/doc/release-notes/exts/ferrocene_relnotes/upcoming_release.py
@@ -46,8 +46,9 @@ class MarkPageAsUpcoming(SphinxTransform):
         # converts the node structure into plain text. To ensure the title is
         # formatted correctly, we add extra markup hidden with CSS that will be
         # displayed only in the HTML title.
-        title_node += span_with_class(" (", "hidden")
-        title_node += span_with_class("upcoming", "relnotes-upcoming-badge")
+        title_node += nodes.Text(" ")
+        title_node += span_with_class("(", "hidden")
+        title_node += span_with_class("upcoming", "badge-yellow")
         title_node += span_with_class(")", "hidden")
 
     def add_caution_after(self, after_node):

--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_qualification/__init__.py
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_qualification/__init__.py
@@ -9,6 +9,7 @@ from . import (
     sphinx_needs_support,
     substitutions,
     target,
+    upcoming,
 )
 import string
 
@@ -21,6 +22,7 @@ def setup(app):
     target.setup(app)
     intersphinx_support.setup(app)
     sphinx_needs_support.setup(app)
+    upcoming.setup(app)
 
     app.connect("config-inited", validate_config)
     app.connect("config-inited", inject_version)

--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_qualification/upcoming.py
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_qualification/upcoming.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+from docutils import nodes
+from sphinx.util.docutils import SphinxRole
+from sphinx.transforms import SphinxTransform
+from sphinx.util.logging import getLogger
+
+
+BADGE_CONTENT = "coming soon"
+
+
+class UpcomingRole(SphinxRole):
+    def run(self):
+        content = self.text
+
+        try:
+            major, minor = content.split(".")
+            role_version = (int(major), int(minor))
+        except ValueError:
+            return self.error(f"{self.text} is not a version in the YY.MM format")
+
+        if self.env.config.ferrocene_version != "rolling":
+            try:
+                current_major, current_minor, *_ = (
+                    self.env.config.ferrocene_version.split(".")
+                )
+                current_version = (int(current_major), int(current_minor))
+            except ValueError:
+                raise RuntimeError("invalid Ferrocene version injected")
+
+            # Don't render the role if we are outside of rolling and the release referenced by this
+            # role is the current or a past one.
+            if current_version >= role_version:
+                return [], []
+
+        return [build_badge_node()], []
+
+    def error(self, message):
+        # Show a warning in the build log and fail the build.
+        logger = getLogger(__name__)
+        logger.warning(
+            f"{self.text} is not a version in the YY.MM format",
+            location=self.get_location(),
+        )
+        # Show the error message in the generated HTML.
+        problematic = nodes.problematic()
+        problematic += nodes.Text(message)
+        return [problematic], []
+
+
+# Annoyingly, Sphinx's :doc: role strips any rich formatting from the page title when generating the
+# link label, which turns the badge into plaintext. This transform re-adds the badge to the links it
+# was removed from.
+class FixLinksWithBadge(SphinxTransform):
+    default_priority = 500
+
+    def apply(self):
+        suffix_text = build_badge_node().astext()
+
+        for link in self.document.findall(nodes.reference):
+            # Match exactly the AST of the links we want to replace.
+            if "internal" not in link:
+                continue
+            if len(link.children) != 1:
+                continue
+            if not isinstance(link[0], nodes.inline):
+                continue
+            if "std-ref" not in link[0]["classes"]:
+                continue
+            if len(link[0].children) != 1:
+                continue
+            if not isinstance(link[0][0], nodes.Text):
+                continue
+
+            # Replace the plaintext badge with the
+            current_text = link[0][0].astext()
+            if current_text.endswith(suffix_text):
+                del link[0][0]
+                link[0] += nodes.Text(current_text.removesuffix(suffix_text))
+                link[0] += build_badge_node()
+
+
+def build_badge_node():
+    # Unfortunately we cannot just return a <span class="badge-yellow">. While doing so would
+    # work great whenever the badge is included in a paragraph/table/list, it would break in
+    # some contexts when used as a page/section title.
+    #
+    # When rich formatting is used inside of a title, in most cases it will be rendered as HTML
+    # (table of contents, navbar, <h1> tag). When used in the page's <title>, Sphinx will not
+    # render any rich formatting, and instead strip all HTML tags. This would leave a "coming
+    # soon" plaintext suffix, which is quite ugly.
+    #
+    # To work around the problem, we add plaintext formatting around the badge with the .hidden
+    # CSS class. This way it won't be rendered in places with rich formatting enabled, but it
+    # will be shown in places where the title is converted to plaintext.
+    #
+    # Note that technically this problem doesn't only appear in the page <title>, but also when
+    # linking to a document using the :doc: role. The `FixLinksWithBadge` fixes that.
+    badge = nodes.inline()
+    badge += span_with_class("(", "hidden")
+    badge += span_with_class(BADGE_CONTENT, "badge-yellow")
+    badge += span_with_class(")", "hidden")
+    return badge
+
+
+def span_with_class(text, css_class):
+    node = nodes.inline()
+    node["classes"].append(css_class)
+    node += nodes.Text(text)
+    return node
+
+
+def setup(app):
+    app.add_role("upcoming", UpcomingRole())
+    app.add_post_transform(FixLinksWithBadge)

--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_theme/static/ferrocene.css
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_theme/static/ferrocene.css
@@ -104,7 +104,7 @@
 
     --content-width: 50rem;
 
-    --relnotes-badge-bg: #ffe033;
+    --badge-yellow-bg: #ffe033;
 
     --spec-error-fg: #f00;
     --spec-syntax-literal-bg: #dbdbdb;
@@ -721,21 +721,21 @@ nav.contents > p.topic-title {
     font-weight: bold;
 }
 
-/****************************
- *   Release notes badges   *
- ****************************/
+/**************
+ *   Badges   *
+ **************/
 
-span.relnotes-upcoming-badge {
+span.badge-yellow {
     display: inline-block;
-    background: var(--relnotes-badge-bg);
+    background: var(--badge-yellow-bg);
     color: var(--text-fg);
 
     text-transform: capitalize;
     font-size: 0.75em;
     font-weight: 700;
+    line-height: 1.75em;
 
-    margin-left: 0.75em;
-    padding: 0.2em 0.5em;
+    padding: 0 0.5em;
     border-radius: 0.3em;
 }
 


### PR DESCRIPTION
This PR adds the `:upcoming:` Sphinx role, which allows to mark a part of the document as "coming soon". The role displays a yellow badge, and can be put either inside of a paragraph/list/table, or in the header of a page/section:

```rst
This is a paragraph describing a new feature :upcoming:`25.05`.

Exciting new feature :upcoming:`25.05`
======================================
```

The badge will be shown if the documentation is built outside of a release branch (so, on the `nightly`, `pre-rolling` and `rolling` channels), or if the version of the current release channel is lower than the version specified as the argument. In other cases the badge will not be rendered. There is no difference of public-docs vs customer docs.

When put in the page title, it will also show up in the table of contents:

![image](https://github.com/user-attachments/assets/7367e3f0-70ae-4c2d-9e41-c592b69db9c2)

...and links to that page will include the badge too:

![image](https://github.com/user-attachments/assets/3f12f4ff-2a17-4ad9-a97c-ed8edb4fe963)

Also, for reference, here is how it looks in the middle of a paragraph:

![image](https://github.com/user-attachments/assets/97e689ec-6991-43c9-9da8-20af7336ba74)
