### PR TITLE
Remove build dir on --clear build

### DIFF
--- a/ferrocene/doc/sphinx-shared-resources/pyproject.toml
+++ b/ferrocene/doc/sphinx-shared-resources/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 
 # Increase the version number to publish a new release to PyPI.
 # Note that you'll also have to run `uv lock` in `ferrocene/doc`, otherwise CI will fail.
-version = "0.0.2"
+version = "0.0.3"
 
 description = "Internal resources used for Ferrocene's Sphinx documentation"
 license = "MIT OR Apache-2.0"

--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_standalone_make_cli.py
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_standalone_make_cli.py
@@ -11,7 +11,8 @@ from pathlib import Path
 import argparse
 import subprocess
 import sys
-
+import os
+import shutil
 
 # Automatically watch the following extra directories when --serve is used.
 EXTRA_WATCH_DIRS = ["exts", "themes"]
@@ -32,6 +33,9 @@ def build_docs(root, builder, clear, serve, debug):
         # Enable parallel builds:
         args += ["-j", "auto"]
     if clear:
+        html_path = Path(f"{dest}/html")
+        if os.path.exists():
+            shutil.rmtree(html_path)
         args.append("-E")
     if serve:
         for extra_watch_dir in EXTRA_WATCH_DIRS:

--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_standalone_make_cli.py
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_standalone_make_cli.py
@@ -10,7 +10,6 @@
 from pathlib import Path
 import argparse
 import subprocess
-import sys
 import os
 import shutil
 
@@ -20,6 +19,7 @@ EXTRA_WATCH_DIRS = ["exts", "themes"]
 
 def build_docs(root, builder, clear, serve, debug):
     dest = root / "build"
+    output_dir = dest / builder
 
     args = ["-b", builder, "-d", dest / "doctrees"]
     if debug:
@@ -33,9 +33,9 @@ def build_docs(root, builder, clear, serve, debug):
         # Enable parallel builds:
         args += ["-j", "auto"]
     if clear:
-        html_path = Path(f"{dest}/html")
         if os.path.exists():
-            shutil.rmtree(html_path)
+            shutil.rmtree(Path(output_dir))
+        # Using a fresh environment
         args.append("-E")
     if serve:
         for extra_watch_dir in EXTRA_WATCH_DIRS:
@@ -56,7 +56,7 @@ def build_docs(root, builder, clear, serve, debug):
                 "sphinx-autobuild" if serve else "sphinx-build",
                 *args,
                 root / "src",
-                dest / builder,
+                output_dir,
             ],
             check=True,
         )

--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_standalone_make_cli.py
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_standalone_make_cli.py
@@ -33,8 +33,8 @@ def build_docs(root, builder, clear, serve, debug):
         # Enable parallel builds:
         args += ["-j", "auto"]
     if clear:
-        if os.path.exists():
-            shutil.rmtree(Path(output_dir))
+        if output_dir.exists():
+            shutil.rmtree(output_dir)
         # Using a fresh environment
         args.append("-E")
     if serve:

--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_standalone_make_cli.py
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_standalone_make_cli.py
@@ -10,7 +10,6 @@
 from pathlib import Path
 import argparse
 import subprocess
-import os
 import shutil
 
 # Automatically watch the following extra directories when --serve is used.

--- a/ferrocene/doc/uv.lock
+++ b/ferrocene/doc/uv.lock
@@ -185,7 +185,7 @@ requires-dist = [
 
 [[package]]
 name = "ferrocene-sphinx-shared-resources"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "sphinx-shared-resources" }
 dependencies = [
     { name = "sphinx" },


### PR DESCRIPTION
We need to remove `build/html` dir on clean build.
