### PR TITLE
Add QEMU_CPU to steps for testing on aarch64 hosts

### DIFF
--- a/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
+++ b/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
@@ -146,6 +146,7 @@ Currently bare metal targets have a similar procedure for testing.
     In a :target:`aarch64-unknown-linux-gnu` environment -- such as a guest on
     :target:`aarch64-apple-darwin` or :target:`x86_64-pc-windows-msvc` -- you **must** skip to the final step, running the tests using::
     
+        export QEMU_CPU=cortex-a53
         ./x test --stage 1 --target aarch64-unknown-ferrocenecoretest library/coretests
 
     Incorrectly configuring your :target:`aarch64-unknown-linux-gnu` environment using the other steps 


### PR DESCRIPTION
I am a goose and totally forgot this env var. While it's not required to run the tests on the `aarch64-unknown-linux-gnu` host, we do have a test that checks for it now and that needs to be satisfied.

If you're merging this, please try to merge it alongside another PR since I'd be sad to gum up the CI with just this.