### PR TITLE
Put variable SCRIPTS nearer where it is used

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -64,10 +64,6 @@ jobs:
         env:
           FERROCENE_CUSTOM_LLVM: /usr/lib/llvm-18
           FERROCENE_HOST: x86_64-unknown-linux-gnu
-          SCRIPT: |
-            ./x.py test tidy
-            ./x.py check library compiler/rustc
-            ./x.py run ferrocene/tools/traceability-matrix
           # Commit checks cannot authenticate with our AWS environment. Disable the parts of CI that
           # rely on that (for example including document signatures).
           OUTSIDE_FERROUS: 1

--- a/ferrocene/ci/run.sh
+++ b/ferrocene/ci/run.sh
@@ -45,8 +45,13 @@ ferrocene/ci/configure.sh
 #   inside the sources directory.
 export CARGO_HOME="$(pwd)/build/cargo-home"
 
-echo "Running:"
-echo "${SCRIPT}"
+declare -a SCRIPTS=(
+     "./x.py test tidy"
+     "./x.py check library compiler/rustc"
+     "./x.py run ferrocene/tools/traceability-matrix")
 
-# Give control to the actual CI script. $SCRIPT
-exec bash -euo pipefail -c "${SCRIPT}"
+for script in ${SCRIPTS[@]}; do
+  echo "Running $script"
+  # Give control to the actual CI script. $SCRIPT
+  exec bash -euo pipefail -c "${script}"
+done


### PR DESCRIPTION
For clarity it is better to have `SCRIPTS` declared where they are used.

1. There is no need to create and pass the variable `SCRIPTS` to `run.sh`.

2. Also, when looking at CI last time, `workflow.yml` echoed all the scripts at once; it looked like the `traceability matrix` had failed when it was, in fact, `tidy` which was running and failing. 

