### PR TITLE
Avoid distributing OxidOS

### DIFF
--- a/ferrocene/packages.toml
+++ b/ferrocene/packages.toml
@@ -96,12 +96,12 @@ targets = [
 name = "rust-std"
 subset = "qnx"
 
-[groups.oxidos]
-targets = ["wasm32-unknown-unknown"]
-
-[[groups.oxidos.packages]]
-name = "oxidos"
-subset = "oxidos"
+#[groups.oxidos]
+#targets = ["wasm32-unknown-unknown"]
+#
+#[[groups.oxidos.packages]]
+#name = "oxidos"
+#subset = "oxidos"
 
 [groups.any-platform]
 targets = ["*"]


### PR DESCRIPTION
The builder for it was temporarily disabled in https://github.com/ferrocene/ferrocene/pull/1263 due to a build failure, but OxidOS was still referenced in the list of packages to release. When re-enabling OxidOS support please also revert this PR, in addition to https://github.com/ferrocene/ferrocene/commit/bbf674cdef2d30d574650048e8b22f2e3d5dd853.