### PR TITLE
Add buttons to expand/collapse all elements of the traceability matrix

### DIFF
--- a/ferrocene/tools/traceability-matrix/templates/report.html
+++ b/ferrocene/tools/traceability-matrix/templates/report.html
@@ -69,7 +69,7 @@
         </table>
 
         {% if !matrix.unknown_annotations.is_empty() %}
-            <h2>Unknown annotations</h2>
+            {% call section_title("Unknown annotations") %}
             <table>
                 <thead>
                     <tr>
@@ -91,7 +91,7 @@
         {% endif %}
 
         {% for analysis in matrix.analyses_by_kind() %}
-            <h2>All {{ analysis.kind.plural }}</h2>
+            {% call section_title("All ".to_string() + analysis.kind.plural) %}
             {% if analysis.informational_count() > 0 %}
                 <p>{{ analysis.informational_count() }} informational {{ analysis.kind.plural }} are not included in this table.</p>
             {% endif %}
@@ -126,7 +126,7 @@
         {% endfor %}
 
         {% if !ignored_tests.is_empty() %}
-            <h2>Ignored tests</h2>
+            {% call section_title("Ignored tests") %}
             <p>
                 These tests contain annotations linking them to one or more
                 elements in this traceability matrix, but are never executed by
@@ -187,6 +187,12 @@
         </td>
     </tr>
     {% endif %}
+{%- endmacro -%}
+
+{%- macro section_title(title) -%}
+<div class="section-title">
+    <h2>{{ title }}</h2>
+</div>
 {%- endmacro -%}
 
 {%- macro page_link(page) -%}

--- a/ferrocene/tools/traceability-matrix/templates/report.html
+++ b/ferrocene/tools/traceability-matrix/templates/report.html
@@ -192,6 +192,8 @@
 {%- macro section_title(title) -%}
 <div class="section-title">
     <h2>{{ title }}</h2>
+    <button class="expand-all">Expand all</button>
+    <button class="collapse-all">Collapse all</button>
 </div>
 {%- endmacro -%}
 

--- a/ferrocene/tools/traceability-matrix/templates/report.js
+++ b/ferrocene/tools/traceability-matrix/templates/report.js
@@ -34,3 +34,13 @@ document.querySelectorAll(".copiable").forEach(elem => {
 
     }).bind(elem));
 });
+
+function detailsButton(selector, setOpenTo) {
+    document.querySelectorAll(selector).forEach(button => {
+        button.addEventListener("click", event => {
+            document.querySelectorAll("details").forEach(details => details.open = setOpenTo);
+        });
+    });
+}
+detailsButton(".expand-all", true);
+detailsButton(".collapse-all", false);

--- a/ferrocene/tools/traceability-matrix/templates/style.css
+++ b/ferrocene/tools/traceability-matrix/templates/style.css
@@ -125,6 +125,10 @@ div.section-title h2 {
     margin: 0;
 }
 
+div.section-title button {
+    margin-left: 0.5em;
+}
+
 /* Circle "icon" */
 
 div.circle {

--- a/ferrocene/tools/traceability-matrix/templates/style.css
+++ b/ferrocene/tools/traceability-matrix/templates/style.css
@@ -1,9 +1,14 @@
 /* SPDX-License-Identifier: MIT OR Apache-2.0 */
 /* SPDX-FileCopyrightText: The Ferrocene Developers */
 
+:root {
+    --header-height: 3.5em;
+}
+
 body {
     font-family: sans-serif;
     margin: 1em;
+    background: #fff;
 }
 
 a {
@@ -16,7 +21,11 @@ header {
     color: #fff;
     background: #194e80;
     margin: -1em -1em 1em -1em;
-    padding: 1em;
+    padding: 0 1em;
+    height: var(--header-height);
+
+    position: sticky;
+    top: 0;
 
     display: flex;
     align-items: center;
@@ -97,6 +106,23 @@ table details summary {
 
 table details ul {
     margin-top: 0.3em;
+}
+
+/* Section titles */
+
+div.section-title {
+    display: flex;
+    align-items: center;
+
+    position: sticky;
+    top: var(--header-height);
+
+    padding: 1em 0;
+    background: #fff;
+}
+
+div.section-title h2 {
+    margin: 0;
 }
 
 /* Circle "icon" */


### PR DESCRIPTION
This PR adds buttons to expand and collapse all elements of the traceability matrix. Unfortunately clicking the buttons takes a couple of seconds to work, due to the large amount of `<details>` we have. I chose not to style the buttons since the OS provide good feedback about a button being "stuck" while it works, and recreating that was a bit overkill.

While I was at it I also tweaked the design of the page, to have the header bar and the section title be sticky at the top of the page.

[Screencast from 13-02-2025 14:52:07.webm](https://github.com/user-attachments/assets/44dafcc5-72bb-468b-bfa8-260b0a713fb7)
