### PR TITLE
Add CI step to ensure `packages.toml` is up to date

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -756,9 +756,15 @@ jobs:
       - run:
           name: Checkout the submodules
           command: ferrocene/ci/scripts/checkout-submodules.sh
+      # The verification has to happen before we upload the build metadata, as the release process
+      # understands build metadata being present as "this commit can be released".
+      - run:
+          name: Verify that all of the expected artifacts were uploaded
+          command: ferrocene/ci/scripts/validate-packages-toml.py ${CIRCLE_SHA1}
       - run:
           name: Generate build metadata
           command: ./x.py dist ferrocene-build-metadata
+      # From this point onwards, the commit can be released by the release process.
       - run:
           name: Upload metadata files to S3
           command: ferrocene/ci/scripts/upload-dist-artifacts.sh

--- a/ferrocene/ci/scripts/validate-packages-toml.py
+++ b/ferrocene/ci/scripts/validate-packages-toml.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env -S uv run
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["boto3 ~= 1.36", "requests ~= 2.32"]
+# ///
+
+# This script ensures that all of the tarballs referenced by packages.toml are uploaded, and that
+# all uploaded artifacts are referenced in packages.toml (except when explicitly ignored).
+
+import argparse
+import boto3
+import fnmatch
+import io
+import os
+import requests
+import tomllib
+
+
+S3_BUCKET = "ferrocene-ci-artifacts"
+S3_PREFIX = "ferrocene/dist"
+
+SUPPORTED_MANIFEST_VERSION = 2
+TARBALL_COMPRESSION = ["xz"]
+
+IGNORE_PATTERNS = [
+    # Files that are not components:
+    "build-metrics/*",
+    "ferrocene-ci-metadata.json",
+    "packages.toml",
+    # Components we don't distribute:
+    "rust-docs-json-*.tar.*",
+    "rustc-dev-*.tar.*",
+    "rust-dev-*.tar.*",
+]
+
+
+s3 = boto3.client("s3")
+
+github = requests.Session()
+github.headers["Authorization"] = f"Bearer {os.environ["GITHUB_TOKEN"]}"
+
+
+def get_version_string(commit):
+    channel = git_file_content(commit, "ferrocene/ci/channel")
+    if channel.strip() == "stable":
+        return git_file_content(commit, "ferrocene/version").strip()
+    else:
+        return commit[:9]
+
+
+def packages_from_toml(commit):
+    raw = s3_file_content(S3_BUCKET, f"{S3_PREFIX}/{commit}/packages.toml")
+    toml = tomllib.loads(raw)
+
+    if toml["manifest-version"] != SUPPORTED_MANIFEST_VERSION:
+        print(
+            f"error: manifest version {toml["manifest-version"]} is not supported by this script"
+        )
+        exit(1)
+
+    version = get_version_string(commit)
+    for group in toml["groups"].values():
+        for target in group["targets"]:
+            for package in group["packages"]:
+                for compression in TARBALL_COMPRESSION:
+                    if target == "*":
+                        target_str = ""
+                    else:
+                        target_str = f"-{target}"
+                    yield f"{package["name"]}{target_str}-{version}.tar.{compression}"
+
+
+class Checker:
+    def __init__(self, ignore_rules):
+        self.ignore_rules = ignore_rules
+        self.unused_ignore_rules = set(ignore_rules)
+        self.errored = False
+
+    def check(self, files, check_presence_in, error_message):
+        for file in files:
+            if file in check_presence_in:
+                continue
+            for pattern in IGNORE_PATTERNS:
+                if fnmatch.fnmatch(file, pattern):
+                    if pattern in self.unused_ignore_rules:
+                        self.unused_ignore_rules.remove(pattern)
+                    break
+            else:
+                self.errored = True
+                print(f"error: {error_message}: {file}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("commit", help="Commit hash to validate")
+    args = parser.parse_args()
+
+    uploaded = set(s3_list_files(S3_BUCKET, f"{S3_PREFIX}/{args.commit}/"))
+    expected = set(packages_from_toml(args.commit))
+
+    checker = Checker(IGNORE_PATTERNS)
+    checker.check(uploaded, expected, "unexpected file uploaded to artifacts")
+    checker.check(expected, uploaded, "expected file missing from artifacts")
+
+    if checker.errored:
+        print()
+        print(
+            "help: if the unexpected files should not be distributed, add new ignore "
+            "patterns in this script."
+        )
+        exit(1)
+
+    # Ensure we never unintentionally leave a stray ignore rule.
+    if checker.unused_ignore_rules:
+        for unused in checker.unused_ignore_rules:
+            print(f"error: unused ignore rule: {unused}")
+        exit(1)
+
+
+def s3_list_files(bucket, prefix):
+    extra_args = {}
+    while True:
+        resp = s3.list_objects_v2(Bucket=bucket, Prefix=prefix, **extra_args)
+        for obj in resp["Contents"]:
+            yield obj["Key"].removeprefix(prefix)
+        if "ContinuationToken" in resp:
+            extra_args["ContinuationToken"] = resp["ContinuationToken"]
+        else:
+            break
+
+
+def s3_file_content(bucket, key):
+    buf = io.BytesIO()
+    s3.download_fileobj(bucket, key, buf)
+    buf.seek(0)
+    return buf.read().decode("utf-8")
+
+
+def git_file_content(commit, path):
+    repo = os.environ["GITHUB_REPOSITORY"]
+    url = f"https://api.github.com/repos/{repo}/contents/{path}?ref={commit}"
+
+    resp = github.get(url, headers={"Accept": "application/vnd.github.raw+json"})
+    resp.raise_for_status()
+    return resp.text
+
+
+if __name__ == "__main__":
+    main()

--- a/ferrocene/packages.toml
+++ b/ferrocene/packages.toml
@@ -67,6 +67,7 @@ subset = "default"
 
 [groups.cross-compilation]
 targets = [
+  "x86_64-apple-darwin",
   "aarch64-unknown-linux-gnu",
   "aarch64-unknown-none",
   "armebv7r-none-eabihf",
@@ -113,6 +114,10 @@ subset = "default"
 [[groups.any-platform.packages]]
 name = "ferrocene-src"
 subset = "source"
+
+[[groups.any-platform.packages]]
+name = "ferrocene-src-signatures"
+subset = "signatures"
 
 [[groups.any-platform.packages]]
 name = "ferrocene-test-outcomes"


### PR DESCRIPTION
As we discovered recently, we stopped releasing nightly builds for almost two weeks due to `packages.toml` requiring OxidOS even after we stopped building it. Releases stopped because the release process expects all files listed in `packages.toml` to be present, and (rightly) refuses to publish an incomplete version.

To prevent problems like this in the future, this PR adds a new CI script executed at the end of a bors job, which verifies that:

* All the tarballs referenced in `packages.toml` are actually uploaded to S3.
* All the files uploaded to S3 are either referenced by `packages.toml` or explicitly ignored in the script.

The second check was actually useful as it discovered two packages that we never referenced in `packages.toml` (even though we should've done that!), so the second commit in the PR fixes that. One of those was x86_64 macOS, which is pending removal in #1267, but until it's removed it should be added back to `packages.toml`.

cc @Hoverbear, the script will have to be called from the upcoming GHA workflow too.