### PR TITLE
Ensure we use the correct uv shebang

### DIFF
--- a/ferrocene/ci/scripts/require-uv-shebang.py
+++ b/ferrocene/ci/scripts/require-uv-shebang.py
@@ -18,7 +18,7 @@ import sys
 CHECK_PATHS = ["ferrocene", ".circleci", ".github"]
 EXCLUDE_PATHS = ["ferrocene/library/libc"]
 
-UV_SHEBANG = b"#!/usr/bin/env -S uv"
+UV_SHEBANG = b"#!/usr/bin/env -S uv run"
 
 
 def main():

--- a/ferrocene/ci/scripts/require-uv-shebang.py
+++ b/ferrocene/ci/scripts/require-uv-shebang.py
@@ -51,7 +51,7 @@ def main():
 
         contents = open(file, "rb").read()
         has_shebang = contents.startswith(b"#!")
-        has_uv_shebang = contents.startswith(UV_SHEBANG)
+        has_uv_shebang = contents.startswith(UV_SHEBANG + b"\n")
         is_executable = os.access(file, os.X_OK)
 
         if has_uv_shebang and is_executable:


### PR DESCRIPTION
While making an unrelated change I discovered that we were checking for the `#!/usr/bin/env -S uv` shebang, not `#!/usr/bin/env -S uv run` shebang. Turns out that the script still passed because it was checking the first line *starts* with that shebang, not that it matches the shebang exactly. This PR fixes that.