### PR TITLE
[1.83] Make 1.83 a stable release

### DIFF
--- a/ferrocene/ci/channel
+++ b/ferrocene/ci/channel
@@ -1,1 +1,1 @@
-beta
+stable


### PR DESCRIPTION
This needs to merge after or alongside #1327 .

Follows https://public-docs.ferrocene.dev/main/qualification/internal-procedures/release/stable.html#publishing-a-stable-release