### PR TITLE
25.02 is no longer upcoming

### DIFF
--- a/ferrocene/doc/release-notes/src/25.02.0.rst
+++ b/ferrocene/doc/release-notes/src/25.02.0.rst
@@ -1,8 +1,6 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-:upcoming-release:
-
 Ferrocene 25.02.0
 =================
 


### PR DESCRIPTION
This depends on https://github.com/ferrocene/ferrocene/pull/1328

Mark 25.02 as no longer upcoming. Fulfills https://public-docs.ferrocene.dev/main/qualification/internal-procedures/release/stable.html#remove-upcoming-notes-in-the-main-branch.
