### PR TITLE
Automated pull from `ferrocene/specification`

### DIFF
--- a/ferrocene/doc/specification/src/conf.py
+++ b/ferrocene/doc/specification/src/conf.py
@@ -7,7 +7,10 @@ import os
 import sys
 
 sys.path.append(os.path.abspath("../exts"))
+<<<<<<< HEAD
 #sys.path.append(os.path.abspath("../shared/exts"))
+=======
+>>>>>>> e6c47421be1a55aa6296631e90f1d597e6eafd9f
 
 
 # -- Project information -----------------------------------------------------

--- a/ferrocene/doc/specification/src/ownership-and-deconstruction.rst
+++ b/ferrocene/doc/specification/src/ownership-and-deconstruction.rst
@@ -204,10 +204,6 @@ A :t:`mutable borrow` is a :t:`mutable reference` produced by :t:`borrowing`.
 :dp:`fls_kup2ou22nwyl`
 Immutably :t:`borrowing` a :t:`value` proceeds as follows:
 
-#. :dp:`fls_5bf2x4sm5ei`
-   **???** (**this should describe the order of borrowing and when the borrow
-   is returned**)
-
 #. :dp:`fls_8q5ly4x104ai`
    An :t:`immutable borrow` of :t:`type` ``&'a T`` is created, where
    :t:`lifetime` ``'a`` is replaced by a :t:`lifetime variable`, and


### PR DESCRIPTION
This PR pulls the following changes from the [`ferrocene/specification`](https://github.com/ferrocene/specification) repository:

* `544`: [Remove old path of the shared resources](https://www.github.com/ferrocene/specification/issues/544)
* `547`: [Remove invalid dummy](https://www.github.com/ferrocene/specification/issues/547)
