### PR TITLE
Stop pulling submodules in parallel in `pull-subtrees`

### DIFF
--- a/.github/workflows/automation-pull-subtrees.yml
+++ b/.github/workflows/automation-pull-subtrees.yml
@@ -58,10 +58,26 @@ jobs:
           APP_ID: "${{ vars.AUTOMATIONS_APP_ID }}"
           APP_PRIVATE_KEY: "${{ secrets.AUTOMATIONS_APP_PRIVATE_KEY }}"
 
+      # This submodule is pretty large, and we only need a small subset of it.
+      - name: Clone a subset of the LLVM submodule rather than the whole thing
+        run: ferrocene/ci/scripts/clone-llvm-subset.sh
+
+      # This submodule is pretty large and not actually needed.
+      - name: Clone an empty GCC submodule
+        run: ferrocene/ci/scripts/clone-empty-submodule.sh src/gcc
+
+      # This submodule is pretty large and not actually needed.
+      - name: Clone an empty Enzyme submodule
+        run: ferrocene/ci/scripts/clone-empty-submodule.sh src/tools/enzyme
+
       # Some subtrees require updating the Cargo.lock once they're updated, and
       # updating the Cargo.lock requires subtrees to be present.
+      #
+      # Pulling multiple subtrees in parallel (with the -j flag) seems to cause
+      # occasional spurious failures. We thus manually handle big submodules
+      # before this step, and then pull submodules sequentially.
       - name: Fetch submodules
-        run: git submodule update --init --depth=1 --jobs=$(nproc)
+        run: git submodule update --init --depth=1
 
       # This avoids builds failing due to a stale version of the toolchain
       - name: Ensure the latest Rust toolchain is installed


### PR DESCRIPTION
This will hopefully fix the spurious failure we've been seeing in the subtree pull job.

The error message referred to the tree being dirty, which shouldn't happen (it's a fresh checkout anyway). Also, only the first subtree fails, the others work correctly.

When I added debug logging in a job the problem stopped happening, probably because either the debugging code (a `git status`) updated some internal git data structures, or because it is a timing issue and the extra code made the job take slightly longer.

In my past experience a lot of these problems can happen with parallel subtree pulls, so this PR removes them.