### PR TITLE
Fix the hash mismatch in zstd on Windows

### DIFF
--- a/ferrocene/ci/scripts/setup-windows.sh
+++ b/ferrocene/ci/scripts/setup-windows.sh
@@ -37,4 +37,5 @@ fi
 
 # Use `cmake.portable` to ensure it is added to path and because the virtual package
 # was previously broken intermittently.
-choco install -y cmake.portable ninja zstandard gcc-arm-embedded llvm
+choco install -y cmake.portable ninja gcc-arm-embedded llvm
+choco install -y zstandard --version=1.5.6 # 1.5.7 was reporting a mismatched SHA


### PR DESCRIPTION
I noticed in https://github.com/ferrocene/ferrocene/pull/1353#issuecomment-2694885274 that the zstd hash was failing in the latest choco package, this pins it back.