### PR TITLE
Move most of `configure.sh` to a bootstrap profile

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -128,11 +128,7 @@ jobs:
     resource_class: large # 4-core
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
-      RUST_CONFIGURE_ARGS: |
-        --set
-        ferrocene.test-outcomes=custom
-        --set
-        ferrocene.test-outcomes-dir=/tmp/test-outcomes
+      FERROCENE_TEST_OUTCOMES_DIR: /tmp/test-outcomes
       SCRIPT: |
         ferrocene/ci/scripts/fetch-test-outcomes.sh
         # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
@@ -219,11 +215,7 @@ jobs:
     resource_class: medium # 2-core
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
-      RUST_CONFIGURE_ARGS: |
-        --set
-        ferrocene.test-outcomes=custom
-        --set
-        ferrocene.test-outcomes-dir=/tmp/test-outcomes
+      FERROCENE_TEST_OUTCOMES_DIR: /tmp/test-outcomes
       SCRIPT: |
         ferrocene/ci/scripts/fetch-test-outcomes.sh
         ./x.py run ferrocene/tools/traceability-matrix

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -73,4 +73,4 @@ jobs:
             ./x.py run ferrocene/tools/traceability-matrix
           # Commit checks cannot authenticate with our AWS environment. Disable the parts of CI that
           # rely on that (for example including document signatures).
-          OUTSIDE_FERROUS: 1
+          FERROCENE_UNPRIVILEGED_CI: 1

--- a/config.example.toml
+++ b/config.example.toml
@@ -996,9 +996,9 @@
 [ferrocene]
 
 # The channel for the Ferrocene build to produce. This is merged with Rust's
-# channel to determine the full channel name.
+# channel to determine the full channel name. Can be "rolling", "beta" or "stable".
 #
-# Can be "rolling", "beta" or "stable".
+# You can also set this to "auto-detect" to load the value from `ferrocene/ci/channel`.
 #channel = "rolling"
 
 # Mode of operations for the traceability matrix tool. This changes the links

--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -16,15 +16,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-add() {
-    # Add each argument split by a `\t` instead of a space. This is needed to
-    # support flags with spaces in them.
-    while [[ $# -gt 0 ]]; do
-        RUST_CONFIGURE_ARGS="${RUST_CONFIGURE_ARGS-}"$'\t'"$1"
-        shift
-    done
-}
-
 if [[ -z "${CI+x}" ]]; then
     echo "error: this doesn't look like it's being executed in CI."
     echo
@@ -34,114 +25,44 @@ if [[ -z "${CI+x}" ]]; then
     echo
     echo "    https://public-docs.ferrocene.dev/main/qualification/internal-procedures/setup-local-env.html"
     echo
-    echo "If you're trying to simulate CI to debug an issue locally, set the"
-    echo '$CI' "environment variable when invoking this script to suppress"
-    echo "this error message."
+    echo "If you're trying to simulate CI to debug an issue locally, change the"
+    echo "profile in your config.toml to 'ferrocene-dist'."
     exit 1
 fi
 
-# Helper function to check whether we should include things that only Ferrous
-# Systems has access to in the configuration.
-is_internal() {
-    if [[ -z "${OUTSIDE_FERROUS+x}" ]]; then
-        return 0
-    else
-        return 1
-    fi
+if [[ -n "${OUTSIDE_FERROUS+x}" ]]; then
+    echo "error: this script is for Ferrous Systems use only."
+    echo "note: caused by the OUSIDE_FERROUS environment variable"
+    echo
+    echo "In the past, the ferrocene/ci/configure.sh script contained both the"
+    echo "configuration of Ferrocene itself, and the configuration specific to"
+    echo "Ferrous System's CI setup. The OUTSIDE_FERROUS environment variable"
+    echo "was created to let the script only configure Ferrocene."
+    echo
+    echo "Now, the Ferrocene configuration lives in the 'ferrocene-dist'"
+    echo "bootstrap profile, and this script contains only the Ferrous Systems"
+    echo "specific configuration. If you want the generic configuration, do not"
+    echo "run this script, and instead run (with your extra arguments):"
+    echo
+    echo "    ./configure --set profile=ferrocene-dist " '$your_arguments_here'
+    echo
+    exit 1
+fi
+
+configure_args=()
+add() {
+    while [[ $# > 0 ]]; do
+        configure_args+=("$1")
+        shift
+    done
 }
 
-##################################################################
-#                                                                #
-#   Configuration items not affecting the resulting toolchain.   #
-#                                                                #
-##################################################################
-
-# Enable the generation of build metrics, which provide extra information on
-# the duration of each step of the build. This is then used by scripts and
-# tools to analyze how time is spent on CI.
-add --set build.metrics
+# Load the generic configuration from our dist profile.
+add --set profile=ferrocene-dist
 
 # Prevent `./x.py` from managing submodules, as those are cloned and managed
 # already by scripts in the CI configuration.
 add --disable-manage-submodules
-
-##############################################################################
-#                                                                            #
-#   Configuration items changing the resulting toolchain WITHOUT affecting   #
-#   its functionality, reliability or security.                              #
-#                                                                            #
-##############################################################################
-
-# Statically link Cargo's native dependencies.
-#
-# If this configuration is missing the resulting `cargo` binary will be
-# different, and might require native dependencies to be installed on the
-# user's systems.
-add --enable-cargo-native-static
-
-# Statically link libstdc++ in the resulting LLVM.
-#
-# If this confiugration is missing the resulting LLVM will be different, and
-# might require libstdc++ to be installed on the user's system.
-add --enable-llvm-static-stdcpp
-
-# Produce XZ-compressed tarballs when building dist artifacts.
-#
-# If this configuration is missing or set to a different value the resulting
-# dist tarballs will be compressed with a different algorithm.
-add --dist-compression-formats=xz
-
-# Increase the compression ratio when building dist artifacts.
-#
-# If this configuration is missing or set to a different value, a different
-# compression ration will be used when creating tarballs.
-add --set dist.compression-profile=balanced
-
-# Remap debuginfo to `/rustc/{commit-sha}`.
-#
-# If this configuration is missing, the directory structure of the build
-# machine will leak into the resulting binaries, preventing reproducibility.
-add --set rust.remap-debuginfo
-
-# Include the lines table in the standard library's debuginfo.
-#
-# If this configuration is missing backtraces will not include file and line
-# information for the standard library, making it harder for end users to debug
-# the cause of a panic.
-add --debuginfo-level-std=1
-
-# Disable debug logging in the compiler, shrinking the binary size.
-#
-# If this configuration is missing all debug logging will be included in the
-# compiler, which can then be shown with the RUSTC_LOG environment variable.
-add --set rust.debug-logging=false
-
-# Switches the compiler from the system allocator to jemalloc. Jemalloc is more
-# performant compared to the system allocator for the compiler workloads,
-# speeding up the compilation process.
-#
-# If this configuration is missing the system allocator will be used, slowing
-# down the compiler.
-#
-# On Windows, Jemalloc is not tested, and manual testing suggests it is not
-# supported.
-if [[ "${FERROCENE_HOST}" != "x86_64-pc-windows-msvc" ]]; then
-    add --set rust.jemalloc
-fi
-
-# Adds a custom string to the output of `rustc --version` to properly mark this
-# is not the upstream compiler.
-#
-# If this configuration is missing or changed the output of `rustc --version`
-# will change accordingly.
-add --release-description="Ferrocene by Ferrous Systems"
-
-##############################################################################
-#                                                                            #
-#   Configuration items changing the resulting toolchain AFFECTING its       #
-#   functionality, reliability or security! NEVER change these items.        #
-#                                                                            #
-##############################################################################
 
 # Set the target used for the build itself (build system, initial compiler
 # stages, etc). This depends on the OS used in CI.
@@ -153,7 +74,7 @@ if [[ -x "${FERROCENE_BUILD_HOST+x}" ]]; then
 fi
 
 # The Rust build system defaults to calling `cc` on Windows, which does not exist
-if [[ is_internal && "${FERROCENE_BUILD_HOST:-}" = "x86_64-pc-windows-msvc" ]]; then
+if [[ "${FERROCENE_BUILD_HOST:-}" = "x86_64-pc-windows-msvc" ]]; then
     add --set target.aarch64-unknown-none.cc=clang
     add --set target.aarch64-unknown-none.cxx=clang
     add --set target.aarch64-unknown-none.ar=llvm-ar
@@ -175,30 +96,22 @@ if [[ is_internal && "${FERROCENE_BUILD_HOST:-}" = "x86_64-pc-windows-msvc" ]]; 
     add --set target.wasm32-unknown-unknown.ar=lld-ar
 fi
 
-if [[ is_internal ]]; then
-    # QNX toolchains aren't automatically inferred, set them explicitly.
-    #
-    # Assumes `qnxsdp-env.sh` has been sourced or the binaries are otherwise
-    # already on path
-    add --set target.aarch64-unknown-nto-qnx710.cc=qcc
-    add --set target.aarch64-unknown-nto-qnx710.cxx=q++
-    add --set target.aarch64-unknown-nto-qnx710.ar=ntoaarch64-ar
-    add --set target.aarch64-unknown-nto-qnx710.profiler=false # Build failures were noted if this is enabled.
-    add --set target.x86_64-pc-nto-qnx710.cc=qcc
-    add --set target.x86_64-pc-nto-qnx710.cxx=q++
-    add --set target.x86_64-pc-nto-qnx710.ar=ntox86_64-ar
-    add --set target.x86_64-pc-nto-qnx710.profiler=false # Build failures were noted if this is enabled.
+# QNX toolchains aren't automatically inferred, set them explicitly.
+#
+# Assumes `qnxsdp-env.sh` has been sourced or the binaries are otherwise
+# already on path
+add --set target.aarch64-unknown-nto-qnx710.cc=qcc
+add --set target.aarch64-unknown-nto-qnx710.cxx=q++
+add --set target.aarch64-unknown-nto-qnx710.ar=ntoaarch64-ar
+add --set target.x86_64-pc-nto-qnx710.cc=qcc
+add --set target.x86_64-pc-nto-qnx710.cxx=q++
+add --set target.x86_64-pc-nto-qnx710.ar=ntox86_64-ar
+add --set target.x86_64-pc-nto-qnx710.profiler=false # Build failures were noted if this is enabled.
 
-    # these default to `cc` but require cross compilation
-    add --set target.aarch64-unknown-ferrocenecoretest.cc=aarch64-linux-gnu-gcc
-    add --set target.aarch64-unknown-ferrocenecoretest.profiler=false # no profiling support
-
-    add --set target.thumbv7em-ferrocenecoretest-eabi.cc=arm-none-eabi-gcc
-    add --set target.thumbv7em-ferrocenecoretest-eabi.profiler=false # no profiling support
-
-    add --set target.thumbv7em-ferrocenecoretest-eabihf.cc=arm-none-eabi-gcc
-    add --set target.thumbv7em-ferrocenecoretest-eabihf.profiler=false # no profiling support
-fi
+# these default to `cc` but require cross compilation
+add --set target.aarch64-unknown-ferrocenecoretest.cc=aarch64-linux-gnu-gcc
+add --set target.thumbv7em-ferrocenecoretest-eabi.cc=arm-none-eabi-gcc
+add --set target.thumbv7em-ferrocenecoretest-eabihf.cc=arm-none-eabi-gcc
 
 # Set the host platform to build. The environment variable is set from the CI
 # configuration (see the .circleci directory).
@@ -229,6 +142,15 @@ if [[ -n "${FERROCENE_CUSTOM_LLVM+x}" ]]; then
     add --llvm-root="${FERROCENE_CUSTOM_LLVM}"
 fi
 
+# Set the directory to the test outcomes files, if CI provides it.
+#
+# If this configuration is missing or changed, the test outcomes use to render our reports and
+# documentation will be incorrect.
+if [[ -n "${FERROCENE_TEST_OUTCOMES_DIR+x}" ]]; then
+    add --set ferrocene.test-outcomes=custom
+    add --set "ferrocene.test-outcomes-dir=${FERROCENE_TEST_OUTCOMES_DIR}"
+fi
+
 # Prevent `cargo` from updating the `Cargo.lock` file if the contents of the
 # file are out of date, failing the build instead.
 #
@@ -236,139 +158,30 @@ fi
 # dependencies rather than the pinned ones. Never remove this flag.
 add --enable-locked-deps
 
-# Use a single codegen unit when compiling the standard library.
-#
-# Rust upstream had issues in the past [1] when compiling the standard library
-# with more than 1 codegen unit. Compiling with more codegen units also
-# prevents some optimizations. Never remove this flag due to the risk of the
-# standard library failing to build correctly.
-#
-# [1] https://github.com/rust-lang/rust/issues/83600
-add --set rust.codegen-units-std=1
-
-# Enable LLVM assertions in the resulting compiler.
-#
-# If this configuration is missing LLVM assertions will be disabled, which
-# could result in compiler bugs or miscompilations not being detected. Never
-# remove this flag.
-add --enable-llvm-assertions
-
-# Enable debug assertions in the resulting compiler.
-#
-# If this configuration is missing Rust's debug assertions will be disabled,
-# which could result in compiler bugs or miscompilations not being detected.
-# Never remove this flag.
-add --enable-debug-assertions
-
-# Enable LLVM IR verification. Verification has a small compiler performance
-# hit, but has a chance of catching compiler bugs.
-#
-# If this configuration is missing LLVM IR verification will be disabled.
-# Never remove this flag.
-add --set rust.verify-llvm-ir
-
-# Enable support for LLVM sanitizers inside the compiler.
-#
-# If this configuration is missing it won't be possible to use sanitizers.
-add --enable-sanitizers
-
-# Enable only the LLVM codegen backend, preventing other codegen backends from
-# being built and shipped.
-#
-# If this configuration is missing we'll build all codegen backends built by upstream,
-# which in the future *might* include GCC.
-add --codegen-backends=llvm
-
-# Enable the extended build, which produces dist artifacts for tools in
-# addition to just the compiler and the documentation.
-#
-# If this configuration is missing, the full distribution won't be built.
-add --enable-extended
-
-# Choose which tools must be built and distributed.
-#
-# If this configuration is missing or changed, the wrong set of tools will be
-# built, and the build could fail if some tool is not tested and fails.
-#
-# NOTE: If you add a new tool here, make sure to also change
-# `ferrocene/packages.toml` to include it in new releases.
-add --tools=rustdoc,cargo,llvm-tools,rustfmt,rust-analyzer,clippy
-
-# Build and enable the profiler runtime.
-#
-# If this configuration is missing, profile guided optimizations and code
-# coverage will not be supported by the resulting compiler.
-add --enable-profiler
-
-# Disable the profiler runtime for WASM. The profiler runtime depends on libc,
-# which is not available on WASM bare metal.
-#
-# If this configuration is missing, building the WASM target will fail.
-add --set target.wasm32-unknown-unknown.profiler=false
-
-# Build and include LLD in the resulting compiler package.
-#
-# If this configuration is missing or changed, LLD will not be included.
-add --enable-lld
-
-# Set the release channel for this branch. The channel is read from the
-# `src/ci/channel` file to easily allow tools and automations to know and
-# update the current channel.
-#
-# Changing the release channel to `nightly` enables unstable features, and it
-# should not be done for any build shipped to customers.
-release_channel="$(cat src/ci/channel)"
-add "--release-channel=${release_channel}"
-
-# Set the Ferrocene channel for this branch. The channel is read from
-# `ferrocene/ci/channel` file to easily allow tools and automations to know and
-# update the current channel.
-add --set "ferrocene.channel=$(cat ferrocene/ci/channel)"
-
-# Run the traceability matrix tool in CI mode, producing the correct links.
-#
-# If this configuration is missing the traceability matrix might not be
-# properly enforced.
-add --set ferrocene.traceability-matrix-mode=ci
-
-# Sign packages generated by CI with the packages key.
-#
-# If this configuration is missing the packages generated by CI will not be
-# signed, and will not be compatible with criticalup.
-if is_internal; then
-    add --set ferrocene.tarball-signing-kms-key-arn="arn:aws:kms:us-east-1:886866542769:key/cfbd0673-04d8-4368-b09f-56998ede9b96"
-fi
-
-# Download the correct version of the OxidOS source code from our mirrors bucket.
-#
-# If this configuration is missing, building OxidOS will fail as the source
-# code will not be available. OxidOS is proprietary, so we cannot fetch the
-# source code automatically from a public repository.
-#
-# This will not work for non-employees of Ferrous Systems
-if is_internal; then
-    add --set ferrocene.oxidos-src="s3://ferrocene-ci-mirrors/manual/oxidos/oxidos-source-2023-09-21.tar.xz"
-fi
-
-# Include the technical report from the assessor in the documentation.
-#
-# If this is not provided, the report will not be included in the generated
-# documentation. This should only be set in stable, qualified releases.
-#if is_internal; then
-#    add --set ferrocene.technical-report-url="s3://ferrocene-ci-mirrors/manual/tuv-technical-reports/YYYY-MM-DD-ferrocene-YY.MM.N-technical-report.pdf"
-#fi
-
-# When building Ferrocene outside of Ferrous Systems, folks will not have
-# access to the document signature files stored in AWS. In that case, configure
-# the build system to ignore document signatures.
-if ! is_internal; then
+if [[ -n "${FERROCENE_UNPRIVILEGED_CI+x}" ]]; then
+    # Disable document signatures if we are in an unprivileged CI environment.
     add --set ferrocene.document-signatures=disabled
+else
+    # Sign packages generated by CI with the packages key.
+    #
+    # If this configuration is missing the packages generated by CI will not be
+    # signed, and will not be compatible with criticalup.
+    add --set ferrocene.tarball-signing-kms-key-arn="arn:aws:kms:us-east-1:886866542769:key/cfbd0673-04d8-4368-b09f-56998ede9b96"
+
+    # Download the correct version of the OxidOS source code from our mirrors bucket.
+    #
+    # If this configuration is missing, building OxidOS will fail as the source
+    # code will not be available. OxidOS is proprietary, so we cannot fetch the
+    # source code automatically from a public repository.
+    #
+    # This will not work for non-employees of Ferrous Systems
+    add --set ferrocene.oxidos-src="s3://ferrocene-ci-mirrors/manual/oxidos/oxidos-source-2023-09-21.tar.xz"
+
+    # Include the technical report from the assessor in the documentation.
+    #
+    # If this is not provided, the report will not be included in the generated
+    # documentation. This should only be set in stable, qualified releases.
+    #add --set ferrocene.technical-report-url="s3://ferrocene-ci-mirrors/manual/tuv-technical-reports/YYYY-MM-DD-ferrocene-YY.MM.N-technical-report.pdf"
 fi
 
-###############################################
-#                                             #
-#  Write the configuration to `config.toml`   #
-#                                             #
-###############################################
-
-./configure ${RUST_CONFIGURE_ARGS}
+./configure ${configure_args[@]}

--- a/src/bootstrap/defaults/config.ferrocene-dist.toml
+++ b/src/bootstrap/defaults/config.ferrocene-dist.toml
@@ -42,6 +42,11 @@ tools = ["rustdoc", "cargo", "llvm-tools", "rustfmt", "rust-analyzer", "clippy"]
 # supported by the resulting compiler.
 profiler = true
 
+# All dist builds should default to `--stage 2`, not `--stage 1`.
+build-stage = 2
+test-stage = 2
+doc-stage = 2
+
 
 
 [llvm]

--- a/src/bootstrap/defaults/config.ferrocene-dist.toml
+++ b/src/bootstrap/defaults/config.ferrocene-dist.toml
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+# Default configuration for a distribution and CI testing build of Ferrocene. It is *not*
+# recommended to run this configuration during local development, except if your development
+# configuration cannot reproduce a CI failure.
+
+[build]
+# Enable the generation of build metrics, which provide extra information on the duration of each
+# step of the build. This is then used by scripts and tools to analyze how time is spent on CI.
+metrics = true
+
+# Statically link Cargo's native dependencies.
+#
+# If this configuration is missing the resulting `cargo` binary will be different, and might require
+# native dependencies to be installed on the user's systems.
+cargo-native-static = true
+
+# Enable support for LLVM sanitizers inside the compiler.
+#
+# If this configuration is missing it won't be possible to use sanitizers.
+sanitizers = true
+
+# Enable the extended build, which produces dist artifacts for tools in addition to just the
+# compiler and the documentation.
+#
+# If this configuration is missing, the full distribution won't be built.
+extended = true
+
+# Choose which tools must be built and distributed.
+#
+# If this configuration is missing or changed, the wrong set of tools will be built, and the build
+# could fail if some tool is not tested and fails.
+#
+# NOTE: If you add a new tool here, make sure to also change `ferrocene/packages.toml` to include it
+# in new releases.
+tools = ["rustdoc", "cargo", "llvm-tools", "rustfmt", "rust-analyzer", "clippy"]
+
+# Build and enable the profiler runtime.
+#
+# If this configuration is missing, profile guided optimizations and code coverage will not be
+# supported by the resulting compiler.
+profiler = true
+
+
+
+[llvm]
+# Statically link libstdc++ in the resulting LLVM.
+#
+# If this confiugration is missing the resulting LLVM will be different, and might require libstdc++
+# to be installed on the user's system.
+static-libstdcpp = true
+
+# Enable LLVM assertions in the resulting compiler.
+#
+# If this configuration is missing LLVM assertions will be disabled, which could result in compiler
+# bugs or miscompilations not being detected. Never remove this flag.
+assertions = true
+
+# Do not download pre-built LLVM, build it from scratch.
+#
+# If this configuration is missing, a pre-built LLVM will be downloaded, which might not match
+# exactly what would be built locally.
+download-ci-llvm = false
+
+
+
+[dist]
+# Produce XZ-compressed tarballs when building dist artifacts.
+#
+# If this configuration is missing or set to a different value the resulting dist tarballs will be
+# compressed with a different algorithm.
+compression-formats = ["xz"]
+
+# Increase the compression ratio when building dist artifacts.
+#
+# If this configuration is missing or set to a different value, a different compression ration will
+# be used when creating tarballs.
+compression-profile = "balanced"
+
+
+
+[rust]
+# Remap debuginfo to `/rustc/{commit-sha}`.
+#
+# If this configuration is missing, the directory structure of the build machine will leak into the
+# resulting binaries, preventing reproducibility.
+remap-debuginfo = true
+
+# Include the lines table in the standard library's debuginfo.
+#
+# If this configuration is missing backtraces will not include file and line information for the
+# standard library, making it harder for end users to debug the cause of a panic.
+debuginfo-level-std = 1
+
+# Disable debug logging in the compiler, shrinking the binary size.
+#
+# If this configuration is missing all debug logging will be included in the compiler, which can
+# then be shown with the RUSTC_LOG environment variable.
+debug-logging = false
+
+# Enable debug assertions in the resulting compiler.
+#
+# If this configuration is missing Rust's debug assertions will be disabled, which could result in
+# compiler bugs or miscompilations not being detected. Never remove this flag.
+debug-assertions = true
+
+# Adds a custom string to the output of `rustc --version` to properly mark this is not the upstream
+# compiler.
+#
+# If this configuration is missing or changed the output of `rustc --version` will change
+# accordingly.
+description = "Ferrocene by Ferrous Systems"
+
+# Use a single codegen unit when compiling the standard library.
+#
+# Rust upstream had issues in the past [1] when compiling the standard library with more than 1
+# codegen unit. Compiling with more codegen units also prevents some optimizations. Never remove
+# this flag due to the risk of the standard library failing to build correctly.
+#
+# [1] https://github.com/rust-lang/rust/issues/83600
+codegen-units-std = 1
+
+# Enable LLVM IR verification. Verification has a small compiler performance hit, but has a chance
+# of catching compiler bugs.
+#
+# If this configuration is missing LLVM IR verification will be disabled. Never remove this flag.
+verify-llvm-ir = true
+
+# Enable only the LLVM codegen backend, preventing other codegen backends from being built and
+# shipped.
+#
+# If this configuration is missing we'll build all codegen backends built by upstream, which in the
+# future *might* include GCC.
+codegen-backends = ["llvm"]
+
+# Build and include LLD in the resulting compiler package.
+#
+# If this configuration is missing or changed, LLD will not be included.
+lld = true
+
+# Do not download pre-built rustc, build it from scratch.
+#
+# If this configuration is missing, a pre-built rustc will be downloaded, which might not match
+# exactly what would be built locally.
+download-rustc = false
+
+# Switches the compiler from the system allocator to jemalloc. Jemalloc is more performant compared
+# to the system allocator for the compiler workloads, speeding up the compilation process.
+#
+# If this configuration is missing the system allocator will be used, slowing down the compiler.
+jemalloc = true
+
+# Set the release channel for this build. Setting this to "auto-detect" will read the channel from
+# the `src/ci/channel` file, to easily allow tools and automations to know and update the current
+# channel.
+#
+# Changing the release channel to `nightly` enables unstable features, and it should not be done for
+# any supported build.
+channel = "auto-detect"
+
+
+
+[target]
+# Disable the profiler runtime for WASM. The profiler runtime depends on libc, which is not
+# available on WASM bare metal.
+#
+# If this configuration is missing, building the WASM target will fail.
+wasm32-unknown-unknown.profiler = false
+
+# The profiler runtime is not supported on QNX.
+aarch64-unknown-nto-qnx710.profiler = false
+x86_64-pc-nto-qnx710.profiler = false
+
+# Bare metal targets cannot run the profiler runtime.
+aarch64-unknown-ferrocenecoretest.profiler = false
+thumbv7em-ferrocenecoretest-eabi.profiler = false
+thumbv7em-ferrocenecoretest-eabihf.profiler = false
+
+# On Windows, Jemalloc is not tested, and manual testing suggests it is not supported.
+x86_64-pc-windows-msvc.jemalloc = false
+
+
+
+[ferrocene]
+# Set the Ferrocene channel for this build. Setting this to "auto-detect" will read the channel from
+# the `ferrocene/ci/channel` file, to easily allow tools and automations to know and update the
+# current channel.
+channel = "auto-detect"
+
+
+# Run the traceability matrix tool in CI mode, producing the correct links.
+#
+# If this configuration is missing the traceability matrix might not be properly enforced.
+traceability-matrix-mode = "ci"

--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -26,6 +26,7 @@ mod tests;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum Profile {
+    FerroceneDist,
     Compiler,
     Library,
     Tools,
@@ -43,12 +44,13 @@ impl Profile {
     pub fn all() -> impl Iterator<Item = Self> {
         use Profile::*;
         // N.B. these are ordered by how they are displayed, not alphabetically
-        [Library, Compiler, Tools, Dist, None].iter().copied()
+        [FerroceneDist, Library, Compiler, Tools, Dist, None].iter().copied()
     }
 
     pub fn purpose(&self) -> String {
         use Profile::*;
         match self {
+            FerroceneDist => "Build Ferrocene as it would be built by CI",
             Library => "Contribute to the standard library",
             Compiler => "Contribute to the compiler itself",
             Tools => "Contribute to tools which depend on the compiler, but do not modify it directly (e.g. rustdoc, clippy, miri)",
@@ -68,6 +70,7 @@ impl Profile {
 
     pub fn as_str(&self) -> &'static str {
         match self {
+            Profile::FerroceneDist => "ferrocene-dist",
             Profile::Compiler => "compiler",
             Profile::Library => "library",
             Profile::Tools => "tools",
@@ -171,6 +174,7 @@ impl Step for Profile {
 
 pub fn setup(config: &Config, profile: Profile) {
     let suggestions: &[&str] = match profile {
+        Profile::FerroceneDist => &["dist", "test"],
         Profile::Compiler | Profile::None => &["check", "build", "test"],
         Profile::Tools => &[
             "check",

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2314,6 +2314,13 @@ impl Config {
 
         if let Some(f) = toml.ferrocene {
             set(&mut config.ferrocene_raw_channel, f.channel);
+            if config.ferrocene_raw_channel == "auto-detect" {
+                let ci_channel = t!(fs::read_to_string(config.src.join("ferrocene/ci/channel")))
+                    .trim()
+                    .to_string();
+                config.ferrocene_raw_channel = ci_channel;
+            }
+
             config.ferrocene_traceability_matrix_mode = match f.traceability_matrix_mode.as_deref()
             {
                 Some("local") | None => FerroceneTraceabilityMatrixMode::Local,


### PR DESCRIPTION
Note: currently a draft as I needed to cherry-pick rust-lang/rust#137220 (it hasn't reached Ferrocene yet).

This PR moves most of the configuration for our CI away from `configure.sh` and into a bootstrap profile. With this change, all of the configuration about how a Ferrocene build should look like will reside in the profile, and `configure.sh` will only contain settings specific to our CI environment.

I also made a few changes:

* Added `ferrocene.channel = "auto-detect"` to load the channel from `ferrocene/ci/channel`. Before we were loading the contents of the file in the bash script, but that's not possible anymore. This mirrors the change we upstreamed in rust-lang/rust#137220.
* Added `FERROCENE_TEST_OUTCOMES_DIR` to load the test outcomes from a directory. Before this was done through the `RUST_CONFIGURE_ARGS`, but it was the only use of that environment variable. Adding `FERROCENE_TEST_OUTCOMES_DIR` removes the need to have `RUST_CONFIGURE_ARGS`.

For our CI nothing will change!

For our developers trying to reproduce CI failures locally, they will be able to set `profile = "ferrocene-dist"` at the top of their `config.toml` instead of running `configure.sh`. Note that this is not the recommended configuration to keep locally, the previous guidance of "don't use `configure.sh` day-to-day" applies to this profile as well.

For third parties building Ferrocene on their systems, instead of running `configure.sh` with the `OUTSIDE_FERROUS=1` environment variable, they'll be able to invoke `./configure --set profile=ferrocene-dist $their_flags_there`.