### PR TITLE
remove misleading edition args

### DIFF
--- a/tests/run-make/ferrocene/compiler-arguments/out-dir/rmake.rs
+++ b/tests/run-make/ferrocene/compiler-arguments/out-dir/rmake.rs
@@ -4,13 +4,7 @@ use run_make_support::{bare_rustc, target};
 
 fn main() {
     let out_dir = Path::new("out");
-    bare_rustc()
-        .edition("2021")
-        .target(target())
-        .crate_type("bin")
-        .input("main.rs")
-        .out_dir(&out_dir)
-        .run();
+    bare_rustc().target(target()).crate_type("bin").input("main.rs").out_dir(&out_dir).run();
 
     assert!(out_dir.is_dir());
     assert!(out_dir.join("main").is_file());

--- a/tests/run-make/ferrocene/compiler-arguments/upper_c_debuginfo/upper_c_debuginfo_multiple/rmake.rs
+++ b/tests/run-make/ferrocene/compiler-arguments/upper_c_debuginfo/upper_c_debuginfo_multiple/rmake.rs
@@ -14,29 +14,15 @@ fn main() {
 
     // Compile with a single debuginfo flag
     let debug_0 = out_dir.join("0");
-    rustc().edition("2021").target(target()).input("main.rs").debuginfo("0").output(&debug_0).run();
+    rustc().target(target()).input("main.rs").debuginfo("0").output(&debug_0).run();
     let debug_2 = out_dir.join("2");
-    rustc().edition("2021").target(target()).input("main.rs").debuginfo("2").output(&debug_2).run();
+    rustc().target(target()).input("main.rs").debuginfo("2").output(&debug_2).run();
 
     // Compile with multiple debuginfo flags
     let debug_02 = out_dir.join("02");
-    rustc()
-        .edition("2021")
-        .target(target())
-        .input("main.rs")
-        .debuginfo("0")
-        .debuginfo("2")
-        .output(&debug_02)
-        .run();
+    rustc().target(target()).input("main.rs").debuginfo("0").debuginfo("2").output(&debug_02).run();
     let debug_20 = out_dir.join("20");
-    rustc()
-        .edition("2021")
-        .target(target())
-        .input("main.rs")
-        .debuginfo("2")
-        .debuginfo("0")
-        .output(&debug_20)
-        .run();
+    rustc().target(target()).input("main.rs").debuginfo("2").debuginfo("0").output(&debug_20).run();
 
     // Compare build artifacts, they must be equal
     assert_eq!(rfs::read(&debug_2), rfs::read(&debug_02));

--- a/tests/run-make/ferrocene/compiler-arguments/upper_c_extra-filename/upper_c_extra-filename/rmake.rs
+++ b/tests/run-make/ferrocene/compiler-arguments/upper_c_extra-filename/upper_c_extra-filename/rmake.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use run_make_support::{rfs, rustc, target};
 
 fn main() {
-    rustc().edition("2021").target(target()).input("main.rs").extra_filename("foo").run();
+    rustc().target(target()).input("main.rs").extra_filename("foo").run();
 
     assert!(Path::new("mainfoo").is_file())
 }

--- a/tests/run-make/ferrocene/compiler-arguments/upper_c_extra-filename/upper_c_extra-filename_mir/rmake.rs
+++ b/tests/run-make/ferrocene/compiler-arguments/upper_c_extra-filename/upper_c_extra-filename_mir/rmake.rs
@@ -4,13 +4,7 @@ use run_make_support::{rfs, rustc, target};
 
 // Suffix is added before the extension
 fn main() {
-    rustc()
-        .edition("2021")
-        .target(target())
-        .emit("mir")
-        .input("main.rs")
-        .extra_filename("foo")
-        .run();
+    rustc().target(target()).emit("mir").input("main.rs").extra_filename("foo").run();
 
     assert!(Path::new("mainfoo.mir").is_file())
 }

--- a/tests/run-make/ferrocene/compiler-arguments/upper_c_extra-filename/upper_c_extra-filename_repeat/rmake.rs
+++ b/tests/run-make/ferrocene/compiler-arguments/upper_c_extra-filename/upper_c_extra-filename_repeat/rmake.rs
@@ -6,13 +6,7 @@ use std::path::Path;
 use run_make_support::{rustc, target};
 
 fn main() {
-    rustc()
-        .edition("2021")
-        .target(target())
-        .input("main.rs")
-        .extra_filename("foo")
-        .extra_filename("bar")
-        .run();
+    rustc().target(target()).input("main.rs").extra_filename("foo").extra_filename("bar").run();
     assert!(!Path::new("mainfoo").exists());
     assert!(Path::new("mainbar").is_file())
 }

--- a/tests/run-make/ferrocene/compiler-arguments/upper_c_link-arg/upper_c_link-arg/rmake.rs
+++ b/tests/run-make/ferrocene/compiler-arguments/upper_c_link-arg/upper_c_link-arg/rmake.rs
@@ -4,7 +4,6 @@ use run_make_support::{rustc, target};
 
 fn main() {
     rustc()
-        .edition("2021")
         .target(target())
         .link_arg("-lfoo")
         .print("link-args")

--- a/tests/run-make/ferrocene/compiler-arguments/upper_c_link-arg/upper_c_link-arg_multiple/rmake.rs
+++ b/tests/run-make/ferrocene/compiler-arguments/upper_c_link-arg/upper_c_link-arg_multiple/rmake.rs
@@ -4,7 +4,6 @@ use run_make_support::{rustc, target};
 
 fn main() {
     rustc()
-        .edition("2021")
         .target(target())
         .link_arg("-lfoo")
         .link_arg("-lbar")

--- a/tests/run-make/ferrocene/compiler-arguments/upper_c_no-vectorize-loops/rmake.rs
+++ b/tests/run-make/ferrocene/compiler-arguments/upper_c_no-vectorize-loops/rmake.rs
@@ -9,13 +9,11 @@ use run_make_support::{bare_rustc, rfs as fs};
 fn main() {
     let input = Path::new("example.rs");
     let output = input.with_extension("s");
-    let edition = "2021";
 
     let with = Path::new("out-dir-with");
     fs::create_dir(with);
     bare_rustc()
         .input(input)
-        .edition(edition)
         .crate_type("lib")
         .opt()
         .emit("asm")
@@ -26,14 +24,7 @@ fn main() {
 
     let without = Path::new("out-dir-without");
     fs::create_dir(without);
-    bare_rustc()
-        .input(input)
-        .edition(edition)
-        .crate_type("lib")
-        .opt()
-        .emit("asm")
-        .out_dir(without)
-        .run();
+    bare_rustc().input(input).crate_type("lib").opt().emit("asm").out_dir(without).run();
 
     assert_ne!(fs::read_to_string(with.join(&output)), fs::read_to_string(without.join(&output)))
 }


### PR DESCRIPTION
This should imply that the tests only run on the specified edition.