### PR TITLE
no need to specify library/coretests separately

### DIFF
--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -126,12 +126,7 @@ JOBS_DEFINITION: JobsDefinition = {
         # them in a separate job to reduce the CI wall clock time. Note that
         # stdlib tests are run in a separate job, as those require IPv6 and
         # thus can't be executed in containers due to CircleCI limitations.
-        "library": [
-            "library/core", # doc tests (tests/examples in doc comments)
-            "library/coretests", # unit tests (`#[test]` functions)
-            "library/alloc",
-            "library/test",
-        ],
+        "library": ["library/core", "library/alloc", "library/test"],
 
         # The standard library tests require IPv6, which is not available in
         # containers. Run them separately in a VM.


### PR DESCRIPTION
This was needed at the time, but has since been changed, such that './x test library/core' also tests library/coretests.

This reverts commit fd246937731fce6a7cc26aecf8ba78631084de03.