### PR TITLE
add complete copyright/licensing info to source tarball

### DIFF
--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -108,6 +108,7 @@ impl Step for SourceTarball {
             "README.md",
             "RELEASES.md",
             "REUSE.toml",
+            "TRADEMARK.md",
             "config.example.toml",
             "Cargo.toml",
             "Cargo.lock",

--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -12,6 +12,7 @@ use std::rc::Rc;
 use serde_json::json;
 
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
+use crate::core::build_steps::run::GenerateCopyright;
 use crate::core::config::TargetSelection;
 use crate::ferrocene::doc::ensure_all_xml_doctrees;
 use crate::ferrocene::test_outcomes::TestOutcomesDir;
@@ -117,6 +118,7 @@ impl Step for SourceTarball {
             "x.py",
             "x.ps1",
             ".gitmodules",
+            "license-metadata.json",
         ];
         const EXTRA_CARGO_TOMLS: &[&str] = &[
             "compiler/rustc_codegen_cranelift/Cargo.toml",
@@ -137,6 +139,14 @@ impl Step for SourceTarball {
         }
         for item in FILES {
             subsetter.add_file(&builder.src, &builder.src.join(item));
+        }
+
+        // Generate comprehensive copyright data and include the generated files in the tarball
+        for path in builder.ensure(GenerateCopyright) {
+            if !builder.config.dry_run() {
+                // First arg gets the file placed in the root of the tarball, instead of in build/
+                subsetter.add_file(path.parent().unwrap(), &path);
+            }
         }
 
         let generic_tarball = subsetter


### PR DESCRIPTION
Upstream recently added an automated way of generating copyright files (https://github.com/rust-lang/rust/pull/135588), so we also need to do similar, because we have a different way of generating release tarballs.