### PR TITLE
"x test library/core" now also tests "library/coretests"

### DIFF
--- a/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
+++ b/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
@@ -152,7 +152,7 @@ Currently bare metal targets have a similar procedure for testing.
     :target:`aarch64-apple-darwin` or :target:`x86_64-pc-windows-msvc` -- you **must** skip to the final step, running the tests using::
     
         export QEMU_CPU=cortex-a53
-        ./x test --stage 1 --target aarch64-unknown-ferrocenecoretest library/coretests
+        ./x test --stage 1 --target aarch64-unknown-ferrocenecoretest library/core
 
     Incorrectly configuring your :target:`aarch64-unknown-linux-gnu` environment using the other steps 
     will damage to the environment and result in "Too many levels of symbolic links" errors.
@@ -195,7 +195,7 @@ After, you can run the tests:
 .. code-block:: bash
 
     export QEMU_CPU=cortex-a53
-    ./x test --stage 1 --target aarch64-unknown-ferrocenecoretest library/coretests
+    ./x test --stage 1 --target aarch64-unknown-ferrocenecoretest library/core
 
 :target-with-triple:`thumbv7em-none-eabihf` & :target-with-triple:`thumbv7em-none-eabi`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -253,4 +253,4 @@ You can now run the tests:
 .. code-block:: bash
 
     export QEMU_CPU=cortex-m4
-    ./x test --stage 1 --target $TARGET library/coretests
+    ./x test --stage 1 --target $TARGET library/core


### PR DESCRIPTION
We previously changed to using `x test library/coretests` instead of `x test library/core` because unit tests were moved to a separate crate, "library/coretest". But later, a change was made so that `x test library/core` also tested unit tests in that crate.

One advantage of switching back to `x test library/core` is that doc tests are also executed.

(this should have been part of 8ae5c72a38d84d6e276ebe24196300637120bfe4)