### PR TITLE
remove support for Makefiles

### DIFF
--- a/ferrocene/tools/traceability-matrix/src/annotations.rs
+++ b/ferrocene/tools/traceability-matrix/src/annotations.rs
@@ -17,7 +17,6 @@ impl std::fmt::Display for AnnotatedFile {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.source {
             AnnotationSource::TestItself => write!(f, "{}", self.test.display()),
-            AnnotationSource::Makefile => write!(f, "{} (from its Makefile)", self.test.display()),
             AnnotationSource::Rmake => write!(f, "{} (from its rmake.rs)", self.test.display()),
             AnnotationSource::ParentDirectory { .. } => {
                 write!(f, "{} (from its parent directory)", self.test.display())
@@ -47,7 +46,6 @@ impl std::fmt::Display for DisplayCommaSeparatedSet {
 pub(crate) enum AnnotationSource {
     TestItself,
     ParentDirectory { bulk_file: PathBuf },
-    Makefile,
     Rmake,
 }
 
@@ -156,14 +154,12 @@ impl Annotations {
                     AnnotationSource::TestItself
                 } else if annotated_in_parent(annotation, file) {
                     AnnotationSource::ParentDirectory { bulk_file: shrink_path(&annotation.file) }
-                } else if annotation.file == file.file.join("Makefile") {
-                    AnnotationSource::Makefile
                 } else if annotation.file == file.file.join("rmake.rs") {
                     AnnotationSource::Rmake
                 } else {
                     anyhow::bail!(
                         "bug: annotation {annotation:?} doesn't come from the file itself, \
-                        its parent directory, or a Makefile. \
+                        its parent directory, or a rmake file. \
                         If you updated compiletest to accept annotations from other sources, \
                         you also need to update traceability-matrix."
                     );

--- a/ferrocene/tools/traceability-matrix/templates/report.html
+++ b/ferrocene/tools/traceability-matrix/templates/report.html
@@ -224,8 +224,6 @@
 {% endif %}
 {% match file.source %}
     {% when AnnotationSource::TestItself %}
-    {% when AnnotationSource::Makefile %}
-    (annotated in its <a href="{{ urls.src }}/{{ file.test.display() }}/Makefile">Makefile</a>)
     {% when AnnotationSource::Rmake %}
     (annotated in its <a href="{{ urls.src }}/{{ file.test.display() }}/rmake.rs">rmake.rs</a>)
     {% when AnnotationSource::ParentDirectory with { bulk_file } %}


### PR DESCRIPTION
The traceability matrix supports annotations being defined in a makefile (for run-make tests). Now that those tests have been removed, we should remove support for Makefiles in our tooling.