### PR TITLE
Fix `./x dist ferrocene-src`

### DIFF
--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "bootstrap"
 version = "0.0.0"
-# Ferrocene note:
-# Setting this to "2024" results in a `./x dist ferrocene-src` fail.
-edition = "2021"
+edition = "2024"
 build = "build.rs"
 default-run = "bootstrap"
 

--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -167,6 +167,8 @@ impl Step for SourceTarball {
         let mut vendor = Command::new(&builder.initial_cargo);
         vendor.arg("vendor").arg("vendor/rust").current_dir(&dest_dir);
         vendor.env("RUSTC_BOOTSTRAP", "1"); // std's Cargo.toml uses unstable features
+        // Resolver 3 needs the `rustc` binary to fetch the compiler version
+        vendor.env("RUSTC", &builder.initial_rustc);
         for extra in EXTRA_CARGO_TOMLS {
             vendor.arg("--sync").arg(&builder.src.join(extra));
         }


### PR DESCRIPTION
This reverts commit 210ca50f4b5f12f6f417e6e29f63aef50be7ef07 and adds a permanent fix to the panic when distributing `ferrocene-src`.

This panic happened because the 2024 edition uses the 3 resolver which is version aware and requires the `rustc` binary to fetch the compiler version.

To fix it, we replicate 61339997194448cd8b18b422f32ced0126963213 in ferrocene's `dist` script.
