### PR TITLE
include copyright files in docs

### DIFF
--- a/ferrocene/doc/index/index.html
+++ b/ferrocene/doc/index/index.html
@@ -166,6 +166,22 @@
                     </a>
                 </div>
             </section>
+            <section>
+                <h2>Licensing and copyrights</h2>
+                <p class="note">These files contain licensing and copyright information for all files distributed with Ferrocene.</p>
+                <div class="docs">
+                    <a href="COPYRIGHT.html">
+                        <h3>Ferrocene codebase</h3>
+                        <p>Open source licenses for the Ferrocene toolchain, for the tools used to develop it, and for the accompanying documentation.</p>
+                    </a>
+                    <a href="COPYRIGHT-library.html">
+                        <h3>Standard library</h3>
+                        <p>
+                            Open source licenses used by the runtime libraries (<b>core</b>, <b>alloc</b>, <b>std</b>) the compiler includes in executables it creates.
+                            All binaries produced by Ferrocene must comply with these licenses.</p>
+                    </a>
+                </div>
+            </section>
         </div>
     </body>
 </body>

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1071,6 +1071,7 @@ impl<'a> Builder<'a> {
                 doc::StyleGuide,
                 doc::Tidy,
                 crate::ferrocene::doc::AllSphinxDocuments,
+                crate::ferrocene::doc::CopyrightFiles,
                 // Basic Documents
                 crate::ferrocene::doc::Index,
                 crate::ferrocene::doc::Specification,

--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -48,6 +48,14 @@ impl Step for Docs {
         let mut subsetter = Subsetter::new(builder, "ferrocene-docs", "share/doc/ferrocene/html");
         subsetter.add_directory(&doc_out, &doc_out);
 
+        // Generate comprehensive copyright data and include the generated files in the tarball
+        for path in builder.ensure(GenerateCopyright) {
+            if !builder.config.dry_run() {
+                // First arg gets the file placed in the root of the tarball, instead of in build/
+                subsetter.add_file(path.parent().unwrap(), &path);
+            }
+        }
+
         subsetter.into_tarballs().map(|tarball| tarball.generate()).collect()
     }
 }

--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -26,6 +26,16 @@ pub(crate) struct Docs {
     pub(crate) target: TargetSelection,
 }
 
+// Generate comprehensive copyright data, and include the generated files in the tarball
+fn add_copyright_files(subsetter: &mut Subsetter<'_>, builder: &Builder<'_>) {
+    for path in builder.ensure(GenerateCopyright) {
+        if !builder.config.dry_run() {
+            // First arg gets the file placed in the root of the tarball, instead of in build/
+            subsetter.add_file(path.parent().unwrap(), &path);
+        }
+    }
+}
+
 impl Step for Docs {
     type Output = Vec<GeneratedTarball>;
     const DEFAULT: bool = true;
@@ -47,14 +57,7 @@ impl Step for Docs {
 
         let mut subsetter = Subsetter::new(builder, "ferrocene-docs", "share/doc/ferrocene/html");
         subsetter.add_directory(&doc_out, &doc_out);
-
-        // Generate comprehensive copyright data and include the generated files in the tarball
-        for path in builder.ensure(GenerateCopyright) {
-            if !builder.config.dry_run() {
-                // First arg gets the file placed in the root of the tarball, instead of in build/
-                subsetter.add_file(path.parent().unwrap(), &path);
-            }
-        }
+        add_copyright_files(&mut subsetter, &builder);
 
         subsetter.into_tarballs().map(|tarball| tarball.generate()).collect()
     }
@@ -149,14 +152,7 @@ impl Step for SourceTarball {
         for item in FILES {
             subsetter.add_file(&builder.src, &builder.src.join(item));
         }
-
-        // Generate comprehensive copyright data and include the generated files in the tarball
-        for path in builder.ensure(GenerateCopyright) {
-            if !builder.config.dry_run() {
-                // First arg gets the file placed in the root of the tarball, instead of in build/
-                subsetter.add_file(path.parent().unwrap(), &path);
-            }
-        }
+        add_copyright_files(&mut subsetter, &builder);
 
         let generic_tarball = subsetter
             .tarballs

--- a/src/bootstrap/src/ferrocene/doc/mod.rs
+++ b/src/bootstrap/src/ferrocene/doc/mod.rs
@@ -8,13 +8,14 @@ use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::{Path, PathBuf, absolute};
 
-use crate::FileType;
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
+use crate::core::build_steps::run::GenerateCopyright;
 use crate::core::config::TargetSelection;
 use crate::ferrocene::sign::signature_files::CacheSignatureFiles;
 use crate::ferrocene::test_outcomes::TestOutcomesDir;
 use crate::ferrocene::uv_command;
 use crate::utils::exec::BootstrapCommand;
+use crate::{FileType, t};
 
 pub(crate) trait IsSphinxBook {
     const SOURCE: &'static str;
@@ -780,6 +781,40 @@ impl Step for TraceabilityMatrix {
 
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         builder.ensure(crate::ferrocene::run::TraceabilityMatrix { target: self.target });
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub(crate) struct CopyrightFiles {
+    target: TargetSelection,
+}
+
+impl Step for CopyrightFiles {
+    type Output = ();
+    const DEFAULT: bool = true;
+    const ONLY_HOSTS: bool = false;
+
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+        run.alias("copyright-files")
+    }
+
+    fn make_run(run: RunConfig<'_>) {
+        run.builder.ensure(Self { target: run.target });
+    }
+
+    fn run(self, builder: &Builder<'_>) -> Self::Output {
+        for path in builder.ensure(GenerateCopyright) {
+            if !builder.config.dry_run() {
+                t!(fs::copy(
+                    &path,
+                    builder
+                        .out
+                        .join(self.target.triple)
+                        .join("doc")
+                        .join(&path.file_name().unwrap()),
+                ));
+            }
+        }
     }
 }
 


### PR DESCRIPTION
this pr has 2 main purposes
- adds copyright files to the doc tarball
- references the copyright files from Ferrocene docs index

context:
- at the moment, we only include copyright files in the ferrocene source tarball
- this pr is a convenience that lets users view the copyright files without having to first download and extract the source tarball

[internal ticket](https://app.clickup.com/t/8697wq828)