### PR TITLE
replace wrong/inconsistent copyright assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
-<!-- SPDX-FileCopyrightText: Ferrous Systems GmbH -->
+<!-- SPDX-FileCopyrightText: The Ferrocene Developers -->
 
 <br>
 <p align="center">

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: CC-BY-3.0 -->
 <!-- SPDX-FileCopyrightText: Model Trademark Guidelines authors -->
 <!-- SPDX-FileCopyrightText: System Initiative -->
-<!-- SPDX-FileCopyrightText: Ferrous Systems GmbH -->
+<!-- SPDX-FileCopyrightText: The Ferrocene Developers -->
 
 # Trademark Policy
 


### PR DESCRIPTION
All open source Ferrocene work assigns copyright to "The Ferrocene Developers", but we had some files that assigns it to "Ferrous Systems GmbH".
This is also not accurate in that Ferrocene contributions are at times external to Ferrous Systems.

[internal ticket](https://app.clickup.com/t/86949v552)