### PR TITLE
Don't add coretests to core when testing crates individually

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2760,15 +2760,20 @@ impl Step for Crate {
         }
 
         let mut crates = self.crates.clone();
-        // The core and alloc crates can't directly be tested. We
-        // could silently ignore them, but adding their own test
-        // crates is less confusing for users. We still keep core and
-        // alloc themself for doctests
-        if crates.iter().any(|crate_| crate_ == "core") {
-            crates.push("coretests".to_owned());
-        }
-        if crates.iter().any(|crate_| crate_ == "alloc") {
-            crates.push("alloctests".to_owned());
+        // When the --ferrocene-test-one-crate-per-cargo-call flag is passed, we don't want multiple
+        // crates to be tested at the same time. The flag is only used in CI, where all crates are
+        // tested anyway, so there is no need to add coretests when testing core.
+        if !builder.config.cmd.ferrocene_test_one_crate_per_cargo_call() {
+            // The core and alloc crates can't directly be tested. We
+            // could silently ignore them, but adding their own test
+            // crates is less confusing for users. We still keep core and
+            // alloc themself for doctests
+            if crates.iter().any(|crate_| crate_ == "core") {
+                crates.push("coretests".to_owned());
+            }
+            if crates.iter().any(|crate_| crate_ == "alloc") {
+                crates.push("alloctests".to_owned());
+            }
         }
 
         run_cargo_test(cargo, &[], &crates, &*crate_description(&self.crates), target, builder);


### PR DESCRIPTION
In CI we pass the `--ferrocene-test-one-crate-per-cargo-call` flag to ensure each crate shows up as a separate line in our qualification report, but a recent upstream change broke it:

![image](https://github.com/user-attachments/assets/a9824433-7dd1-45d4-9642-493486c46c4a)

Since core's test suite is split between core and coretests (and the alloc test suite is split between alloc and alloctests), upstream recently changed bootstrap to run both core and coretests when testing `library/core`. This is done *after* our implementation of `--ferrocene-test-one-crate-per-cargo-call`, which would result in coretests and alloctests being executed twice.

This PR fixes the problem by suppressing the implicit addition of coretests and alloctests when the flag is passed. They will still be tested standalone.