### PR TITLE
Add testing categories to the CLI docs

### DIFF
--- a/ferrocene/doc/evaluation-report/src/rustc/method.rst
+++ b/ferrocene/doc/evaluation-report/src/rustc/method.rst
@@ -105,3 +105,31 @@ directory, and executes the ``ferrocene-self-test`` tool on it. The tool
 ensures that packages contain the correct files, that files are installed in
 the correct places, and that the installed toolchain can successfully compile a
 small number of example programs.
+
+.. _rustc-cli-testing-categories:
+
+Compiler arguments affecting the compilation outcome
+----------------------------------------------------
+
+The compiler supports :doc:`multiple command-line arguments
+<user-manual:rustc/cli>` affecting its behavior. Not all of them affect the
+compilation process the same way, so different testing strategies are required.
+For the purpose of testing, we categorize command-line arguments in:
+
+- **Informational:** these arguments do not affect the compilation process, but
+  instead configure the compiler to output information. An example of such
+  arguments is ``--version``, showing the compiler version number.
+
+- **Narrow impact:** these arguments do affect the compilation process, but
+  their effect is narrow and well scoped, and they can be tested independently.
+  An example is ``-C debuginfo``, to configure the compiler to emit debug
+  information alongside executable code.
+
+- **Wide impact:** these arguments affect the compilation process, and their
+  effects can influence all parts of the compilation process. An example is ``-C
+  opt-level``, to configure the code generation optimization level.
+
+For informational and narrow impact arguments it is sufficient to add tests in
+the test suite verifying their effects. For wide impact arguments, since every
+test could be affected by them, we deem it necessary to re-execute every test
+suite with each combination of wide impact argument values.

--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_domain_cli/domain.py
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_domain_cli/domain.py
@@ -32,8 +32,12 @@ UNQUALIFIED_MESSAGE = (
     "safety critical context. Its documentation is presented for your convenience."
 )
 
-
 CATEGORIES_TARGET_REF = "evaluation-report:rustc-cli-testing-categories"
+
+
+ARGUMENT_PLACEHOLDER_RE = re.compile(r"(<[^>]+>|\[[^\]]+\])")
+MULTIPLE_UNDERSCORES_RE = re.compile(r"__+")
+ALLOWED_CHARS_IN_OPTION_ID = string.ascii_letters + string.digits + "_"
 
 
 @dataclass
@@ -78,9 +82,21 @@ class OptionDirective(ObjectDescription):
     option_spec = {"category": directives.unchanged}
 
     def handle_signature(self, sig, signode):
-        name = addnodes.desc_name("", sig)
+        name = addnodes.desc_name()
         name["classes"].append("inline-code")
         name["classes"].append("ferrocene-cli-title")
+
+        # When the regex is wrapped in parentheses, split returns a list alternating text not
+        # matching the regex and text matching the regex.
+        is_argument = False
+        for part in ARGUMENT_PLACEHOLDER_RE.split(sig):
+            if is_argument:
+                name += nodes.emphasis("", part)
+                is_argument = False
+            else:
+                name += nodes.Text(part)
+                is_argument = True
+
         signode += name
 
     def transform_content(self, content_node):
@@ -144,11 +160,6 @@ class OptionDirective(ObjectDescription):
             return ProgramStorage("PLACEHOLDER", False)
         else:
             return self.env.temp_data[PROGRAM_STORAGE]
-
-
-ARGUMENT_PLACEHOLDER_RE = re.compile(r"(<[^>]+>|\[[^\]]+\])")
-MULTIPLE_UNDERSCORES_RE = re.compile(r"__+")
-ALLOWED_CHARS_IN_OPTION_ID = string.ascii_letters + string.digits + "_"
 
 
 @dataclass

--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_domain_cli/domain.py
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_domain_cli/domain.py
@@ -78,7 +78,10 @@ class OptionDirective(ObjectDescription):
     option_spec = {"category": directives.unchanged}
 
     def handle_signature(self, sig, signode):
-        signode += addnodes.desc_name("", sig)
+        name = addnodes.desc_name("", sig)
+        name["classes"].append("inline-code")
+        name["classes"].append("ferrocene-cli-title")
+        signode += name
 
     def transform_content(self, content_node):
         category = None

--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_domain_cli/domain.py
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_domain_cli/domain.py
@@ -27,6 +27,11 @@ ALLOWED_CATEGORIES = {
     "unqualified": "not qualified",
 }
 
+UNQUALIFIED_MESSAGE = (
+    "This argument is outside the scope of the Ferrocene qualification, and must not be used in a "
+    "safety critical context. Its documentation is presented for your convenience."
+)
+
 
 CATEGORIES_TARGET_REF = "evaluation-report:rustc-cli-testing-categories"
 
@@ -80,7 +85,12 @@ class OptionDirective(ObjectDescription):
         if self._program_storage().qualified and self.options["category"] in ALLOWED_CATEGORIES:
             category = self.options["category"]
 
-        if category is not None:
+        if category == "unqualified":
+            caution = nodes.caution()
+            caution += nodes.paragraph("", UNQUALIFIED_MESSAGE)
+            content_node.insert(0, caution)
+
+        if category is not None and category != "unqualified":
             xref = addnodes.pending_xref()
             xref["reftype"] = "ref"
             xref["refdomain"] = "std"

--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_theme/static/ferrocene.css
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_theme/static/ferrocene.css
@@ -277,7 +277,7 @@ pre {
     overflow-y: scroll;
 }
 
-code {
+code, .inline-code {
     display: inline-block;
     background: var(--inline-code-bg);
     padding: 0 0.2em;
@@ -773,6 +773,16 @@ pre.spec-syntax .spec-syntax-literal {
     font-weight: 700;
     background: var(--spec-syntax-literal-bg);
     border-radius: 0.2em;
+}
+
+/****************************
+ *   Ferrocene CLI domain   *
+ ****************************/
+
+.ferrocene-cli-title {
+    font-size: 1.25em;
+    margin-top: 1.5em;
+    margin-bottom: 0.2em;
 }
 
 /********+***********

--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_theme/static/ferrocene.css
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_theme/static/ferrocene.css
@@ -785,6 +785,10 @@ pre.spec-syntax .spec-syntax-literal {
     margin-bottom: 0.2em;
 }
 
+.ferrocene-cli-title em {
+    font-weight: 400;
+}
+
 /********+***********
  *   sphinx-needs   *
  ********************/

--- a/ferrocene/doc/user-manual/src/rustc/cli.rst
+++ b/ferrocene/doc/user-manual/src/rustc/cli.rst
@@ -34,12 +34,6 @@
 
          $ rustc -A warnings -A absolute-paths-not-starting-with-crate
 
-   .. cli:option:: -C
-      :category: narrow
-
-      Compiler argument ``-C`` customizes code generation. The compiler
-      argument must be followed by at least one code generation option.
-
    .. cli:option:: -C codegen-units=<number>
       :category: narrow
 
@@ -596,11 +590,6 @@
       attribute ``#[cfg(key = "value")]``.
 
       Multiple ``--cfg`` compiler arguments are allowed on the command line.
-
-   .. cli:option:: --codegen
-      :category: narrow
-
-      Compiler argument ``--codegen`` is identical to compiler argument ``-C``.
 
    .. cli:option:: --color <option>
       :category: informational

--- a/ferrocene/doc/user-manual/src/rustc/cli.rst
+++ b/ferrocene/doc/user-manual/src/rustc/cli.rst
@@ -133,12 +133,6 @@
    .. cli:option:: -C llvm-args=<args>
       :category: unqualified
 
-      .. caution::
-
-         This code generation option is outside the scope of the Ferrocene
-         qualification, and must not be used in a safety critical
-         context. Its documentation is presented for your convenience.
-
       Code generation option ``llvm-args`` can be used to pass a list of arguments
       directly to LLVM.
       The list must be separated by spaces.
@@ -324,12 +318,6 @@
    .. cli:option:: -C no-vectorize-loops
       :category: unqualified
 
-      .. caution::
-
-         This code generation option is outside the scope of the Ferrocene
-         qualification, and must not be used in a safety critical
-         context. Its documentation is presented for your convenience.
-
       Code generation option ``no-vectorize-loops`` disables loop
       vectorization.
 
@@ -457,13 +445,7 @@
       command line, where precedence increases from left to right.
 
    .. cli:option:: -C relocation-model=<model>
-      :category: narrow
-
-      .. caution::
-
-         This code generation option is outside the scope of the Ferrocene
-         qualification, and must not be used in a safety critical
-         context. Its documentation is presented for your convenience.
+      :category: unqualified
 
       Code generation option ``relocation-model`` enables the generation of
       position-independent code.
@@ -504,12 +486,6 @@
    .. cli:option:: -C target-cpu=<cpu>
       :category: unqualified
 
-      .. caution::
-
-         This code generation option is outside the scope of the Ferrocene
-         qualification, and must not be used in a safety critical
-         context. Its documentation is presented for your convenience.
-
       Code generation option ``target-cpu`` indicates the CPU of the target to
       generate code for.
 
@@ -527,12 +503,6 @@
 
    .. cli:option:: -C target-feature=<features>
       :category: unqualified
-
-      .. caution::
-
-         This code generation option is outside the scope of the Ferrocene
-         qualification, and must not be used in a safety critical
-         context. Its documentation is presented for your convenience.
 
       Code generation option ``target-feature`` enables (or disables) a
       feature of the target.

--- a/ferrocene/doc/user-manual/src/rustc/cli.rst
+++ b/ferrocene/doc/user-manual/src/rustc/cli.rst
@@ -7,6 +7,7 @@
 .. cli:program:: rustc
 
    .. cli:option:: -A <lints>
+      :category: narrow
 
       Compiler argument ``-A`` indicates which lints are suppressed. A
       suppressed lint is never checked and does not emit a diagnostic.
@@ -34,11 +35,13 @@
          $ rustc -A warnings -A absolute-paths-not-starting-with-crate
 
    .. cli:option:: -C
+      :category: narrow
 
       Compiler argument ``-C`` customizes code generation. The compiler
       argument must be followed by at least one code generation option.
 
    .. cli:option:: -C codegen-units=<number>
+      :category: narrow
 
       Code generation option ``codegen-units`` instructs the compiler to
       split the crate being compiled into multiple units. This may increase
@@ -56,6 +59,7 @@
       command line, where precedence increases from left to right.
 
    .. cli:option:: -C debug-assertions=<flag>
+      :category: narrow
 
       Code generation option ``debug-assertions`` enables (or disables)
       conditional compilation that is predicated on attribute
@@ -83,6 +87,7 @@
       command line, where precedence increases from left to right.
 
    .. cli:option:: -C debuginfo=<level>
+      :category: narrow
 
       Code generation option ``debuginfo`` indicates the level of detail of
       the debug information produced by the compiler.
@@ -109,6 +114,7 @@
       line, where precedence increases from left to right.
 
    .. cli:option:: -C extra-filename=<suffix>
+      :category: narrow
 
       Code generation option ``extra-filename`` appends a suffix to the name
       of each output file.
@@ -125,6 +131,7 @@
       command line, where precedence increases from left to right.
 
    .. cli:option:: -C llvm-args=<args>
+      :category: unqualified
 
       .. caution::
 
@@ -143,6 +150,7 @@
          $ rustc -C llvm-args=--inline-threshold=123 my_program.rs
 
    .. cli:option:: -C link-arg=<arg>
+      :category: wide
 
       .. caution::
 
@@ -168,6 +176,7 @@
       line.
 
    .. cli:option:: -C link-args=<args>
+      :category: wide
 
       .. caution::
 
@@ -194,6 +203,7 @@
       line.
 
    .. cli:option:: -C link-dead-code=<flag>
+      :category: narrow
 
       Code generation option ``link-dead-code`` indicates whether dead code
       is linked.
@@ -220,6 +230,7 @@
       command line, where precedence increases from left to right.
 
    .. cli:option:: -C linker=<path>
+      :category: wide
 
       .. caution::
 
@@ -243,6 +254,7 @@
       line, where precedence increases from left to right.
 
    .. cli:option:: -C linker-flavor=<flavor>
+      :category: wide
 
       .. caution::
 
@@ -292,6 +304,7 @@
       command line.
 
    .. cli:option:: -C metadata=<data>
+      :category: narrow
 
       Code generation option ``metadata`` enhances symbol mangling by supplying
       additional data used in the hashed suffixes of symbols.
@@ -309,6 +322,7 @@
       line, where precedence increases from left to right.
 
    .. cli:option:: -C no-vectorize-loops
+      :category: unqualified
 
       .. caution::
 
@@ -329,6 +343,7 @@
       the command line, where precedence increases from left to right.
 
    .. cli:option:: -C opt-level=<level>
+      :category: wide
 
       .. caution::
 
@@ -361,6 +376,7 @@
       line, where precedence increases from left to right.
 
    .. cli:option:: -C overflow-checks=<flag>
+      :category: narrow
 
       Code generation option ``overflow-checks`` enables (or disables)
       checks on runtime integer overflow. If overflow checks are enabled
@@ -388,6 +404,7 @@
       command line, where precedence increases from left to right.
 
    .. cli:option:: -C panic=<behavior>
+      :category: narrow
 
       Code generation option ``panic`` indicates the behavior of panics.
 
@@ -412,6 +429,7 @@
       line, where precedence increases from left to right.
 
    .. cli:option:: -C prefer-dynamic=<flag>
+      :category: narrow
 
       Code generation option ``prefer-dynamic`` indicates whether dynamic
       linking is preferable when both a static and a dynamic version of a
@@ -439,6 +457,7 @@
       command line, where precedence increases from left to right.
 
    .. cli:option:: -C relocation-model=<model>
+      :category: narrow
 
       .. caution::
 
@@ -455,6 +474,7 @@
       command line, where precedence increases from left to right.
 
    .. cli:option:: -C rpath=<flag>
+      :category: narrow
 
       Code generation option ``rpath`` indicates whether the run-time search
       path is enabled (or disabled).
@@ -482,6 +502,7 @@
       line, where precedence increases from left to right.
 
    .. cli:option:: -C target-cpu=<cpu>
+      :category: unqualified
 
       .. caution::
 
@@ -505,6 +526,7 @@
       command line, where precedence increases from left to right.
 
    .. cli:option:: -C target-feature=<features>
+      :category: unqualified
 
       .. caution::
 
@@ -548,6 +570,7 @@
       command line.
 
    .. cli:option:: --cap-lints <level>
+      :category: narrow
 
       Compiler argument ``--cap-lints`` indicates the overall diagnostic level
       of all lints.
@@ -581,6 +604,7 @@
       line.
 
    .. cli:option:: --cfg <option>
+      :category: narrow
 
       Compiler argument ``--cfg`` specifies conditional compilation option
       keys and values.
@@ -604,10 +628,12 @@
       Multiple ``--cfg`` compiler arguments are allowed on the command line.
 
    .. cli:option:: --codegen
+      :category: narrow
 
       Compiler argument ``--codegen`` is identical to compiler argument ``-C``.
 
    .. cli:option:: --color <option>
+      :category: informational
 
       Compiler argument ``--color`` sets the color of the output.
 
@@ -633,6 +659,7 @@
       Only one ``--color`` compiler argument is allowed on the command line.
 
    .. cli:option:: --crate-name <name>
+      :category: narrow
 
       Compiler argument ``--crate-name`` specifies the name of the crate to
       build.
@@ -652,6 +679,7 @@
       line.
 
    .. cli:option:: --crate-type <types>
+      :category: narrow
 
       .. caution::
 
@@ -696,6 +724,7 @@
          $ rustc --crate-type dylib --crate-type rlib my_library.rs
 
    .. cli:option:: -D <lints>
+      :category: narrow
 
       Compiler argument ``-D`` indicates which lints emit their diagnostics as
       errors. This compiler argument may be used to treat warnings as errors.
@@ -724,6 +753,7 @@
          $ rustc -D warnings -D absolute-paths-not-starting-with-crate
 
    .. cli:option:: --edition <edition>
+      :category: wide
 
       .. caution::
 
@@ -745,6 +775,7 @@
       Only one ``--edition`` compiler argument is allowed on the command line.
 
    .. cli:option:: --emit <kinds>
+      :category: narrow
 
       Compiler argument ``--emit`` indicates which kind of output to emit.
 
@@ -778,6 +809,7 @@
          $ rustc --emit dep-info --emit metadata my_program.rs
 
    .. cli:option:: --error-format <kind>
+      :category: informational
 
       Indicate which kind of error format to use.
 
@@ -807,6 +839,7 @@
       line.
 
    .. cli:option:: --explain <code>
+      :category: informational
 
       Compiler argument ``--explain`` outputs a verbose explanation of an error
       denoted by a code.
@@ -823,6 +856,7 @@
       Only one ``--explain`` compiler argument is allowed on the command line.
 
    .. cli:option:: --extern <details>
+      :category: narrow
 
       Compiler argument ``--extern`` indicates the name and location of an
       external crate. The crate is added to the external prelude, and will
@@ -866,6 +900,7 @@
                  my_program.rs
 
    .. cli:option:: -F <lints>
+      :category: narrow
 
       Compiler argument ``-F`` indicates which lints always emit their
       diagnostics as errors, regardless of whether other lint-related compiler
@@ -895,15 +930,18 @@
          $ rustc -F warnings -F absolute-paths-not-starting-with-crate
 
    .. cli:option:: -g
+      :category: narrow
 
       Compiler argument ``-g`` is identical to compiler argument
       ``-C debuginfo=2``.
 
    .. cli:option:: -h
+      :category: informational
 
       Compiler option ``-h`` is identical to compiler argument ``--help``.
 
    .. cli:option:: --help
+      :category: informational
 
       Compiler argument ``--help`` emits usage and help information.
 
@@ -914,6 +952,7 @@
          $ rustc -help
 
    .. cli:option:: --json <format>
+      :category: informational
 
       Compiler argument ``--json`` indicates the format of the JSON output when
       compiler argument ``--error-format json`` is in effect.
@@ -944,6 +983,7 @@
       Only one ``--json`` compiler argument is allowed on the command line.
 
    .. cli:option:: -L <details>
+      :category: narrow
 
       Compiler argument ``-L`` indicates the kind and location of a search
       path.
@@ -980,6 +1020,7 @@
          $ rust -L libraries -L native=include/c_libraries my_program.rs
 
    .. cli:option:: -l <details>
+      :category: narrow
 
       Compiler argument ``-l`` indicates a native library to link.
 
@@ -1057,11 +1098,13 @@
          $ rustc -l static+bundle=mine:libmy_static_library my_program.rs
 
    .. cli:option:: -O
+      :category: wide
 
       Compiler argument ``-O`` is identical to compiler argument
       ``-C opt-level=2``.
 
    .. cli:option:: -o <name>
+      :category: narrow
 
       Compiler argument ``-o`` indicates the name of the compilation output
       file.
@@ -1080,6 +1123,7 @@
       Only one ``-o`` compiler argument is allowed on the command line.
 
    .. cli:option:: --out-dir <directory>
+      :category: narrow
 
       Compiler argument ``--out-dir`` indicates the output directory.
 
@@ -1098,6 +1142,7 @@
       Only one ``--out-dir`` compiler argument is allowed on the command line.
 
    .. cli:option:: --print <option>
+      :category: informational
 
       Compiler argument ``--print`` emits information about the compiler.
 
@@ -1129,6 +1174,7 @@
       Multiple ``--print`` compiler arguments are allowed on the command line.
 
    .. cli:option:: --remap-path-prefix <from>=<to>
+      :category: narrow
 
       Remap source path prefixes in all output.
       Compiler argument ``--remap-path-prefix`` causes path prefixes in all
@@ -1149,6 +1195,7 @@
       command line.
 
    .. cli:option:: --sysroot
+      :category: narrow
 
       Compiler option ``--sysroot`` indicates the compiler installation root.
 
@@ -1161,6 +1208,7 @@
       Only one ``--sysroot`` compiler argument is allowed on the command line.
 
    .. cli:option:: --target <target>
+      :category: wide
 
       Compiler argument ``--target`` indicates the target triple to build.
 
@@ -1175,6 +1223,7 @@
       Only one ``--target`` compiler argument is allowed on the command line.
 
    .. cli:option:: --test
+      :category: narrow
 
       Compiler argument ``--test`` builds a test harness in the form of an
       executable binary.
@@ -1188,14 +1237,17 @@
       Only one ``--test`` compiler argument is allowed on the command line.
 
    .. cli:option:: -V
+      :category: informational
 
       Compiler argument ``-V`` is identical to compiler argument ``--version``.
 
    .. cli:option:: -v
+      :category: informational
 
       Compiler argument ``-v`` is identical to compiler argument ``--verbose``.
 
    .. cli:option:: --verbose
+      :category: informational
 
       Compiler argument ``--verbose`` emits verbose output.
 
@@ -1208,6 +1260,7 @@
       Only one ``--verbose`` compiler argument is allowed on the command line.
 
    .. cli:option:: --version
+      :category: informational
 
       Compiler argument ``--version`` emits the compiler version.
 
@@ -1220,6 +1273,7 @@
       Only one ``--version`` compiler argument is allowed on the command line.
 
    .. cli:option:: -W <lints>
+      :category: narrow
 
       Compiler argument ``-W`` indicates which lints emit their diagnostics as
       warnings. This compiler argument may be used to treat errors as warnings.

--- a/ferrocene/doc/user-manual/src/rustfmt/cli.rst
+++ b/ferrocene/doc/user-manual/src/rustfmt/cli.rst
@@ -5,7 +5,7 @@
 ==================================
 
 .. cli:program:: rustfmt
-   :no_traceability_matrix:
+   :not_qualified:
 
    .. cli:option:: --check
 

--- a/tests/ui/ferrocene/compiler-arguments/codegen/codegen_C.rs
+++ b/tests/ui/ferrocene/compiler-arguments/codegen/codegen_C.rs
@@ -1,7 +1,0 @@
-//@ check-fail
-//@ compile-flags: --codegen -C
-//~? unknown codegen option
-
-fn main() {}
-
-// ferrocene-annotations: um_rustc_codegen

--- a/tests/ui/ferrocene/compiler-arguments/codegen/codegen_C.stderr
+++ b/tests/ui/ferrocene/compiler-arguments/codegen/codegen_C.stderr
@@ -1,2 +1,0 @@
-error: unknown codegen option: `-C`
-

--- a/tests/ui/ferrocene/compiler-arguments/codegen/codegen_bad-syntax.rs
+++ b/tests/ui/ferrocene/compiler-arguments/codegen/codegen_bad-syntax.rs
@@ -1,4 +1,0 @@
-//@ check-fail
-//@ compile-flags: -codegen
-
-fn main() {}

--- a/tests/ui/ferrocene/compiler-arguments/codegen/codegen_bad-syntax.stderr
+++ b/tests/ui/ferrocene/compiler-arguments/codegen/codegen_bad-syntax.stderr
@@ -1,2 +1,0 @@
-error: Unrecognized option: 'c'
-

--- a/tests/ui/ferrocene/compiler-arguments/codegen/codegen_codegen.rs
+++ b/tests/ui/ferrocene/compiler-arguments/codegen/codegen_codegen.rs
@@ -1,7 +1,0 @@
-//@ check-fail
-//@ compile-flags: --codegen --codegen
-//~? unknown codegen option
-
-fn main() {}
-
-// ferrocene-annotations: um_rustc_codegen

--- a/tests/ui/ferrocene/compiler-arguments/codegen/codegen_codegen.stderr
+++ b/tests/ui/ferrocene/compiler-arguments/codegen/codegen_codegen.stderr
@@ -1,2 +1,0 @@
-error: unknown codegen option: `--codegen`
-

--- a/tests/ui/ferrocene/compiler-arguments/codegen/codegen_no-option.rs
+++ b/tests/ui/ferrocene/compiler-arguments/codegen/codegen_no-option.rs
@@ -1,6 +1,0 @@
-//@ check-fail
-//@ compile-flags: --codegen
-
-fn main() {}
-
-// ferrocene-annotations: um_rustc_codegen

--- a/tests/ui/ferrocene/compiler-arguments/codegen/codegen_no-option.stderr
+++ b/tests/ui/ferrocene/compiler-arguments/codegen/codegen_no-option.stderr
@@ -1,5 +1,0 @@
-error: Argument to option 'codegen' missing
-       Usage:
-           -C, --codegen OPT[=VALUE]
-                               Set a codegen option
-

--- a/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c.rs
+++ b/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c.rs
@@ -1,6 +1,0 @@
-//@ check-pass
-//@ compile-flags: -C lto
-
-fn main() {}
-
-// ferrocene-annotations: um_rustc_C

--- a/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_codegen.rs
+++ b/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_codegen.rs
@@ -1,7 +1,0 @@
-//@ check-fail
-//@ compile-flags: -C --codegen
-//~? unknown codegen option
-
-fn main() {}
-
-// ferrocene-annotations: um_rustc_C

--- a/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_codegen.stderr
+++ b/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_codegen.stderr
@@ -1,2 +1,0 @@
-error: unknown codegen option: `--codegen`
-

--- a/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_eq.rs
+++ b/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_eq.rs
@@ -1,7 +1,0 @@
-//@ check-fail
-//@ compile-flags: -C=lto
-//~? unknown codegen option
-
-fn main() {}
-
-// ferrocene-annotations: um_rustc_C

--- a/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_eq.stderr
+++ b/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_eq.stderr
@@ -1,2 +1,0 @@
-error: unknown codegen option: ``
-

--- a/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_hyphen-hyphen.rs
+++ b/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_hyphen-hyphen.rs
@@ -1,6 +1,0 @@
-//@ check-pass
-//@ compile-flags: --C lto
-
-fn main() {}
-
-// ferrocene-annotations: um_rustc_C

--- a/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_no-option.rs
+++ b/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_no-option.rs
@@ -1,6 +1,0 @@
-//@ check-fail
-//@ compile-flags: -C
-
-fn main() {}
-
-// ferrocene-annotations: um_rustc_C

--- a/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_no-option.stderr
+++ b/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_no-option.stderr
@@ -1,2 +1,0 @@
-error: Argument to option 'C' missing
-

--- a/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_no-space.rs
+++ b/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_no-space.rs
@@ -1,6 +1,0 @@
-//@ check-pass
-//@ compile-flags: -Clto
-
-fn main() {}
-
-// ferrocene-annotations: um_rustc_C

--- a/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_unknown-option.rs
+++ b/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_unknown-option.rs
@@ -1,7 +1,0 @@
-//@ check-fail
-//@ compile-flags: -C this-codegen-option-does-not-exist
-//~? unknown codegen option
-
-fn main() {}
-
-// ferrocene-annotations: um_rustc_C

--- a/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_unknown-option.stderr
+++ b/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_unknown-option.stderr
@@ -1,2 +1,0 @@
-error: unknown codegen option: `this-codegen-option-does-not-exist`
-

--- a/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_upper-c.rs
+++ b/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_upper-c.rs
@@ -1,7 +1,0 @@
-//@ check-fail
-//@ compile-flags: -C -C
-//~? unknown codegen option
-
-fn main() {}
-
-// ferrocene-annotations: um_rustc_C

--- a/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_upper-c.stderr
+++ b/tests/ui/ferrocene/compiler-arguments/upper_c/upper-c_upper-c.stderr
@@ -1,2 +1,0 @@
-error: unknown codegen option: `-C`
-


### PR DESCRIPTION
When considering how to test CLI flags, we categorized them internally in informational, narrow impact, or high impact. We used this terminology when talking to assessors too, but we never actually wrote it down in the qualification material. This PR adds our categorization criteria to the evaluation report, and actually categorizes each CLI flag in the user manual.

Categories can be set by adding the required `:category:` option to the CLI argument directive, as it is currently done in `cli.rst`. The extension will verify the value belongs in an allowlist, and it will automatically style the list.

Along with the changes I spent a bit of time improving the styling of the CLI page:

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/fa362647-641e-4a5f-8d3b-27ce20595a15) | ![image](https://github.com/user-attachments/assets/b3c0798b-8ff0-4e84-876a-9237fee2b48b) |

Other notable changes are the removal of the `-C` and `--codegen` from the page, since those are not actually flags the user can use, and the "unsupported in a qualified environment" caution snippet being added automatically by the extension.

This PR is best reviewed commit-by-commit.

