### PR TITLE
Explicitly annotate edition for some unpretty tests

### DIFF
--- a/tests/ui/asm/unpretty-expanded.rs
+++ b/tests/ui/asm/unpretty-expanded.rs
@@ -1,4 +1,5 @@
 //@ needs-asm-support
 //@ check-pass
 //@ compile-flags: -Zunpretty=expanded
+//@ edition: 2015
 core::arch::global_asm!("x: .byte 42");

--- a/tests/ui/asm/unpretty-expanded.stdout
+++ b/tests/ui/asm/unpretty-expanded.stdout
@@ -7,4 +7,5 @@ extern crate std;
 //@ needs-asm-support
 //@ check-pass
 //@ compile-flags: -Zunpretty=expanded
+//@ edition: 2015
 global_asm! ("x: .byte 42");

--- a/tests/ui/deriving/built-in-proc-macro-scope.rs
+++ b/tests/ui/deriving/built-in-proc-macro-scope.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 //@ proc-macro: another-proc-macro.rs
 //@ compile-flags: -Zunpretty=expanded
+//@ edition:2015
 
 #![feature(derive_coerce_pointee)]
 

--- a/tests/ui/deriving/built-in-proc-macro-scope.stdout
+++ b/tests/ui/deriving/built-in-proc-macro-scope.stdout
@@ -3,6 +3,7 @@
 //@ check-pass
 //@ proc-macro: another-proc-macro.rs
 //@ compile-flags: -Zunpretty=expanded
+//@ edition:2015
 
 #![feature(derive_coerce_pointee)]
 #[prelude_import]

--- a/tests/ui/deriving/deriving-coerce-pointee-expanded.rs
+++ b/tests/ui/deriving/deriving-coerce-pointee-expanded.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ compile-flags: -Zunpretty=expanded
+//@ edition: 2015
 #![feature(derive_coerce_pointee)]
 use std::marker::CoercePointee;
 

--- a/tests/ui/deriving/deriving-coerce-pointee-expanded.stdout
+++ b/tests/ui/deriving/deriving-coerce-pointee-expanded.stdout
@@ -2,6 +2,7 @@
 #![no_std]
 //@ check-pass
 //@ compile-flags: -Zunpretty=expanded
+//@ edition: 2015
 #![feature(derive_coerce_pointee)]
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/deriving/proc-macro-attribute-mixing.rs
+++ b/tests/ui/deriving/proc-macro-attribute-mixing.rs
@@ -7,6 +7,7 @@
 //@ check-pass
 //@ proc-macro: another-proc-macro.rs
 //@ compile-flags: -Zunpretty=expanded
+//@ edition: 2015
 
 #![feature(derive_coerce_pointee)]
 

--- a/tests/ui/drop/issue-23338-ensure-param-drop-order.rs
+++ b/tests/ui/drop/issue-23338-ensure-param-drop-order.rs
@@ -163,7 +163,7 @@ pub mod d {
             };
             self.log.borrow_mut().push(self.uid);
             indent_println(self.trail, &format!("+-- Drop {}", self));
-            indent_println(::PREF_INDENT, "");
+            indent_println(super::PREF_INDENT, "");
         }
     }
 }

--- a/tests/ui/dyn-drop/dyn-drop.rs
+++ b/tests/ui/dyn-drop/dyn-drop.rs
@@ -2,7 +2,7 @@
 #![allow(bare_trait_objects)]
 fn foo(_: Box<dyn Drop>) {} //~ ERROR
 fn bar(_: &dyn Drop) {} //~ERROR
-fn baz(_: *mut Drop) {} //~ ERROR
+fn baz(_: *mut dyn Drop) {} //~ ERROR
 struct Foo {
   _x: Box<dyn Drop> //~ ERROR
 }

--- a/tests/ui/macros/genercs-in-path-with-prettry-hir.rs
+++ b/tests/ui/macros/genercs-in-path-with-prettry-hir.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: -Zunpretty=hir
+//@ edition: 2015
 
 // issue#97006
 

--- a/tests/ui/macros/genercs-in-path-with-prettry-hir.stderr
+++ b/tests/ui/macros/genercs-in-path-with-prettry-hir.stderr
@@ -1,5 +1,5 @@
 error: unexpected generic arguments in path
-  --> $DIR/genercs-in-path-with-prettry-hir.rs:12:10
+  --> $DIR/genercs-in-path-with-prettry-hir.rs:13:10
    |
 LL | m!(inline<u8>);
    |          ^^^^

--- a/tests/ui/macros/genercs-in-path-with-prettry-hir.stdout
+++ b/tests/ui/macros/genercs-in-path-with-prettry-hir.stdout
@@ -3,6 +3,7 @@ use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
+//@ edition: 2015
 
 // issue#97006
 

--- a/tests/ui/match/issue-82392.rs
+++ b/tests/ui/match/issue-82392.rs
@@ -1,6 +1,7 @@
 // https://github.com/rust-lang/rust/issues/82329
 //@ compile-flags: -Zunpretty=hir,typed
 //@ check-pass
+//@ edition:2015
 
 pub fn main() {
     if true {

--- a/tests/ui/match/issue-82392.stdout
+++ b/tests/ui/match/issue-82392.stdout
@@ -5,6 +5,7 @@ extern crate std;
 // https://github.com/rust-lang/rust/issues/82329
 //@ compile-flags: -Zunpretty=hir,typed
 //@ check-pass
+//@ edition:2015
 
 fn main() ({
     (if (true as bool)

--- a/tests/ui/unpretty/bad-literal.rs
+++ b/tests/ui/unpretty/bad-literal.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=hir
 //@ check-fail
+//@ edition: 2015
 
 // In #100948 this caused an ICE with -Zunpretty=hir.
 fn main() {

--- a/tests/ui/unpretty/bad-literal.stderr
+++ b/tests/ui/unpretty/bad-literal.stderr
@@ -1,5 +1,5 @@
 error: invalid suffix `u` for number literal
-  --> $DIR/bad-literal.rs:6:5
+  --> $DIR/bad-literal.rs:7:5
    |
 LL |     1u;
    |     ^^ invalid suffix `u`

--- a/tests/ui/unpretty/bad-literal.stdout
+++ b/tests/ui/unpretty/bad-literal.stdout
@@ -4,6 +4,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-fail
+//@ edition: 2015
 
 // In #100948 this caused an ICE with -Zunpretty=hir.
 fn main() {

--- a/tests/ui/unpretty/debug-fmt-hir.rs
+++ b/tests/ui/unpretty/debug-fmt-hir.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 use std::fmt;
 

--- a/tests/ui/unpretty/debug-fmt-hir.stdout
+++ b/tests/ui/unpretty/debug-fmt-hir.stdout
@@ -4,6 +4,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 use std::fmt;
 

--- a/tests/ui/unpretty/deprecated-attr.rs
+++ b/tests/ui/unpretty/deprecated-attr.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 #[deprecated]
 pub struct PlainDeprecated;

--- a/tests/ui/unpretty/deprecated-attr.stdout
+++ b/tests/ui/unpretty/deprecated-attr.stdout
@@ -4,6 +4,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
 struct PlainDeprecated;

--- a/tests/ui/unpretty/diagnostic-attr.rs
+++ b/tests/ui/unpretty/diagnostic-attr.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 #[diagnostic::on_unimplemented(
     message = "My Message for `ImportantTrait<{A}>` implemented for `{Self}`",

--- a/tests/ui/unpretty/diagnostic-attr.stdout
+++ b/tests/ui/unpretty/diagnostic-attr.stdout
@@ -4,6 +4,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 #[diagnostic::on_unimplemented(message =
 "My Message for `ImportantTrait<{A}>` implemented for `{Self}`", label =

--- a/tests/ui/unpretty/expanded-interpolation.rs
+++ b/tests/ui/unpretty/expanded-interpolation.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=expanded
 //@ check-pass
+//@ edition: 2015
 
 // This test covers the AST pretty-printer's insertion of parentheses in some
 // macro metavariable edge cases. Synthetic parentheses (i.e. not appearing in

--- a/tests/ui/unpretty/expanded-interpolation.stdout
+++ b/tests/ui/unpretty/expanded-interpolation.stdout
@@ -2,6 +2,7 @@
 #![no_std]
 //@ compile-flags: -Zunpretty=expanded
 //@ check-pass
+//@ edition: 2015
 
 // This test covers the AST pretty-printer's insertion of parentheses in some
 // macro metavariable edge cases. Synthetic parentheses (i.e. not appearing in

--- a/tests/ui/unpretty/flattened-format-args.rs
+++ b/tests/ui/unpretty/flattened-format-args.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=hir -Zflatten-format-args=yes
 //@ check-pass
+//@ edition: 2015
 
 fn main() {
     let x = 1;

--- a/tests/ui/unpretty/flattened-format-args.stdout
+++ b/tests/ui/unpretty/flattened-format-args.stdout
@@ -4,6 +4,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 //@ compile-flags: -Zunpretty=hir -Zflatten-format-args=yes
 //@ check-pass
+//@ edition: 2015
 
 fn main() {
     let x = 1;

--- a/tests/ui/unpretty/let-else-hir.rs
+++ b/tests/ui/unpretty/let-else-hir.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 
 

--- a/tests/ui/unpretty/let-else-hir.stdout
+++ b/tests/ui/unpretty/let-else-hir.stdout
@@ -4,6 +4,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 
 

--- a/tests/ui/unpretty/self-hir.rs
+++ b/tests/ui/unpretty/self-hir.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 pub struct Bar {
     a: String,

--- a/tests/ui/unpretty/self-hir.stdout
+++ b/tests/ui/unpretty/self-hir.stdout
@@ -4,6 +4,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 struct Bar {
     a: String,

--- a/tests/ui/unpretty/unpretty-expr-fn-arg.rs
+++ b/tests/ui/unpretty/unpretty-expr-fn-arg.rs
@@ -6,6 +6,7 @@
 
 //@ check-pass
 //@ compile-flags: -Zunpretty=hir,typed
+//@ edition: 2015
 #![allow(dead_code)]
 
 fn main() {}

--- a/tests/ui/unpretty/unpretty-expr-fn-arg.stdout
+++ b/tests/ui/unpretty/unpretty-expr-fn-arg.stdout
@@ -6,6 +6,7 @@
 
 //@ check-pass
 //@ compile-flags: -Zunpretty=hir,typed
+//@ edition: 2015
 #![allow(dead_code)]
 #[prelude_import]
 use ::std::prelude::rust_2015::*;


### PR DESCRIPTION
`unpretty=HIR`/`unpretty=expanded` tests always output edition dependent things (prelude imports), also contains 2 other fixes as examples for those