### PR TITLE
Implement test variants

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -305,6 +305,8 @@ jobs:
     parameters:
       job:
         type: string
+      test-variant:
+        type: string
       resource-class:
         type: string
     resource_class: << parameters.resource-class >>
@@ -312,7 +314,7 @@ jobs:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       FERROCENE_TARGETS: x86_64-pc-nto-qnx710
       SCRIPT: |
-        set +u; source ./qnx710-472/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.11:12345 ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call
+        set +u; source ./qnx710-472/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.11:12345 ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
     steps:
       - aws-oidc-auth
       - ferrocene-checkout

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -200,6 +200,8 @@ jobs:
     parameters:
       job:
         type: string
+      test-variant:
+        type: string
       resource-class:
         type: string
     resource_class: << parameters.resource-class >>
@@ -207,7 +209,7 @@ jobs:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       SCRIPT: |
         # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
-        ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call
+        ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
     steps:
       - ferrocene-job-test-container:
           restore-from-job: x86_64-linux-build
@@ -233,13 +235,16 @@ jobs:
   x86_64-linux-test-library-std:
     executor: linux-vm
     resource_class: large # 4-core
+    parameters:
+      test-variant:
+        type: string
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       # Standard library tests need IPv6, which is not available in container
       # jobs. Because of that we need to run *just* standard library tests in a
       # virtual machine.
       # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
-      SCRIPT: ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py test:library-std) --ferrocene-test-one-crate-per-cargo-call
+      SCRIPT: ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py test:library-std) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
     steps:
       - aws-oidc-auth
       - ferrocene-job-test-vm:
@@ -593,7 +598,7 @@ jobs:
     parameters:
       qemu-arch:
         type: string
-      qemu-cpu:
+      test-variant:
         type: string
       target:
         type: string
@@ -606,7 +611,7 @@ jobs:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       FERROCENE_TARGETS: << parameters.target >>
       SCRIPT: |
-        sudo update-binfmts --import && sudo update-binfmts --enable << parameters.qemu-arch >> && QEMU_CPU=<< parameters.qemu-cpu >> ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call
+        sudo update-binfmts --import && sudo update-binfmts --enable << parameters.qemu-arch >> && ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
     steps:
       - aws-oidc-auth
       - ferrocene-checkout
@@ -640,6 +645,8 @@ jobs:
     parameters:
       job:
         type: string
+      test-variant:
+        type: string
       resource-class:
         type: string
     resource_class: << parameters.resource-class >>
@@ -647,7 +654,7 @@ jobs:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       FERROCENE_TARGETS: aarch64-unknown-nto-qnx710
       SCRIPT: |
-        set +u; source ./qnx710-472/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.105:12345 ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call
+        set +u; source ./qnx710-472/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.105:12345 ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
     steps:
       - aws-oidc-auth
       - ferrocene-checkout
@@ -875,21 +882,25 @@ workflows:
           name: x86_64-linux-test
           job: test
           resource-class: large # 4-core
+          test-variant: "2021"
           requires:
             - x86_64-linux-build
       - x86_64-linux-generic-test-container:
           name: x86_64-linux-test-library
           job: test:library
           resource-class: large # 4-core
+          test-variant: "2021"
           requires:
             - x86_64-linux-build
       - x86_64-linux-generic-test-container:
           name: x86_64-linux-compiletest
           job: test:compiletest
           resource-class: xlarge # 8-core
+          test-variant: "2021"
           requires:
             - x86_64-linux-build
       - x86_64-linux-test-library-std:
+          test-variant: "2021"
           requires:
             - x86_64-linux-build
       - x86_64-linux-library-coverage:
@@ -899,8 +910,8 @@ workflows:
       - ferrocenecoretest-generic-test:
           name: aarch64-none-compiletest
           target: aarch64-unknown-ferrocenecoretest
+          test-variant: 2021-cortex-a53
           qemu-arch: qemu-aarch64
-          qemu-cpu: cortex-a53
           job: qnx:compiletest-no-only-hosts
           resource-class: large # 4-core
           requires:
@@ -908,8 +919,8 @@ workflows:
       - ferrocenecoretest-generic-test:
           name: aarch64-none-test-library
           target: aarch64-unknown-ferrocenecoretest
+          test-variant: 2021-cortex-a53
           qemu-arch: qemu-aarch64
-          qemu-cpu: cortex-a53
           job: test:library
           resource-class: large # 4-core
           requires:
@@ -929,6 +940,7 @@ workflows:
       - x86_64-qnx-generic-test-vm:
           name: x86_64-qnx-test-library
           job: test:library
+          test-variant: "2021"
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build
@@ -937,6 +949,7 @@ workflows:
       - x86_64-qnx-generic-test-vm:
           name: x86_64-qnx-test-library-std
           job: test:library-std
+          test-variant: "2021"
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build
@@ -945,6 +958,7 @@ workflows:
       - x86_64-qnx-generic-test-vm:
           name: x86_64-qnx-test-compiletest
           job: qnx:compiletest-no-only-hosts
+          test-variant: "2021"
           resource-class: xlarge # 8-core
           requires:
             - x86_64-linux-build
@@ -953,8 +967,8 @@ workflows:
       - ferrocenecoretest-generic-test:
           name: thumbv7em-eabihf-test-library
           target: thumbv7em-ferrocenecoretest-eabihf
+          test-variant: 2021-cortex-m4
           qemu-arch: qemu-arm
-          qemu-cpu: cortex-m4
           job: test:library
           resource-class: large # 4-core
           requires:
@@ -963,8 +977,8 @@ workflows:
       - ferrocenecoretest-generic-test:
           name: thumbv7em-eabi-test-library
           target: thumbv7em-ferrocenecoretest-eabi
+          test-variant: 2021-cortex-m4
           qemu-arch: qemu-arm
-          qemu-cpu: cortex-m4
           job: test:library
           resource-class: large # 4-core
           requires:
@@ -973,8 +987,8 @@ workflows:
       - ferrocenecoretest-generic-test:
           name: thumbv7em-eabihf-test-compiletest
           target: thumbv7em-ferrocenecoretest-eabihf
+          test-variant: 2021-cortex-m4
           qemu-arch: qemu-arm
-          qemu-cpu: cortex-m4
           job: qnx:compiletest-no-only-hosts
           resource-class: xlarge # 8-core
           requires:
@@ -983,8 +997,8 @@ workflows:
       - ferrocenecoretest-generic-test:
           name: thumbv7em-eabi-test-compiletest
           target: thumbv7em-ferrocenecoretest-eabi
+          test-variant: 2021-cortex-m4
           qemu-arch: qemu-arm
-          qemu-cpu: cortex-m4
           job: qnx:compiletest-no-only-hosts
           resource-class: xlarge # 8-core
           requires:
@@ -993,6 +1007,7 @@ workflows:
       - aarch64-qnx-generic-test-vm:
           name: aarch64-qnx-test-library
           job: test:library
+          test-variant: "2021"
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build
@@ -1001,6 +1016,7 @@ workflows:
       - aarch64-qnx-generic-test-vm:
           name: aarch64-qnx-test-library-std
           job: test:library-std
+          test-variant: "2021"
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build
@@ -1009,6 +1025,7 @@ workflows:
       - aarch64-qnx-generic-test-vm:
           name: aarch64-qnx-test-compiletest
           job: qnx:compiletest-no-only-hosts
+          test-variant: "2021"
           resource-class: xlarge # 8-core
           requires:
             - x86_64-linux-build

--- a/ferrocene/doc/internal-procedures/src/index.rst
+++ b/ferrocene/doc/internal-procedures/src/index.rst
@@ -16,7 +16,6 @@ based on software engineering best practices.
    onboarding
    setup-local-env
    working-with-the-ci
-   testing-other-targets
    upstream-pulls
    subtree-pulls
    known-problems
@@ -25,6 +24,13 @@ based on software engineering best practices.
    release-notes
    bors
    external-contributions
+
+.. toctree::
+   :maxdepth: 4
+   :caption: Testing
+
+   test-variants
+   testing-other-targets
 
 .. toctree::
    :maxdepth: 4

--- a/ferrocene/doc/internal-procedures/src/test-variants.rst
+++ b/ferrocene/doc/internal-procedures/src/test-variants.rst
@@ -1,0 +1,29 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Test variants
+=============
+
+As described :ref:`in the qualification plan
+<qualification-plan:test-variants>`, test variants are a way to run a test suite
+multiple times for each target, each time varying some of the configuration.
+
+To enable a variant when running tests, add the ``--test-variant=NAME`` to ``./x
+test``. The default variant (when the flag is not passed) depends on the target
+you are testing: if you are reproducing a CI failure make sure to specify the
+correct variant.
+
+Available variants
+------------------
+
+The available variants are defined in
+``src/bootstrap/src/ferrocene/test_variants.rs``:
+
+.. This is not the best presentation possible for the test variants (it would be
+   prettier to have a table), but it's not worth the time to create a whole new
+   extension and pass the content from bootstrap to Sphinx just to render them.
+
+.. literalinclude:: ../../../../src/bootstrap/src/ferrocene/test_variants.rs
+   :start-after: INTERNAL_PROCEDURES_START_TEST_VARIANTS
+   :end-before: INTERNAL_PROCEDURES_END_TEST_VARIANTS
+   :dedent:

--- a/ferrocene/doc/qualification-plan/src/ci.rst
+++ b/ferrocene/doc/qualification-plan/src/ci.rst
@@ -144,3 +144,26 @@ Since the only difference between the two targets is the implementation of the
 APIs in the ``std`` crate, and that crate is not shipped to customers for bare
 metal targets, we can conclude that the test results of the two targets are
 equivalent.
+
+.. _test-variants:
+
+Test variants
+-------------
+
+During :ref:`ci-phase-full`, we need to verify that each of our qualified host
+compilers can compile for each of our qualified compilation targets. It is not
+enough to execute the test suites once for each pair of host and target:
+
+- A bare metal target can run on a multitude of embedded CPUs, and some CPUs
+  might expose more functionality than the baseline for that target. We thus
+  need to configure our emulator to precisely emulate the CPU we target.
+
+- Some of the command-line arguments we qualify :ref:`have a wide impact
+  <evaluation-report:rustc-cli-testing-categories>`, and they could affect the
+  whole test suite. We thus need to run a copy of the test suite for each
+  combination of those flags's values.
+
+To address this, we define multiple "test variants": each variant consists of
+the target to be tested, one of the combinations of wide impact flags, and (if
+applicable) the embedded CPU to emulate. Each test suite will be executed for
+all applicable test variants, and each variant will have its own test results.

--- a/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/outcomes.py
+++ b/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/outcomes.py
@@ -77,7 +77,7 @@ class Platform:
 
 @dataclass
 class Outcomes:
-    platforms: OrderedDict[(str, str), Platform] = field(default_factory=OrderedDict)
+    platforms: OrderedDict[tuple[str, str], Platform] = field(default_factory=OrderedDict)
 
     def load_file(self, file):
         with open(file, "r", encoding="utf-8") as f:

--- a/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/outcomes.py
+++ b/ferrocene/doc/qualification-report/exts/ferrocene_test_outcomes/outcomes.py
@@ -39,12 +39,19 @@ class CargoPackageInvocation:
 
 
 @dataclass(order=True)
+class Variant:
+    id: str
+    fields: dict[str, str]
+
+
+@dataclass(order=True)
 class Invocation:
     bootstrap_types: list[str]
     host: str
     target: str
     stage: int
     kind: Union[CompiletestInvocation, CargoPackageInvocation]
+    variant: Variant
 
     passed_tests: int = 0
     failed_tests: int = 0
@@ -141,12 +148,18 @@ class FileLoader:
         else:
             raise RuntimeError(f"unknown test suite kind: {metadata['kind']}")
 
+        variant = Variant(
+            id=metadata["ferrocene_variant"]["id"],
+            fields=metadata["ferrocene_variant"]["human_readable_fields"],
+        )
+
         invocation = Invocation(
             bootstrap_types=list(self.bootstrap_type_stack),
             host=metadata["host"],
             target=metadata["target"],
             stage=metadata["stage"],
             kind=kind,
+            variant=variant,
         )
 
         for test in suite["tests"]:

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -36,6 +36,12 @@ As a result, the {{ suite }} test suite reports a **pass** for this
 qualification.
 {% endmacro %}
 
+{% macro render_variant(variant) -%}
+    {%- for key, value in variant.fields.items() -%}
+        {% if not loop.first %} , {% endif -%}{{ key }}: {{ value }}
+    {%- endfor -%}
+{%- endmacro %}
+
 {% macro cargo_tests_summary(bootstrap_type, only_match_root_node=False) %}
 {% if platform_outcomes is none %}
 {{ no_outcomes_error() }}
@@ -46,6 +52,7 @@ qualification.
    :header-rows: 1
 
    * - Crate name
+     - Variant
      - Passed tests
      - Ignored tests
      - Failed tests
@@ -58,6 +65,8 @@ qualification.
        {%- else -%}
            N/A
        {%- endif %}
+
+     - {{ render_variant(invocation.variant) }}
 
        .. rst-class:: align-right
      - {{ invocation.passed_tests }}
@@ -128,6 +137,7 @@ The following compiletest suites were executed as part of this test suite:
    :header-rows: 1
 
    * - Compiletest suite
+     - Variant
      - Passed tests
      - Ignored tests
      - Failed tests
@@ -135,6 +145,8 @@ The following compiletest suites were executed as part of this test suite:
 
    {% for invocation in invocations %}
    * - ``{{ invocation.kind.suite }}`` {% if invocation.kind.mode is not none %} (mode: ``{{ invocation.kind.mode }}``){% endif %}
+
+     - {{ render_variant(invocation.variant) }}
 
        .. rst-class:: align-right
      - {{ invocation.passed_tests }}

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -52,7 +52,7 @@ qualification.
    :header-rows: 1
 
    * - Crate name
-     - Variant
+     - :ref:`Variant <qualification-plan:test-variants>`
      - Passed tests
      - Ignored tests
      - Failed tests
@@ -137,7 +137,7 @@ The following compiletest suites were executed as part of this test suite:
    :header-rows: 1
 
    * - Compiletest suite
-     - Variant
+     - :ref:`Variant <qualification-plan:test-variants>`
      - Passed tests
      - Ignored tests
      - Failed tests

--- a/ferrocene/tools/traceability-matrix/src/annotations.rs
+++ b/ferrocene/tools/traceability-matrix/src/annotations.rs
@@ -2,9 +2,10 @@
 // SPDX-FileCopyrightText: The Ferrocene Developers
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Display;
 use std::path::{Path, PathBuf};
 
-use crate::test_outcomes::TestOutcomes;
+use crate::test_outcomes::{On, TestOutcomes};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct AnnotatedFile {
@@ -13,7 +14,7 @@ pub(crate) struct AnnotatedFile {
     pub(crate) targets: Targets,
 }
 
-impl std::fmt::Display for AnnotatedFile {
+impl Display for AnnotatedFile {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.source {
             AnnotationSource::TestItself => write!(f, "{}", self.test.display()),
@@ -27,18 +28,24 @@ impl std::fmt::Display for AnnotatedFile {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub(crate) struct Targets {
-    pub(crate) executed: DisplayCommaSeparatedSet,
-    pub(crate) ignored: DisplayCommaSeparatedSet,
+    pub(crate) executed: DisplayCommaSeparatedSet<On>,
+    pub(crate) ignored: DisplayCommaSeparatedSet<On>,
 }
 
 // created only so as to impl Display for Targets fields
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub(crate) struct DisplayCommaSeparatedSet(pub BTreeSet<String>);
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct DisplayCommaSeparatedSet<T: Display>(pub BTreeSet<T>);
 
-impl std::fmt::Display for DisplayCommaSeparatedSet {
+impl<T: Display> Display for DisplayCommaSeparatedSet<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let targets: Vec<_> = self.0.clone().into_iter().collect();
-        write!(f, "{}", targets.as_slice().join(", "))
+        let values: Vec<_> = self.0.iter().map(|value| value.to_string()).collect();
+        write!(f, "{}", values.as_slice().join(", "))
+    }
+}
+
+impl<T: Display> Default for DisplayCommaSeparatedSet<T> {
+    fn default() -> Self {
+        DisplayCommaSeparatedSet(BTreeSet::new())
     }
 }
 
@@ -52,7 +59,7 @@ pub(crate) enum AnnotationSource {
 #[derive(Debug)]
 pub(crate) struct Annotations {
     pub(crate) ids: BTreeMap<String, BTreeSet<AnnotatedFile>>,
-    pub(crate) ignored_tests: BTreeMap<String, BTreeSet<String>>,
+    pub(crate) ignored_tests: BTreeMap<String, BTreeSet<On>>,
     pub(crate) considers_ignored_tests: bool,
 }
 

--- a/ferrocene/tools/traceability-matrix/src/matrix.rs
+++ b/ferrocene/tools/traceability-matrix/src/matrix.rs
@@ -7,6 +7,7 @@ use std::ops::Deref;
 
 use crate::annotations::{AnnotatedFile, Annotations};
 use crate::documentations::{CliOption, Documentation, Section};
+use crate::test_outcomes::On;
 
 pub(crate) const ELEMENT_KIND_SECTION: ElementKind = ElementKind {
     singular: "specification section",
@@ -168,9 +169,9 @@ impl MatrixAnalysis {
     }
 }
 
-fn filter_targets_from_tests<F>(tests: &[LinkTest], getter: F) -> BTreeSet<&String>
+fn filter_targets_from_tests<F>(tests: &[LinkTest], getter: F) -> BTreeSet<&On>
 where
-    F: Fn(&AnnotatedFile) -> &BTreeSet<String>,
+    F: Fn(&AnnotatedFile) -> &BTreeSet<On>,
 {
     tests.iter().filter_map(LinkTest::unwrap_file).flat_map(getter).collect()
 }

--- a/ferrocene/tools/traceability-matrix/src/report.rs
+++ b/ferrocene/tools/traceability-matrix/src/report.rs
@@ -8,6 +8,7 @@ use askama::Template;
 
 use crate::annotations::{AnnotationSource, Annotations};
 use crate::matrix::{Element, ElementKind, LinkTest, Page, TraceabilityMatrix};
+use crate::test_outcomes::On;
 
 #[derive(Template)]
 #[template(path = "report.html")]
@@ -15,7 +16,7 @@ struct Report<'a> {
     considers_ignored_tests: bool,
     matrix: &'a TraceabilityMatrix,
     summary: Vec<SummaryRow<'a>>,
-    ignored_tests: BTreeMap<String, BTreeSet<String>>,
+    ignored_tests: BTreeMap<String, BTreeSet<On>>,
     urls: Urls,
 }
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -25,6 +25,7 @@ use crate::core::config::TargetSelection;
 use crate::core::config::flags::{Subcommand, get_completion};
 use crate::ferrocene::code_coverage::measure_coverage;
 use crate::ferrocene::secret_sauce::SecretSauceArtifacts;
+use crate::ferrocene::test_variants::{TestVariant, VariantCondition};
 use crate::utils::build_stamp::{self, BuildStamp};
 use crate::utils::exec::{BootstrapCommand, command};
 use crate::utils::helpers::{
@@ -339,6 +340,16 @@ impl Step for Cargo {
         // same value as `-Zroot-dir`.
         cargo.env("CARGO_RUSTC_CURRENT_DIR", builder.src.display().to_string());
 
+        let variant = TestVariant::current(builder, self.host);
+        for condition in variant.condititions() {
+            match condition.get() {
+                VariantCondition::Edition(_) => condition.mark_unused(),
+                VariantCondition::QemuCpu(cpu) => {
+                    cargo.env("QEMU_CPU", cpu);
+                }
+            }
+        }
+
         #[cfg(feature = "build-metrics")]
         builder.metrics.begin_test_suite(
             build_helper::metrics::TestSuiteMetadata::CargoPackage {
@@ -346,6 +357,7 @@ impl Step for Cargo {
                 target: self.host.triple.to_string(),
                 host: self.host.triple.to_string(),
                 stage,
+                ferrocene_variant: variant.for_metrics(),
             },
             builder,
         );
@@ -2076,6 +2088,18 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
         cmd.arg("--git-merge-commit-email").arg(git_config.git_merge_commit_email);
         cmd.force_coloring_in_ci();
 
+        let variant = TestVariant::current(builder, self.target);
+        for condition in variant.condititions() {
+            match condition.get() {
+                VariantCondition::Edition(edition) => {
+                    cmd.arg(format!("--edition={edition}"));
+                }
+                VariantCondition::QemuCpu(cpu) => {
+                    cmd.env("QEMU_CPU", cpu);
+                }
+            }
+        }
+
         #[cfg(feature = "build-metrics")]
         builder.metrics.begin_test_suite(
             build_helper::metrics::TestSuiteMetadata::Compiletest {
@@ -2085,6 +2109,7 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
                 target: self.target.triple.to_string(),
                 host: self.compiler.host.triple.to_string(),
                 stage: self.compiler.stage,
+                ferrocene_variant: variant.for_metrics(),
             },
             builder,
         );
@@ -2114,6 +2139,7 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
                     target: self.target.triple.to_string(),
                     host: self.compiler.host.triple.to_string(),
                     stage: self.compiler.stage,
+                    ferrocene_variant: variant.for_metrics(),
                 },
                 builder,
             );
@@ -2499,6 +2525,16 @@ pub(crate) fn run_cargo_test<'a>(
         builder.msg_sysroot_tool(Kind::Test, compiler.stage, what, compiler.host, target)
     });
 
+    let variant = TestVariant::current(builder, target);
+    for condition in variant.condititions() {
+        match condition.get() {
+            VariantCondition::Edition(_) => condition.mark_unused(),
+            VariantCondition::QemuCpu(cpu) => {
+                cargo.env("QEMU_CPU", cpu);
+            }
+        }
+    }
+
     #[cfg(feature = "build-metrics")]
     builder.metrics.begin_test_suite(
         build_helper::metrics::TestSuiteMetadata::CargoPackage {
@@ -2506,6 +2542,7 @@ pub(crate) fn run_cargo_test<'a>(
             target: target.triple.to_string(),
             host: compiler.host.triple.to_string(),
             stage: compiler.stage,
+            ferrocene_variant: variant.for_metrics(),
         },
         builder,
     );

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -763,6 +763,7 @@ mod dist {
             no_capture: false,
             coverage: None,
             ferrocene_test_one_crate_per_cargo_call: false,
+            test_variant: None,
         };
 
         let build = Build::new(config);
@@ -843,6 +844,7 @@ mod dist {
             no_capture: false,
             coverage: None,
             ferrocene_test_one_crate_per_cargo_call: false,
+            test_variant: None,
         };
         // Make sure rustfmt binary not being found isn't an error.
         config.channel = "beta".to_string();

--- a/src/bootstrap/src/core/config/flags.rs
+++ b/src/bootstrap/src/core/config/flags.rs
@@ -430,6 +430,9 @@ pub enum Subcommand {
         /// documents to ensure there is enough granularity for the test outcomes report.
         #[arg(long)]
         ferrocene_test_one_crate_per_cargo_call: bool,
+        /// Choose the test variant to use for this execution.
+        #[arg(long)]
+        test_variant: Option<String>,
     },
     /// Build and run some test suites *in Miri*
     Miri {

--- a/src/bootstrap/src/ferrocene/mod.rs
+++ b/src/bootstrap/src/ferrocene/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod secret_sauce;
 pub(crate) mod sign;
 pub(crate) mod test;
 pub(crate) mod test_outcomes;
+pub(crate) mod test_variants;
 pub(crate) mod tool;
 
 use std::collections::HashMap;

--- a/src/bootstrap/src/ferrocene/test_variants.rs
+++ b/src/bootstrap/src/ferrocene/test_variants.rs
@@ -59,6 +59,7 @@ static VARIANTS: &[(&str, &[VariantCondition])] = &[
 ];
 static DEFAULT_VARIANTS_BY_TARGET: &[(&str, &str)] = &[
     ("aarch64-unknown-ferrocenecoretest", "2021-cortex-a53"),
+    ("thumbv7em-ferrocenecoretest-eabi", "2021-cortex-m4"),
     ("thumbv7em-ferrocenecoretest-eabihf", "2021-cortex-m4"),
 ];
 static DEFAULT_VARIANT_FALLBACK: &str = "2021";
@@ -99,6 +100,9 @@ impl TestVariant {
     pub(crate) fn id(&self) -> String {
         let mut id = String::new();
         for condition in self.condititions() {
+            if !id.is_empty() {
+                id.push('-');
+            }
             match condition.get() {
                 VariantCondition::Edition(edition) => id.push_str(&format!("e{edition}")),
                 VariantCondition::QemuCpu(cpu) => id.push_str(&format!("q{cpu}")),

--- a/src/build_helper/src/metrics.rs
+++ b/src/build_helper/src/metrics.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use serde_derive::{Deserialize, Serialize};
@@ -69,6 +70,7 @@ pub enum TestSuiteMetadata {
         target: String,
         host: String,
         stage: u32,
+        ferrocene_variant: FerroceneVariantMetadata,
     },
     Compiletest {
         suite: String,
@@ -77,6 +79,7 @@ pub enum TestSuiteMetadata {
         target: String,
         host: String,
         stage: u32,
+        ferrocene_variant: FerroceneVariantMetadata,
     },
 }
 
@@ -109,6 +112,13 @@ pub struct JsonInvocationSystemStats {
 pub struct JsonStepSystemStats {
     #[serde(deserialize_with = "null_as_f64_nan")]
     pub cpu_utilization_percent: f64,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FerroceneVariantMetadata {
+    pub id: String,
+    pub human_readable_fields: BTreeMap<String, String>,
 }
 
 fn null_as_f64_nan<'de, D: serde::Deserializer<'de>>(d: D) -> Result<f64, D::Error> {

--- a/src/etc/completions/x.fish
+++ b/src/etc/completions/x.fish
@@ -337,6 +337,7 @@ complete -c x -n "__fish_x_using_subcommand test" -l compare-mode -d 'mode descr
 complete -c x -n "__fish_x_using_subcommand test" -l pass -d 'force {check,build,run}-pass tests to this mode' -r
 complete -c x -n "__fish_x_using_subcommand test" -l run -d 'whether to execute run-* tests' -r
 complete -c x -n "__fish_x_using_subcommand test" -l coverage -d 'generate coverage for tests' -r -f -a "library\t''"
+complete -c x -n "__fish_x_using_subcommand test" -l test-variant -d 'Choose the test variant to use for this execution' -r
 complete -c x -n "__fish_x_using_subcommand test" -l config -d 'TOML configuration file for build' -r -F
 complete -c x -n "__fish_x_using_subcommand test" -l build-dir -d 'Build directory, overrides `build.build-dir` in `bootstrap.toml`' -r -f -a "(__fish_complete_directories)"
 complete -c x -n "__fish_x_using_subcommand test" -l build -d 'build target of the stage0 compiler' -r -f

--- a/src/etc/completions/x.ps1
+++ b/src/etc/completions/x.ps1
@@ -348,6 +348,7 @@ Register-ArgumentCompleter -Native -CommandName 'x' -ScriptBlock {
             [CompletionResult]::new('--pass', '--pass', [CompletionResultType]::ParameterName, 'force {check,build,run}-pass tests to this mode')
             [CompletionResult]::new('--run', '--run', [CompletionResultType]::ParameterName, 'whether to execute run-* tests')
             [CompletionResult]::new('--coverage', '--coverage', [CompletionResultType]::ParameterName, 'generate coverage for tests')
+            [CompletionResult]::new('--test-variant', '--test-variant', [CompletionResultType]::ParameterName, 'Choose the test variant to use for this execution')
             [CompletionResult]::new('--config', '--config', [CompletionResultType]::ParameterName, 'TOML configuration file for build')
             [CompletionResult]::new('--build-dir', '--build-dir', [CompletionResultType]::ParameterName, 'Build directory, overrides `build.build-dir` in `bootstrap.toml`')
             [CompletionResult]::new('--build', '--build', [CompletionResultType]::ParameterName, 'build target of the stage0 compiler')

--- a/src/etc/completions/x.py.fish
+++ b/src/etc/completions/x.py.fish
@@ -337,6 +337,7 @@ complete -c x.py -n "__fish_x.py_using_subcommand test" -l compare-mode -d 'mode
 complete -c x.py -n "__fish_x.py_using_subcommand test" -l pass -d 'force {check,build,run}-pass tests to this mode' -r
 complete -c x.py -n "__fish_x.py_using_subcommand test" -l run -d 'whether to execute run-* tests' -r
 complete -c x.py -n "__fish_x.py_using_subcommand test" -l coverage -d 'generate coverage for tests' -r -f -a "library\t''"
+complete -c x.py -n "__fish_x.py_using_subcommand test" -l test-variant -d 'Choose the test variant to use for this execution' -r
 complete -c x.py -n "__fish_x.py_using_subcommand test" -l config -d 'TOML configuration file for build' -r -F
 complete -c x.py -n "__fish_x.py_using_subcommand test" -l build-dir -d 'Build directory, overrides `build.build-dir` in `bootstrap.toml`' -r -f -a "(__fish_complete_directories)"
 complete -c x.py -n "__fish_x.py_using_subcommand test" -l build -d 'build target of the stage0 compiler' -r -f

--- a/src/etc/completions/x.py.ps1
+++ b/src/etc/completions/x.py.ps1
@@ -348,6 +348,7 @@ Register-ArgumentCompleter -Native -CommandName 'x.py' -ScriptBlock {
             [CompletionResult]::new('--pass', '--pass', [CompletionResultType]::ParameterName, 'force {check,build,run}-pass tests to this mode')
             [CompletionResult]::new('--run', '--run', [CompletionResultType]::ParameterName, 'whether to execute run-* tests')
             [CompletionResult]::new('--coverage', '--coverage', [CompletionResultType]::ParameterName, 'generate coverage for tests')
+            [CompletionResult]::new('--test-variant', '--test-variant', [CompletionResultType]::ParameterName, 'Choose the test variant to use for this execution')
             [CompletionResult]::new('--config', '--config', [CompletionResultType]::ParameterName, 'TOML configuration file for build')
             [CompletionResult]::new('--build-dir', '--build-dir', [CompletionResultType]::ParameterName, 'Build directory, overrides `build.build-dir` in `bootstrap.toml`')
             [CompletionResult]::new('--build', '--build', [CompletionResultType]::ParameterName, 'build target of the stage0 compiler')

--- a/src/etc/completions/x.py.sh
+++ b/src/etc/completions/x.py.sh
@@ -4407,7 +4407,7 @@ _x.py() {
             return 0
             ;;
         x.py__test)
-            opts="-v -i -j -h --no-fail-fast --test-args --compiletest-rustc-args --no-doc --doc --bless --extra-checks --force-rerun --only-modified --compare-mode --pass --run --rustfix-coverage --no-capture --coverage --ferrocene-test-one-crate-per-cargo-call --verbose --incremental --config --build-dir --build --host --target --exclude --skip --include-default-paths --rustc-error-format --on-fail --dry-run --dump-bootstrap-shims --stage --keep-stage --keep-stage-std --src --jobs --warnings --error-format --json-output --color --bypass-bootstrap-lock --rust-profile-generate --rust-profile-use --llvm-profile-use --llvm-profile-generate --enable-bolt-settings --skip-stage0-validation --reproducible-artifact --set --ci --help [PATHS]... [ARGS]..."
+            opts="-v -i -j -h --no-fail-fast --test-args --compiletest-rustc-args --no-doc --doc --bless --extra-checks --force-rerun --only-modified --compare-mode --pass --run --rustfix-coverage --no-capture --coverage --ferrocene-test-one-crate-per-cargo-call --test-variant --verbose --incremental --config --build-dir --build --host --target --exclude --skip --include-default-paths --rustc-error-format --on-fail --dry-run --dump-bootstrap-shims --stage --keep-stage --keep-stage-std --src --jobs --warnings --error-format --json-output --color --bypass-bootstrap-lock --rust-profile-generate --rust-profile-use --llvm-profile-use --llvm-profile-generate --enable-bolt-settings --skip-stage0-validation --reproducible-artifact --set --ci --help [PATHS]... [ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4439,6 +4439,10 @@ _x.py() {
                     ;;
                 --coverage)
                     COMPREPLY=($(compgen -W "library" -- "${cur}"))
+                    return 0
+                    ;;
+                --test-variant)
+                    COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 --config)

--- a/src/etc/completions/x.py.zsh
+++ b/src/etc/completions/x.py.zsh
@@ -346,6 +346,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pass=[force {check,build,run}-pass tests to this mode]:check | build | run:_default' \
 '--run=[whether to execute run-* tests]:auto | always | never:_default' \
 '--coverage=[generate coverage for tests]:COVERAGE:(library)' \
+'--test-variant=[Choose the test variant to use for this execution]:TEST_VARIANT:_default' \
 '--config=[TOML configuration file for build]:FILE:_files' \
 '--build-dir=[Build directory, overrides \`build.build-dir\` in \`bootstrap.toml\`]:DIR:_files -/' \
 '--build=[build target of the stage0 compiler]:BUILD:' \

--- a/src/etc/completions/x.sh
+++ b/src/etc/completions/x.sh
@@ -4407,7 +4407,7 @@ _x() {
             return 0
             ;;
         x__test)
-            opts="-v -i -j -h --no-fail-fast --test-args --compiletest-rustc-args --no-doc --doc --bless --extra-checks --force-rerun --only-modified --compare-mode --pass --run --rustfix-coverage --no-capture --coverage --ferrocene-test-one-crate-per-cargo-call --verbose --incremental --config --build-dir --build --host --target --exclude --skip --include-default-paths --rustc-error-format --on-fail --dry-run --dump-bootstrap-shims --stage --keep-stage --keep-stage-std --src --jobs --warnings --error-format --json-output --color --bypass-bootstrap-lock --rust-profile-generate --rust-profile-use --llvm-profile-use --llvm-profile-generate --enable-bolt-settings --skip-stage0-validation --reproducible-artifact --set --ci --help [PATHS]... [ARGS]..."
+            opts="-v -i -j -h --no-fail-fast --test-args --compiletest-rustc-args --no-doc --doc --bless --extra-checks --force-rerun --only-modified --compare-mode --pass --run --rustfix-coverage --no-capture --coverage --ferrocene-test-one-crate-per-cargo-call --test-variant --verbose --incremental --config --build-dir --build --host --target --exclude --skip --include-default-paths --rustc-error-format --on-fail --dry-run --dump-bootstrap-shims --stage --keep-stage --keep-stage-std --src --jobs --warnings --error-format --json-output --color --bypass-bootstrap-lock --rust-profile-generate --rust-profile-use --llvm-profile-use --llvm-profile-generate --enable-bolt-settings --skip-stage0-validation --reproducible-artifact --set --ci --help [PATHS]... [ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4439,6 +4439,10 @@ _x() {
                     ;;
                 --coverage)
                     COMPREPLY=($(compgen -W "library" -- "${cur}"))
+                    return 0
+                    ;;
+                --test-variant)
+                    COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 --config)

--- a/src/etc/completions/x.zsh
+++ b/src/etc/completions/x.zsh
@@ -346,6 +346,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pass=[force {check,build,run}-pass tests to this mode]:check | build | run:_default' \
 '--run=[whether to execute run-* tests]:auto | always | never:_default' \
 '--coverage=[generate coverage for tests]:COVERAGE:(library)' \
+'--test-variant=[Choose the test variant to use for this execution]:TEST_VARIANT:_default' \
 '--config=[TOML configuration file for build]:FILE:_files' \
 '--build-dir=[Build directory, overrides \`build.build-dir\` in \`bootstrap.toml\`]:DIR:_files -/' \
 '--build=[build target of the stage0 compiler]:BUILD:' \


### PR DESCRIPTION
Test variants are a mechanism to run a test suite multiple times for each target, each time with a different configuration. For example, it can be used to test multiple editions, or multiple QEMU emulated CPUs.

The high level overview is that variants are defined in `src/bootstrap/src/ferrocene/test_variants.rs`, and they can be enabled by passing the `--test-variant=NAME` flag to `./x test`:

```
./x test tests/ui --test-variant=2021
```

> [!NOTE]
>
> Currently the 2021 test variant actually runs tests for the 2015 edition. This should be changed once we update the test suite.

Test variants are then propagated to the qualification report (each variant will be a separate line in the report), and in the traceability matrix (the matrix needs to cover all `(target, variant)` tuples). CI is also configured to explicitly require a variant.

More documentation is present in the PR, and in code comments. This PR is best reviewed commit-by-commit.