### PR TITLE
Document coverage and add download-ci for it

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -1050,6 +1050,7 @@
 # Can be one of the following values:
 #
 # - disabled (default): do not include coverage outcomes
+# - download-ci: download the outcomes of the git merge base from CI
 # - local: use the code coverage outcomes from the current build directory (see
 #          the internal procedures for instructions on how to use this).
 # - custom: provide a custom path to the outcomes (see coverage-outcomes-dir)

--- a/ferrocene/doc/internal-procedures/src/code-coverage.rst
+++ b/ferrocene/doc/internal-procedures/src/code-coverage.rst
@@ -1,0 +1,46 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Code coverage
+=============
+
+The build system allows measuring code coverage with ``./x test --coverage``
+when running tests.
+
+The code coverage feature is designed to instrument a single component of
+Ferrocene (for example, the standard library) and gather code coverage metrics
+from multiple test suites, even if they are not strictly related to the
+component whose coverage is being measured.
+
+Because of this, the ``--coverage`` flag requires the name of the component to
+measure as the flag value. If you need to gather coverage metrics for multiple
+components, you will need to make multiple invocations of ``./x test``. The
+following components are currently instrumented:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Flag
+     - Measured components
+
+   * - ``--coverage=library``
+     - Standard library crates ``core``, ``alloc``, ``test``
+
+When the flag is passed, the component to measure will be instrumented, and all
+test suites will gather coverage metrics. Finally, an HTML report will be
+generated, and its URL will appear at the end.
+
+Gathering standard library coverage
+-----------------------------------
+
+To gather the standard library coverage, we recommend this command:
+
+.. code-block::
+
+   ./x test --no-doc --coverage=library library/core
+
+.. note::
+
+   Right now, only the ``core`` crate's coverage will be displayed in the
+   report, as the other crates are ignored in
+   ``src/bootstrap/src/ferrocene/code_coverage.rs``.

--- a/ferrocene/doc/internal-procedures/src/code-coverage.rst
+++ b/ferrocene/doc/internal-procedures/src/code-coverage.rst
@@ -44,3 +44,8 @@ To gather the standard library coverage, we recommend this command:
    Right now, only the ``core`` crate's coverage will be displayed in the
    report, as the other crates are ignored in
    ``src/bootstrap/src/ferrocene/code_coverage.rs``.
+
+.. note::
+
+   Doctests are not supported when gathering the coverage of the standard
+   library, and the build system will enforce the presence of ``--no-doc``.

--- a/ferrocene/doc/internal-procedures/src/index.rst
+++ b/ferrocene/doc/internal-procedures/src/index.rst
@@ -29,6 +29,7 @@ based on software engineering best practices.
    :maxdepth: 4
    :caption: Testing
 
+   code-coverage
    test-variants
    testing-other-targets
 

--- a/ferrocene/doc/internal-procedures/src/setup-local-env.rst
+++ b/ferrocene/doc/internal-procedures/src/setup-local-env.rst
@@ -182,6 +182,7 @@ content in it:
    [ferrocene]
    aws-profile = "ferrocene-ci"
    test-outcomes = "download-ci"
+   coverage-outcomes = "download-ci"
 
    [rust]
    lld = true

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -22,7 +22,7 @@ use crate::core::builder::{
     self, Alias, Builder, Compiler, Kind, RunConfig, ShouldRun, Step, crate_description,
 };
 use crate::core::config::TargetSelection;
-use crate::core::config::flags::{Subcommand, get_completion};
+use crate::core::config::flags::{FerroceneCoverageFor, Subcommand, get_completion};
 use crate::ferrocene::code_coverage::measure_coverage;
 use crate::ferrocene::secret_sauce::SecretSauceArtifacts;
 use crate::ferrocene::test_variants::{TestVariant, VariantCondition};
@@ -2672,11 +2672,30 @@ impl Step for Crate {
         let target = self.target;
         let mode = self.mode;
 
-        if builder.config.cmd.ferrocene_coverage_for().is_some()
+        // Doctests are incompatible with gathering the code coverage of libcore.
+        //
+        // In general, testing libcore has the problem that everything depends on libcore, and
+        // building a different libcore with testing flags enabled will generate errors due to
+        // duplicated lang items. This is why upstream defines the libcore tests in the coretests
+        // crate instead of the core crate.
+        //
+        // Running doctests with coverage instrumentation enabled causes similar problems, as Pietro
+        // was getting duplicate language items errors when trying to make it work. If in the future
+        // you want to try and make this work again:
+        //
+        // - Ensure that the flags we add to libcore for coverage instrumentation are added every
+        //   time libcore is built, by changing the `std_cargo` function.
+        //
+        // - If you need to persist the test binaries to pass to llvm-cov, check out this:
+        //   https://doc.rust-lang.org/stable/rustc/instrument-coverage.html#including-doc-tests
+        //   I don't think the `cargo test --no-run` step is necessary, we can just list the
+        //   binaries with bootstrap code. Please note the rustdoc flags from that page though.
+        if builder.config.cmd.ferrocene_coverage_for() == Some(FerroceneCoverageFor::Library)
             && builder.doc_tests != DocTests::No
         {
             panic!("Cannot generate coverage for doc tests");
         }
+
         // Prepare sysroot
         // See [field@compile::Std::force_recompile].
         builder.ensure(compile::Std::new(compiler, compiler.host).force_recompile(true));

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -465,6 +465,7 @@ pub enum FerroceneCoverageOutcomes {
     #[default]
     Disabled,
     Local,
+    DownloadCi,
     Custom(PathBuf),
 }
 
@@ -2608,6 +2609,7 @@ impl Config {
             ) {
                 (None | Some("disabled"), None) => FerroceneCoverageOutcomes::Disabled,
                 (Some("local"), None) => FerroceneCoverageOutcomes::Local,
+                (Some("download-ci"), None) => FerroceneCoverageOutcomes::DownloadCi,
                 (Some("custom"), Some(path)) => FerroceneCoverageOutcomes::Custom(path),
                 // Error messages:
                 (Some(value), Some(_)) => panic!(

--- a/src/bootstrap/src/ferrocene/code_coverage.rs
+++ b/src/bootstrap/src/ferrocene/code_coverage.rs
@@ -8,6 +8,7 @@ use crate::core::builder::{Cargo, ShouldRun, Step};
 use crate::core::config::flags::FerroceneCoverageFor;
 use crate::core::config::{FerroceneCoverageOutcomes, TargetSelection};
 use crate::ferrocene::doc::code_coverage::{CoverageMetadata, SingleCoverageReport};
+use crate::ferrocene::download_and_extract_ci_outcomes;
 use crate::utils::build_stamp::libstd_stamp;
 use crate::{BootstrapCommand, Compiler, DependencyType, GitRepo, t};
 
@@ -225,6 +226,9 @@ impl Step for CoverageOutcomesDir {
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         match &builder.config.ferrocene_coverage_outcomes {
             FerroceneCoverageOutcomes::Disabled => None,
+            FerroceneCoverageOutcomes::DownloadCi => {
+                Some(download_and_extract_ci_outcomes(builder, "coverage"))
+            }
             FerroceneCoverageOutcomes::Local => {
                 Some(builder.out.join("ferrocene").join("coverage"))
             }

--- a/src/bootstrap/src/ferrocene/test_outcomes.rs
+++ b/src/bootstrap/src/ferrocene/test_outcomes.rs
@@ -3,12 +3,9 @@
 
 use std::path::PathBuf;
 
-use build_helper::git::get_closest_merge_commit;
-
 use crate::core::builder::{Builder, ShouldRun, Step};
 use crate::core::config::FerroceneTestOutcomes;
-
-static DOWNLOAD_PREFIX: &str = "s3://ferrocene-ci-artifacts/ferrocene/dist";
+use crate::ferrocene::download_and_extract_ci_outcomes;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub(super) struct TestOutcomesDir;
@@ -23,11 +20,7 @@ impl Step for TestOutcomesDir {
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         match &builder.config.ferrocene_test_outcomes {
             FerroceneTestOutcomes::DownloadCi => {
-                let commit = get_closest_merge_commit(None, &builder.config.git_config(), &[])
-                    .expect(
-                        "failed to retrieve the git commit for ferrocene.test-outcomes=download-ci",
-                    );
-                Some(download_and_extract_outcomes(builder, &commit))
+                Some(download_and_extract_ci_outcomes(builder, "test"))
             }
             FerroceneTestOutcomes::Disabled => None,
             FerroceneTestOutcomes::Custom(path) => Some(std::fs::canonicalize(path).unwrap()),
@@ -47,37 +40,4 @@ impl Step for TestOutcomesDir {
             }
         }
     }
-}
-
-fn download_and_extract_outcomes(builder: &Builder<'_>, commit: &str) -> PathBuf {
-    if builder.config.dry_run() {
-        return PathBuf::new();
-    }
-
-    let base = builder.out.join("cache").join("ferrocene").join("test-outcomes");
-    let extracted_dir = base.join("extracted");
-    let tarballs_dir = base.join("tarballs");
-
-    let commit_file = extracted_dir.join(".ferrocene-commit");
-    let tarball_file = tarballs_dir.join(&format!("{commit}.tar.xz"));
-
-    if !tarball_file.exists() {
-        builder.info(&format!("Downloading test outcomes for commit {commit}"));
-        let version = builder.config.artifact_version_part(commit);
-        let url = format!("{DOWNLOAD_PREFIX}/{commit}/ferrocene-test-outcomes-{version}.tar.xz");
-        builder.create_dir(&tarballs_dir);
-        builder.config.download_file(&url, &tarball_file, "Could not download the test outcomes.");
-    }
-
-    if !commit_file.exists() || builder.read(&commit_file) != commit {
-        builder.info(&format!("Extracting test outcomes for commit {commit}"));
-        if extracted_dir.exists() {
-            builder.remove_dir(&extracted_dir);
-        }
-        builder.create_dir(&extracted_dir);
-        builder.config.unpack(&tarball_file, &extracted_dir, "");
-        std::fs::write(&commit_file, commit.as_bytes()).unwrap();
-    }
-
-    extracted_dir.join("share").join("ferrocene").join("test-outcomes")
 }


### PR DESCRIPTION
:warning: This PR builds on top of https://github.com/ferrocene/ferrocene/pull/1421, commits from it are present here :warning: 

This PR adds the last piece of the puzzle for coverage, `coverage-outcomes = "download-ci";`, to download the latest coverage metadata from CI when generating a report locally. It also adds documentation for the whole coverage work.