### PR TITLE
remove unused backtrace codebase

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,10 +38,6 @@
 	path = src/doc/embedded-book
 	url = https://github.com/rust-embedded/book.git
 	shallow = true
-[submodule "library/backtrace"]
-	path = library/backtrace
-	url = https://github.com/rust-lang/backtrace-rs.git
-	shallow = true
 [submodule "src/tools/rustc-perf"]
 	path = src/tools/rustc-perf
 	url = https://github.com/rust-lang/rustc-perf.git

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -489,7 +489,7 @@ impl Build {
 
             // Make sure we update these before gathering metadata so we don't get an error about missing
             // Cargo.toml files.
-            let rust_submodules = ["library/backtrace", "library/stdarch"];
+            let rust_submodules = ["ferrocene/library/backtrace-rs", "library/stdarch"];
             for s in rust_submodules {
                 build.require_submodule(
                     s,


### PR DESCRIPTION
Upstream pulls in a backtrace repo as a submodule, while we do that as well as pull in another as a subtree. This causes confusion, so this change makes things more clear.