### PR TITLE
ci: avoid some build warnings

### DIFF
--- a/src/bootstrap/defaults/bootstrap.ferrocene-dist.toml
+++ b/src/bootstrap/defaults/bootstrap.ferrocene-dist.toml
@@ -47,6 +47,13 @@ build-stage = 2
 test-stage = 2
 doc-stage = 2
 
+# Adds a custom string to the output of `rustc --version` to properly mark this is not the upstream
+# compiler.
+#
+# If this configuration is missing or changed the output of `rustc --version` will change
+# accordingly.
+description = "Ferrocene by Ferrous Systems"
+
 
 
 [llvm]
@@ -109,13 +116,6 @@ debug-logging = false
 # If this configuration is missing Rust's debug assertions will be disabled, which could result in
 # compiler bugs or miscompilations not being detected. Never remove this flag.
 debug-assertions = true
-
-# Adds a custom string to the output of `rustc --version` to properly mark this is not the upstream
-# compiler.
-#
-# If this configuration is missing or changed the output of `rustc --version` will change
-# accordingly.
-description = "Ferrocene by Ferrous Systems"
 
 # Use a single codegen unit when compiling the standard library.
 #


### PR DESCRIPTION
- `change-id` is informative, and needs only be set during development... it is not useful in CI
- `rust.description` is deprecated, and instead moved to build.description