### PR TITLE
Rename triple to tuple

### DIFF
--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -142,7 +142,7 @@ JOBS_DEFINITION: JobsDefinition = {
         # like 'test:compiletest' minus the ONLY_HOSTS test groups
         # the ONLY_HOSTS tests will run on the host even when
         # `--target $NOT_THE_HOST` is passed to `x.py test`
-        # this avoids re-running tests on the same host triple across
+        # this avoids re-running tests on the same host tuple across
         # different CI jobs
         #
         # this is in a separate category and not under `test:` because that
@@ -172,6 +172,7 @@ JOBS_DEFINITION: JobsDefinition = {
     },
 }
 # fmt: on
+
 
 def sorted_tasks(tasks: Iterable[str | Task]) -> list[Task]:
     tasks = list(tasks)

--- a/ferrocene/doc/internal-procedures/src/docs/sphinx-extensions.rst
+++ b/ferrocene/doc/internal-procedures/src/docs/sphinx-extensions.rst
@@ -94,24 +94,24 @@ Mentioning targets
 
 When you need to refer to targets across the documentation, it's better to use
 a human-readable name (like ":target:`aarch64-unknown-none`") than the target
-triple, as the latter is often inconsistent between similar targets and could
+tuple, as the latter is often inconsistent between similar targets and could
 be confusing to customers.
 
 To keep the target names consistent, you can use the ``:target:`` role with the
-target triple as its content, which will be rendered as the human-readable
+target tuple as its content, which will be rendered as the human-readable
 name:
 
 .. code-block:: rst
 
    :target:`x86_64-unknown-linux-gnu`
 
-The ``:target-with-triple:`` role will also add the triple following the
+The ``:target-with-tuple:`` role will also add the tuple following the
 human-readable name, which is best used when customers then need to copy/paste
-the triple:
+the tuple:
 
 .. code-block:: rst
 
-   :target-with-triple:`aarch64-unknown-none`
+   :target-with-tuple:`aarch64-unknown-none`
 
 The human-readable names are stored in ``ferrocene/doc/target-names.toml``, and
 referring to a target not defined in that file will emit a warning.
@@ -189,7 +189,7 @@ the CLI option:
 
       .. cli::option: --target <name>
 
-         Used to specify the target triple.
+         Used to specify the target tuple.
 
       .. cli::option: --help
 
@@ -271,9 +271,9 @@ with the :ref:`test outcomes <test-outcomes>` of a tested target. The
 directive accepts a single argument, the path to the template to render. It
 also accepts multiple options:
 
-* ``host`` (required): the target triple of the host platform
-* ``target`` (required): the target triple of the compilation target
-* ``bare_metal_test_target`` (optional): the target triple of the special
+* ``host`` (required): the target tuple of the host platform
+* ``target`` (required): the target tuple of the compilation target
+* ``bare_metal_test_target`` (optional): the target tuple of the special
   target used for bare metal testing; it should be omitted if no special target
   was used
 * ``remote_testing`` (optional): whether the tests were executed on CI or on a

--- a/ferrocene/doc/internal-procedures/src/setup-local-env.rst
+++ b/ferrocene/doc/internal-procedures/src/setup-local-env.rst
@@ -20,7 +20,7 @@ Rust, as well as the following:
   CLI, while we explicitly require version 2.
 
 
-:target-with-triple:`x86_64-unknown-linux-gnu`
+:target-with-tuple:`x86_64-unknown-linux-gnu`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 On Ubuntu 24.10, install the software requirements by running:
@@ -45,7 +45,7 @@ from the official repositories:
 
    sudo pacman -S ninja bzip2 cmake gcc uv
 
-:target-with-triple:`aarch64-apple-darwin`
+:target-with-tuple:`aarch64-apple-darwin`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you don't already have XCode set up, get the XCode command line tools as
@@ -66,7 +66,7 @@ Then use Homebrew to install the remaining packages:
    brew install ninja bzip2 cmake awscli uv gnu-tar
 
 
-:target-with-triple:`x86_64-pc-windows-msvc`
+:target-with-tuple:`x86_64-pc-windows-msvc`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::

--- a/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
+++ b/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
@@ -23,7 +23,7 @@ Host Setup
 Unless otherwise noted, all bare-metal targets are tested via QEMU on a Linux host.
 On macOS, a tool like Lima or Docker must be used. On Windows, WSL2 must be used.
 
-:target-with-triple:`x86_64-unknown-linux-gnu`
+:target-with-tuple:`x86_64-unknown-linux-gnu`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You need to have all the normal prerequisites from :doc:`internal-procedures:setup-local-env`
@@ -34,7 +34,7 @@ installed, as well as a few extras:
    sudo apt install qemu-user-static binfmt-support
 
 
-:target-with-triple:`aarch64-apple-darwin`
+:target-with-tuple:`aarch64-apple-darwin`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Install Lima, if you don't have it:
@@ -82,7 +82,7 @@ Shell into the guest:
 You can also point `Visual Studio Code's SSH extension <https://code.visualstudio.com/docs/remote/ssh>`_ at it
 using `these steps <https://github.com/lima-vm/lima/discussions/1890#discussioncomment-7221563>`_.
 
-Finally, ensure the guest is configured according to :doc:`internal-procedures:setup-local-env` as well as the :target-with-triple:`x86_64-unknown-linux-gnu` on this page.
+Finally, ensure the guest is configured according to :doc:`internal-procedures:setup-local-env` as well as the :target-with-tuple:`x86_64-unknown-linux-gnu` on this page.
 
 .. Warning::
     
@@ -91,7 +91,7 @@ Finally, ensure the guest is configured according to :doc:`internal-procedures:s
 
     Please ensure you always work from the guest-local repository.
 
-:target-with-triple:`x86_64-pc-windows-msvc`
+:target-with-tuple:`x86_64-pc-windows-msvc`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Setup WSL2, if you don't have it:
@@ -124,7 +124,7 @@ Shell into the guest:
     
 You can also point `Visual Studio Code WSL extension <https://code.visualstudio.com/docs/remote/wsl-tutorial>`_ at it.
 
-Finally, ensure the guest is configured according to :doc:`internal-procedures:setup-local-env` as well as the :target-with-triple:`x86_64-unknown-linux-gnu` on this page.
+Finally, ensure the guest is configured according to :doc:`internal-procedures:setup-local-env` as well as the :target-with-tuple:`x86_64-unknown-linux-gnu` on this page.
 
 .. Warning::
     
@@ -143,7 +143,7 @@ Currently bare metal targets have a similar procedure for testing.
    Currently, these targets use our *secret sauce*.
    This will eventually be an open source component, but for now, it's our little bit of arcane magic.
 
-:target-with-triple:`aarch64-unknown-none`
+:target-with-tuple:`aarch64-unknown-none`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. Warning::
@@ -197,8 +197,8 @@ After, you can run the tests:
     export QEMU_CPU=cortex-a53
     ./x test --stage 1 --target aarch64-unknown-ferrocenecoretest library/core
 
-:target-with-triple:`thumbv7em-none-eabihf` & :target-with-triple:`thumbv7em-none-eabi`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:target-with-tuple:`thumbv7em-none-eabihf` & :target-with-tuple:`thumbv7em-none-eabi`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Install the necessary packages:
 

--- a/ferrocene/doc/internal-procedures/src/working-with-the-ci.rst
+++ b/ferrocene/doc/internal-procedures/src/working-with-the-ci.rst
@@ -127,7 +127,7 @@ download and execute them::
 Using the CI ``config.toml``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To create the ``config.toml`` used by the CI, set ``FERROCENE_HOST`` to your host triple,
+To create the ``config.toml`` used by the CI, set ``FERROCENE_HOST`` to your host tuple,
 then run the ``configure.sh``:
 
 .. code-block:: bash
@@ -168,10 +168,10 @@ Most CI jobs are formatted similar to this:
       - ferrocene-job-dist:
           restore-from-job: x86_64-linux-build
 
-Jobs can only be reproduced on the host triple specified in ``FERROCENE_HOST``.
+Jobs can only be reproduced on the host tuple specified in ``FERROCENE_HOST``.
 Ensure your host is correct.
 
-If ``FERROCENE_TARGETS`` is different than your host triple,
+If ``FERROCENE_TARGETS`` is different than your host tuple,
 update your ``config.toml``'s ``[build]`` section's ``host`` and ``target`` to
 reflect that.
 

--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -104,7 +104,7 @@ This page outlines the testing of Ferrocene |ferrocene_version| (based on Rust
 
    * -
      - Target name
-     - Target triple
+     - Target tuple
 
    * - Host platform:
      - :target:`{{ host }}`

--- a/ferrocene/doc/release-notes/src/24.05.0.rst
+++ b/ferrocene/doc/release-notes/src/24.05.0.rst
@@ -29,9 +29,9 @@ shipped as a preview.
   Note that experimental targets are not qualified for safety critical use. The
   new targets are:
 
-  * :target-with-triple:`thumbv7em-none-eabi`
-  * :target-with-triple:`thumbv7em-none-eabihf`
-  * :target-with-triple:`wasm32-unknown-unknown`
+  * :target-with-tuple:`thumbv7em-none-eabi`
+  * :target-with-tuple:`thumbv7em-none-eabihf`
+  * :target-with-tuple:`wasm32-unknown-unknown`
 
 * The self-testing tool now checks the correct behavior of *linker drivers*,
   according to the new requirements for linkers. Note that the self-testing

--- a/ferrocene/doc/release-notes/src/24.08.0.rst
+++ b/ferrocene/doc/release-notes/src/24.08.0.rst
@@ -32,24 +32,24 @@ shipped as a preview.
   Note that experimental targets are not qualified for safety critical use. The
   new targets are:
 
-  * :target-with-triple:`armv8r-none-eabihf`
-  * :target-with-triple:`armv7r-none-eabihf`
-  * :target-with-triple:`armebv7r-none-eabihf`
-  * :target-with-triple:`x86_64-apple-darwin`
-  * :target-with-triple:`aarch64-unknown-nto-qnx710`
-  * :target-with-triple:`x86_64-pc-nto-qnx710`
+  * :target-with-tuple:`armv8r-none-eabihf`
+  * :target-with-tuple:`armv7r-none-eabihf`
+  * :target-with-tuple:`armebv7r-none-eabihf`
+  * :target-with-tuple:`x86_64-apple-darwin`
+  * :target-with-tuple:`aarch64-unknown-nto-qnx710`
+  * :target-with-tuple:`x86_64-pc-nto-qnx710`
 
 * Experimental support has been added for new host platforms. Note that
   experimental targets are not qualified for safety critical use. The new
   targets are:
 
-  * :target-with-triple:`aarch64-apple-darwin`
-  * :target-with-triple:`x86_64-pc-windows-msvc`
+  * :target-with-tuple:`aarch64-apple-darwin`
+  * :target-with-tuple:`x86_64-pc-windows-msvc`
 
 Changes
 -------
 
-* The :target-with-triple:`x86_64-unknown-linux-gnu` target now requires
+* The :target-with-tuple:`x86_64-unknown-linux-gnu` target now requires
   glibc version of 2.31 or higher.
 
 Rust changes

--- a/ferrocene/doc/release-notes/src/24.11.0.rst
+++ b/ferrocene/doc/release-notes/src/24.11.0.rst
@@ -17,8 +17,8 @@ New features
 * Ferrocene is now supported and qualified for use in medical devices (IEC 62304).
 * Two new targets are now supported and qualified for safety critical use.
 
-  * :target-with-triple:`aarch64-unknown-nto-qnx710`
-  * :target-with-triple:`x86_64-pc-nto-qnx710`
+  * :target-with-tuple:`aarch64-unknown-nto-qnx710`
+  * :target-with-tuple:`x86_64-pc-nto-qnx710`
 
 New experimental features
 -------------------------
@@ -30,7 +30,7 @@ shipped as a preview.
   Note that experimental targets are not qualified for safety critical use. The
   new target is:
 
-  * :target-with-triple:`aarch64-unknown-linux-gnu`
+  * :target-with-tuple:`aarch64-unknown-linux-gnu`
 
 Rust changes
 ------------

--- a/ferrocene/doc/release-notes/src/25.02.0.rst
+++ b/ferrocene/doc/release-notes/src/25.02.0.rst
@@ -17,7 +17,7 @@ New features
   qualified for safety critical use, but are otherwise fully tested and supported. The new
   target is:
 
-  * :target-with-triple:`aarch64-apple-darwin`
+  * :target-with-tuple:`aarch64-apple-darwin`
 
 
 New experimental features
@@ -30,11 +30,11 @@ shipped as a preview.
   Note that experimental targets are not qualified for safety critical use. The
   new targets are:
 
-  * :target-with-triple:`thumbv6m-none-eabi`
-  * :target-with-triple:`thumbv8m.base-none-eabi`
-  * :target-with-triple:`thumbv8m.main-none-eabi`
-  * :target-with-triple:`thumbv8m.main-none-eabihf`
-  * :target-with-triple:`riscv64gc-unknown-linux-gnu`
+  * :target-with-tuple:`thumbv6m-none-eabi`
+  * :target-with-tuple:`thumbv8m.base-none-eabi`
+  * :target-with-tuple:`thumbv8m.main-none-eabi`
+  * :target-with-tuple:`thumbv8m.main-none-eabihf`
+  * :target-with-tuple:`riscv64gc-unknown-linux-gnu`
 
 Fixed known problems
 --------------------

--- a/ferrocene/doc/release-notes/src/25.05.0.rst
+++ b/ferrocene/doc/release-notes/src/25.05.0.rst
@@ -15,8 +15,8 @@ New features
 
 * Two new targets are now supported and qualified for safety critical use:
 
-  * :target-with-triple:`thumbv7em-none-eabi`
-  * :target-with-triple:`thumbv7em-none-eabihf`
+  * :target-with-tuple:`thumbv7em-none-eabi`
+  * :target-with-tuple:`thumbv7em-none-eabihf`
 
 Fixed known problems
 --------------------

--- a/ferrocene/doc/release-notes/src/next.rst
+++ b/ferrocene/doc/release-notes/src/next.rst
@@ -17,4 +17,4 @@ shipped as a preview. In some circumstances, these features are removed.
 
 * Experimental support has been removed for the following platforms:
 
-  * :target-with-triple:`x86_64-apple-darwin`
+  * :target-with-tuple:`x86_64-apple-darwin`

--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_qualification/target.py
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_qualification/target.py
@@ -8,9 +8,9 @@ import tomli
 
 
 class TargetRole(SphinxRole):
-    def __init__(self, *, include_triple=False):
+    def __init__(self, *, include_tuple=False):
         super().__init__()
-        self.include_triple = include_triple
+        self.include_tuple = include_tuple
 
     def run(self):
         target = self.text.strip()
@@ -19,17 +19,17 @@ class TargetRole(SphinxRole):
                 self.env,
                 self.config,
                 target,
-                include_triple=self.include_triple,
+                include_tuple=self.include_tuple,
                 location=self.get_location(),
             )
         ], []
 
 
-def render_target_name(env, config, target, *, include_triple=False, location=None):
+def render_target_name(env, config, target, *, include_tuple=False, location=None):
     if target in env.ferrocene_target_names:
         inline = nodes.inline()
         inline += nodes.Text(env.ferrocene_target_names[target])
-        if include_triple:
+        if include_tuple:
             inline += nodes.Text(" (")
             inline += nodes.literal("", target)
             inline += nodes.Text(")")
@@ -50,4 +50,4 @@ def load_target_names(app, env, _docnames):
 def setup(app):
     app.connect("env-before-read-docs", load_target_names)
     app.add_role("target", TargetRole())
-    app.add_role("target-with-triple", TargetRole(include_triple=True))
+    app.add_role("target-with-tuple", TargetRole(include_tuple=True))

--- a/ferrocene/doc/target-names.toml
+++ b/ferrocene/doc/target-names.toml
@@ -5,7 +5,7 @@
 # Ferrocene, to provide consistency across documents on how we refer to them.
 #
 # In the documents, as long as the ferrocene_qualification extension is added,
-# you can refer to them with :target:`triple`.
+# you can refer to them with :target:`tuple`.
 
 
 aarch64-apple-darwin        = "Apple Silicon macOS"

--- a/ferrocene/doc/user-manual/src/rustc/cli.rst
+++ b/ferrocene/doc/user-manual/src/rustc/cli.rst
@@ -1169,7 +1169,7 @@
    .. cli:option:: --target <target>
       :category: wide
 
-      Compiler argument ``--target`` indicates the target triple to build.
+      Compiler argument ``--target`` indicates the target tuple to build.
 
       ``<target>`` must denote **what is it for ARM?**
 

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -47,7 +47,7 @@ qualified upon request.
    :header-rows: 1
 
    * - Target
-     - Triple
+     - Tuple
      - Kind
      - Standard library
      - Notes
@@ -107,7 +107,7 @@ Quality managed targets are not qualified, but can usually be qualified on reque
    :header-rows: 1
 
    * - Target
-     - Triple
+     - Tuple
      - Kind
      - Standard library
      - Notes
@@ -131,7 +131,7 @@ should not be used in production.
    :header-rows: 1
 
    * - Target
-     - Triple
+     - Tuple
      - Kind
      - Standard library
      - Notes

--- a/ferrocene/tools/self-test/src/binaries.rs
+++ b/ferrocene/tools/self-test/src/binaries.rs
@@ -311,10 +311,10 @@ mod tests {
     #[test]
     fn test_check_binary_wrong_host() {
         test_wrong_version_data(
-            CliVersionContent { host: "bad-target-triple", ..CliVersionContent::default() },
+            CliVersionContent { host: "bad-target-tuple", ..CliVersionContent::default() },
             "host",
             CliVersionContent::default().host,
-            "bad-target-triple",
+            "bad-target-tuple",
         );
     }
 

--- a/ferrocene/tools/self-test/src/compile.rs
+++ b/ferrocene/tools/self-test/src/compile.rs
@@ -95,7 +95,7 @@ fn check_target(
         let expected_binary_paths = program
             .expected_executables
             .into_iter()
-            .flat_map(|expected| match target.spec.triple {
+            .flat_map(|expected| match target.spec.tuple {
                 windows if windows.ends_with("-pc-windows-msvc") => {
                     vec![format!("{expected}.exe"), format!("{expected}.pdb")]
                 }
@@ -107,7 +107,7 @@ fn check_target(
         let expected_library_paths = program
             .expected_libraries
             .into_iter()
-            .map(|expected| match target.spec.triple {
+            .map(|expected| match target.spec.tuple {
                 windows if windows.ends_with("-pc-windows-msvc") => format!("{expected}.lib"),
                 _ => format!("lib{expected}.a"),
             })
@@ -124,7 +124,7 @@ fn check_target(
         compile(&ctx, program)?;
         expected_artifacts.check(program.name)?;
 
-        let should_run = (ctx.target.triple == env::SELFTEST_TARGET)
+        let should_run = (ctx.target.tuple == env::SELFTEST_TARGET)
             .then_some(program.executable_output)
             .flatten();
         if let Some(expected_output) = should_run {
@@ -135,7 +135,7 @@ fn check_target(
             "compiled {}sample program `{}` for target {}",
             if should_run.is_some() { "and ran " } else { "" },
             program.name,
-            target.triple
+            target.tuple
         ));
     }
     Ok(())
@@ -161,7 +161,7 @@ fn compile(ctx: &Context<'_>, program: &SampleProgram) -> Result<(), Error> {
     remap_path_prefix.push("=/self-test");
 
     let mut cmd = Command::new(&ctx.rustc);
-    cmd.args(["--target", ctx.target.triple]);
+    cmd.args(["--target", ctx.target.tuple]);
     cmd.arg("-L").arg(&ctx.output_dir);
     cmd.arg("--out-dir").arg(&ctx.output_dir);
     cmd.arg("--remap-path-prefix").arg(&remap_path_prefix);
@@ -372,7 +372,7 @@ mod tests {
 
         let target = Target {
             spec: &TargetSpec {
-                triple: "x86_64-unknown-linux-gnu",
+                tuple: "x86_64-unknown-linux-gnu",
                 std: true,
                 linker: Linker::BundledLld,
             },
@@ -440,7 +440,7 @@ mod tests {
         let context = Context {
             target: &Target {
                 spec: &TargetSpec {
-                    triple: "x86_64-unknown-linux-gnu",
+                    tuple: "x86_64-unknown-linux-gnu",
                     std: true,
                     linker: Linker::BundledLld,
                 },
@@ -487,7 +487,7 @@ mod tests {
         let context = Context {
             target: &Target {
                 spec: &TargetSpec {
-                    triple: "x86_64-unknown-linux-gnu",
+                    tuple: "x86_64-unknown-linux-gnu",
                     std: true,
                     linker: Linker::BundledLld,
                 },
@@ -560,13 +560,13 @@ mod tests {
                 // cannot dynamically set std depending on the function parameter.
                 spec: if std {
                     &TargetSpec {
-                        triple: "x86_64-unknown-linux-gnu",
+                        tuple: "x86_64-unknown-linux-gnu",
                         linker: Linker::BundledLld,
                         std: true,
                     }
                 } else {
                     &TargetSpec {
-                        triple: "x86_64-unknown-linux-gnu",
+                        tuple: "x86_64-unknown-linux-gnu",
                         linker: Linker::BundledLld,
                         std: false,
                     }

--- a/ferrocene/tools/self-test/src/env.rs
+++ b/ferrocene/tools/self-test/src/env.rs
@@ -14,7 +14,7 @@ use crate::error::Error;
 //
 /// The Rust release ferrocene-self-test is being compiled for
 pub(crate) const CFG_RELEASE: &str = env!("CFG_RELEASE");
-/// The target-tuple ferroce-self-test is being compiled for
+/// The target-tuple ferrocene-self-test is being compiled for
 pub(crate) const SELFTEST_TARGET: &str = env!("SELFTEST_TARGET");
 pub(crate) const SELFTEST_RUST_HASH: Option<&str> = option_env!("SELFTEST_RUST_HASH");
 pub(crate) const SELFTEST_CARGO_HASH: Option<&str> = option_env!("SELFTEST_CARGO_HASH");

--- a/ferrocene/tools/self-test/src/env.rs
+++ b/ferrocene/tools/self-test/src/env.rs
@@ -14,7 +14,7 @@ use crate::error::Error;
 //
 /// The Rust release ferrocene-self-test is being compiled for
 pub(crate) const CFG_RELEASE: &str = env!("CFG_RELEASE");
-/// The target-triple ferroce-self-test is being compiled for
+/// The target-tuple ferroce-self-test is being compiled for
 pub(crate) const SELFTEST_TARGET: &str = env!("SELFTEST_TARGET");
 pub(crate) const SELFTEST_RUST_HASH: Option<&str> = option_env!("SELFTEST_RUST_HASH");
 pub(crate) const SELFTEST_CARGO_HASH: Option<&str> = option_env!("SELFTEST_CARGO_HASH");

--- a/ferrocene/tools/self-test/src/linkers.rs
+++ b/ferrocene/tools/self-test/src/linkers.rs
@@ -59,7 +59,7 @@ pub(crate) fn check_and_add_rustflags(
         let prefix_list: &[&str] = match target.linker {
             Linker::BundledLld => {
                 reporter
-                    .skipped(&format!("Target `{}` does not require a C compiler", target.triple));
+                    .skipped(&format!("Target `{}` does not require a C compiler", target.tuple));
                 continue 'target_loop;
             }
             Linker::HostCc => &[""],
@@ -79,7 +79,7 @@ pub(crate) fn check_and_add_rustflags(
                     let compiler_name = format!("{cc_prefix}{compiler_kind}");
                     let cc_result = check_system_compiler(
                         env,
-                        target.triple,
+                        target.tuple,
                         &compiler_name,
                         lld_dir,
                         temp_dir.path(),
@@ -90,12 +90,12 @@ pub(crate) fn check_and_add_rustflags(
                             if env.print_detailed_args {
                                 reporter.note(&format!(
                                     "Target `{}`, detected args `{:?}`",
-                                    target.triple, &linker_args
+                                    target.tuple, &linker_args
                                 ));
                             }
 
                             match linker_args_ok(
-                                target.triple,
+                                target.tuple,
                                 linker_args.iter().map(|s| s.as_str()),
                                 &mut cc_args,
                             ) {
@@ -117,7 +117,7 @@ pub(crate) fn check_and_add_rustflags(
                             }
                             reporter.success(&format!(
                                 "Found C compiler `{}` for target `{}`",
-                                compiler_name, target.triple
+                                compiler_name, target.tuple
                             ));
                             target.rustflags.push(format!("-Clinker={compiler_name}"));
                             for cc_arg in cc_args {
@@ -138,7 +138,7 @@ pub(crate) fn check_and_add_rustflags(
                 }
             }
         }
-        return Err(Error::SuitableCCompilerNotFound { target: target.triple.into() });
+        return Err(Error::SuitableCCompilerNotFound { target: target.tuple.into() });
     }
 
     Ok(())
@@ -443,9 +443,9 @@ fn find_bundled_lld_wrapper(reporter: &dyn Reporter, sysroot: &Path) -> Result<P
 pub(crate) fn report_linker_flags(reporter: &dyn Reporter, targets: &[Target]) {
     for target in targets {
         if target.rustflags.is_empty() {
-            reporter.info(&format!("Target '{}' requires no special linker flags", target.triple));
+            reporter.info(&format!("Target '{}' requires no special linker flags", target.tuple));
         } else {
-            reporter.info(&format!("Target '{}' requires special linker flags:", target.triple));
+            reporter.info(&format!("Target '{}' requires special linker flags:", target.tuple));
             for flag in &target.rustflags {
                 reporter.info(&format!("\t{}", flag));
             }

--- a/ferrocene/tools/self-test/src/targets.rs
+++ b/ferrocene/tools/self-test/src/targets.rs
@@ -12,52 +12,52 @@ use crate::report::Reporter;
 static SUPPORTED_TARGETS: &[TargetSpec] = &[
     #[cfg(target_arch = "x86_64")]
     TargetSpec {
-        triple: "aarch64-unknown-linux-gnu",
+        tuple: "aarch64-unknown-linux-gnu",
         std: true,
         linker: Linker::CrossCc(&["aarch64-linux-gnu-"]),
     },
     #[cfg(target_arch = "aarch64")]
-    TargetSpec { triple: "aarch64-unknown-linux-gnu", std: true, linker: Linker::HostCc },
-    TargetSpec { triple: "aarch64-apple-darwin", std: true, linker: Linker::BundledLld },
-    TargetSpec { triple: "aarch64-unknown-none", std: false, linker: Linker::BundledLld },
-    TargetSpec { triple: "aarch64-unknown-nto-qnx710", std: true, linker: Linker::BundledLld },
-    TargetSpec { triple: "armebv7r-none-eabihf", std: false, linker: Linker::BundledLld },
-    TargetSpec { triple: "armv7r-none-eabihf", std: false, linker: Linker::BundledLld },
-    TargetSpec { triple: "armv8r-none-eabihf", std: false, linker: Linker::BundledLld },
+    TargetSpec { tuple: "aarch64-unknown-linux-gnu", std: true, linker: Linker::HostCc },
+    TargetSpec { tuple: "aarch64-apple-darwin", std: true, linker: Linker::BundledLld },
+    TargetSpec { tuple: "aarch64-unknown-none", std: false, linker: Linker::BundledLld },
+    TargetSpec { tuple: "aarch64-unknown-nto-qnx710", std: true, linker: Linker::BundledLld },
+    TargetSpec { tuple: "armebv7r-none-eabihf", std: false, linker: Linker::BundledLld },
+    TargetSpec { tuple: "armv7r-none-eabihf", std: false, linker: Linker::BundledLld },
+    TargetSpec { tuple: "armv8r-none-eabihf", std: false, linker: Linker::BundledLld },
     TargetSpec {
-        triple: "riscv64gc-unknown-linux-gnu",
+        tuple: "riscv64gc-unknown-linux-gnu",
         std: true,
         // https://www.embecosm.com/resources/tool-chain-downloads/#riscv-linux's toolchains use
         // the `riscv64-unknown-linux-gnu-` prefix instead of `riscv64-linux-gnu-`
         linker: Linker::CrossCc(&["riscv64-unknown-linux-gnu-"]),
     },
-    TargetSpec { triple: "thumbv6m-none-eabi", std: false, linker: Linker::BundledLld },
-    TargetSpec { triple: "thumbv7em-none-eabi", std: false, linker: Linker::BundledLld },
-    TargetSpec { triple: "thumbv7em-none-eabihf", std: false, linker: Linker::BundledLld },
+    TargetSpec { tuple: "thumbv6m-none-eabi", std: false, linker: Linker::BundledLld },
+    TargetSpec { tuple: "thumbv7em-none-eabi", std: false, linker: Linker::BundledLld },
+    TargetSpec { tuple: "thumbv7em-none-eabihf", std: false, linker: Linker::BundledLld },
     TargetSpec {
-        triple: "thumbv7em-ferrocenecoretest-eabihf",
+        tuple: "thumbv7em-ferrocenecoretest-eabihf",
         std: true,
         linker: Linker::BundledLld,
     },
-    TargetSpec { triple: "thumbv8m.base-none-eabi", std: false, linker: Linker::BundledLld },
-    TargetSpec { triple: "thumbv8m.main-none-eabi", std: false, linker: Linker::BundledLld },
-    TargetSpec { triple: "thumbv8m.main-none-eabihf", std: false, linker: Linker::BundledLld },
-    TargetSpec { triple: "x86_64-pc-nto-qnx710", std: true, linker: Linker::BundledLld },
-    TargetSpec { triple: "x86_64-pc-windows-msvc", std: true, linker: Linker::BundledLld },
+    TargetSpec { tuple: "thumbv8m.base-none-eabi", std: false, linker: Linker::BundledLld },
+    TargetSpec { tuple: "thumbv8m.main-none-eabi", std: false, linker: Linker::BundledLld },
+    TargetSpec { tuple: "thumbv8m.main-none-eabihf", std: false, linker: Linker::BundledLld },
+    TargetSpec { tuple: "x86_64-pc-nto-qnx710", std: true, linker: Linker::BundledLld },
+    TargetSpec { tuple: "x86_64-pc-windows-msvc", std: true, linker: Linker::BundledLld },
     #[cfg(target_arch = "aarch64")]
     TargetSpec {
-        triple: "x86_64-unknown-linux-gnu",
+        tuple: "x86_64-unknown-linux-gnu",
         std: true,
         linker: Linker::CrossCc(&["x86_64-linux-gnu-"]),
     },
     #[cfg(target_arch = "x86_64")]
-    TargetSpec { triple: "x86_64-unknown-linux-gnu", std: true, linker: Linker::HostCc },
+    TargetSpec { tuple: "x86_64-unknown-linux-gnu", std: true, linker: Linker::HostCc },
 ];
 
 #[derive(Debug)]
 pub(crate) struct TargetSpec {
-    /// The rustc triple for the target
-    pub(crate) triple: &'static str,
+    /// The rustc tuple for the target
+    pub(crate) tuple: &'static str,
     /// Indicates if the target provides libstd.
     pub(crate) std: bool,
     /// Indicates if the target requires a system C compiler as a linker driver
@@ -96,7 +96,7 @@ fn check_target(
     sysroot: &Path,
     target: &TargetSpec,
 ) -> Result<CheckTargetOutcome, Error> {
-    let target_dir = sysroot.join("lib").join("rustlib").join(target.triple);
+    let target_dir = sysroot.join("lib").join("rustlib").join(target.tuple);
     if !target_dir.is_dir() {
         // Target not present, ignore it.
         return Ok(CheckTargetOutcome::Missing);
@@ -108,7 +108,7 @@ fn check_target(
     };
     check_libraries(target, &target_dir, expected_libs)?;
 
-    reporter.success(&format!("target installed correctly: {}", target.triple));
+    reporter.success(&format!("target installed correctly: {}", target.tuple));
     Ok(CheckTargetOutcome::Found)
 }
 
@@ -124,14 +124,14 @@ fn check_libraries(target: &TargetSpec, target_dir: &Path, expected: &[&str]) ->
     let mut expected_to_find = expected.iter().cloned().collect::<HashSet<_>>();
     for (library, count) in find_libraries_in(&lib_dir)?.into_iter() {
         if count > 1 {
-            return Err(Error::DuplicateTargetLibrary { target: target.triple.into(), library });
+            return Err(Error::DuplicateTargetLibrary { target: target.tuple.into(), library });
         }
         expected_to_find.remove(library.as_str());
     }
 
     if let Some(library) = expected_to_find.iter().next() {
         Err(Error::TargetLibraryMissing {
-            target: target.triple.into(),
+            target: target.tuple.into(),
             library: library.to_string(),
         })
     } else {
@@ -176,12 +176,12 @@ mod tests {
 
     #[test]
     fn test_check_target_std() {
-        let triple = "x86_64-unknown-linux-gnu";
-        let target = TargetSpec { triple, std: true, linker: Linker::HostCc };
+        let tuple = "x86_64-unknown-linux-gnu";
+        let target = TargetSpec { tuple, std: true, linker: Linker::HostCc };
 
         let utils = TestUtils::new();
         utils
-            .target(triple)
+            .target(tuple)
             .lib("core", "0123456789abcdef")
             .lib("alloc", "0123456789abcdef")
             .lib("std", "0123456789abcdef")
@@ -199,12 +199,12 @@ mod tests {
 
     #[test]
     fn test_check_target_no_std() {
-        let triple = "x86_64-unknown-none";
-        let target = TargetSpec { triple, std: false, linker: Linker::BundledLld };
+        let tuple = "x86_64-unknown-none";
+        let target = TargetSpec { tuple, std: false, linker: Linker::BundledLld };
 
         let utils = TestUtils::new();
         utils
-            .target(triple)
+            .target(tuple)
             .lib("core", "0123456789abcdef")
             .lib("alloc", "0123456789abcdef")
             .lib("other", "0123456789abcdef") // Unknown libraries are ignored
@@ -214,20 +214,20 @@ mod tests {
             CheckTargetOutcome::Found,
             check_target(utils.reporter(), utils.sysroot(), &target).unwrap()
         );
-        utils.assert_report_success(format!("target installed correctly: {triple}").as_str());
+        utils.assert_report_success(format!("target installed correctly: {tuple}").as_str());
     }
 
     #[test]
     fn test_check_target_missing_library() {
-        let triple = "x86_64-unknown-none";
-        let target = TargetSpec { triple, std: false, linker: Linker::BundledLld };
+        let tuple = "x86_64-unknown-none";
+        let target = TargetSpec { tuple, std: false, linker: Linker::BundledLld };
 
         let utils = TestUtils::new();
-        utils.target(triple).lib("core", "0123456789abcdef").create();
+        utils.target(tuple).lib("core", "0123456789abcdef").create();
 
         match check_target(utils.reporter(), utils.sysroot(), &target) {
             Err(Error::TargetLibraryMissing { target, library }) => {
-                assert_eq!(target, triple);
+                assert_eq!(target, tuple);
                 assert_eq!(library, "alloc");
             }
             other => panic!("unexpected result: {other:?}"),
@@ -237,12 +237,12 @@ mod tests {
 
     #[test]
     fn test_check_target_duplicate_required_library() {
-        let triple = "x86_64-unknown-none";
-        let target = TargetSpec { triple, std: false, linker: Linker::BundledLld };
+        let tuple = "x86_64-unknown-none";
+        let target = TargetSpec { tuple, std: false, linker: Linker::BundledLld };
 
         let utils = TestUtils::new();
         utils
-            .target(triple)
+            .target(tuple)
             .lib("core", "0123456789abcdef")
             .lib("core", "abcdef0123456789")
             .lib("alloc", "0123456789abcdef")
@@ -250,7 +250,7 @@ mod tests {
 
         match check_target(utils.reporter(), utils.sysroot(), &target) {
             Err(Error::DuplicateTargetLibrary { target, library }) => {
-                assert_eq!(target, triple);
+                assert_eq!(target, tuple);
                 assert_eq!(library, "core");
             }
             other => panic!("unexpected result: {other:?}"),
@@ -260,12 +260,12 @@ mod tests {
 
     #[test]
     fn test_check_target_duplicate_other_library() {
-        let triple = "x86_64-unknown-none";
-        let target = TargetSpec { triple, std: false, linker: Linker::BundledLld };
+        let tuple = "x86_64-unknown-none";
+        let target = TargetSpec { tuple, std: false, linker: Linker::BundledLld };
 
         let utils = TestUtils::new();
         utils
-            .target(triple)
+            .target(tuple)
             .lib("core", "0123456789abcdef")
             .lib("other", "0123456789abcdef")
             .lib("other", "abcdef0123456789")
@@ -274,7 +274,7 @@ mod tests {
 
         match check_target(utils.reporter(), utils.sysroot(), &target) {
             Err(Error::DuplicateTargetLibrary { target, library }) => {
-                assert_eq!(target, triple);
+                assert_eq!(target, tuple);
                 assert_eq!(library, "other");
             }
             other => panic!("unexpected result: {other:?}"),
@@ -284,18 +284,18 @@ mod tests {
 
     #[test]
     fn test_find_libraries_in() {
-        let triple = "x86_64-unknown-linux-gnu";
+        let tuple = "x86_64-unknown-linux-gnu";
 
         let utils = TestUtils::new();
         utils
-            .target(triple)
+            .target(tuple)
             .lib("core", "0123456789abcdef")
             .lib("core", "abcdef0123456789")
             .lib("alloc", "0123456789abcdef")
             .lib("proc_macro", "0123456789abcdef")
             .create();
 
-        let lib_dir = utils.target_dir(triple).join("lib");
+        let lib_dir = utils.target_dir(tuple).join("lib");
         std::fs::write(lib_dir.join("foo-0123456789abcdef.so"), b"").unwrap(); // Invalid files are not counted.
 
         let output = find_libraries_in(&lib_dir).unwrap();


### PR DESCRIPTION
Renames "target triples" to "target tuples" wherever I can find it.