### PR TITLE
Remove myself from organization roles (as I'm leaving Ferrous)

### DIFF
--- a/ferrocene/doc/qualification-plan/src/organization.rst
+++ b/ferrocene/doc/qualification-plan/src/organization.rst
@@ -24,11 +24,8 @@ Leadership roles
    * - Technical Lead
      - Ana Hobden
 
-   * - Technical Expert
-     - Pietro Albini
-
    * - Release Lead
-     - Pietro Albini
+     - Ana Hobden
 
    * - ISO 9001 Quality Manager
      - Sina Krause
@@ -40,5 +37,5 @@ Release managers are allowed to :ref:`approve manually published releases
 <release:Manually-started Releases>`. This role does not have the
 responsibilities of the Release Lead. The current release managers are:
 
-* Pietro Albini
+* Ana Hobden
 * Florian Gilcher


### PR DESCRIPTION
I'll leave Ferrous on May 8th, so this PR removes me from the organization roles. On the side I'm updating the permissions to grant Ana the release management permissions.