### PR TITLE
Show a dash when there is no test variant

### DIFF
--- a/ferrocene/doc/qualification-report/src/templates/tests.jinja2
+++ b/ferrocene/doc/qualification-report/src/templates/tests.jinja2
@@ -37,9 +37,15 @@ qualification.
 {% endmacro %}
 
 {% macro render_variant(variant) -%}
-    {%- for key, value in variant.fields.items() -%}
-        {% if not loop.first %} , {% endif -%}{{ key }}: {{ value }}
-    {%- endfor -%}
+    {%- if variant.fields -%}
+        {%- for key, value in variant.fields.items() -%}
+            {% if not loop.first %} , {% endif -%}{{ key }}: {{ value }}
+        {%- endfor -%}
+    {%- else -%}
+        .. rst-class:: align-center
+
+        \-
+    {%- endif -%}
 {%- endmacro %}
 
 {% macro cargo_tests_summary(bootstrap_type, only_match_root_node=False) %}


### PR DESCRIPTION
After https://github.com/ferrocene/ferrocene/pull/1421 got merged, I noticed that the template wouldn't include anything when no test variable was available:

![image](https://github.com/user-attachments/assets/a6a883e4-1d1e-44fb-9d5a-21d839c90113)

This PR quickly fixes it by adding a dash:

![image](https://github.com/user-attachments/assets/024b7a05-b29f-4f57-99e9-6cb01474e188)
