### PR TITLE
Build tools without debuginfo

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -888,11 +888,16 @@ impl Builder<'_> {
         }
         cargo.env(
             profile_var("DEBUG_ASSERTIONS"),
-            if mode == Mode::Std {
-                self.config.std_debug_assertions.to_string()
-            } else {
-                self.config.rustc_debug_assertions.to_string()
-            },
+            match mode {
+                Mode::Std => self.config.std_debug_assertions,
+                Mode::Rustc => self.config.rustc_debug_assertions,
+                Mode::Codegen => self.config.rustc_debug_assertions,
+                Mode::ToolBootstrap => false,
+                Mode::ToolStd => false,
+                Mode::ToolRustc => false,
+                Mode::ToolCustom { .. } => false,
+            }
+            .to_string(),
         );
         cargo.env(
             profile_var("OVERFLOW_CHECKS"),


### PR DESCRIPTION
For Ferrocene we configure both the compiler and the standard library to be compiled with debug assertions, to be able to potentially catch more issues in our qualified products. Bootstrap doesn't have a separate setting for controlling the debug assertions of tools, and they thus inherit the setting from rustc.

A customer though reported hitting [this debug assertion in Cargo](https://github.com/rust-lang/cargo/blob/2887f0755466903c3437077a227227b2f65f4e1c/src/cargo/core/resolver/types.rs#L69-L77). The assertion is meant to only be used when executing the test suite, which hints to me that the Cargo team assumes builds with debug assertions are never shipped to end users. This PR quickly patches the problem by disabling debug assertions for tools.

This is a quick patch to get the fix to that customer ASAP, I'll send a PR upstream with the proper fix later.