### PR TITLE
Distribute `rust-analyzer-proc-macro-srv` in `rustc` package

### DIFF
--- a/src/bootstrap/defaults/bootstrap.ferrocene-dist.toml
+++ b/src/bootstrap/defaults/bootstrap.ferrocene-dist.toml
@@ -34,7 +34,7 @@ extended = true
 #
 # NOTE: If you add a new tool here, make sure to also change `ferrocene/packages.toml` to include it
 # in new releases.
-tools = ["rustdoc", "cargo", "llvm-tools", "rustfmt", "rust-analyzer", "clippy"]
+tools = ["rustdoc", "cargo", "llvm-tools", "rustfmt", "rust-analyzer", "rust-analyzer-proc-macro-srv", "clippy"]
 
 # Build and enable the profiler runtime.
 #


### PR DESCRIPTION
Turns out we weren't doing this, and we should!

You can test this by doing `uv run x.py dist rustc` and expanding the `build/rustc-*.tar.xz` to see in `libexec` there is the `rust-analyzer-proc-macro-srv` binary.

Re: https://github.com/ferrocene/ferrocene/blob/466de87e29b9086f5cc5b2a4cd08bc4de1bcf4a1/src/bootstrap/defaults/bootstrap.ferrocene-dist.toml#L35

I do not *believe* we need to include this in `packages.toml`, since it's a component of `rustc`, not it's own package...