### PR TITLE
Update the spec repo we pull from

### DIFF
--- a/ferrocene/tools/pull-subtrees/subtrees.yml
+++ b/ferrocene/tools/pull-subtrees/subtrees.yml
@@ -18,7 +18,7 @@
 # - "update-cargo-lock": regenerate the Cargo.lock after the pull.
 
 - path: ferrocene/doc/specification
-  repo: ferrocene/specification
+  repo: rust-lang/fls
   pull: branch:main
 
 - path: ferrocene/library/libc


### PR DESCRIPTION
The FLS now lives at https://github.com/rust-lang/fls. This PR updates the repo we pull in with our subtree pull automation.