### PR TITLE
Include rust-analyzer tool when building rustc 

### DIFF
--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -87,7 +87,7 @@ JOBS_DEFINITION: JobsDefinition = {
 
         "oxidos": ["ferrocene-oxidos"],
 
-        "tools": ["rust-analyzer", "clippy", "rustfmt", "flip-link"],
+        "tools": ["clippy", "rustfmt", "flip-link"],
     },
 
     "test": {


### PR DESCRIPTION
... so we can build `rust-analyzer-proc-macro-srv`

Follow up on #1441 . I didn't notice it wasn't working since I didn't use `split-tasks.py` during testing.

When reviewing this PR, please make sure the CI uploaded rustc package has `libexec/rust-analyzer-proc-macro-srv` and that the `rust-analyzer` package is also uploaded using `aws s3 ls` and `aws s3 cp` on the urls in the "Upload Artifacts to S3" stage of the dist jobs.