### PR TITLE
Fix CI download of test outcomes

### DIFF
--- a/src/bootstrap/src/ferrocene/test_outcomes.rs
+++ b/src/bootstrap/src/ferrocene/test_outcomes.rs
@@ -3,9 +3,6 @@
 
 use std::path::PathBuf;
 
-use build_helper::ci::CiEnv;
-use build_helper::git::get_closest_upstream_commit;
-
 use crate::core::builder::{Builder, ShouldRun, Step};
 use crate::core::config::FerroceneTestOutcomes;
 use crate::ferrocene::download_and_extract_ci_outcomes;
@@ -23,15 +20,7 @@ impl Step for TestOutcomesDir {
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         match &builder.config.ferrocene_test_outcomes {
             FerroceneTestOutcomes::DownloadCi => {
-                let commit = get_closest_upstream_commit(
-                    None,
-                    &builder.config.git_config(),
-                    CiEnv::None,
-                )
-                .expect(
-                    "failed to retrieve the git commit for ferrocene.test-outcomes=download-ci",
-                );
-                Some(download_and_extract_ci_outcomes(builder, &commit.unwrap()))
+                Some(download_and_extract_ci_outcomes(builder, "test"))
             }
             FerroceneTestOutcomes::Disabled => None,
             FerroceneTestOutcomes::Custom(path) => Some(std::fs::canonicalize(path).unwrap()),


### PR DESCRIPTION
This reverts commit fccdce16804f9392aa049d3719256acfae8ce6d5.

This cherry picked commit was not needed after the changes in c3f8514