### PR TITLE
[1.86] Backport: Fix breakage when running compiletest with `--test-args=--edition=2015`

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/directives.md
+++ b/src/doc/rustc-dev-guide/src/tests/directives.md
@@ -233,14 +233,14 @@ ignoring debuggers.
 
 ### Affecting how tests are built
 
-| Directive           | Explanation                                                                                  | Supported test suites     | Possible values                                                              |
-|---------------------|----------------------------------------------------------------------------------------------|---------------------------|------------------------------------------------------------------------------|
-| `compile-flags`     | Flags passed to `rustc` when building the test or aux file                                   | All except for `run-make` | Any valid `rustc` flags, e.g. `-Awarnings -Dfoo`. Cannot be `-Cincremental`. |
-| `edition`           | Alias for `compile-flags: --edition=xxx`                                                     | All except for `run-make` | Any valid `--edition` value                                                  |
-| `rustc-env`         | Env var to set when running `rustc`                                                          | All except for `run-make` | `<KEY>=<VALUE>`                                                              |
-| `unset-rustc-env`   | Env var to unset when running `rustc`                                                        | All except for `run-make` | Any env var name                                                             |
-| `incremental`       | Proper incremental support for tests outside of incremental test suite                       | `ui`, `crashes`           | N/A                                                                          |
-| `no-prefer-dynamic` | Don't use `-C prefer-dynamic`, don't build as a dylib via a `--crate-type=dylib` preset flag | `ui`, `crashes`           | N/A                                                                          |
+| Directive           | Explanation                                                                                  | Supported test suites     | Possible values                                                                            |
+|---------------------|----------------------------------------------------------------------------------------------|---------------------------|--------------------------------------------------------------------------------------------|
+| `compile-flags`     | Flags passed to `rustc` when building the test or aux file                                   | All except for `run-make` | Any valid `rustc` flags, e.g. `-Awarnings -Dfoo`. Cannot be `-Cincremental` or `--edition` |
+| `edition`           | The edition used to build the test                                                           | All except for `run-make` | Any valid `--edition` value                                                                |
+| `rustc-env`         | Env var to set when running `rustc`                                                          | All except for `run-make` | `<KEY>=<VALUE>`                                                                            |
+| `unset-rustc-env`   | Env var to unset when running `rustc`                                                        | All except for `run-make` | Any env var name                                                                           |
+| `incremental`       | Proper incremental support for tests outside of incremental test suite                       | `ui`, `crashes`           | N/A                                                                                        |
+| `no-prefer-dynamic` | Don't use `-C prefer-dynamic`, don't build as a dylib via a `--crate-type=dylib` preset flag | `ui`, `crashes`           | N/A                                                                                        |
 
 <div class="warning">
 Tests (outside of `run-make`) that want to use incremental tests not in the

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -388,7 +388,13 @@ impl TestProps {
                     }
 
                     if let Some(flags) = config.parse_name_value_directive(ln, COMPILE_FLAGS) {
-                        self.compile_flags.extend(split_flags(&flags));
+                        let flags = split_flags(&flags);
+                        for flag in &flags {
+                            if flag == "--edition" || flag.starts_with("--edition=") {
+                                panic!("you must use `//@ edition` to configure the edition");
+                            }
+                        }
+                        self.compile_flags.extend(flags);
                     }
                     if config.parse_name_value_directive(ln, INCORRECT_COMPILER_FLAGS).is_some() {
                         panic!("`compiler-flags` directive should be spelled `compile-flags`");

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -395,7 +395,9 @@ impl TestProps {
                     }
 
                     if let Some(edition) = config.parse_edition(ln) {
-                        self.compile_flags.push(format!("--edition={}", edition.trim()));
+                        // The edition is added at the start, since flags from //@compile-flags must
+                        // be passed to rustc last.
+                        self.compile_flags.insert(0, format!("--edition={}", edition.trim()));
                         has_edition = true;
                     }
 
@@ -627,7 +629,9 @@ impl TestProps {
         }
 
         if let (Some(edition), false) = (&config.edition, has_edition) {
-            self.compile_flags.push(format!("--edition={}", edition));
+            // The edition is added at the start, since flags from //@compile-flags must be passed
+            // to rustc last.
+            self.compile_flags.insert(0, format!("--edition={}", edition));
         }
     }
 

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -178,6 +178,7 @@ pub fn compute_stamp_hash(config: &Config) -> String {
     let mut hash = DefaultHasher::new();
     config.stage_id.hash(&mut hash);
     config.run.hash(&mut hash);
+    config.edition.hash(&mut hash);
 
     match config.debugger {
         Some(Debugger::Cdb) => {

--- a/tests/codegen/async-closure-debug.rs
+++ b/tests/codegen/async-closure-debug.rs
@@ -1,6 +1,7 @@
 // Just make sure that async closures don't ICE.
 //
-//@ compile-flags: -C debuginfo=2 --edition=2018
+//@ compile-flags: -C debuginfo=2
+//@ edition: 2018
 //@ ignore-msvc
 
 // CHECK-DAG:  [[GEN_FN:!.*]] = !DINamespace(name: "async_closure_test"

--- a/tests/codegen/async-fn-debug-awaitee-field.rs
+++ b/tests/codegen/async-fn-debug-awaitee-field.rs
@@ -7,7 +7,8 @@
 //@[MSVC] only-msvc
 //@[NONMSVC] ignore-msvc
 
-//@ compile-flags: -C debuginfo=2 --edition=2018 -Copt-level=0
+//@ compile-flags: -C debuginfo=2 -Copt-level=0
+//@ edition: 2018
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/async-fn-debug-msvc.rs
+++ b/tests/codegen/async-fn-debug-msvc.rs
@@ -4,7 +4,8 @@
 //  - Other fields are not marked artificial
 //
 //
-//@ compile-flags: -C debuginfo=2 --edition=2018
+//@ compile-flags: -C debuginfo=2
+//@ edition: 2018
 //@ only-msvc
 
 async fn foo() {}

--- a/tests/codegen/async-fn-debug-msvc.rs
+++ b/tests/codegen/async-fn-debug-msvc.rs
@@ -20,23 +20,23 @@ async fn async_fn_test() {
 // CHECK-DAG:  [[GEN:!.*]] = !DICompositeType(tag: DW_TAG_union_type, name: "enum2$<async_fn_debug_msvc::async_fn_test::async_fn_env$0>",
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant0", scope: [[GEN]],
 // For brevity, we only check the struct name and members of the last variant.
-// CHECK-SAME: file: [[FILE:![0-9]*]], line: 11,
+// CHECK-SAME: file: [[FILE:![0-9]*]], line: 12,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant1", scope: [[GEN]],
-// CHECK-SAME: file: [[FILE]], line: 15,
+// CHECK-SAME: file: [[FILE]], line: 16,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant2", scope: [[GEN]],
-// CHECK-SAME: file: [[FILE]], line: 15,
+// CHECK-SAME: file: [[FILE]], line: 16,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant3", scope: [[GEN]],
-// CHECK-SAME: file: [[FILE]], line: 12,
+// CHECK-SAME: file: [[FILE]], line: 13,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant4", scope: [[GEN]],
-// CHECK-SAME: file: [[FILE]], line: 14,
+// CHECK-SAME: file: [[FILE]], line: 15,
 // CHECK-SAME: baseType: [[VARIANT_WRAPPER:![0-9]*]]
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )

--- a/tests/codegen/async-fn-debug.rs
+++ b/tests/codegen/async-fn-debug.rs
@@ -4,7 +4,8 @@
 //  - Other fields are not marked artificial
 //
 //
-//@ compile-flags: -C debuginfo=2 --edition=2018
+//@ compile-flags: -C debuginfo=2
+//@ edition: 2018
 //@ ignore-msvc
 
 async fn foo() {}
@@ -22,26 +23,26 @@ async fn async_fn_test() {
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: discriminator: [[DISC:![0-9]*]]
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "0", scope: [[VARIANT]],
-// CHECK-SAME: file: [[FILE:![0-9]*]], line: 11,
+// CHECK-SAME: file: [[FILE:![0-9]*]], line: 12,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DICompositeType(tag: DW_TAG_structure_type, name: "Unresumed", scope: [[GEN]],
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "1", scope: [[VARIANT]],
-// CHECK-SAME: file: [[FILE]], line: 15,
+// CHECK-SAME: file: [[FILE]], line: 16,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "2", scope: [[VARIANT]],
-// CHECK-SAME: file: [[FILE]], line: 15,
+// CHECK-SAME: file: [[FILE]], line: 16,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "3", scope: [[VARIANT]],
-// CHECK-SAME: file: [[FILE]], line: 12,
+// CHECK-SAME: file: [[FILE]], line: 13,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "4", scope: [[VARIANT]],
-// CHECK-SAME: file: [[FILE]], line: 14,
+// CHECK-SAME: file: [[FILE]], line: 15,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      [[S1:!.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Suspend1", scope: [[GEN]],

--- a/tests/codegen/coroutine-debug.rs
+++ b/tests/codegen/coroutine-debug.rs
@@ -4,7 +4,8 @@
 //  - Other fields are not marked artificial
 //
 //
-//@ compile-flags: -C debuginfo=2 --edition=2018
+//@ compile-flags: -C debuginfo=2
+//@ edition: 2018
 //@ ignore-msvc
 
 #![feature(coroutines, coroutine_trait)]
@@ -27,26 +28,26 @@ fn coroutine_test() -> impl Coroutine<Yield = i32, Return = ()> {
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: discriminator: [[DISC:![0-9]*]]
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "0", scope: [[VARIANT]],
-// CHECK-SAME: file: [[FILE:![0-9]*]], line: 15,
+// CHECK-SAME: file: [[FILE:![0-9]*]], line: 16,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DICompositeType(tag: DW_TAG_structure_type, name: "Unresumed", scope: [[GEN]],
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "1", scope: [[VARIANT]],
-// CHECK-SAME: file: [[FILE]], line: 19,
+// CHECK-SAME: file: [[FILE]], line: 20,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "2", scope: [[VARIANT]],
-// CHECK-SAME: file: [[FILE]], line: 19,
+// CHECK-SAME: file: [[FILE]], line: 20,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "3", scope: [[VARIANT]],
-// CHECK-SAME: file: [[FILE]], line: 16,
+// CHECK-SAME: file: [[FILE]], line: 17,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "4", scope: [[VARIANT]],
-// CHECK-SAME: file: [[FILE]], line: 18,
+// CHECK-SAME: file: [[FILE]], line: 19,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
 // CHECK:      [[S1:!.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Suspend1", scope: [[GEN]],

--- a/tests/codegen/debuginfo-generic-closure-env-names.rs
+++ b/tests/codegen/debuginfo-generic-closure-env-names.rs
@@ -18,7 +18,8 @@
 // legacy mangling scheme rustc version and generic parameters are both hashed into a single part
 // of the name, thus randomizing item order with respect to rustc version.
 
-//@ compile-flags: -Cdebuginfo=2 --edition 2021 -Copt-level=0 -Csymbol-mangling-version=v0
+//@ compile-flags: -Cdebuginfo=2 -Copt-level=0 -Csymbol-mangling-version=v0
+//@ edition: 2021
 
 // non_generic_closure()
 // NONMSVC: !DICompositeType(tag: DW_TAG_structure_type, name: "{closure_env#0}", scope: ![[non_generic_closure_NAMESPACE:[0-9]+]],

--- a/tests/codegen/infallible-unwrap-in-opt-z.rs
+++ b/tests/codegen/infallible-unwrap-in-opt-z.rs
@@ -1,4 +1,5 @@
-//@ compile-flags: -C opt-level=z --edition=2021
+//@ compile-flags: -C opt-level=z
+//@ edition: 2021
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/inline-function-args-debug-info.rs
+++ b/tests/codegen/inline-function-args-debug-info.rs
@@ -2,7 +2,8 @@
 // gets inlined by MIR inlining. Without function argument indexes, `info args` in gdb won't show
 // arguments and their values for the current function.
 
-//@ compile-flags: -Zinline-mir=yes -Cdebuginfo=2 --edition=2021
+//@ compile-flags: -Zinline-mir=yes -Cdebuginfo=2
+//@ edition: 2021
 
 #![crate_type = "lib"]
 
@@ -14,9 +15,9 @@ pub fn outer_function(x: usize, y: usize) -> usize {
 #[inline]
 fn inner_function(aaaa: usize, bbbb: usize) -> usize {
     // CHECK: !DILocalVariable(name: "aaaa", arg: 1
-    // CHECK-SAME: line: 15
+    // CHECK-SAME: line: 16
     // CHECK-NOT: !DILexicalBlock(
     // CHECK: !DILocalVariable(name: "bbbb", arg: 2
-    // CHECK-SAME: line: 15
+    // CHECK-SAME: line: 16
     aaaa + bbbb
 }

--- a/tests/codegen/issues/issue-119422.rs
+++ b/tests/codegen/issues/issue-119422.rs
@@ -1,7 +1,8 @@
 //! This test checks that compiler don't generate useless compares to zeros
 //! for `NonZero` integer types.
 //!
-//@ compile-flags: -Copt-level=3 --edition=2021 -Zmerge-functions=disabled
+//@ compile-flags: -Copt-level=3 -Zmerge-functions=disabled
+//@ edition: 2021
 //@ only-64bit (because the LLVM type of i64 for usize shows up)
 #![crate_type = "lib"]
 

--- a/tests/codegen/simd/simd-wide-sum.rs
+++ b/tests/codegen/simd/simd-wide-sum.rs
@@ -1,5 +1,6 @@
 //@ revisions: llvm mir-opt3
-//@ compile-flags: -C opt-level=3 -Z merge-functions=disabled --edition=2021
+//@ compile-flags: -C opt-level=3 -Z merge-functions=disabled
+//@ edition: 2021
 //@ only-x86_64
 //@ [mir-opt3]compile-flags: -Zmir-opt-level=3
 //@ [mir-opt3]build-pass

--- a/tests/codegen/try_question_mark_nop.rs
+++ b/tests/codegen/try_question_mark_nop.rs
@@ -1,4 +1,5 @@
-//@ compile-flags: -Copt-level=3 -Z merge-functions=disabled --edition=2021
+//@ compile-flags: -Copt-level=3 -Z merge-functions=disabled
+//@ edition: 2021
 //@ only-x86_64
 // FIXME: Remove the `min-llvm-version`.
 //@ revisions: NINETEEN TWENTY

--- a/tests/crashes/119095.rs
+++ b/tests/crashes/119095.rs
@@ -1,5 +1,5 @@
 //@ known-bug: #119095
-//@ compile-flags: --edition=2021
+//@ edition: 2021
 
 fn any<T>() -> T {
     loop {}

--- a/tests/crashes/120016.rs
+++ b/tests/crashes/120016.rs
@@ -1,5 +1,6 @@
 //@ known-bug: #120016
-//@ compile-flags: -Zcrate-attr=feature(const_async_blocks) --edition=2021
+//@ compile-flags: -Zcrate-attr=feature(const_async_blocks)
+//@ edition: 2021
 
 #![feature(type_alias_impl_trait, const_async_blocks)]
 

--- a/tests/crashes/127033.rs
+++ b/tests/crashes/127033.rs
@@ -1,5 +1,5 @@
 //@ known-bug: #127033
-//@ compile-flags: --edition=2021
+//@ edition: 2021
 
 pub trait RaftLogStorage {
     fn save_vote(vote: ()) -> impl std::future::Future + Send;

--- a/tests/crashes/128094.rs
+++ b/tests/crashes/128094.rs
@@ -1,5 +1,6 @@
 //@ known-bug: rust-lang/rust#128094
-//@ compile-flags: -Zmir-enable-passes=+GVN --edition=2018
+//@ compile-flags: -Zmir-enable-passes=+GVN
+//@ edition: 2018
 
 pub enum Request {
     TestSome(T),

--- a/tests/crashes/132103.rs
+++ b/tests/crashes/132103.rs
@@ -1,5 +1,6 @@
 //@ known-bug: #132103
-//@compile-flags: -Zvalidate-mir --edition=2018 -Zinline-mir=yes
+//@ compile-flags: -Zvalidate-mir -Zinline-mir=yes
+//@ edition: 2018
 use core::future::{async_drop_in_place, Future};
 use core::mem::{self};
 use core::pin::pin;

--- a/tests/crashes/132335.rs
+++ b/tests/crashes/132335.rs
@@ -1,5 +1,10 @@
+// Regression test for #132335. This previously ICE'd due to ambiguity
+// in MIR typeck.
+
 //@ known-bug: #132335
-//@ compile-flags: -Znext-solver=globally --crate-type lib --edition=2018
+//@ compile-flags: -Znext-solver=globally --crate-type lib
+//@ edition: 2018
+//@ check-pass
 use core::future::Future;
 use core::pin::Pin;
 

--- a/tests/crashes/132430.rs
+++ b/tests/crashes/132430.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #132430
 
-//@compile-flags: --edition=2018 --crate-type=lib
+//@ compile-flags: --crate-type=lib
+//@ edition: 2018
 #![feature(cmse_nonsecure_entry)]
 struct Test;
 

--- a/tests/crashes/135128.rs
+++ b/tests/crashes/135128.rs
@@ -1,5 +1,6 @@
 //@ known-bug: #135128
-//@ compile-flags: -Copt-level=1 --edition=2021
+//@ compile-flags: -Copt-level=1
+//@ edition: 2021
 
 async fn return_str() -> str
 where

--- a/tests/crashes/135470.rs
+++ b/tests/crashes/135470.rs
@@ -1,5 +1,6 @@
 //@ known-bug: #135470
-//@ compile-flags: --edition=2021 -Copt-level=0
+//@ compile-flags: -Copt-level=0
+//@ edition: 2021
 
 use std::future::Future;
 trait Access {

--- a/tests/crashes/135646.rs
+++ b/tests/crashes/135646.rs
@@ -1,5 +1,7 @@
 //@ known-bug: #135646
-//@ compile-flags: --edition=2024 -Zpolonius=next
+//@ compile-flags: -Zpolonius=next
+//@ edition: 2024
+
 fn main() {
     &{ [1, 2, 3][4] };
 }

--- a/tests/crashes/135668.rs
+++ b/tests/crashes/135668.rs
@@ -1,5 +1,5 @@
 //@ known-bug: #135668
-//@ compile-flags: --edition=2021
+//@ edition: 2021
 use std::future::Future;
 
 pub async fn foo() {

--- a/tests/debuginfo/coroutine-closure.rs
+++ b/tests/debuginfo/coroutine-closure.rs
@@ -1,6 +1,7 @@
 #![feature(async_closure)]
 //@ only-cdb
-//@ compile-flags:-g --edition=2021
+//@ compile-flags: -g
+//@ edition: 2021
 
 // === CDB TESTS ==================================================================================
 

--- a/tests/incremental/issue-85360-eval-obligation-ice.rs
+++ b/tests/incremental/issue-85360-eval-obligation-ice.rs
@@ -1,6 +1,7 @@
 //@ revisions:cfail1 cfail2
-//@[cfail1] compile-flags: --crate-type=lib --edition=2021 -Zassert-incr-state=not-loaded
-//@[cfail2] compile-flags: --crate-type=lib --edition=2021 -Zassert-incr-state=loaded
+//@[cfail1] compile-flags: --crate-type=lib -Zassert-incr-state=not-loaded
+//@[cfail2] compile-flags: --crate-type=lib -Zassert-incr-state=loaded
+//@ edition: 2021
 //@ build-pass
 
 use core::any::Any;

--- a/tests/rustdoc-ui/doctest/failed-doctest-should-panic-2021.rs
+++ b/tests/rustdoc-ui/doctest/failed-doctest-should-panic-2021.rs
@@ -1,7 +1,8 @@
 // FIXME: if/when the output of the test harness can be tested on its own, this test should be
 // adapted to use that, and that normalize line can go away
 
-//@ compile-flags:--test --edition 2021
+//@ compile-flags: --test
+//@ edition: 2021
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ failure-status: 101

--- a/tests/rustdoc-ui/doctest/failed-doctest-should-panic-2021.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-should-panic-2021.stdout
@@ -1,14 +1,14 @@
 
 running 1 test
-test $DIR/failed-doctest-should-panic-2021.rs - Foo (line 9) ... FAILED
+test $DIR/failed-doctest-should-panic-2021.rs - Foo (line 10) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-should-panic-2021.rs - Foo (line 9) stdout ----
+---- $DIR/failed-doctest-should-panic-2021.rs - Foo (line 10) stdout ----
 Test executable succeeded, but it's marked `should_panic`.
 
 failures:
-    $DIR/failed-doctest-should-panic-2021.rs - Foo (line 9)
+    $DIR/failed-doctest-should-panic-2021.rs - Foo (line 10)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/intra-doc/import-inline-merge-module.rs
+++ b/tests/rustdoc-ui/intra-doc/import-inline-merge-module.rs
@@ -3,7 +3,8 @@
 
 //@ check-pass
 //@ aux-build: inner-crate-doc.rs
-//@ compile-flags: --extern inner_crate_doc --edition 2018
+//@ compile-flags: --extern inner_crate_doc
+//@ edition: 2018
 
 /// Import doc comment [inner_crate_doc]
 #[doc(inline)]

--- a/tests/rustdoc/auxiliary/primitive-doc.rs
+++ b/tests/rustdoc/auxiliary/primitive-doc.rs
@@ -1,4 +1,5 @@
-//@ compile-flags: --crate-type lib --edition 2018
+//@ compile-flags: --crate-type lib
+//@ edition: 2018
 
 #![feature(rustc_attrs)]
 #![feature(no_core)]

--- a/tests/rustdoc/auxiliary/primitive-reexport.rs
+++ b/tests/rustdoc/auxiliary/primitive-reexport.rs
@@ -1,4 +1,5 @@
-//@ compile-flags: --emit metadata --crate-type lib --edition 2018
+//@ compile-flags: --emit metadata --crate-type lib
+//@ edition: 2018
 
 #![crate_name = "foo"]
 

--- a/tests/rustdoc/intra-doc/extern-crate-only-used-in-link.rs
+++ b/tests/rustdoc/intra-doc/extern-crate-only-used-in-link.rs
@@ -6,7 +6,8 @@
 //@ aux-build:empty2.rs
 //@ aux-crate:priv:empty2=empty2.rs
 //@ build-aux-docs
-//@ compile-flags:-Z unstable-options --edition 2018
+//@ compile-flags:-Z unstable-options
+//@ edition: 2018
 
 //@ has extern_crate_only_used_in_link/index.html
 //@ has - '//a[@href="../issue_66159_1/struct.Something.html"]' 'issue_66159_1::Something'

--- a/tests/rustdoc/primitive-reexport.rs
+++ b/tests/rustdoc/primitive-reexport.rs
@@ -1,5 +1,6 @@
 //@ aux-build: primitive-reexport.rs
-//@ compile-flags:--extern foo --edition 2018
+//@ compile-flags: --extern foo
+//@ edition: 2018
 
 #![crate_name = "bar"]
 

--- a/tests/rustdoc/primitive-slice-auto-trait.rs
+++ b/tests/rustdoc/primitive-slice-auto-trait.rs
@@ -1,4 +1,5 @@
-//@ compile-flags: --crate-type lib --edition 2018
+//@ compile-flags: --crate-type lib
+//@ edition: 2018
 
 #![crate_name = "foo"]
 #![feature(rustc_attrs)]

--- a/tests/rustdoc/primitive-tuple-auto-trait.rs
+++ b/tests/rustdoc/primitive-tuple-auto-trait.rs
@@ -1,4 +1,5 @@
-//@ compile-flags: --crate-type lib --edition 2018
+//@ compile-flags: --crate-type lib
+//@ edition: 2018
 
 #![crate_name = "foo"]
 #![feature(rustc_attrs)]

--- a/tests/rustdoc/primitive-tuple-variadic.rs
+++ b/tests/rustdoc/primitive-tuple-variadic.rs
@@ -1,4 +1,5 @@
-//@ compile-flags: --crate-type lib --edition 2018
+//@ compile-flags: --crate-type lib
+//@ edition: 2018
 
 #![crate_name = "foo"]
 #![feature(rustdoc_internals)]

--- a/tests/rustdoc/primitive-unit-auto-trait.rs
+++ b/tests/rustdoc/primitive-unit-auto-trait.rs
@@ -1,4 +1,5 @@
-//@ compile-flags: --crate-type lib --edition 2018
+//@ compile-flags: --crate-type lib
+//@ edition: 2018
 
 #![crate_name = "foo"]
 #![feature(rustc_attrs)]

--- a/tests/ui/async-await/async-closures/closure-shim-borrowck-error.rs
+++ b/tests/ui/async-await/async-closures/closure-shim-borrowck-error.rs
@@ -1,4 +1,5 @@
-//@ compile-flags: -Zvalidate-mir --edition=2018 --crate-type=lib -Copt-level=3
+//@ compile-flags: -Zvalidate-mir --crate-type=lib -Copt-level=3
+//@ edition: 2018
 
 fn main() {}
 

--- a/tests/ui/async-await/async-closures/closure-shim-borrowck-error.stderr
+++ b/tests/ui/async-await/async-closures/closure-shim-borrowck-error.stderr
@@ -1,5 +1,5 @@
 error[E0507]: cannot move out of `x` which is behind a mutable reference
-  --> $DIR/closure-shim-borrowck-error.rs:10:18
+  --> $DIR/closure-shim-borrowck-error.rs:11:18
    |
 LL |     needs_fn_mut(async || {
    |                  ^^^^^^^^ `x` is moved here
@@ -11,7 +11,7 @@ LL |         x.hello();
    |         move occurs because `x` has type `Ty`, which does not implement the `Copy` trait
    |
 note: if `Ty` implemented `Clone`, you could clone the value
-  --> $DIR/closure-shim-borrowck-error.rs:16:1
+  --> $DIR/closure-shim-borrowck-error.rs:17:1
    |
 LL |         x.hello();
    |         - you could clone this value

--- a/tests/ui/async-await/issue-60709.rs
+++ b/tests/ui/async-await/issue-60709.rs
@@ -1,6 +1,7 @@
 // This used to compile the future down to ud2, due to uninhabited types being
 // handled incorrectly in coroutines.
-//@ compile-flags: -Copt-level=z -Cdebuginfo=2 --edition=2018
+//@ compile-flags: -Copt-level=z -Cdebuginfo=2
+//@ edition: 2018
 
 //@ run-pass
 

--- a/tests/ui/async-await/issues/issue-59972.rs
+++ b/tests/ui/async-await/issues/issue-59972.rs
@@ -4,7 +4,8 @@
 
 //@ run-pass
 
-//@ compile-flags: --edition=2018 -Aunused
+//@ compile-flags: -Aunused
+//@ edition: 2018
 
 pub enum Uninhabited { }
 

--- a/tests/ui/check-cfg/raw-keywords.edition2015.stderr
+++ b/tests/ui/check-cfg/raw-keywords.edition2015.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `tru`
-  --> $DIR/raw-keywords.rs:14:7
+  --> $DIR/raw-keywords.rs:15:7
    |
 LL | #[cfg(tru)]
    |       ^^^ help: there is a config with a similar name: `r#true`
@@ -9,7 +9,7 @@ LL | #[cfg(tru)]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition name: `r#false`
-  --> $DIR/raw-keywords.rs:19:7
+  --> $DIR/raw-keywords.rs:20:7
    |
 LL | #[cfg(r#false)]
    |       ^^^^^^^
@@ -19,7 +19,7 @@ LL | #[cfg(r#false)]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `await`
-  --> $DIR/raw-keywords.rs:27:29
+  --> $DIR/raw-keywords.rs:28:29
    |
 LL | #[cfg_attr(edition2015, cfg(await))]
    |                             ^^^^^
@@ -28,7 +28,7 @@ LL | #[cfg_attr(edition2015, cfg(await))]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `raw`
-  --> $DIR/raw-keywords.rs:33:7
+  --> $DIR/raw-keywords.rs:34:7
    |
 LL | #[cfg(r#raw)]
    |       ^^^^^

--- a/tests/ui/check-cfg/raw-keywords.edition2021.stderr
+++ b/tests/ui/check-cfg/raw-keywords.edition2021.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `tru`
-  --> $DIR/raw-keywords.rs:14:7
+  --> $DIR/raw-keywords.rs:15:7
    |
 LL | #[cfg(tru)]
    |       ^^^ help: there is a config with a similar name: `r#true`
@@ -9,7 +9,7 @@ LL | #[cfg(tru)]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition name: `r#false`
-  --> $DIR/raw-keywords.rs:19:7
+  --> $DIR/raw-keywords.rs:20:7
    |
 LL | #[cfg(r#false)]
    |       ^^^^^^^
@@ -19,7 +19,7 @@ LL | #[cfg(r#false)]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `r#await`
-  --> $DIR/raw-keywords.rs:28:29
+  --> $DIR/raw-keywords.rs:29:29
    |
 LL | #[cfg_attr(edition2021, cfg(r#await))]
    |                             ^^^^^^^
@@ -28,7 +28,7 @@ LL | #[cfg_attr(edition2021, cfg(r#await))]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `raw`
-  --> $DIR/raw-keywords.rs:33:7
+  --> $DIR/raw-keywords.rs:34:7
    |
 LL | #[cfg(r#raw)]
    |       ^^^^^

--- a/tests/ui/check-cfg/raw-keywords.rs
+++ b/tests/ui/check-cfg/raw-keywords.rs
@@ -6,7 +6,8 @@
 //@ compile-flags: --cfg=true --cfg=async --check-cfg=cfg(r#true,r#async,edition2015,edition2021)
 //
 //@ revisions: edition2015 edition2021
-//@ [edition2021] compile-flags: --edition 2021
+//@ [edition2015] edition: 2015
+//@ [edition2021] edition: 2021
 
 #[cfg(r#true)]
 fn foo() {}

--- a/tests/ui/closures/2229_closure_analysis/issue-89606.rs
+++ b/tests/ui/closures/2229_closure_analysis/issue-89606.rs
@@ -2,8 +2,8 @@
 //
 //@ check-pass
 //@ revisions: twenty_eighteen twenty_twentyone
-//@ [twenty_eighteen]compile-flags: --edition 2018
-//@ [twenty_twentyone]compile-flags: --edition 2021
+//@ [twenty_eighteen] edition: 2018
+//@ [twenty_twentyone] edition: 2021
 
 struct S<'a>(Option<&'a mut i32>);
 

--- a/tests/ui/closures/2229_closure_analysis/preserve_field_drop_order2.rs
+++ b/tests/ui/closures/2229_closure_analysis/preserve_field_drop_order2.rs
@@ -1,8 +1,8 @@
 //@ run-pass
 //@ check-run-results
 //@ revisions: twenty_eighteen twenty_twentyone
-//@ [twenty_eighteen]compile-flags: --edition 2018
-//@ [twenty_twentyone]compile-flags: --edition 2021
+//@ [twenty_eighteen] edition: 2018
+//@ [twenty_twentyone] edition: 2021
 
 #[derive(Debug)]
 struct Dropable(&'static str);

--- a/tests/ui/conditional-compilation/cfg_accessible-not_sure.rs
+++ b/tests/ui/conditional-compilation/cfg_accessible-not_sure.rs
@@ -1,6 +1,6 @@
 //@ revisions: edition2015 edition2021
-//@ [edition2015]compile-flags: --edition=2015
-//@ [edition2021]compile-flags: --edition=2021
+//@ [edition2015] edition: 2015
+//@ [edition2021] edition: 2021
 
 #![feature(extern_types)]
 #![feature(cfg_accessible)]

--- a/tests/ui/consts/const-suggest-feature.rs
+++ b/tests/ui/consts/const-suggest-feature.rs
@@ -1,4 +1,4 @@
-//@compile-flags: --edition 2018
+//@ edition: 2018
 use std::cell::Cell;
 
 const WRITE: () = unsafe {

--- a/tests/ui/consts/min_const_fn/min_const_fn_libstd_stability.rs
+++ b/tests/ui/consts/min_const_fn/min_const_fn_libstd_stability.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 #![unstable(feature = "humans",
             reason = "who ever let humans program computers,
             we're apparently really bad at it",

--- a/tests/ui/coroutine/async-gen-deduce-yield.rs
+++ b/tests/ui/coroutine/async-gen-deduce-yield.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2024
+//@ edition: 2024
 //@ check-pass
 
 #![feature(async_iterator, gen_blocks)]

--- a/tests/ui/coroutine/async-gen-yield-ty-is-unit.rs
+++ b/tests/ui/coroutine/async-gen-yield-ty-is-unit.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2024
+//@ edition: 2024
 //@ check-pass
 
 #![feature(async_iterator, gen_blocks)]

--- a/tests/ui/debuginfo/issue-105386-debuginfo-ub.rs
+++ b/tests/ui/debuginfo/issue-105386-debuginfo-ub.rs
@@ -1,5 +1,6 @@
 //@ run-pass
-//@ compile-flags: --edition 2021 -Copt-level=3 -Cdebuginfo=2 -Zmir-opt-level=3
+//@ compile-flags: -Copt-level=3 -Cdebuginfo=2 -Zmir-opt-level=3
+//@ edition: 2021
 
 fn main() {
     TranslatorI.visit_pre();

--- a/tests/ui/deprecation/try-macro-suggestion.rs
+++ b/tests/ui/deprecation/try-macro-suggestion.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 fn foo() -> Result<(), ()> {
     Ok(try!()); //~ ERROR use of deprecated `try` macro
     Ok(try!(Ok(()))) //~ ERROR use of deprecated `try` macro

--- a/tests/ui/feature-gates/feature-gate-try_blocks.rs
+++ b/tests/ui/feature-gates/feature-gate-try_blocks.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 pub fn main() {
     let try_result: Option<_> = try { //~ ERROR `try` expression is experimental

--- a/tests/ui/feature-gates/feature-gate-yeet_expr-in-cfg.rs
+++ b/tests/ui/feature-gates/feature-gate-yeet_expr-in-cfg.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2021
+//@ edition: 2021
 
 pub fn demo() -> Option<i32> {
     #[cfg(FALSE)]

--- a/tests/ui/feature-gates/feature-gate-yeet_expr.rs
+++ b/tests/ui/feature-gates/feature-gate-yeet_expr.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 pub fn demo() -> Option<i32> {
     do yeet //~ ERROR `do yeet` expression is experimental

--- a/tests/ui/higher-ranked/trait-bounds/issue-95034.rs
+++ b/tests/ui/higher-ranked/trait-bounds/issue-95034.rs
@@ -1,5 +1,6 @@
 //@ check-pass
-//@ compile-flags: --edition=2021 --crate-type=lib
+//@ compile-flags: --crate-type=lib
+//@ edition: 2021
 
 use std::{
     future::Future,

--- a/tests/ui/impl-trait/auto-trait-contains-err.rs
+++ b/tests/ui/impl-trait/auto-trait-contains-err.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition=2021
+//@ edition: 2021
 
 use std::future::Future;
 

--- a/tests/ui/imports/redundant-import-extern-prelude.rs
+++ b/tests/ui/imports/redundant-import-extern-prelude.rs
@@ -5,7 +5,8 @@
 
 // See also the discussion in <https://github.com/rust-lang/rust/pull/122954>.
 
-//@ compile-flags: --extern aux_issue_121915 --edition 2018
+//@ compile-flags: --extern aux_issue_121915
+//@ edition: 2018
 //@ aux-build: aux-issue-121915.rs
 
 #[deny(redundant_imports)]

--- a/tests/ui/imports/redundant-import-extern-prelude.stderr
+++ b/tests/ui/imports/redundant-import-extern-prelude.stderr
@@ -1,11 +1,11 @@
 error: the item `aux_issue_121915` is imported redundantly
-  --> $DIR/redundant-import-extern-prelude.rs:14:9
+  --> $DIR/redundant-import-extern-prelude.rs:15:9
    |
 LL |     use aux_issue_121915;
    |         ^^^^^^^^^^^^^^^^ the item `aux_issue_121915` is already defined by the extern prelude
    |
 note: the lint level is defined here
-  --> $DIR/redundant-import-extern-prelude.rs:11:8
+  --> $DIR/redundant-import-extern-prelude.rs:12:8
    |
 LL | #[deny(redundant_imports)]
    |        ^^^^^^^^^^^^^^^^^

--- a/tests/ui/imports/redundant-import-issue-121915-2015.rs
+++ b/tests/ui/imports/redundant-import-issue-121915-2015.rs
@@ -1,4 +1,5 @@
-//@ compile-flags: --extern aux_issue_121915 --edition 2015
+//@ compile-flags: --extern aux_issue_121915
+//@ edition: 2015
 //@ aux-build: aux-issue-121915.rs
 
 extern crate aux_issue_121915;

--- a/tests/ui/imports/redundant-import-issue-121915-2015.stderr
+++ b/tests/ui/imports/redundant-import-issue-121915-2015.stderr
@@ -1,5 +1,5 @@
 error: the item `aux_issue_121915` is imported redundantly
-  --> $DIR/redundant-import-issue-121915-2015.rs:8:9
+  --> $DIR/redundant-import-issue-121915-2015.rs:9:9
    |
 LL | extern crate aux_issue_121915;
    | ------------------------------ the item `aux_issue_121915` is already imported here
@@ -8,7 +8,7 @@ LL |     use aux_issue_121915;
    |         ^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/redundant-import-issue-121915-2015.rs:6:8
+  --> $DIR/redundant-import-issue-121915-2015.rs:7:8
    |
 LL | #[deny(redundant_imports)]
    |        ^^^^^^^^^^^^^^^^^

--- a/tests/ui/imports/suggest-remove-issue-121315.rs
+++ b/tests/ui/imports/suggest-remove-issue-121315.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2021
+//@ edition: 2021
 #![deny(unused_imports, redundant_imports)]
 #![allow(dead_code)]
 

--- a/tests/ui/label/label_break_value_desugared_break.rs
+++ b/tests/ui/label/label_break_value_desugared_break.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 #![feature(try_blocks)]
 
 //@ run-pass

--- a/tests/ui/let-else/issue-102317.rs
+++ b/tests/ui/let-else/issue-102317.rs
@@ -1,6 +1,7 @@
 // issue #102317
 //@ build-pass
-//@ compile-flags: --edition 2021 -C opt-level=3 -Zvalidate-mir
+//@ compile-flags: -C opt-level=3 -Zvalidate-mir
+//@ edition: 2021
 
 struct SegmentJob;
 

--- a/tests/ui/lifetimes/issue-83737-binders-across-types.rs
+++ b/tests/ui/lifetimes/issue-83737-binders-across-types.rs
@@ -1,5 +1,5 @@
 //@ build-pass
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 //@ compile-flags: --crate-type rlib
 
 use std::future::Future;

--- a/tests/ui/lifetimes/issue-83737-erasing-bound-vars.rs
+++ b/tests/ui/lifetimes/issue-83737-erasing-bound-vars.rs
@@ -1,5 +1,5 @@
 //@ build-pass
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 //@ compile-flags: --crate-type rlib
 
 use std::future::Future;

--- a/tests/ui/lint/unqualified_local_imports.rs
+++ b/tests/ui/lint/unqualified_local_imports.rs
@@ -1,4 +1,4 @@
-//@compile-flags: --edition 2018
+//@ edition: 2018
 #![feature(unqualified_local_imports)]
 #![deny(unqualified_local_imports)]
 

--- a/tests/ui/lint/unused/issue-70041.rs
+++ b/tests/ui/lint/unused/issue-70041.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition=2018
+//@ edition: 2018
 //@ run-pass
 
 macro_rules! regex {

--- a/tests/ui/macros/expr_2021_cargo_fix_edition.fixed
+++ b/tests/ui/macros/expr_2021_cargo_fix_edition.fixed
@@ -1,6 +1,6 @@
 //@ run-rustfix
 //@ check-pass
-//@ compile-flags: --edition=2021
+//@ edition: 2021
 #![warn(edition_2024_expr_fragment_specifier)]
 
 macro_rules! m {

--- a/tests/ui/macros/expr_2021_cargo_fix_edition.rs
+++ b/tests/ui/macros/expr_2021_cargo_fix_edition.rs
@@ -1,6 +1,6 @@
 //@ run-rustfix
 //@ check-pass
-//@ compile-flags: --edition=2021
+//@ edition: 2021
 #![warn(edition_2024_expr_fragment_specifier)]
 
 macro_rules! m {

--- a/tests/ui/mir/issue-105809.rs
+++ b/tests/ui/mir/issue-105809.rs
@@ -1,7 +1,8 @@
 // Non-regression test ICE from issue #105809 and duplicates.
 
 //@ build-pass: the ICE is during codegen
-//@ compile-flags: --edition 2018 -Zmir-opt-level=1
+//@ compile-flags: -Zmir-opt-level=1
+//@ edition: 2018
 
 use std::{future::Future, pin::Pin};
 

--- a/tests/ui/parser/keyword-try-as-identifier-edition2018.rs
+++ b/tests/ui/parser/keyword-try-as-identifier-edition2018.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 fn main() {
     let try = "foo"; //~ error: expected identifier, found reserved keyword `try`

--- a/tests/ui/sanitizer/cfi/assoc-ty-lifetime-issue-123053.rs
+++ b/tests/ui/sanitizer/cfi/assoc-ty-lifetime-issue-123053.rs
@@ -2,7 +2,8 @@
 // trait object type to fail, causing an ICE.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi --edition=2021
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi
+//@ edition: 2021
 //@ no-prefer-dynamic
 //@ only-x86_64-unknown-linux-gnu
 //@ build-pass

--- a/tests/ui/sanitizer/issue-111184-cfi-coroutine-witness.rs
+++ b/tests/ui/sanitizer/issue-111184-cfi-coroutine-witness.rs
@@ -2,7 +2,8 @@
 // encode_ty and caused the compiler to ICE.
 //
 //@ needs-sanitizer-cfi
-//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi --edition=2021
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi
+//@ edition: 2021
 //@ no-prefer-dynamic
 //@ only-x86_64-unknown-linux-gnu
 //@ build-pass

--- a/tests/ui/suggestions/enum-method-probe.fixed
+++ b/tests/ui/suggestions/enum-method-probe.fixed
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition=2021
+//@ edition: 2021
 //@ run-rustfix
 
 #![allow(unused)]

--- a/tests/ui/suggestions/enum-method-probe.rs
+++ b/tests/ui/suggestions/enum-method-probe.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition=2021
+//@ edition: 2021
 //@ run-rustfix
 
 #![allow(unused)]

--- a/tests/ui/suggestions/inner_type.fixed
+++ b/tests/ui/suggestions/inner_type.fixed
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition=2021
+//@ edition: 2021
 //@ run-rustfix
 
 pub struct Struct<T> {

--- a/tests/ui/suggestions/inner_type.rs
+++ b/tests/ui/suggestions/inner_type.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition=2021
+//@ edition: 2021
 //@ run-rustfix
 
 pub struct Struct<T> {

--- a/tests/ui/suggestions/issue-86667.rs
+++ b/tests/ui/suggestions/issue-86667.rs
@@ -1,7 +1,7 @@
 // Regression test for #86667, where a garbled suggestion was issued for
 // a missing named lifetime parameter.
 
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 async fn a(s1: &str, s2: &str) -> &str {
     //~^ ERROR: missing lifetime specifier [E0106]

--- a/tests/ui/traits/issue-85360-eval-obligation-ice.rs
+++ b/tests/ui/traits/issue-85360-eval-obligation-ice.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition=2021
+//@ edition: 2021
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/try-block/issue-45124.rs
+++ b/tests/ui/try-block/issue-45124.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unreachable_code)]
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 #![feature(try_blocks)]
 

--- a/tests/ui/try-block/try-block-bad-lifetime.rs
+++ b/tests/ui/try-block/try-block-bad-lifetime.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 #![feature(try_blocks)]
 

--- a/tests/ui/try-block/try-block-bad-type.rs
+++ b/tests/ui/try-block/try-block-bad-type.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 #![feature(try_blocks)]
 

--- a/tests/ui/try-block/try-block-catch.rs
+++ b/tests/ui/try-block/try-block-catch.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 #![feature(try_blocks)]
 

--- a/tests/ui/try-block/try-block-in-edition2015.rs
+++ b/tests/ui/try-block/try-block-in-edition2015.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2015
+//@ edition: 2015
 
 pub fn main() {
     let try_result: Option<_> = try {

--- a/tests/ui/try-block/try-block-in-match-arm.rs
+++ b/tests/ui/try-block/try-block-in-match-arm.rs
@@ -1,5 +1,5 @@
 //@ check-pass
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 #![feature(try_blocks)]
 

--- a/tests/ui/try-block/try-block-in-match.rs
+++ b/tests/ui/try-block/try-block-in-match.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 #![feature(try_blocks)]
 

--- a/tests/ui/try-block/try-block-in-return.rs
+++ b/tests/ui/try-block/try-block-in-return.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 #![feature(try_blocks)]
 

--- a/tests/ui/try-block/try-block-in-while.rs
+++ b/tests/ui/try-block/try-block-in-while.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 #![feature(try_blocks)]
 

--- a/tests/ui/try-block/try-block-maybe-bad-lifetime.rs
+++ b/tests/ui/try-block/try-block-maybe-bad-lifetime.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 #![feature(try_blocks)]
 

--- a/tests/ui/try-block/try-block-opt-init.rs
+++ b/tests/ui/try-block/try-block-opt-init.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 #![feature(try_blocks)]
 

--- a/tests/ui/try-block/try-block-type-error.rs
+++ b/tests/ui/try-block/try-block-type-error.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 #![feature(try_blocks)]
 

--- a/tests/ui/try-block/try-block-unreachable-code-lint.rs
+++ b/tests/ui/try-block/try-block-unreachable-code-lint.rs
@@ -1,6 +1,6 @@
 // Test unreachable_code lint for `try {}` block ok-wrapping. See issues #54165, #63324.
 
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 //@ check-pass
 #![feature(try_blocks)]
 #![warn(unreachable_code)]

--- a/tests/ui/try-block/try-block-unused-delims.fixed
+++ b/tests/ui/try-block/try-block-unused-delims.fixed
@@ -1,5 +1,5 @@
 //@ check-pass
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 //@ run-rustfix
 
 #![feature(try_blocks)]

--- a/tests/ui/try-block/try-block-unused-delims.rs
+++ b/tests/ui/try-block/try-block-unused-delims.rs
@@ -1,5 +1,5 @@
 //@ check-pass
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 //@ run-rustfix
 
 #![feature(try_blocks)]

--- a/tests/ui/try-block/try-block.rs
+++ b/tests/ui/try-block/try-block.rs
@@ -2,7 +2,7 @@
 
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
-//@ compile-flags: --edition 2018
+//@ edition: 2018
 
 #![feature(try_blocks)]
 

--- a/tests/ui/try-block/try-is-identifier-edition2015.rs
+++ b/tests/ui/try-block/try-is-identifier-edition2015.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 
 #![allow(non_camel_case_types)]
-//@ compile-flags: --edition 2015
+//@ edition: 2015
 
 fn main() {
     let try = 2;

--- a/tests/ui/type-alias-impl-trait/cross_inference_pattern_bug.rs
+++ b/tests/ui/type-alias-impl-trait/cross_inference_pattern_bug.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition=2021
+//@ edition: 2021
 //@ build-pass
 #![feature(type_alias_impl_trait)]
 

--- a/tests/ui/type-alias-impl-trait/cross_inference_pattern_bug_no_type.rs
+++ b/tests/ui/type-alias-impl-trait/cross_inference_pattern_bug_no_type.rs
@@ -1,4 +1,5 @@
-//@ compile-flags: --edition=2021 --crate-type=lib
+//@ compile-flags: --crate-type=lib
+//@ edition: 2021
 //@ rustc-env:RUST_BACKTRACE=0
 //@ check-pass
 

--- a/tests/ui/type-alias-impl-trait/issue-93411.rs
+++ b/tests/ui/type-alias-impl-trait/issue-93411.rs
@@ -2,7 +2,7 @@
 
 // this test used to stack overflow due to infinite recursion.
 //@ check-pass
-//@ compile-flags: --edition=2018
+//@ edition: 2018
 
 use std::future::Future;
 

--- a/tests/ui/type-alias-impl-trait/issue-96572-unconstrained.rs
+++ b/tests/ui/type-alias-impl-trait/issue-96572-unconstrained.rs
@@ -1,7 +1,7 @@
 #![feature(type_alias_impl_trait)]
 //@ check-pass
 //@ revisions: default edition2021
-//@[edition2021] compile-flags: --edition 2021
+//@[edition2021]edition: 2021
 
 fn main() {
     type T = impl Copy;

--- a/tests/ui/use/auxiliary/extern-use-primitive-type-lib.rs
+++ b/tests/ui/use/auxiliary/extern-use-primitive-type-lib.rs
@@ -1,3 +1,3 @@
-//@ compile-flags: --edition=2018
+//@ edition: 2018
 
 pub use u32;


### PR DESCRIPTION
Backport https://github.com/rust-lang/rust/pull/139578