### PR TITLE
25.05 release notes use `target-with-tuple`

### DIFF
--- a/ferrocene/doc/release-notes/src/25.05.0.rst
+++ b/ferrocene/doc/release-notes/src/25.05.0.rst
@@ -15,8 +15,8 @@ New features
 
 * Two new targets are now supported and qualified for safety critical use:
 
-  * ``thumbv7em-none-eabi`` (Arm Cortex-M4, Arm Cortex-M7)
-  * ``thumbv7em-none-eabihf`` (Arm Cortex-M4F, Arm Cortex-M7F)
+  * :target-with-triple:`thumbv7em-none-eabi`
+  * :target-with-triple:`thumbv7em-none-eabihf`
 
 Fixed known problems
 --------------------


### PR DESCRIPTION
While reviewing the 25.05 release notes I realized that we weren't using `target-with-tuple` in the release notes, and that the "(Arm Cortex-M4, Arm Cortex-M7)" bit looked off, so I removed it.