### PR TITLE
code coverage: Instrument coretests

### DIFF
--- a/library/coretests/tests/num/flt2dec/strategy/grisu.rs
+++ b/library/coretests/tests/num/flt2dec/strategy/grisu.rs
@@ -4,6 +4,7 @@ use super::super::*;
 
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
+#[cfg_attr(ferrocene_coverage, ignore = "test too slow with coverage enabled")]
 fn test_cached_power() {
     assert_eq!(CACHED_POW10.first().unwrap().1, CACHED_POW10_FIRST_E);
     assert_eq!(CACHED_POW10.last().unwrap().1, CACHED_POW10_LAST_E);

--- a/library/coretests/tests/slice.rs
+++ b/library/coretests/tests/slice.rs
@@ -1765,6 +1765,7 @@ fn test_rotate_right() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
+#[cfg_attr(ferrocene_coverage, ignore = "test too slow with coverage enabled")]
 fn brute_force_rotate_test_0() {
     // In case of edge cases involving multiple algorithms
     let n = 300;
@@ -1804,6 +1805,7 @@ fn brute_force_rotate_test_1() {
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg_attr(miri, ignore)] // Miri is too slow
+#[cfg_attr(ferrocene_coverage, ignore = "test too slow with coverage enabled")]
 fn select_nth_unstable() {
     use core::cmp::Ordering::{Equal, Greater, Less};
 
@@ -2413,6 +2415,7 @@ macro_rules! split_off_tests {
     (ty: $ty:ty, slice: $slice:expr, method: $method:ident, $(($test_name:ident, ($($args:expr),*), $output:expr, $remaining:expr),)*) => {
         $(
             #[test]
+            #[cfg_attr(ferrocene_coverage, ignore = "test too slow with coverage enabled")]
             fn $test_name() {
                 let mut slice: $ty = $slice;
                 assert_eq!($output, slice.$method($($args)*));

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -23,7 +23,7 @@ use crate::core::builder::{
 };
 use crate::core::config::TargetSelection;
 use crate::core::config::flags::{FerroceneCoverageFor, Subcommand, get_completion};
-use crate::ferrocene::code_coverage::measure_coverage;
+use crate::ferrocene::code_coverage::{instrument_coverage, measure_coverage};
 use crate::ferrocene::secret_sauce::SecretSauceArtifacts;
 use crate::ferrocene::test_variants::{TestVariant, VariantCondition};
 use crate::utils::build_stamp::{self, BuildStamp};
@@ -2782,6 +2782,10 @@ impl Step for Crate {
         };
 
         if let Some(coverage_for) = builder.config.cmd.ferrocene_coverage_for() {
+            if coverage_for == FerroceneCoverageFor::Library {
+                instrument_coverage(builder, &mut cargo);
+            }
+
             measure_coverage(builder, cargo.as_mut(), compiler, target, coverage_for);
             cargo.rustflag("--cfg=ferrocene_coverage");
         }


### PR DESCRIPTION
In the work to enable code coverage for libstd and libcore (#1422 and previous) we forgot to also instrument the test runner binaries (e.g. `coretests`). This is necessary because generic functions only get monomorphised in the test runner binaries. Without instrumenting the test runner, generic functions and methods on generic types will always show up as uncovered, even when they are tested.

As a reference, libstd/libcore is instrumented here: https://github.com/ferrocene/ferrocene/blob/ecd298803cfae0e0448de9a0d83a7d25377120d0/src/bootstrap/src/core/build_steps/compile.rs#L282:L307

### Slower

This change makes compiling and executing `coretests` slower. Therefore a few tests have to be disabled on coverage runs because otherwise they time out.   

### Higher

This change raises code coverage on libcore from 24.74 to 27.95%.

### Lower (🤔)

There is one surprising change in the report here: Instrumenting coretests raises the covered lines (as epxected), but it also (in a few modules) reduces the total number of coverable lines. Functions that are previously shown as uncovered are now not even shown as coverable in the report (e.g. Cell::is_writing).

This is related to inlining. These functions come back when inlining is disabled for those functions. So this problem will be fixed in a later PR, when solving the overall inlining problem.