### PR TITLE
[1.86] Mark 1.86 as no longer upcoming

### DIFF
--- a/ferrocene/doc/release-notes/src/25.05.0.rst
+++ b/ferrocene/doc/release-notes/src/25.05.0.rst
@@ -1,8 +1,6 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-:upcoming-release:
-
 Ferrocene 25.05.0
 =================
 


### PR DESCRIPTION
Removes the "Upcoming" label from our upcoming stable release.