### PR TITLE
Exclude `CARGO_HOME` from `generate-copyright` in-tree determination

### DIFF
--- a/src/bootstrap/src/core/build_steps/run.rs
+++ b/src/bootstrap/src/core/build_steps/run.rs
@@ -5,7 +5,6 @@
 
 use std::path::PathBuf;
 
-use crate::Mode;
 use crate::core::build_steps::dist::distdir;
 use crate::core::build_steps::test;
 use crate::core::build_steps::tool::{self, SourceType, Tool};
@@ -14,6 +13,7 @@ use crate::core::builder::{Builder, Kind, RunConfig, ShouldRun, Step};
 use crate::core::config::TargetSelection;
 use crate::core::config::flags::get_completion;
 use crate::utils::exec::command;
+use crate::{Mode, t};
 
 #[derive(Debug, PartialOrd, Ord, Clone, Hash, PartialEq, Eq)]
 pub struct BuildManifest;
@@ -243,6 +243,7 @@ impl Step for GenerateCopyright {
         cmd.env("SRC_DIR", &builder.src);
         cmd.env("VENDOR_DIR", &vendored_sources);
         cmd.env("CARGO", &builder.initial_cargo);
+        cmd.env("CARGO_HOME", t!(home::cargo_home()));
         // it is important that generate-copyright runs from the root of the
         // source tree, because it uses relative paths
         cmd.current_dir(&builder.src);

--- a/src/tools/generate-copyright/src/main.rs
+++ b/src/tools/generate-copyright/src/main.rs
@@ -15,6 +15,7 @@ mod cargo_metadata;
 ///
 /// Run `x.py run generate-copyright`
 fn main() -> Result<(), Error> {
+    let cargo_home = env_path("CARGO_HOME")?;
     let dest_file = env_path("DEST")?;
     let libstd_dest_file = env_path("DEST_LIBSTD")?;
     let src_dir = env_path("SRC_DIR")?;
@@ -39,11 +40,17 @@ fn main() -> Result<(), Error> {
         .collect::<Vec<_>>();
 
     // Scan Cargo dependencies
-    let mut collected_cargo_metadata =
-        cargo_metadata::get_metadata_and_notices(&cargo, &vendor_dir, &src_dir, &cargo_manifests)?;
+    let mut collected_cargo_metadata = cargo_metadata::get_metadata_and_notices(
+        &cargo,
+        &cargo_home,
+        &vendor_dir,
+        &src_dir,
+        &cargo_manifests,
+    )?;
 
     let library_collected_cargo_metadata = cargo_metadata::get_metadata_and_notices(
         &cargo,
+        &cargo_home,
         &vendor_dir,
         &src_dir,
         &library_manifests,


### PR DESCRIPTION
We noticed that in our releases the out-of-tree notices were not being included. When `x.py run generate-copyright` was ran on local development machines, it worked fine.

After some investigations @tshepang and I determined that the problem was that the cargo registry (located in `CARGO_HOME`) started with the source directory on CI jobs, and was being excluded by this line:

https://github.com/ferrocene/ferrocene/blob/96a45dd9a18c6e54d3cd81750a78fe459fa48af0/src/tools/generate-copyright/src/cargo_metadata.rs#L85-L88

In our `run.sh` we set `CARGO_HOME` to be `build/cargo-home`:
https://github.com/ferrocene/ferrocene/blob/96a45dd9a18c6e54d3cd81750a78fe459fa48af0/ferrocene/ci/run.sh#L34-L46

This PR passes the `CARGO_HOME` variable to the `generate-copyright` tool and expands the consideration of in-tree-ness to be aware of `CARGO_HOME`.

## Testing

Run `CARGO_HOME=build/cargo-home ./x.py run generate-copyright` on `main`, then check `build/host/doc/COPYRIGHT` and look for out of tree dependencies (at the bottom).

Then, try running the same command in this branch.