### PR TITLE
Exclude `literal_block` with `source` attribute from Document ID

### DIFF
--- a/ferrocene/doc/sphinx-shared-resources/src/ferrocene_qualification/document_id.py
+++ b/ferrocene/doc/sphinx-shared-resources/src/ferrocene_qualification/document_id.py
@@ -37,9 +37,10 @@ class Hasher:
         else:
             self.state.update(struct.pack("<Q", len(node.non_default_attributes())))
             for name, value in node.attlist():
-                # The <document source=".."> attribute contains absolute paths
+                # These elements have a `source` attribute which contains absolute paths
                 # in it, breaking reproducibility.
-                if isinstance(node, nodes.document) and name == "source":
+                may_have_source = isinstance(node, nodes.document) or isinstance(node, nodes.literal_block)
+                if may_have_source and name == "source":
                     continue
 
                 self.string(name)


### PR DESCRIPTION
While testing signing (#1493, #1471, #1469) we noticed that Internal Procedures was creating a different Document ID when built locally vs CI. When we diffed the doctrees we noticed the following diff:

```diff
-            <literal_block force="False" highlight_args="{'linenostart': 1}" language="default" linenos="False" source="/home/ci/project/src/bootstrap/src/ferrocene/test_variants.rs" xml:space="preserve">("2021", &amp;[
+            <literal_block force="False" highlight_args="{'linenostart': 1}" language="default" linenos="False" source="/Users/ana/git/ferrocene/ferrocene/src/bootstrap/src/ferrocene/test_variants.rs" xml:space="preserve">("2021", &amp;[
```

This PR expands our existing exclusion to cover this as well.