### PR TITLE
Sign Ferrocene 25.05

### DIFF
--- a/ferrocene/doc/document-list/signature/signature.toml
+++ b/ferrocene/doc/document-list/signature/signature.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+[files]
+"pinned.toml" = "0758c2ba-0591-4baa-a227-13d2da8c2019"
+"safety-manager.cosign-bundle" = "f596e6c5-1b2b-4b7b-9abe-ff69921371c1"

--- a/ferrocene/doc/evaluation-plan/signature/signature.toml
+++ b/ferrocene/doc/evaluation-plan/signature/signature.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+[files]
+"pinned.toml" = "42d25e19-534b-41ce-a017-25f2516868b9"
+"safety-manager.cosign-bundle" = "122c02ce-8350-4fad-b0fe-ff305d31b206"

--- a/ferrocene/doc/evaluation-report/signature/signature.toml
+++ b/ferrocene/doc/evaluation-report/signature/signature.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+[files]
+"pinned.toml" = "699586a0-4ad5-4eae-9352-e6fc93fc4ccf"
+"safety-manager.cosign-bundle" = "73f002ba-3710-4201-91bd-fa1af971a528"

--- a/ferrocene/doc/internal-procedures/signature/signature.toml
+++ b/ferrocene/doc/internal-procedures/signature/signature.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+[files]
+"pinned.toml" = "e5f78e43-7a7c-4090-8aa5-22ca4ff92b68"
+"safety-manager.cosign-bundle" = "23512e91-f40f-4a92-9b81-9e6bc9424d53"

--- a/ferrocene/doc/qualification-plan/signature/signature.toml
+++ b/ferrocene/doc/qualification-plan/signature/signature.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+[files]
+"pinned.toml" = "3e49dec2-f79f-4ab3-92c9-08c87133f0ca"
+"safety-manager.cosign-bundle" = "2ed2b798-90b9-4309-8ddd-5492f12af6be"

--- a/ferrocene/doc/qualification-report/signature/signature.toml
+++ b/ferrocene/doc/qualification-report/signature/signature.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+[files]
+"pinned.toml" = "68c3a5a8-9f1c-4e9a-8cb4-dfc211e968ff"
+"safety-manager.cosign-bundle" = "7762c641-6c13-4ce0-b157-128e8eec8f86"

--- a/ferrocene/doc/safety-manual/signature/signature.toml
+++ b/ferrocene/doc/safety-manual/signature/signature.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+[files]
+"pinned.toml" = "4920e1ce-2ed6-493d-bd98-c5831682e925"
+"safety-manager.cosign-bundle" = "35bc4aaa-7d89-4013-a2b6-43b66c4fc8aa"


### PR DESCRIPTION
Documentation semantic diff:

* **Index**
    * Added "Licensing and Copyright" pages

* **Document list**
	* Version number changed
	* Document IDs changed

* **Evaluation Plan**
    * No semantically meaningful differences

* **Evaluation Report**
    * Added "Compiler arguments affecting the compilation outcome"

* **Internal procedures**
    * Updated "Handling Backports" * Clarified *feature* development happens on `main`
    * Updated "Sphinx Extensions"
        * Added "Marking changes as upcoming"
        * Removed "Sphinx Needs Integration"
    * Updated "Digital Signatures" * Removed "Signing documents" * Added "Signing all documents" * Added "Signing a single document" * Added "Configuring the roles allowed to sign" * Added "Inspecting the signature contents"
    * Updated "Setting up a local development environment"
        * Updated "Required software" to show `uv`
        * Added "x86-64 Linux (glibc) (x86_64-unknown-linux-gnu)" * Added "Apple Silicon macOS (aarch64-apple-darwin)" * Added "x86-64 Windows (x86_64-pc-windows-msvc)"
    * Updated "Working with the CI" * Removed "Using the Python virtual environment" * Added "Using Python scripts and tools" * Updated "Reproducing CI jobs" * Added "Preserving build artifacts" * Added "Sharing miscellaneous directories with the container"
    * Added "Testing Other Targets"
    * Updated "Known Problems"
        * Clarify we ignore some problems with the target as an ignore reason and why
    * Updated "Release Process Overview" * Updated "Publishing a manual release"
    * Updated "Stable Release Process"
        * Updated "Determine the Ferrocene version number"
        * Updated "Branching from rolling into beta" * Updated "Remove upcoming notes in the `main` branch"
    * Updated "Subtree Pulls" * Updated "Performing the pull"
    * Updated "Upstream Pulls"
        * Updated "Checkout PR"
    * Added "Test Variants"

* **Qualification Plan**
    * Updated "6.2 Build and Test Phase 1: Spot Testing"
    * Updated "9. Known Problems Tracking" to mention `Affected Branches`
    * Updated "2. Ferrocene Organization"

* **Qualification Report**
    * Version number changed
    * Updated test numbers and ignore reasons for all targets
    * Added "6. Armv7E-M bare-metal (soft-float)"
    * Added "7. Armv7E-M bare-metal (hard-float)"
    * Added "Variant" column to all results.
        * This shows the variant used (eg edition 2021). Note that some tests can override the variant options. For example, some tests checking the transition from Rust edition 2015 to edition 2018 cannot be run with edition 2021.

* **Release Notes**
    * Updated "Ferrocene 24.08.0" * Updated "Armv8-R AArch32 bare-metal (hard-float)" target name * https://github.com/rust-lang/rust/pull/133192 removed `--test-builder-wrapper` from the changelog
    * Updated "Ferrocene 25.02.0"
        * Reflect updated name for RFC 3617
        * Update syntax documenting `from_str_radix`
    * Added "Ferrocene 25.05.0"

* **Safety Manual**
     * Version number changed

* **Specification**
    * Changelog: * Updated to include changes from Rust 1.84 to Rust 1.86
    * (Please see "FLS Changelog" page for remaining changes)

* **User Manual**
    * Added "10. Armv7E-M bare-metal (soft-float)"
    * Added "11. Armv7E-M bare-metal (hard-float)"
    * Version number changed
    * Updated "9.1. Qualified targets"
        * Updated description
        * Added Armv7E-M targets
    * Updated "B. rustc Command-Line Interface" * Added impact for each flag