### PR TITLE
ci: reduce runtime of Commit workflow

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -72,7 +72,7 @@ jobs:
           SCRIPT: |
             set -e
             ./x test tidy
-            ./x check library compiler/rustc
+            ./x check rustc
             ./x run ferrocene/tools/traceability-matrix
             ./x test collect-license-metadata
           # Commit checks cannot authenticate with our AWS environment. Disable the parts of CI that


### PR DESCRIPTION
Upstream now builds `rustc` before it can check `std`, because `std` can only be built with in-tree `rustc`. This is a lot for what is supposed to be a quick check.