### PR TITLE
Include rustbook in vendor tarball

### DIFF
--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -140,7 +140,7 @@ impl Step for SourceTarball {
             "src/tools/cargo/Cargo.toml",
             "src/tools/rust-analyzer/Cargo.toml",
             "src/tools/rustc-perf/site/Cargo.toml",
-            "src/tools/rustbook/Cargo.toml"
+            "src/tools/rustbook/Cargo.toml",
         ];
         const UV_PROJECTS: &[&str] = &["ferrocene/doc"];
 


### PR DESCRIPTION
A customer reported that while trying to build ferrocene from vendor tarballs they were receiving an error related to missing the dependencies of `rustbook`. This adds them.

An easy way to validate this PR is to note that `rustbook` is the only crate in the repo that depends on `mdbook-i18n-helpers` (according to `Cargo.lock`s) and is present in the result of `./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist:src)`