### PR TITLE
Mark `Iterator` and `IntoIterator` as certified

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -1383,7 +1383,6 @@ pub const unsafe fn assume(b: bool) {
 #[rustc_nounwind]
 #[miri::intrinsic_fallback_is_spec]
 #[cold]
-#[cfg(not(feature = "ferrocene_certified"))]
 pub const fn cold_path() {}
 
 /// Hints to the compiler that branch condition is likely to be true.
@@ -1424,7 +1423,6 @@ pub const fn likely(b: bool) -> bool {
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_nounwind]
 #[inline(always)]
-#[cfg(not(feature = "ferrocene_certified"))]
 pub const fn unlikely(b: bool) -> bool {
     if b {
         cold_path();
@@ -1858,13 +1856,12 @@ pub const fn needs_drop<T: ?Sized>() -> bool;
 /// If the computed offset is non-zero, then both the starting and resulting pointer must be
 /// either in bounds or at the end of an allocated object. If either pointer is out
 /// of bounds or arithmetic overflow occurs then this operation is undefined behavior.
-///
-/// The stabilized version of this intrinsic is [`pointer::offset`].
+// ///
+// /// The stabilized version of this intrinsic is [`pointer::offset`].
 #[must_use = "returns a new pointer rather than modifying its argument"]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-#[cfg(not(feature = "ferrocene_certified"))]
 pub const unsafe fn offset<Ptr, Delta>(dst: Ptr, offset: Delta) -> Ptr;
 
 /// Calculates the offset from a pointer, potentially wrapping.
@@ -2901,7 +2898,6 @@ pub const unsafe fn disjoint_bitor<T: ~const fallback::DisjointBitOr>(a: T, b: T
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-#[cfg(not(feature = "ferrocene_certified"))]
 pub const fn add_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 
 /// Performs checked integer subtraction
@@ -2917,7 +2913,6 @@ pub const fn add_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-#[cfg(not(feature = "ferrocene_certified"))]
 pub const fn sub_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 
 /// Performs checked integer multiplication
@@ -2933,7 +2928,6 @@ pub const fn sub_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-#[cfg(not(feature = "ferrocene_certified"))]
 pub const fn mul_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 
 /// Performs full-width multiplication and addition with a carry:
@@ -3891,7 +3885,6 @@ impl<P: ?Sized, T: ptr::Thin> AggregateRawPtr<*mut T> for *mut P {
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
-#[cfg(not(feature = "ferrocene_certified"))]
 pub const fn ptr_metadata<P: ptr::Pointee<Metadata = M> + ?Sized, M>(ptr: *const P) -> M;
 
 // Some functions are defined here because they accidentally got made

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -475,8 +475,6 @@ pub use self::traits::FusedIterator;
 #[unstable(issue = "none", feature = "inplace_iteration")]
 #[cfg(not(feature = "ferrocene_certified"))]
 pub use self::traits::InPlaceIterable;
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use self::traits::Iterator;
 #[unstable(issue = "none", feature = "trusted_fused")]
 #[cfg(not(feature = "ferrocene_certified"))]
 pub use self::traits::TrustedFused;
@@ -491,8 +489,10 @@ pub(crate) use self::traits::UncheckedIterator;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg(not(feature = "ferrocene_certified"))]
 pub use self::traits::{
-    DoubleEndedIterator, ExactSizeIterator, Extend, FromIterator, IntoIterator, Product, Sum,
+    DoubleEndedIterator, ExactSizeIterator, Extend, FromIterator, Product, Sum,
 };
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use self::traits::{IntoIterator, Iterator};
 
 #[cfg(not(feature = "ferrocene_certified"))]
 mod adapters;

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -1,359 +1,360 @@
 //! Composable external iteration.
-//!
-//! If you've found yourself with a collection of some kind, and needed to
-//! perform an operation on the elements of said collection, you'll quickly run
-//! into 'iterators'. Iterators are heavily used in idiomatic Rust code, so
-//! it's worth becoming familiar with them.
-//!
-//! Before explaining more, let's talk about how this module is structured:
-//!
-//! # Organization
-//!
-//! This module is largely organized by type:
-//!
-//! * [Traits] are the core portion: these traits define what kind of iterators
-//!   exist and what you can do with them. The methods of these traits are worth
-//!   putting some extra study time into.
-//! * [Functions] provide some helpful ways to create some basic iterators.
-//! * [Structs] are often the return types of the various methods on this
-//!   module's traits. You'll usually want to look at the method that creates
-//!   the `struct`, rather than the `struct` itself. For more detail about why,
-//!   see '[Implementing Iterator](#implementing-iterator)'.
-//!
-//! [Traits]: #traits
-//! [Functions]: #functions
-//! [Structs]: #structs
-//!
-//! That's it! Let's dig into iterators.
-//!
-//! # Iterator
-//!
-//! The heart and soul of this module is the [`Iterator`] trait. The core of
-//! [`Iterator`] looks like this:
-//!
-//! ```
-//! trait Iterator {
-//!     type Item;
-//!     fn next(&mut self) -> Option<Self::Item>;
-//! }
-//! ```
-//!
-//! An iterator has a method, [`next`], which when called, returns an
-//! <code>[Option]\<Item></code>. Calling [`next`] will return [`Some(Item)`] as long as there
-//! are elements, and once they've all been exhausted, will return `None` to
-//! indicate that iteration is finished. Individual iterators may choose to
-//! resume iteration, and so calling [`next`] again may or may not eventually
-//! start returning [`Some(Item)`] again at some point (for example, see [`TryIter`]).
-//!
-//! [`Iterator`]'s full definition includes a number of other methods as well,
-//! but they are default methods, built on top of [`next`], and so you get
-//! them for free.
-//!
-//! Iterators are also composable, and it's common to chain them together to do
-//! more complex forms of processing. See the [Adapters](#adapters) section
-//! below for more details.
-//!
-//! [`Some(Item)`]: Some
-//! [`next`]: Iterator::next
-//! [`TryIter`]: ../../std/sync/mpsc/struct.TryIter.html
-//!
-//! # The three forms of iteration
-//!
-//! There are three common methods which can create iterators from a collection:
-//!
-//! * `iter()`, which iterates over `&T`.
-//! * `iter_mut()`, which iterates over `&mut T`.
-//! * `into_iter()`, which iterates over `T`.
-//!
-//! Various things in the standard library may implement one or more of the
-//! three, where appropriate.
-//!
-//! # Implementing Iterator
-//!
-//! Creating an iterator of your own involves two steps: creating a `struct` to
-//! hold the iterator's state, and then implementing [`Iterator`] for that `struct`.
-//! This is why there are so many `struct`s in this module: there is one for
-//! each iterator and iterator adapter.
-//!
-//! Let's make an iterator named `Counter` which counts from `1` to `5`:
-//!
-//! ```
-//! // First, the struct:
-//!
-//! /// An iterator which counts from one to five
-//! struct Counter {
-//!     count: usize,
-//! }
-//!
-//! // we want our count to start at one, so let's add a new() method to help.
-//! // This isn't strictly necessary, but is convenient. Note that we start
-//! // `count` at zero, we'll see why in `next()`'s implementation below.
-//! impl Counter {
-//!     fn new() -> Counter {
-//!         Counter { count: 0 }
-//!     }
-//! }
-//!
-//! // Then, we implement `Iterator` for our `Counter`:
-//!
-//! impl Iterator for Counter {
-//!     // we will be counting with usize
-//!     type Item = usize;
-//!
-//!     // next() is the only required method
-//!     fn next(&mut self) -> Option<Self::Item> {
-//!         // Increment our count. This is why we started at zero.
-//!         self.count += 1;
-//!
-//!         // Check to see if we've finished counting or not.
-//!         if self.count < 6 {
-//!             Some(self.count)
-//!         } else {
-//!             None
-//!         }
-//!     }
-//! }
-//!
-//! // And now we can use it!
-//!
-//! let mut counter = Counter::new();
-//!
-//! assert_eq!(counter.next(), Some(1));
-//! assert_eq!(counter.next(), Some(2));
-//! assert_eq!(counter.next(), Some(3));
-//! assert_eq!(counter.next(), Some(4));
-//! assert_eq!(counter.next(), Some(5));
-//! assert_eq!(counter.next(), None);
-//! ```
-//!
-//! Calling [`next`] this way gets repetitive. Rust has a construct which can
-//! call [`next`] on your iterator, until it reaches `None`. Let's go over that
-//! next.
-//!
-//! Also note that `Iterator` provides a default implementation of methods such as `nth` and `fold`
-//! which call `next` internally. However, it is also possible to write a custom implementation of
-//! methods like `nth` and `fold` if an iterator can compute them more efficiently without calling
-//! `next`.
-//!
-//! # `for` loops and `IntoIterator`
-//!
-//! Rust's `for` loop syntax is actually sugar for iterators. Here's a basic
-//! example of `for`:
-//!
-//! ```
-//! let values = vec![1, 2, 3, 4, 5];
-//!
-//! for x in values {
-//!     println!("{x}");
-//! }
-//! ```
-//!
-//! This will print the numbers one through five, each on their own line. But
-//! you'll notice something here: we never called anything on our vector to
-//! produce an iterator. What gives?
-//!
-//! There's a trait in the standard library for converting something into an
-//! iterator: [`IntoIterator`]. This trait has one method, [`into_iter`],
-//! which converts the thing implementing [`IntoIterator`] into an iterator.
-//! Let's take a look at that `for` loop again, and what the compiler converts
-//! it into:
-//!
-//! [`into_iter`]: IntoIterator::into_iter
-//!
-//! ```
-//! let values = vec![1, 2, 3, 4, 5];
-//!
-//! for x in values {
-//!     println!("{x}");
-//! }
-//! ```
-//!
-//! Rust de-sugars this into:
-//!
-//! ```
-//! let values = vec![1, 2, 3, 4, 5];
-//! {
-//!     let result = match IntoIterator::into_iter(values) {
-//!         mut iter => loop {
-//!             let next;
-//!             match iter.next() {
-//!                 Some(val) => next = val,
-//!                 None => break,
-//!             };
-//!             let x = next;
-//!             let () = { println!("{x}"); };
-//!         },
-//!     };
-//!     result
-//! }
-//! ```
-//!
-//! First, we call `into_iter()` on the value. Then, we match on the iterator
-//! that returns, calling [`next`] over and over until we see a `None`. At
-//! that point, we `break` out of the loop, and we're done iterating.
-//!
-//! There's one more subtle bit here: the standard library contains an
-//! interesting implementation of [`IntoIterator`]:
-//!
-//! ```ignore (only-for-syntax-highlight)
-//! impl<I: Iterator> IntoIterator for I
-//! ```
-//!
-//! In other words, all [`Iterator`]s implement [`IntoIterator`], by just
-//! returning themselves. This means two things:
-//!
-//! 1. If you're writing an [`Iterator`], you can use it with a `for` loop.
-//! 2. If you're creating a collection, implementing [`IntoIterator`] for it
-//!    will allow your collection to be used with the `for` loop.
-//!
-//! # Iterating by reference
-//!
-//! Since [`into_iter()`] takes `self` by value, using a `for` loop to iterate
-//! over a collection consumes that collection. Often, you may want to iterate
-//! over a collection without consuming it. Many collections offer methods that
-//! provide iterators over references, conventionally called `iter()` and
-//! `iter_mut()` respectively:
-//!
-//! ```
-//! let mut values = vec![41];
-//! for x in values.iter_mut() {
-//!     *x += 1;
-//! }
-//! for x in values.iter() {
-//!     assert_eq!(*x, 42);
-//! }
-//! assert_eq!(values.len(), 1); // `values` is still owned by this function.
-//! ```
-//!
-//! If a collection type `C` provides `iter()`, it usually also implements
-//! `IntoIterator` for `&C`, with an implementation that just calls `iter()`.
-//! Likewise, a collection `C` that provides `iter_mut()` generally implements
-//! `IntoIterator` for `&mut C` by delegating to `iter_mut()`. This enables a
-//! convenient shorthand:
-//!
-//! ```
-//! let mut values = vec![41];
-//! for x in &mut values { // same as `values.iter_mut()`
-//!     *x += 1;
-//! }
-//! for x in &values { // same as `values.iter()`
-//!     assert_eq!(*x, 42);
-//! }
-//! assert_eq!(values.len(), 1);
-//! ```
-//!
-//! While many collections offer `iter()`, not all offer `iter_mut()`. For
-//! example, mutating the keys of a [`HashSet<T>`] could put the collection
-//! into an inconsistent state if the key hashes change, so this collection
-//! only offers `iter()`.
-//!
-//! [`into_iter()`]: IntoIterator::into_iter
-//! [`HashSet<T>`]: ../../std/collections/struct.HashSet.html
-//!
-//! # Adapters
-//!
-//! Functions which take an [`Iterator`] and return another [`Iterator`] are
-//! often called 'iterator adapters', as they're a form of the 'adapter
-//! pattern'.
-//!
-//! Common iterator adapters include [`map`], [`take`], and [`filter`].
-//! For more, see their documentation.
-//!
-//! If an iterator adapter panics, the iterator will be in an unspecified (but
-//! memory safe) state.  This state is also not guaranteed to stay the same
-//! across versions of Rust, so you should avoid relying on the exact values
-//! returned by an iterator which panicked.
-//!
-//! [`map`]: Iterator::map
-//! [`take`]: Iterator::take
-//! [`filter`]: Iterator::filter
-//!
-//! # Laziness
-//!
-//! Iterators (and iterator [adapters](#adapters)) are *lazy*. This means that
-//! just creating an iterator doesn't _do_ a whole lot. Nothing really happens
-//! until you call [`next`]. This is sometimes a source of confusion when
-//! creating an iterator solely for its side effects. For example, the [`map`]
-//! method calls a closure on each element it iterates over:
-//!
-//! ```
-//! # #![allow(unused_must_use)]
-//! # #![allow(map_unit_fn)]
-//! let v = vec![1, 2, 3, 4, 5];
-//! v.iter().map(|x| println!("{x}"));
-//! ```
-//!
-//! This will not print any values, as we only created an iterator, rather than
-//! using it. The compiler will warn us about this kind of behavior:
-//!
-//! ```text
-//! warning: unused result that must be used: iterators are lazy and
-//! do nothing unless consumed
-//! ```
-//!
-//! The idiomatic way to write a [`map`] for its side effects is to use a
-//! `for` loop or call the [`for_each`] method:
-//!
-//! ```
-//! let v = vec![1, 2, 3, 4, 5];
-//!
-//! v.iter().for_each(|x| println!("{x}"));
-//! // or
-//! for x in &v {
-//!     println!("{x}");
-//! }
-//! ```
-//!
-//! [`map`]: Iterator::map
-//! [`for_each`]: Iterator::for_each
-//!
-//! Another common way to evaluate an iterator is to use the [`collect`]
-//! method to produce a new collection.
-//!
-//! [`collect`]: Iterator::collect
-//!
-//! # Infinity
-//!
-//! Iterators do not have to be finite. As an example, an open-ended range is
-//! an infinite iterator:
-//!
-//! ```
-//! let numbers = 0..;
-//! ```
-//!
-//! It is common to use the [`take`] iterator adapter to turn an infinite
-//! iterator into a finite one:
-//!
-//! ```
-//! let numbers = 0..;
-//! let five_numbers = numbers.take(5);
-//!
-//! for number in five_numbers {
-//!     println!("{number}");
-//! }
-//! ```
-//!
-//! This will print the numbers `0` through `4`, each on their own line.
-//!
-//! Bear in mind that methods on infinite iterators, even those for which a
-//! result can be determined mathematically in finite time, might not terminate.
-//! Specifically, methods such as [`min`], which in the general case require
-//! traversing every element in the iterator, are likely not to return
-//! successfully for any infinite iterators.
-//!
-//! ```no_run
-//! let ones = std::iter::repeat(1);
-//! let least = ones.min().unwrap(); // Oh no! An infinite loop!
-//! // `ones.min()` causes an infinite loop, so we won't reach this point!
-//! println!("The smallest number one is {least}.");
-//! ```
-//!
-//! [`take`]: Iterator::take
-//! [`min`]: Iterator::min
+// //!
+// //! If you've found yourself with a collection of some kind, and needed to
+// //! perform an operation on the elements of said collection, you'll quickly run
+// //! into 'iterators'. Iterators are heavily used in idiomatic Rust code, so
+// //! it's worth becoming familiar with them.
+// //!
+// //! Before explaining more, let's talk about how this module is structured:
+// //!
+// //! # Organization
+// //!
+// //! This module is largely organized by type:
+// //!
+// //! * [Traits] are the core portion: these traits define what kind of iterators
+// //!   exist and what you can do with them. The methods of these traits are worth
+// //!   putting some extra study time into.
+// //! * [Functions] provide some helpful ways to create some basic iterators.
+// //! * [Structs] are often the return types of the various methods on this
+// //!   module's traits. You'll usually want to look at the method that creates
+// //!   the `struct`, rather than the `struct` itself. For more detail about why,
+// //!   see '[Implementing Iterator](#implementing-iterator)'.
+// //!
+// //! [Traits]: #traits
+// //! [Functions]: #functions
+// //! [Structs]: #structs
+// //!
+// //! That's it! Let's dig into iterators.
+// //!
+// //! # Iterator
+// //!
+// //! The heart and soul of this module is the [`Iterator`] trait. The core of
+// //! [`Iterator`] looks like this:
+// //!
+// //! ```
+// //! trait Iterator {
+// //!     type Item;
+// //!     fn next(&mut self) -> Option<Self::Item>;
+// //! }
+// //! ```
+// //!
+// //! An iterator has a method, [`next`], which when called, returns an
+// //! <code>[Option]\<Item></code>. Calling [`next`] will return [`Some(Item)`] as long as there
+// //! are elements, and once they've all been exhausted, will return `None` to
+// //! indicate that iteration is finished. Individual iterators may choose to
+// //! resume iteration, and so calling [`next`] again may or may not eventually
+// //! start returning [`Some(Item)`] again at some point (for example, see [`TryIter`]).
+// //!
+// //! [`Iterator`]'s full definition includes a number of other methods as well,
+// //! but they are default methods, built on top of [`next`], and so you get
+// //! them for free.
+// //!
+// //! Iterators are also composable, and it's common to chain them together to do
+// //! more complex forms of processing. See the [Adapters](#adapters) section
+// //! below for more details.
+// //!
+// //! [`Some(Item)`]: Some
+// //! [`next`]: Iterator::next
+// //! [`TryIter`]: ../../std/sync/mpsc/struct.TryIter.html
+// //!
+// //! # The three forms of iteration
+// //!
+// //! There are three common methods which can create iterators from a collection:
+// //!
+// //! * `iter()`, which iterates over `&T`.
+// //! * `iter_mut()`, which iterates over `&mut T`.
+// //! * `into_iter()`, which iterates over `T`.
+// //!
+// //! Various things in the standard library may implement one or more of the
+// //! three, where appropriate.
+// //!
+// //! # Implementing Iterator
+// //!
+// //! Creating an iterator of your own involves two steps: creating a `struct` to
+// //! hold the iterator's state, and then implementing [`Iterator`] for that `struct`.
+// //! This is why there are so many `struct`s in this module: there is one for
+// //! each iterator and iterator adapter.
+// //!
+// //! Let's make an iterator named `Counter` which counts from `1` to `5`:
+// //!
+// //! ```
+// //! // First, the struct:
+// //!
+// //! /// An iterator which counts from one to five
+// //! struct Counter {
+// //!     count: usize,
+// //! }
+// //!
+// //! // we want our count to start at one, so let's add a new() method to help.
+// //! // This isn't strictly necessary, but is convenient. Note that we start
+// //! // `count` at zero, we'll see why in `next()`'s implementation below.
+// //! impl Counter {
+// //!     fn new() -> Counter {
+// //!         Counter { count: 0 }
+// //!     }
+// //! }
+// //!
+// //! // Then, we implement `Iterator` for our `Counter`:
+// //!
+// //! impl Iterator for Counter {
+// //!     // we will be counting with usize
+// //!     type Item = usize;
+// //!
+// //!     // next() is the only required method
+// //!     fn next(&mut self) -> Option<Self::Item> {
+// //!         // Increment our count. This is why we started at zero.
+// //!         self.count += 1;
+// //!
+// //!         // Check to see if we've finished counting or not.
+// //!         if self.count < 6 {
+// //!             Some(self.count)
+// //!         } else {
+// //!             None
+// //!         }
+// //!     }
+// //! }
+// //!
+// //! // And now we can use it!
+// //!
+// //! let mut counter = Counter::new();
+// //!
+// //! assert_eq!(counter.next(), Some(1));
+// //! assert_eq!(counter.next(), Some(2));
+// //! assert_eq!(counter.next(), Some(3));
+// //! assert_eq!(counter.next(), Some(4));
+// //! assert_eq!(counter.next(), Some(5));
+// //! assert_eq!(counter.next(), None);
+// //! ```
+// //!
+// //! Calling [`next`] this way gets repetitive. Rust has a construct which can
+// //! call [`next`] on your iterator, until it reaches `None`. Let's go over that
+// //! next.
+// //!
+// //! Also note that `Iterator` provides a default implementation of methods such as `nth` and `fold`
+// //! which call `next` internally. However, it is also possible to write a custom implementation of
+// //! methods like `nth` and `fold` if an iterator can compute them more efficiently without calling
+// //! `next`.
+// //!
+// //! # `for` loops and `IntoIterator`
+// //!
+// //! Rust's `for` loop syntax is actually sugar for iterators. Here's a basic
+// //! example of `for`:
+// //!
+// //! ```
+// //! let values = vec![1, 2, 3, 4, 5];
+// //!
+// //! for x in values {
+// //!     println!("{x}");
+// //! }
+// //! ```
+// //!
+// //! This will print the numbers one through five, each on their own line. But
+// //! you'll notice something here: we never called anything on our vector to
+// //! produce an iterator. What gives?
+// //!
+// //! There's a trait in the standard library for converting something into an
+// //! iterator: [`IntoIterator`]. This trait has one method, [`into_iter`],
+// //! which converts the thing implementing [`IntoIterator`] into an iterator.
+// //! Let's take a look at that `for` loop again, and what the compiler converts
+// //! it into:
+// //!
+// //! [`into_iter`]: IntoIterator::into_iter
+// //!
+// //! ```
+// //! let values = vec![1, 2, 3, 4, 5];
+// //!
+// //! for x in values {
+// //!     println!("{x}");
+// //! }
+// //! ```
+// //!
+// //! Rust de-sugars this into:
+// //!
+// //! ```
+// //! let values = vec![1, 2, 3, 4, 5];
+// //! {
+// //!     let result = match IntoIterator::into_iter(values) {
+// //!         mut iter => loop {
+// //!             let next;
+// //!             match iter.next() {
+// //!                 Some(val) => next = val,
+// //!                 None => break,
+// //!             };
+// //!             let x = next;
+// //!             let () = { println!("{x}"); };
+// //!         },
+// //!     };
+// //!     result
+// //! }
+// //! ```
+// //!
+// //! First, we call `into_iter()` on the value. Then, we match on the iterator
+// //! that returns, calling [`next`] over and over until we see a `None`. At
+// //! that point, we `break` out of the loop, and we're done iterating.
+// //!
+// //! There's one more subtle bit here: the standard library contains an
+// //! interesting implementation of [`IntoIterator`]:
+// //!
+// //! ```ignore (only-for-syntax-highlight)
+// //! impl<I: Iterator> IntoIterator for I
+// //! ```
+// //!
+// //! In other words, all [`Iterator`]s implement [`IntoIterator`], by just
+// //! returning themselves. This means two things:
+// //!
+// //! 1. If you're writing an [`Iterator`], you can use it with a `for` loop.
+// //! 2. If you're creating a collection, implementing [`IntoIterator`] for it
+// //!    will allow your collection to be used with the `for` loop.
+// //!
+// //! # Iterating by reference
+// //!
+// //! Since [`into_iter()`] takes `self` by value, using a `for` loop to iterate
+// //! over a collection consumes that collection. Often, you may want to iterate
+// //! over a collection without consuming it. Many collections offer methods that
+// //! provide iterators over references, conventionally called `iter()` and
+// //! `iter_mut()` respectively:
+// //!
+// //! ```
+// //! let mut values = vec![41];
+// //! for x in values.iter_mut() {
+// //!     *x += 1;
+// //! }
+// //! for x in values.iter() {
+// //!     assert_eq!(*x, 42);
+// //! }
+// //! assert_eq!(values.len(), 1); // `values` is still owned by this function.
+// //! ```
+// //!
+// //! If a collection type `C` provides `iter()`, it usually also implements
+// //! `IntoIterator` for `&C`, with an implementation that just calls `iter()`.
+// //! Likewise, a collection `C` that provides `iter_mut()` generally implements
+// //! `IntoIterator` for `&mut C` by delegating to `iter_mut()`. This enables a
+// //! convenient shorthand:
+// //!
+// //! ```
+// //! let mut values = vec![41];
+// //! for x in &mut values { // same as `values.iter_mut()`
+// //!     *x += 1;
+// //! }
+// //! for x in &values { // same as `values.iter()`
+// //!     assert_eq!(*x, 42);
+// //! }
+// //! assert_eq!(values.len(), 1);
+// //! ```
+// //!
+// //! While many collections offer `iter()`, not all offer `iter_mut()`. For
+// //! example, mutating the keys of a [`HashSet<T>`] could put the collection
+// //! into an inconsistent state if the key hashes change, so this collection
+// //! only offers `iter()`.
+// //!
+// //! [`into_iter()`]: IntoIterator::into_iter
+// //! [`HashSet<T>`]: ../../std/collections/struct.HashSet.html
+// //!
+// //! # Adapters
+// //!
+// //! Functions which take an [`Iterator`] and return another [`Iterator`] are
+// //! often called 'iterator adapters', as they're a form of the 'adapter
+// //! pattern'.
+// //!
+// //! Common iterator adapters include [`map`], [`take`], and [`filter`].
+// //! For more, see their documentation.
+// //!
+// //! If an iterator adapter panics, the iterator will be in an unspecified (but
+// //! memory safe) state.  This state is also not guaranteed to stay the same
+// //! across versions of Rust, so you should avoid relying on the exact values
+// //! returned by an iterator which panicked.
+// //!
+// //! [`map`]: Iterator::map
+// //! [`take`]: Iterator::take
+// //! [`filter`]: Iterator::filter
+// //!
+// //! # Laziness
+// //!
+// //! Iterators (and iterator [adapters](#adapters)) are *lazy*. This means that
+// //! just creating an iterator doesn't _do_ a whole lot. Nothing really happens
+// //! until you call [`next`]. This is sometimes a source of confusion when
+// //! creating an iterator solely for its side effects. For example, the [`map`]
+// //! method calls a closure on each element it iterates over:
+// //!
+// //! ```
+// //! # #![allow(unused_must_use)]
+// //! # #![allow(map_unit_fn)]
+// //! let v = vec![1, 2, 3, 4, 5];
+// //! v.iter().map(|x| println!("{x}"));
+// //! ```
+// //!
+// //! This will not print any values, as we only created an iterator, rather than
+// //! using it. The compiler will warn us about this kind of behavior:
+// //!
+// //! ```text
+// //! warning: unused result that must be used: iterators are lazy and
+// //! do nothing unless consumed
+// //! ```
+// //!
+// //! The idiomatic way to write a [`map`] for its side effects is to use a
+// //! `for` loop or call the [`for_each`] method:
+// //!
+// //! ```
+// //! let v = vec![1, 2, 3, 4, 5];
+// //!
+// //! v.iter().for_each(|x| println!("{x}"));
+// //! // or
+// //! for x in &v {
+// //!     println!("{x}");
+// //! }
+// //! ```
+// //!
+// //! [`map`]: Iterator::map
+// //! [`for_each`]: Iterator::for_each
+// //!
+// //! Another common way to evaluate an iterator is to use the [`collect`]
+// //! method to produce a new collection.
+// //!
+// //! [`collect`]: Iterator::collect
+// //!
+// //! # Infinity
+// //!
+// //! Iterators do not have to be finite. As an example, an open-ended range is
+// //! an infinite iterator:
+// //!
+// //! ```
+// //! let numbers = 0..;
+// //! ```
+// //!
+// //! It is common to use the [`take`] iterator adapter to turn an infinite
+// //! iterator into a finite one:
+// //!
+// //! ```
+// //! let numbers = 0..;
+// //! let five_numbers = numbers.take(5);
+// //!
+// //! for number in five_numbers {
+// //!     println!("{number}");
+// //! }
+// //! ```
+// //!
+// //! This will print the numbers `0` through `4`, each on their own line.
+// //!
+// //! Bear in mind that methods on infinite iterators, even those for which a
+// //! result can be determined mathematically in finite time, might not terminate.
+// //! Specifically, methods such as [`min`], which in the general case require
+// //! traversing every element in the iterator, are likely not to return
+// //! successfully for any infinite iterators.
+// //!
+// //! ```no_run
+// //! let ones = std::iter::repeat(1);
+// //! let least = ones.min().unwrap(); // Oh no! An infinite loop!
+// //! // `ones.min()` causes an infinite loop, so we won't reach this point!
+// //! println!("The smallest number one is {least}.");
+// //! ```
+// //!
+// //! [`take`]: Iterator::take
+// //! [`min`]: Iterator::min
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
 // This needs to be up here in order to be usable in the child modules
+#[cfg(not(feature = "ferrocene_certified"))]
 macro_rules! impl_fold_via_try_fold {
     (fold -> try_fold) => {
         impl_fold_via_try_fold! { @internal fold -> try_fold }
@@ -381,86 +382,122 @@ macro_rules! impl_fold_via_try_fold {
 }
 
 #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::adapters::ArrayChunks;
 #[unstable(feature = "std_internals", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::adapters::ByRefSized;
 #[stable(feature = "iter_cloned", since = "1.1.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::adapters::Cloned;
 #[stable(feature = "iter_copied", since = "1.36.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::adapters::Copied;
 #[stable(feature = "iterator_flatten", since = "1.29.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::adapters::Flatten;
 #[stable(feature = "iter_map_while", since = "1.57.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::adapters::MapWhile;
 #[unstable(feature = "iter_map_windows", reason = "recently added", issue = "87155")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::adapters::MapWindows;
 #[unstable(feature = "inplace_iteration", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::adapters::SourceIter;
 #[stable(feature = "iterator_step_by", since = "1.28.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::adapters::StepBy;
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::adapters::TrustedRandomAccess;
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::adapters::TrustedRandomAccessNoCoerce;
 #[unstable(feature = "iter_chain", reason = "recently added", issue = "125964")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::adapters::chain;
+#[cfg(not(feature = "ferrocene_certified"))]
 pub(crate) use self::adapters::try_process;
 #[stable(feature = "iter_zip", since = "1.59.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::adapters::zip;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::adapters::{
     Chain, Cycle, Enumerate, Filter, FilterMap, FlatMap, Fuse, Inspect, Map, Peekable, Rev, Scan,
     Skip, SkipWhile, Take, TakeWhile, Zip,
 };
 #[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::adapters::{Intersperse, IntersperseWith};
 #[unstable(
     feature = "step_trait",
     reason = "likely to be replaced by finer-grained traits",
     issue = "42168"
 )]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::range::Step;
 #[stable(feature = "iter_empty", since = "1.2.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::sources::{Empty, empty};
 #[unstable(
     feature = "iter_from_coroutine",
     issue = "43122",
     reason = "coroutines are unstable"
 )]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::sources::{FromCoroutine, from_coroutine};
 #[stable(feature = "iter_from_fn", since = "1.34.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::sources::{FromFn, from_fn};
 #[stable(feature = "iter_once", since = "1.2.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::sources::{Once, once};
 #[stable(feature = "iter_once_with", since = "1.43.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::sources::{OnceWith, once_with};
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::sources::{Repeat, repeat};
 #[stable(feature = "iter_repeat_n", since = "1.82.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::sources::{RepeatN, repeat_n};
 #[stable(feature = "iterator_repeat_with", since = "1.28.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::sources::{RepeatWith, repeat_with};
 #[stable(feature = "iter_successors", since = "1.34.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::sources::{Successors, successors};
 #[stable(feature = "fused", since = "1.26.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::traits::FusedIterator;
 #[unstable(issue = "none", feature = "inplace_iteration")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::traits::InPlaceIterable;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::traits::Iterator;
 #[unstable(issue = "none", feature = "trusted_fused")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::traits::TrustedFused;
 #[unstable(feature = "trusted_len", issue = "37572")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::traits::TrustedLen;
 #[unstable(feature = "trusted_step", issue = "85731")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::traits::TrustedStep;
+#[cfg(not(feature = "ferrocene_certified"))]
 pub(crate) use self::traits::UncheckedIterator;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::traits::{
     DoubleEndedIterator, ExactSizeIterator, Extend, FromIterator, IntoIterator, Product, Sum,
 };
 
+#[cfg(not(feature = "ferrocene_certified"))]
 mod adapters;
+#[cfg(not(feature = "ferrocene_certified"))]
 mod range;
+#[cfg(not(feature = "ferrocene_certified"))]
 mod sources;
 mod traits;

--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -1,3 +1,4 @@
+#[cfg(not(feature = "ferrocene_certified"))]
 use super::TrustedLen;
 
 /// Conversion from an [`Iterator`].
@@ -131,6 +132,7 @@ use super::TrustedLen;
     label = "value of type `{Self}` cannot be built from `std::iter::Iterator<Item={A}>`"
 )]
 #[rustc_diagnostic_item = "FromIterator"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub trait FromIterator<A>: Sized {
     /// Creates a value from an iterator.
     ///
@@ -149,93 +151,94 @@ pub trait FromIterator<A>: Sized {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_diagnostic_item = "from_iter_fn"]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn from_iter<T: IntoIterator<Item = A>>(iter: T) -> Self;
 }
 
 /// Conversion into an [`Iterator`].
-///
-/// By implementing `IntoIterator` for a type, you define how it will be
-/// converted to an iterator. This is common for types which describe a
-/// collection of some kind.
-///
-/// One benefit of implementing `IntoIterator` is that your type will [work
-/// with Rust's `for` loop syntax](crate::iter#for-loops-and-intoiterator).
-///
-/// See also: [`FromIterator`].
-///
-/// # Examples
-///
-/// Basic usage:
-///
-/// ```
-/// let v = [1, 2, 3];
-/// let mut iter = v.into_iter();
-///
-/// assert_eq!(Some(1), iter.next());
-/// assert_eq!(Some(2), iter.next());
-/// assert_eq!(Some(3), iter.next());
-/// assert_eq!(None, iter.next());
-/// ```
-/// Implementing `IntoIterator` for your type:
-///
-/// ```
-/// // A sample collection, that's just a wrapper over Vec<T>
-/// #[derive(Debug)]
-/// struct MyCollection(Vec<i32>);
-///
-/// // Let's give it some methods so we can create one and add things
-/// // to it.
-/// impl MyCollection {
-///     fn new() -> MyCollection {
-///         MyCollection(Vec::new())
-///     }
-///
-///     fn add(&mut self, elem: i32) {
-///         self.0.push(elem);
-///     }
-/// }
-///
-/// // and we'll implement IntoIterator
-/// impl IntoIterator for MyCollection {
-///     type Item = i32;
-///     type IntoIter = std::vec::IntoIter<Self::Item>;
-///
-///     fn into_iter(self) -> Self::IntoIter {
-///         self.0.into_iter()
-///     }
-/// }
-///
-/// // Now we can make a new collection...
-/// let mut c = MyCollection::new();
-///
-/// // ... add some stuff to it ...
-/// c.add(0);
-/// c.add(1);
-/// c.add(2);
-///
-/// // ... and then turn it into an Iterator:
-/// for (i, n) in c.into_iter().enumerate() {
-///     assert_eq!(i as i32, n);
-/// }
-/// ```
-///
-/// It is common to use `IntoIterator` as a trait bound. This allows
-/// the input collection type to change, so long as it is still an
-/// iterator. Additional bounds can be specified by restricting on
-/// `Item`:
-///
-/// ```rust
-/// fn collect_as_strings<T>(collection: T) -> Vec<String>
-/// where
-///     T: IntoIterator,
-///     T::Item: std::fmt::Debug,
-/// {
-///     collection
-///         .into_iter()
-///         .map(|item| format!("{item:?}"))
-///         .collect()
-/// }
-/// ```
+// ///
+// /// By implementing `IntoIterator` for a type, you define how it will be
+// /// converted to an iterator. This is common for types which describe a
+// /// collection of some kind.
+// ///
+// /// One benefit of implementing `IntoIterator` is that your type will [work
+// /// with Rust's `for` loop syntax](crate::iter#for-loops-and-intoiterator).
+// ///
+// /// See also: [`FromIterator`].
+// ///
+// /// # Examples
+// ///
+// /// Basic usage:
+// ///
+// /// ```
+// /// let v = [1, 2, 3];
+// /// let mut iter = v.into_iter();
+// ///
+// /// assert_eq!(Some(1), iter.next());
+// /// assert_eq!(Some(2), iter.next());
+// /// assert_eq!(Some(3), iter.next());
+// /// assert_eq!(None, iter.next());
+// /// ```
+// /// Implementing `IntoIterator` for your type:
+// ///
+// /// ```
+// /// // A sample collection, that's just a wrapper over Vec<T>
+// /// #[derive(Debug)]
+// /// struct MyCollection(Vec<i32>);
+// ///
+// /// // Let's give it some methods so we can create one and add things
+// /// // to it.
+// /// impl MyCollection {
+// ///     fn new() -> MyCollection {
+// ///         MyCollection(Vec::new())
+// ///     }
+// ///
+// ///     fn add(&mut self, elem: i32) {
+// ///         self.0.push(elem);
+// ///     }
+// /// }
+// ///
+// /// // and we'll implement IntoIterator
+// /// impl IntoIterator for MyCollection {
+// ///     type Item = i32;
+// ///     type IntoIter = std::vec::IntoIter<Self::Item>;
+// ///
+// ///     fn into_iter(self) -> Self::IntoIter {
+// ///         self.0.into_iter()
+// ///     }
+// /// }
+// ///
+// /// // Now we can make a new collection...
+// /// let mut c = MyCollection::new();
+// ///
+// /// // ... add some stuff to it ...
+// /// c.add(0);
+// /// c.add(1);
+// /// c.add(2);
+// ///
+// /// // ... and then turn it into an Iterator:
+// /// for (i, n) in c.into_iter().enumerate() {
+// ///     assert_eq!(i as i32, n);
+// /// }
+// /// ```
+// ///
+// /// It is common to use `IntoIterator` as a trait bound. This allows
+// /// the input collection type to change, so long as it is still an
+// /// iterator. Additional bounds can be specified by restricting on
+// /// `Item`:
+// ///
+// /// ```rust
+// /// fn collect_as_strings<T>(collection: T) -> Vec<String>
+// /// where
+// ///     T: IntoIterator,
+// ///     T::Item: std::fmt::Debug,
+// /// {
+// ///     collection
+// ///         .into_iter()
+// ///         .map(|item| format!("{item:?}"))
+// ///         .collect()
+// /// }
+// /// ```
 #[rustc_diagnostic_item = "IntoIterator"]
 #[rustc_on_unimplemented(
     on(
@@ -314,11 +317,15 @@ pub trait IntoIterator {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<I: Iterator> IntoIterator for I {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = I::Item;
+    #[cfg(not(feature = "ferrocene_certified"))]
     type IntoIter = I;
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn into_iter(self) -> I {
         self
     }
@@ -394,6 +401,7 @@ impl<I: Iterator> IntoIterator for I {
 /// assert_eq!("MyCollection([5, 6, 7, 1, 2, 3])", format!("{c:?}"));
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub trait Extend<A> {
     /// Extends a collection with the contents of an iterator.
     ///
@@ -413,10 +421,12 @@ pub trait Extend<A> {
     /// assert_eq!("abcdef", &message);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn extend<T: IntoIterator<Item = A>>(&mut self, iter: T);
 
     /// Extends a collection with exactly one element.
     #[unstable(feature = "extend_one", issue = "72631")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn extend_one(&mut self, item: A) {
         self.extend(Some(item));
     }
@@ -425,6 +435,7 @@ pub trait Extend<A> {
     ///
     /// The default implementation does nothing.
     #[unstable(feature = "extend_one", issue = "72631")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn extend_reserve(&mut self, additional: usize) {
         let _ = additional;
     }
@@ -443,6 +454,7 @@ pub trait Extend<A> {
     // This method is for internal usage only. It is only on the trait because of specialization's limitations.
     #[unstable(feature = "extend_one_unchecked", issue = "none")]
     #[doc(hidden)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     unsafe fn extend_one_unchecked(&mut self, item: A)
     where
         Self: Sized,
@@ -452,13 +464,17 @@ pub trait Extend<A> {
 }
 
 #[stable(feature = "extend_for_unit", since = "1.28.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl Extend<()> for () {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn extend<T: IntoIterator<Item = ()>>(&mut self, iter: T) {
         iter.into_iter().for_each(drop)
     }
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn extend_one(&mut self, _item: ()) {}
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 macro_rules! spec_tuple_impl {
     (
         (
@@ -676,6 +692,7 @@ macro_rules! spec_tuple_impl {
     };
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 spec_tuple_impl!(
     (L, l, EL, TraitL, default_extend_tuple_l, 11),
     (K, k, EK, TraitK, default_extend_tuple_k, 10),

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1,14 +1,20 @@
+#[cfg(not(feature = "ferrocene_certified"))]
 use super::super::{
     ArrayChunks, ByRefSized, Chain, Cloned, Copied, Cycle, Enumerate, Filter, FilterMap, FlatMap,
     Flatten, Fuse, Inspect, Intersperse, IntersperseWith, Map, MapWhile, MapWindows, Peekable,
     Product, Rev, Scan, Skip, SkipWhile, StepBy, Sum, Take, TakeWhile, TrustedRandomAccessNoCoerce,
     Zip, try_process,
 };
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::array;
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::cmp::{self, Ordering};
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::num::NonZero;
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::ops::{ChangeOutputType, ControlFlow, FromResidual, Residual, Try};
 
+#[cfg(not(feature = "ferrocene_certified"))]
 fn _assert_is_dyn_compatible(_: &dyn Iterator<Item = ()>) {}
 
 /// A trait for dealing with iterators.
@@ -32,7 +38,7 @@ fn _assert_is_dyn_compatible(_: &dyn Iterator<Item = ()>) {}
     label = "`{Self}` is not an iterator",
     message = "`{Self}` is not an iterator"
 )]
-#[doc(notable_trait)]
+#[cfg_attr(not(feature = "ferrocene_certified"), doc(notable_trait))]
 #[lang = "iterator"]
 #[rustc_diagnostic_item = "Iterator"]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
@@ -106,6 +112,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[unstable(feature = "iter_next_chunk", reason = "recently added", issue = "98326")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_chunk<const N: usize>(
         &mut self,
     ) -> Result<[Self::Item; N], array::IntoIter<Self::Item, N>>
@@ -183,6 +190,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (0, None)
     }
@@ -218,6 +226,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn count(self) -> usize
     where
         Self: Sized,
@@ -246,6 +255,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn last(self) -> Option<Self::Item>
     where
         Self: Sized,
@@ -293,6 +303,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[unstable(feature = "iter_advance_by", reason = "recently added", issue = "77404")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
         for i in 0..n {
             if self.next().is_none() {
@@ -344,6 +355,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         self.advance_by(n).ok()?;
         self.next()
@@ -394,6 +406,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "iterator_step_by", since = "1.28.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn step_by(self, step: usize) -> StepBy<Self>
     where
         Self: Sized,
@@ -465,6 +478,7 @@ pub trait Iterator {
     /// [`OsStr`]: ../../std/ffi/struct.OsStr.html
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn chain<U>(self, other: U) -> Chain<Self, U::IntoIter>
     where
         Self: Sized,
@@ -583,6 +597,7 @@ pub trait Iterator {
     /// [`zip`]: crate::iter::zip
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn zip<U>(self, other: U) -> Zip<Self, U::IntoIter>
     where
         Self: Sized,
@@ -626,6 +641,7 @@ pub trait Iterator {
     /// [`intersperse_with`]: Iterator::intersperse_with
     #[inline]
     #[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn intersperse(self, separator: Self::Item) -> Intersperse<Self>
     where
         Self: Sized,
@@ -684,6 +700,7 @@ pub trait Iterator {
     /// [`intersperse`]: Iterator::intersperse
     #[inline]
     #[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn intersperse_with<G>(self, separator: G) -> IntersperseWith<Self, G>
     where
         Self: Sized,
@@ -743,6 +760,7 @@ pub trait Iterator {
     #[rustc_diagnostic_item = "IteratorMap"]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn map<B, F>(self, f: F) -> Map<Self, F>
     where
         Self: Sized,
@@ -788,6 +806,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "iterator_for_each", since = "1.21.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn for_each<F>(self, f: F)
     where
         Self: Sized,
@@ -863,6 +882,7 @@ pub trait Iterator {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_diagnostic_item = "iter_filter"]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn filter<P>(self, predicate: P) -> Filter<Self, P>
     where
         Self: Sized,
@@ -908,6 +928,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn filter_map<B, F>(self, f: F) -> FilterMap<Self, F>
     where
         Self: Sized,
@@ -955,6 +976,7 @@ pub trait Iterator {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_diagnostic_item = "enumerate_method"]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn enumerate(self) -> Enumerate<Self>
     where
         Self: Sized,
@@ -1026,6 +1048,7 @@ pub trait Iterator {
     /// [`next`]: Iterator::next
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn peekable(self) -> Peekable<Self>
     where
         Self: Sized,
@@ -1091,6 +1114,7 @@ pub trait Iterator {
     #[inline]
     #[doc(alias = "drop_while")]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn skip_while<P>(self, predicate: P) -> SkipWhile<Self, P>
     where
         Self: Sized,
@@ -1169,6 +1193,7 @@ pub trait Iterator {
     /// the iteration should stop, but wasn't placed back into the iterator.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn take_while<P>(self, predicate: P) -> TakeWhile<Self, P>
     where
         Self: Sized,
@@ -1257,6 +1282,7 @@ pub trait Iterator {
     /// [`fuse`]: Iterator::fuse
     #[inline]
     #[stable(feature = "iter_map_while", since = "1.57.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn map_while<B, P>(self, predicate: P) -> MapWhile<Self, P>
     where
         Self: Sized,
@@ -1286,6 +1312,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn skip(self, n: usize) -> Skip<Self>
     where
         Self: Sized,
@@ -1358,6 +1385,7 @@ pub trait Iterator {
     #[doc(alias = "limit")]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn take(self, n: usize) -> Take<Self>
     where
         Self: Sized,
@@ -1405,6 +1433,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn scan<St, B, F>(self, initial_state: St, f: F) -> Scan<Self, St, F>
     where
         Self: Sized,
@@ -1443,6 +1472,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn flat_map<U, F>(self, f: F) -> FlatMap<Self, U, F>
     where
         Self: Sized,
@@ -1527,6 +1557,7 @@ pub trait Iterator {
     /// [`flat_map()`]: Iterator::flat_map
     #[inline]
     #[stable(feature = "iterator_flatten", since = "1.29.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn flatten(self) -> Flatten<Self>
     where
         Self: Sized,
@@ -1683,6 +1714,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[unstable(feature = "iter_map_windows", reason = "recently added", issue = "87155")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn map_windows<F, R, const N: usize>(self, f: F) -> MapWindows<Self, F, N>
     where
         Self: Sized,
@@ -1745,6 +1777,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fuse(self) -> Fuse<Self>
     where
         Self: Sized,
@@ -1829,6 +1862,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn inspect<F>(self, f: F) -> Inspect<Self, F>
     where
         Self: Sized,
@@ -1866,6 +1900,7 @@ pub trait Iterator {
     /// assert_eq!(of_rust, vec!["of", "Rust"]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn by_ref(&mut self) -> &mut Self
     where
         Self: Sized,
@@ -1985,6 +2020,7 @@ pub trait Iterator {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use = "if you really need to exhaust the iterator, consider `.for_each(drop)` instead"]
     #[rustc_diagnostic_item = "iterator_collect_fn"]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn collect<B: FromIterator<Self::Item>>(self) -> B
     where
         Self: Sized,
@@ -2072,6 +2108,7 @@ pub trait Iterator {
     /// [`collect`]: Iterator::collect
     #[inline]
     #[unstable(feature = "iterator_try_collect", issue = "94047")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn try_collect<B>(&mut self) -> ChangeOutputType<Self::Item, B>
     where
         Self: Sized,
@@ -2144,6 +2181,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[unstable(feature = "iter_collect_into", reason = "new API", issue = "94780")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn collect_into<E: Extend<Self::Item>>(self, collection: &mut E) -> &mut E
     where
         Self: Sized,
@@ -2176,6 +2214,7 @@ pub trait Iterator {
     /// assert_eq!(odd, [1, 3]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn partition<B, F>(self, f: F) -> (B, B)
     where
         Self: Sized,
@@ -2238,6 +2277,7 @@ pub trait Iterator {
     /// assert!(a[i..].iter().all(|n| n % 2 == 1)); // odds
     /// ```
     #[unstable(feature = "iter_partition_in_place", reason = "new API", issue = "62543")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn partition_in_place<'a, T: 'a, P>(mut self, ref mut predicate: P) -> usize
     where
         Self: Sized + DoubleEndedIterator<Item = &'a mut T>,
@@ -2295,6 +2335,7 @@ pub trait Iterator {
     /// assert!(!"IntoIterator".chars().is_partitioned(char::is_uppercase));
     /// ```
     #[unstable(feature = "iter_is_partitioned", reason = "new API", issue = "62544")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_partitioned<P>(mut self, mut predicate: P) -> bool
     where
         Self: Sized,
@@ -2389,6 +2430,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "iterator_try_fold", since = "1.27.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn try_fold<B, F, R>(&mut self, init: B, mut f: F) -> R
     where
         Self: Sized,
@@ -2447,6 +2489,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "iterator_try_fold", since = "1.27.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn try_for_each<F, R>(&mut self, f: F) -> R
     where
         Self: Sized,
@@ -2566,6 +2609,7 @@ pub trait Iterator {
     #[doc(alias = "inject", alias = "foldl")]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fold<B, F>(mut self, init: B, mut f: F) -> B
     where
         Self: Sized,
@@ -2603,6 +2647,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "iterator_fold_self", since = "1.51.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn reduce<F>(mut self, f: F) -> Option<Self::Item>
     where
         Self: Sized,
@@ -2674,6 +2719,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[unstable(feature = "iterator_try_reduce", reason = "new API", issue = "87053")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn try_reduce<R>(
         &mut self,
         f: impl FnMut(Self::Item, Self::Item) -> R,
@@ -2732,6 +2778,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn all<F>(&mut self, f: F) -> bool
     where
         Self: Sized,
@@ -2785,6 +2832,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn any<F>(&mut self, f: F) -> bool
     where
         Self: Sized,
@@ -2847,6 +2895,7 @@ pub trait Iterator {
     /// Note that `iter.find(f)` is equivalent to `iter.filter(f).next()`.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn find<P>(&mut self, predicate: P) -> Option<Self::Item>
     where
         Self: Sized,
@@ -2878,6 +2927,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "iterator_find_map", since = "1.30.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn find_map<B, F>(&mut self, f: F) -> Option<B>
     where
         Self: Sized,
@@ -2936,6 +2986,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[unstable(feature = "try_find", reason = "new API", issue = "63178")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn try_find<R>(
         &mut self,
         f: impl FnMut(&Self::Item) -> R,
@@ -3019,6 +3070,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn position<P>(&mut self, predicate: P) -> Option<usize>
     where
         Self: Sized,
@@ -3084,6 +3136,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn rposition<P>(&mut self, predicate: P) -> Option<usize>
     where
         P: FnMut(Self::Item) -> bool,
@@ -3133,6 +3186,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn max(self) -> Option<Self::Item>
     where
         Self: Sized,
@@ -3169,6 +3223,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn min(self) -> Option<Self::Item>
     where
         Self: Sized,
@@ -3191,6 +3246,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "iter_cmp_by_key", since = "1.6.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn max_by_key<B: Ord, F>(self, f: F) -> Option<Self::Item>
     where
         Self: Sized,
@@ -3224,6 +3280,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "iter_max_by", since = "1.15.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn max_by<F>(self, compare: F) -> Option<Self::Item>
     where
         Self: Sized,
@@ -3251,6 +3308,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "iter_cmp_by_key", since = "1.6.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn min_by_key<B: Ord, F>(self, f: F) -> Option<Self::Item>
     where
         Self: Sized,
@@ -3284,6 +3342,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "iter_min_by", since = "1.15.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn min_by<F>(self, compare: F) -> Option<Self::Item>
     where
         Self: Sized,
@@ -3321,6 +3380,7 @@ pub trait Iterator {
     #[inline]
     #[doc(alias = "reverse")]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn rev(self) -> Rev<Self>
     where
         Self: Sized + DoubleEndedIterator,
@@ -3357,6 +3417,7 @@ pub trait Iterator {
     /// assert_eq!(z, [3, 6]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn unzip<A, B, FromA, FromB>(self) -> (FromA, FromB)
     where
         FromA: Default + Extend<A>,
@@ -3388,6 +3449,7 @@ pub trait Iterator {
     /// ```
     #[stable(feature = "iter_copied", since = "1.36.0")]
     #[rustc_diagnostic_item = "iter_copied"]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn copied<'a, T: 'a>(self) -> Copied<Self>
     where
         Self: Sized + Iterator<Item = &'a T>,
@@ -3436,6 +3498,7 @@ pub trait Iterator {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_diagnostic_item = "iter_cloned"]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn cloned<'a, T: 'a>(self) -> Cloned<Self>
     where
         Self: Sized + Iterator<Item = &'a T>,
@@ -3467,6 +3530,7 @@ pub trait Iterator {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn cycle(self) -> Cycle<Self>
     where
         Self: Sized + Clone,
@@ -3510,6 +3574,7 @@ pub trait Iterator {
     /// ```
     #[track_caller]
     #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn array_chunks<const N: usize>(self) -> ArrayChunks<Self, N>
     where
         Self: Sized,
@@ -3546,6 +3611,7 @@ pub trait Iterator {
     /// assert_eq!(sum, -0.0_f32);
     /// ```
     #[stable(feature = "iter_arith", since = "1.11.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn sum<S>(self) -> S
     where
         Self: Sized,
@@ -3578,6 +3644,7 @@ pub trait Iterator {
     /// assert_eq!(factorial(5), 120);
     /// ```
     #[stable(feature = "iter_arith", since = "1.11.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn product<P>(self) -> P
     where
         Self: Sized,
@@ -3599,6 +3666,7 @@ pub trait Iterator {
     /// assert_eq!([1, 2].iter().cmp([1].iter()), Ordering::Greater);
     /// ```
     #[stable(feature = "iter_order", since = "1.5.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn cmp<I>(self, other: I) -> Ordering
     where
         I: IntoIterator<Item = Self::Item>,
@@ -3626,6 +3694,7 @@ pub trait Iterator {
     /// assert_eq!(xs.into_iter().cmp_by(ys, |x, y| (2 * x).cmp(&y)), Ordering::Greater);
     /// ```
     #[unstable(feature = "iter_order_by", issue = "64295")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn cmp_by<I, F>(self, other: I, cmp: F) -> Ordering
     where
         Self: Sized,
@@ -3682,6 +3751,7 @@ pub trait Iterator {
     /// ```
     ///
     #[stable(feature = "iter_order", since = "1.5.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn partial_cmp<I>(self, other: I) -> Option<Ordering>
     where
         I: IntoIterator,
@@ -3718,6 +3788,7 @@ pub trait Iterator {
     /// );
     /// ```
     #[unstable(feature = "iter_order_by", issue = "64295")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn partial_cmp_by<I, F>(self, other: I, partial_cmp: F) -> Option<Ordering>
     where
         Self: Sized,
@@ -3751,6 +3822,7 @@ pub trait Iterator {
     /// assert_eq!([1].iter().eq([1, 2].iter()), false);
     /// ```
     #[stable(feature = "iter_order", since = "1.5.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn eq<I>(self, other: I) -> bool
     where
         I: IntoIterator,
@@ -3774,6 +3846,7 @@ pub trait Iterator {
     /// assert!(xs.iter().eq_by(ys, |x, y| x * x == y));
     /// ```
     #[unstable(feature = "iter_order_by", issue = "64295")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn eq_by<I, F>(self, other: I, eq: F) -> bool
     where
         Self: Sized,
@@ -3806,6 +3879,7 @@ pub trait Iterator {
     /// assert_eq!([1].iter().ne([1, 2].iter()), true);
     /// ```
     #[stable(feature = "iter_order", since = "1.5.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn ne<I>(self, other: I) -> bool
     where
         I: IntoIterator,
@@ -3827,6 +3901,7 @@ pub trait Iterator {
     /// assert_eq!([1, 2].iter().lt([1, 2].iter()), false);
     /// ```
     #[stable(feature = "iter_order", since = "1.5.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn lt<I>(self, other: I) -> bool
     where
         I: IntoIterator,
@@ -3848,6 +3923,7 @@ pub trait Iterator {
     /// assert_eq!([1, 2].iter().le([1, 2].iter()), true);
     /// ```
     #[stable(feature = "iter_order", since = "1.5.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn le<I>(self, other: I) -> bool
     where
         I: IntoIterator,
@@ -3869,6 +3945,7 @@ pub trait Iterator {
     /// assert_eq!([1, 2].iter().gt([1, 2].iter()), false);
     /// ```
     #[stable(feature = "iter_order", since = "1.5.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn gt<I>(self, other: I) -> bool
     where
         I: IntoIterator,
@@ -3890,6 +3967,7 @@ pub trait Iterator {
     /// assert_eq!([1, 2].iter().ge([1, 2].iter()), true);
     /// ```
     #[stable(feature = "iter_order", since = "1.5.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn ge<I>(self, other: I) -> bool
     where
         I: IntoIterator,
@@ -3919,6 +3997,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "is_sorted", since = "1.82.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_sorted(self) -> bool
     where
         Self: Sized,
@@ -3945,6 +4024,7 @@ pub trait Iterator {
     /// assert!(std::iter::empty::<i32>().is_sorted_by(|a, b| true));
     /// ```
     #[stable(feature = "is_sorted", since = "1.82.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_sorted_by<F>(mut self, compare: F) -> bool
     where
         Self: Sized,
@@ -3989,6 +4069,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "is_sorted", since = "1.82.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_sorted_by_key<F, K>(self, f: F) -> bool
     where
         Self: Sized,
@@ -4004,6 +4085,7 @@ pub trait Iterator {
     #[inline]
     #[doc(hidden)]
     #[unstable(feature = "trusted_random_access", issue = "none")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     unsafe fn __iterator_get_unchecked(&mut self, _idx: usize) -> Self::Item
     where
         Self: TrustedRandomAccessNoCoerce,
@@ -4023,6 +4105,7 @@ pub trait Iterator {
 /// Isolates the logic shared by ['cmp_by'](Iterator::cmp_by),
 /// ['partial_cmp_by'](Iterator::partial_cmp_by), and ['eq_by'](Iterator::eq_by).
 #[inline]
+#[cfg(not(feature = "ferrocene_certified"))]
 fn iter_compare<A, B, F, T>(mut a: A, mut b: B, f: F) -> ControlFlow<T, Ordering>
 where
     A: Iterator,
@@ -4056,27 +4139,35 @@ where
 ///
 /// This implementation passes all method calls on to the original iterator.
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<I: Iterator + ?Sized> Iterator for &mut I {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = I::Item;
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<I::Item> {
         (**self).next()
     }
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (**self).size_hint()
     }
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
         (**self).advance_by(n)
     }
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         (**self).nth(n)
     }
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fold<B, F>(self, init: B, f: F) -> B
     where
         F: FnMut(B, Self::Item) -> B,
     {
         self.spec_fold(init, f)
     }
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn try_fold<B, F, R>(&mut self, init: B, f: F) -> R
     where
         F: FnMut(B, Self::Item) -> R,
@@ -4087,18 +4178,23 @@ impl<I: Iterator + ?Sized> Iterator for &mut I {
 }
 
 /// Helper trait to specialize `fold` and `try_fold` for `&mut I where I: Sized`
+#[cfg(not(feature = "ferrocene_certified"))]
 trait IteratorRefSpec: Iterator {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn spec_fold<B, F>(self, init: B, f: F) -> B
     where
         F: FnMut(B, Self::Item) -> B;
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn spec_try_fold<B, F, R>(&mut self, init: B, f: F) -> R
     where
         F: FnMut(B, Self::Item) -> R,
         R: Try<Output = B>;
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<I: Iterator + ?Sized> IteratorRefSpec for &mut I {
+    #[cfg(not(feature = "ferrocene_certified"))]
     default fn spec_fold<B, F>(self, init: B, mut f: F) -> B
     where
         F: FnMut(B, Self::Item) -> B,
@@ -4110,6 +4206,7 @@ impl<I: Iterator + ?Sized> IteratorRefSpec for &mut I {
         accum
     }
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     default fn spec_try_fold<B, F, R>(&mut self, init: B, mut f: F) -> R
     where
         F: FnMut(B, Self::Item) -> R,
@@ -4123,9 +4220,12 @@ impl<I: Iterator + ?Sized> IteratorRefSpec for &mut I {
     }
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<I: Iterator> IteratorRefSpec for &mut I {
+    #[cfg(not(feature = "ferrocene_certified"))]
     impl_fold_via_try_fold! { spec_fold -> spec_try_fold }
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn spec_try_fold<B, F, R>(&mut self, init: B, f: F) -> R
     where
         F: FnMut(B, Self::Item) -> R,

--- a/library/core/src/iter/traits/mod.rs
+++ b/library/core/src/iter/traits/mod.rs
@@ -1,24 +1,36 @@
+#[cfg(not(feature = "ferrocene_certified"))]
 mod accum;
+#[cfg(not(feature = "ferrocene_certified"))]
 mod collect;
+#[cfg(not(feature = "ferrocene_certified"))]
 mod double_ended;
+#[cfg(not(feature = "ferrocene_certified"))]
 mod exact_size;
 mod iterator;
+#[cfg(not(feature = "ferrocene_certified"))]
 mod marker;
+#[cfg(not(feature = "ferrocene_certified"))]
 mod unchecked_iterator;
 
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use self::iterator::Iterator;
 #[unstable(issue = "none", feature = "inplace_iteration")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::marker::InPlaceIterable;
 #[unstable(issue = "none", feature = "trusted_fused")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::marker::TrustedFused;
 #[unstable(feature = "trusted_step", issue = "85731")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::marker::TrustedStep;
+#[cfg(not(feature = "ferrocene_certified"))]
 pub(crate) use self::unchecked_iterator::UncheckedIterator;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::{
     accum::{Product, Sum},
     collect::{Extend, FromIterator, IntoIterator},
     double_ended::DoubleEndedIterator,
     exact_size::ExactSizeIterator,
-    iterator::Iterator,
     marker::{FusedIterator, TrustedLen},
 };

--- a/library/core/src/iter/traits/mod.rs
+++ b/library/core/src/iter/traits/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "ferrocene_certified"))]
 mod accum;
-#[cfg(not(feature = "ferrocene_certified"))]
+
 mod collect;
 #[cfg(not(feature = "ferrocene_certified"))]
 mod double_ended;
@@ -12,8 +12,6 @@ mod marker;
 #[cfg(not(feature = "ferrocene_certified"))]
 mod unchecked_iterator;
 
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use self::iterator::Iterator;
 #[unstable(issue = "none", feature = "inplace_iteration")]
 #[cfg(not(feature = "ferrocene_certified"))]
 pub use self::marker::InPlaceIterable;
@@ -29,8 +27,10 @@ pub(crate) use self::unchecked_iterator::UncheckedIterator;
 #[cfg(not(feature = "ferrocene_certified"))]
 pub use self::{
     accum::{Product, Sum},
-    collect::{Extend, FromIterator, IntoIterator},
+    collect::{Extend, FromIterator},
     double_ended::DoubleEndedIterator,
     exact_size::ExactSizeIterator,
     marker::{FusedIterator, TrustedLen},
 };
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use self::{collect::IntoIterator, iterator::Iterator};

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -89,7 +89,8 @@
 #![allow(internal_features)]
 #![deny(ffi_unwind_calls)]
 #![warn(unreachable_pub)]
-#![allow(unused_attributes)] // Ferrocene addition: accept coverage(off) no-ops
+#![allow(unused_attributes)]
+// Ferrocene addition: accept coverage(off) no-ops
 // Do not check link redundancy on bootstraping phase
 #![allow(rustdoc::redundant_explicit_links)]
 #![warn(rustdoc::unescaped_backticks)]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -366,7 +366,6 @@ pub mod ffi;
 #[unstable(feature = "core_io_borrowed_buf", issue = "117693")]
 #[cfg(not(feature = "ferrocene_certified"))]
 pub mod io;
-#[cfg(not(feature = "ferrocene_certified"))]
 pub mod iter;
 #[cfg(not(feature = "ferrocene_certified"))]
 pub mod net;

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -150,7 +150,6 @@
 #![cfg_attr(not(feature = "ferrocene_certified"), feature(generic_arg_infer))]
 #![cfg_attr(not(feature = "ferrocene_certified"), feature(if_let_guard))]
 #![cfg_attr(not(feature = "ferrocene_certified"), feature(intra_doc_pointers))]
-#![cfg_attr(not(feature = "ferrocene_certified"), feature(let_chains))]
 #![cfg_attr(not(feature = "ferrocene_certified"), feature(link_llvm_intrinsics))]
 #![cfg_attr(not(feature = "ferrocene_certified"), feature(macro_metavar_expr))]
 #![cfg_attr(not(feature = "ferrocene_certified"), feature(marker_trait_attr))]
@@ -174,6 +173,7 @@
 #![feature(fundamental)]
 #![feature(intrinsics)]
 #![feature(lang_items)]
+#![feature(let_chains)]
 #![feature(multiple_supertrait_upcastable)]
 #![feature(negative_impls)]
 #![feature(no_core)]
@@ -394,7 +394,6 @@ pub mod unsafe_binder;
 pub mod fmt;
 #[cfg(not(feature = "ferrocene_certified"))]
 pub mod hash;
-#[cfg(not(feature = "ferrocene_certified"))]
 pub mod slice;
 #[cfg(not(feature = "ferrocene_certified"))]
 pub mod str;

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -7,7 +7,6 @@ use crate::intrinsics;
 use crate::panic::const_panic;
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::str::FromStr;
-#[cfg(not(feature = "ferrocene_certified"))]
 use crate::ub_checks::assert_unsafe_precondition;
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::{ascii, mem};

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -53,11 +53,11 @@ pub use crate::convert::{AsMut, AsRef, From, Into};
 pub use crate::default::Default;
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use crate::iter::Iterator;
+pub use crate::iter::{IntoIterator, Iterator};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 #[cfg(not(feature = "ferrocene_certified"))]
-pub use crate::iter::{DoubleEndedIterator, ExactSizeIterator, Extend, IntoIterator};
+pub use crate::iter::{DoubleEndedIterator, ExactSizeIterator, Extend};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 pub use crate::option::Option::{self, None, Some};

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -53,8 +53,11 @@ pub use crate::convert::{AsMut, AsRef, From, Into};
 pub use crate::default::Default;
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
+pub use crate::iter::Iterator;
+#[stable(feature = "core_prelude", since = "1.4.0")]
+#[doc(no_inline)]
 #[cfg(not(feature = "ferrocene_certified"))]
-pub use crate::iter::{DoubleEndedIterator, ExactSizeIterator, Extend, IntoIterator, Iterator};
+pub use crate::iter::{DoubleEndedIterator, ExactSizeIterator, Extend, IntoIterator};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 pub use crate::option::Option::{self, None, Some};

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -840,111 +840,110 @@ mod prim_array {}
 ///
 /// Contiguous here means that elements are laid out so that every element is the same
 /// distance from its neighbors.
-///
-/// *[See also the `std::slice` module](crate::slice).*
-///
-/// Slices are a view into a block of memory represented as a pointer and a
-/// length.
-///
-/// ```
-/// // slicing a Vec
-/// let vec = vec![1, 2, 3];
-/// let int_slice = &vec[..];
-/// // coercing an array to a slice
-/// let str_slice: &[&str] = &["one", "two", "three"];
-/// ```
-///
-/// Slices are either mutable or shared. The shared slice type is `&[T]`,
-/// while the mutable slice type is `&mut [T]`, where `T` represents the element
-/// type. For example, you can mutate the block of memory that a mutable slice
-/// points to:
-///
-/// ```
-/// let mut x = [1, 2, 3];
-/// let x = &mut x[..]; // Take a full slice of `x`.
-/// x[1] = 7;
-/// assert_eq!(x, &[1, 7, 3]);
-/// ```
-///
-/// It is possible to slice empty subranges of slices by using empty ranges (including `slice.len()..slice.len()`):
-/// ```
-/// let x = [1, 2, 3];
-/// let empty = &x[0..0];   // subslice before the first element
-/// assert_eq!(empty, &[]);
-/// let empty = &x[..0];    // same as &x[0..0]
-/// assert_eq!(empty, &[]);
-/// let empty = &x[1..1];   // empty subslice in the middle
-/// assert_eq!(empty, &[]);
-/// let empty = &x[3..3];   // subslice after the last element
-/// assert_eq!(empty, &[]);
-/// let empty = &x[3..];    // same as &x[3..3]
-/// assert_eq!(empty, &[]);
-/// ```
-///
-/// It is not allowed to use subranges that start with lower bound bigger than `slice.len()`:
-/// ```should_panic
-/// let x = vec![1, 2, 3];
-/// let _ = &x[4..4];
-/// ```
-///
-/// As slices store the length of the sequence they refer to, they have twice
-/// the size of pointers to [`Sized`](marker/trait.Sized.html) types.
-/// Also see the reference on
-/// [dynamically sized types](../reference/dynamically-sized-types.html).
-///
-/// ```
-/// # use std::rc::Rc;
-/// let pointer_size = size_of::<&u8>();
-/// assert_eq!(2 * pointer_size, size_of::<&[u8]>());
-/// assert_eq!(2 * pointer_size, size_of::<*const [u8]>());
-/// assert_eq!(2 * pointer_size, size_of::<Box<[u8]>>());
-/// assert_eq!(2 * pointer_size, size_of::<Rc<[u8]>>());
-/// ```
-///
-/// ## Trait Implementations
-///
-/// Some traits are implemented for slices if the element type implements
-/// that trait. This includes [`Eq`], [`Hash`] and [`Ord`].
-///
-/// ## Iteration
-///
-/// The slices implement `IntoIterator`. The iterator yields references to the
-/// slice elements.
-///
-/// ```
-/// let numbers: &[i32] = &[0, 1, 2];
-/// for n in numbers {
-///     println!("{n} is a number!");
-/// }
-/// ```
-///
-/// The mutable slice yields mutable references to the elements:
-///
-/// ```
-/// let mut scores: &mut [i32] = &mut [7, 8, 9];
-/// for score in scores {
-///     *score += 1;
-/// }
-/// ```
-///
-/// This iterator yields mutable references to the slice's elements, so while
-/// the element type of the slice is `i32`, the element type of the iterator is
-/// `&mut i32`.
-///
-/// * [`.iter`] and [`.iter_mut`] are the explicit methods to return the default
-///   iterators.
-/// * Further methods that return iterators are [`.split`], [`.splitn`],
-///   [`.chunks`], [`.windows`] and more.
-///
-/// [`Hash`]: core::hash::Hash
-/// [`.iter`]: slice::iter
-/// [`.iter_mut`]: slice::iter_mut
-/// [`.split`]: slice::split
-/// [`.splitn`]: slice::splitn
-/// [`.chunks`]: slice::chunks
-/// [`.windows`]: slice::windows
+// ///
+// /// *[See also the `std::slice` module](crate::slice).*
+// ///
+// /// Slices are a view into a block of memory represented as a pointer and a
+// /// length.
+// ///
+// /// ```
+// /// // slicing a Vec
+// /// let vec = vec![1, 2, 3];
+// /// let int_slice = &vec[..];
+// /// // coercing an array to a slice
+// /// let str_slice: &[&str] = &["one", "two", "three"];
+// /// ```
+// ///
+// /// Slices are either mutable or shared. The shared slice type is `&[T]`,
+// /// while the mutable slice type is `&mut [T]`, where `T` represents the element
+// /// type. For example, you can mutate the block of memory that a mutable slice
+// /// points to:
+// ///
+// /// ```
+// /// let mut x = [1, 2, 3];
+// /// let x = &mut x[..]; // Take a full slice of `x`.
+// /// x[1] = 7;
+// /// assert_eq!(x, &[1, 7, 3]);
+// /// ```
+// ///
+// /// It is possible to slice empty subranges of slices by using empty ranges (including `slice.len()..slice.len()`):
+// /// ```
+// /// let x = [1, 2, 3];
+// /// let empty = &x[0..0];   // subslice before the first element
+// /// assert_eq!(empty, &[]);
+// /// let empty = &x[..0];    // same as &x[0..0]
+// /// assert_eq!(empty, &[]);
+// /// let empty = &x[1..1];   // empty subslice in the middle
+// /// assert_eq!(empty, &[]);
+// /// let empty = &x[3..3];   // subslice after the last element
+// /// assert_eq!(empty, &[]);
+// /// let empty = &x[3..];    // same as &x[3..3]
+// /// assert_eq!(empty, &[]);
+// /// ```
+// ///
+// /// It is not allowed to use subranges that start with lower bound bigger than `slice.len()`:
+// /// ```should_panic
+// /// let x = vec![1, 2, 3];
+// /// let _ = &x[4..4];
+// /// ```
+// ///
+// /// As slices store the length of the sequence they refer to, they have twice
+// /// the size of pointers to [`Sized`](marker/trait.Sized.html) types.
+// /// Also see the reference on
+// /// [dynamically sized types](../reference/dynamically-sized-types.html).
+// ///
+// /// ```
+// /// # use std::rc::Rc;
+// /// let pointer_size = size_of::<&u8>();
+// /// assert_eq!(2 * pointer_size, size_of::<&[u8]>());
+// /// assert_eq!(2 * pointer_size, size_of::<*const [u8]>());
+// /// assert_eq!(2 * pointer_size, size_of::<Box<[u8]>>());
+// /// assert_eq!(2 * pointer_size, size_of::<Rc<[u8]>>());
+// /// ```
+// ///
+// /// ## Trait Implementations
+// ///
+// /// Some traits are implemented for slices if the element type implements
+// /// that trait. This includes [`Eq`], [`Hash`] and [`Ord`].
+// ///
+// /// ## Iteration
+// ///
+// /// The slices implement `IntoIterator`. The iterator yields references to the
+// /// slice elements.
+// ///
+// /// ```
+// /// let numbers: &[i32] = &[0, 1, 2];
+// /// for n in numbers {
+// ///     println!("{n} is a number!");
+// /// }
+// /// ```
+// ///
+// /// The mutable slice yields mutable references to the elements:
+// ///
+// /// ```
+// /// let mut scores: &mut [i32] = &mut [7, 8, 9];
+// /// for score in scores {
+// ///     *score += 1;
+// /// }
+// /// ```
+// ///
+// /// This iterator yields mutable references to the slice's elements, so while
+// /// the element type of the slice is `i32`, the element type of the iterator is
+// /// `&mut i32`.
+// ///
+// /// * [`.iter`] and [`.iter_mut`] are the explicit methods to return the default
+// ///   iterators.
+// /// * Further methods that return iterators are [`.split`], [`.splitn`],
+// ///   [`.chunks`], [`.windows`] and more.
+// ///
+// /// [`Hash`]: core::hash::Hash
+// /// [`.iter`]: slice::iter
+// /// [`.iter_mut`]: slice::iter_mut
+// /// [`.split`]: slice::split
+// /// [`.splitn`]: slice::splitn
+// /// [`.chunks`]: slice::chunks
+// /// [`.windows`]: slice::windows
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg(not(feature = "ferrocene_certified"))]
 mod prim_slice {}
 
 #[rustc_doc_primitive = "str"]

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -951,7 +951,6 @@ impl<T: ?Sized> *const T {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
-    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn add(self, count: usize) -> Self
     where
         T: Sized,

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -4,9 +4,7 @@
 use crate::fmt;
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::hash::{Hash, Hasher};
-use crate::intrinsics::aggregate_raw_ptr;
-#[cfg(not(feature = "ferrocene_certified"))]
-use crate::intrinsics::ptr_metadata;
+use crate::intrinsics::{aggregate_raw_ptr, ptr_metadata};
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::marker::Freeze;
 #[cfg(not(feature = "ferrocene_certified"))]
@@ -107,7 +105,6 @@ pub trait Thin = Pointee<Metadata = ()>;
 /// assert_eq!(std::ptr::metadata("foo"), 3_usize);
 /// ```
 #[inline]
-#[cfg(not(feature = "ferrocene_certified"))]
 pub const fn metadata<T: ?Sized>(ptr: *const T) -> <T as Pointee>::Metadata {
     ptr_metadata(ptr)
 }

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -429,16 +429,16 @@ pub use crate::intrinsics::write_bytes;
 mod metadata;
 #[unstable(feature = "ptr_metadata", issue = "81513")]
 #[cfg(not(feature = "ferrocene_certified"))]
-pub use metadata::{DynMetadata, metadata};
+pub use metadata::DynMetadata;
+#[unstable(feature = "ptr_metadata", issue = "81513")]
+pub use metadata::metadata;
 #[unstable(feature = "ptr_metadata", issue = "81513")]
 pub use metadata::{Pointee, Thin};
 #[unstable(feature = "ptr_metadata", issue = "81513")]
 pub use metadata::{from_raw_parts, from_raw_parts_mut};
 
-#[cfg(not(feature = "ferrocene_certified"))]
 mod non_null;
 #[stable(feature = "nonnull", since = "1.25.0")]
-#[cfg(not(feature = "ferrocene_certified"))]
 pub use non_null::NonNull;
 
 #[cfg(not(feature = "ferrocene_certified"))]

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1,15 +1,12 @@
-#[cfg(not(feature = "ferrocene_certified"))]
 use super::*;
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::cmp::Ordering::{Equal, Greater, Less};
-#[cfg(not(feature = "ferrocene_certified"))]
 use crate::intrinsics::const_eval_select;
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::mem::{self, SizedTypeProperties};
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::slice::{self, SliceIndex};
 
-#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized> *mut T {
     /// Returns `true` if the pointer is null.
     ///
@@ -41,6 +38,7 @@ impl<T: ?Sized> *mut T {
     #[rustc_const_stable(feature = "const_ptr_is_null", since = "1.84.0")]
     #[rustc_diagnostic_item = "ptr_is_null"]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn is_null(self) -> bool {
         self.cast_const().is_null()
     }
@@ -105,6 +103,7 @@ impl<T: ?Sized> *mut T {
     #[unstable(feature = "set_ptr_value", issue = "75091")]
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn with_metadata_of<U>(self, meta: *const U) -> *mut U
     where
         U: ?Sized,
@@ -126,32 +125,33 @@ impl<T: ?Sized> *mut T {
     #[rustc_const_stable(feature = "ptr_const_cast", since = "1.65.0")]
     #[rustc_diagnostic_item = "ptr_cast_const"]
     #[inline(always)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn cast_const(self) -> *const T {
         self as _
     }
 
     /// Gets the "address" portion of the pointer.
-    ///
-    /// This is similar to `self as usize`, except that the [provenance][crate::ptr#provenance] of
-    /// the pointer is discarded and not [exposed][crate::ptr#exposed-provenance]. This means that
-    /// casting the returned address back to a pointer yields a [pointer without
-    /// provenance][without_provenance_mut], which is undefined behavior to dereference. To properly
-    /// restore the lost information and obtain a dereferenceable pointer, use
-    /// [`with_addr`][pointer::with_addr] or [`map_addr`][pointer::map_addr].
-    ///
-    /// If using those APIs is not possible because there is no way to preserve a pointer with the
-    /// required provenance, then Strict Provenance might not be for you. Use pointer-integer casts
-    /// or [`expose_provenance`][pointer::expose_provenance] and [`with_exposed_provenance`][with_exposed_provenance]
-    /// instead. However, note that this makes your code less portable and less amenable to tools
-    /// that check for compliance with the Rust memory model.
-    ///
-    /// On most platforms this will produce a value with the same bytes as the original
-    /// pointer, because all the bytes are dedicated to describing the address.
-    /// Platforms which need to store additional information in the pointer may
-    /// perform a change of representation to produce a value containing only the address
-    /// portion of the pointer. What that means is up to the platform to define.
-    ///
-    /// This is a [Strict Provenance][crate::ptr#strict-provenance] API.
+    // ///
+    // /// This is similar to `self as usize`, except that the [provenance][crate::ptr#provenance] of
+    // /// the pointer is discarded and not [exposed][crate::ptr#exposed-provenance]. This means that
+    // /// casting the returned address back to a pointer yields a [pointer without
+    // /// provenance][without_provenance_mut], which is undefined behavior to dereference. To properly
+    // /// restore the lost information and obtain a dereferenceable pointer, use
+    // /// [`with_addr`][pointer::with_addr] or [`map_addr`][pointer::map_addr].
+    // ///
+    // /// If using those APIs is not possible because there is no way to preserve a pointer with the
+    // /// required provenance, then Strict Provenance might not be for you. Use pointer-integer casts
+    // /// or [`expose_provenance`][pointer::expose_provenance] and [`with_exposed_provenance`][with_exposed_provenance]
+    // /// instead. However, note that this makes your code less portable and less amenable to tools
+    // /// that check for compliance with the Rust memory model.
+    // ///
+    // /// On most platforms this will produce a value with the same bytes as the original
+    // /// pointer, because all the bytes are dedicated to describing the address.
+    // /// Platforms which need to store additional information in the pointer may
+    // /// perform a change of representation to produce a value containing only the address
+    // /// portion of the pointer. What that means is up to the platform to define.
+    // ///
+    // /// This is a [Strict Provenance][crate::ptr#strict-provenance] API.
     #[must_use]
     #[inline(always)]
     #[stable(feature = "strict_provenance", since = "1.84.0")]
@@ -188,6 +188,7 @@ impl<T: ?Sized> *mut T {
     /// [`with_exposed_provenance_mut`]: with_exposed_provenance_mut
     #[inline(always)]
     #[stable(feature = "exposed_provenance", since = "1.84.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn expose_provenance(self) -> usize {
         self.cast::<()>() as usize
     }
@@ -206,6 +207,7 @@ impl<T: ?Sized> *mut T {
     #[must_use]
     #[inline]
     #[stable(feature = "strict_provenance", since = "1.84.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn with_addr(self, addr: usize) -> Self {
         // This should probably be an intrinsic to avoid doing any sort of arithmetic, but
         // meanwhile, we can implement it with `wrapping_offset`, which preserves the pointer's
@@ -225,6 +227,7 @@ impl<T: ?Sized> *mut T {
     #[must_use]
     #[inline]
     #[stable(feature = "strict_provenance", since = "1.84.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn map_addr(self, f: impl FnOnce(usize) -> usize) -> Self {
         self.with_addr(f(self.addr()))
     }
@@ -234,6 +237,7 @@ impl<T: ?Sized> *mut T {
     /// The pointer can be later reconstructed with [`from_raw_parts_mut`].
     #[unstable(feature = "ptr_metadata", issue = "81513")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn to_raw_parts(self) -> (*mut (), <T as super::Pointee>::Metadata) {
         (self.cast(), super::metadata(self))
     }
@@ -288,6 +292,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "ptr_as_ref", since = "1.9.0")]
     #[rustc_const_stable(feature = "const_ptr_is_null", since = "1.84.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn as_ref<'a>(self) -> Option<&'a T> {
         // SAFETY: the caller must guarantee that `self` is valid for a
         // reference if it isn't null.
@@ -322,6 +327,7 @@ impl<T: ?Sized> *mut T {
     #[unstable(feature = "ptr_as_ref_unchecked", issue = "122034")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn as_ref_unchecked<'a>(self) -> &'a T {
         // SAFETY: the caller must guarantee that `self` is valid for a reference
         unsafe { &*self }
@@ -365,6 +371,7 @@ impl<T: ?Sized> *mut T {
     /// ```
     #[inline]
     #[unstable(feature = "ptr_as_uninit", issue = "75402")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn as_uninit_ref<'a>(self) -> Option<&'a MaybeUninit<T>>
     where
         T: Sized,
@@ -419,6 +426,7 @@ impl<T: ?Sized> *mut T {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn offset(self, count: isize) -> *mut T
     where
         T: Sized,
@@ -474,6 +482,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "pointer_byte_offsets", since = "1.75.0")]
     #[rustc_const_stable(feature = "const_pointer_byte_offsets", since = "1.75.0")]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn byte_offset(self, count: isize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `offset`.
         unsafe { self.cast::<u8>().offset(count).with_metadata_of(self) }
@@ -532,6 +541,7 @@ impl<T: ?Sized> *mut T {
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     #[inline(always)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn wrapping_offset(self, count: isize) -> *mut T
     where
         T: Sized,
@@ -554,6 +564,7 @@ impl<T: ?Sized> *mut T {
     #[inline(always)]
     #[stable(feature = "pointer_byte_offsets", since = "1.75.0")]
     #[rustc_const_stable(feature = "const_pointer_byte_offsets", since = "1.75.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn wrapping_byte_offset(self, count: isize) -> Self {
         self.cast::<u8>().wrapping_offset(count).with_metadata_of(self)
     }
@@ -595,6 +606,7 @@ impl<T: ?Sized> *mut T {
     #[unstable(feature = "ptr_mask", issue = "98290")]
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[inline(always)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn mask(self, mask: usize) -> *mut T {
         intrinsics::ptr_mask(self.cast::<()>(), mask).cast_mut().with_metadata_of(self)
     }
@@ -649,6 +661,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "ptr_as_ref", since = "1.9.0")]
     #[rustc_const_stable(feature = "const_ptr_is_null", since = "1.84.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn as_mut<'a>(self) -> Option<&'a mut T> {
         // SAFETY: the caller must guarantee that `self` is be valid for
         // a mutable reference if it isn't null.
@@ -685,6 +698,7 @@ impl<T: ?Sized> *mut T {
     #[unstable(feature = "ptr_as_ref_unchecked", issue = "122034")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn as_mut_unchecked<'a>(self) -> &'a mut T {
         // SAFETY: the caller must guarantee that `self` is valid for a reference
         unsafe { &mut *self }
@@ -712,6 +726,7 @@ impl<T: ?Sized> *mut T {
     /// [`is_null`]: #method.is_null-1
     #[inline]
     #[unstable(feature = "ptr_as_uninit", issue = "75402")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn as_uninit_mut<'a>(self) -> Option<&'a mut MaybeUninit<T>>
     where
         T: Sized,
@@ -741,6 +756,7 @@ impl<T: ?Sized> *mut T {
     #[unstable(feature = "const_raw_ptr_comparison", issue = "53020")]
     #[rustc_const_unstable(feature = "const_raw_ptr_comparison", issue = "53020")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn guaranteed_eq(self, other: *mut T) -> Option<bool>
     where
         T: Sized,
@@ -768,6 +784,7 @@ impl<T: ?Sized> *mut T {
     #[unstable(feature = "const_raw_ptr_comparison", issue = "53020")]
     #[rustc_const_unstable(feature = "const_raw_ptr_comparison", issue = "53020")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn guaranteed_ne(self, other: *mut T) -> Option<bool>
     where
         T: Sized,
@@ -860,6 +877,7 @@ impl<T: ?Sized> *mut T {
     #[rustc_const_stable(feature = "const_ptr_offset_from", since = "1.65.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn offset_from(self, origin: *const T) -> isize
     where
         T: Sized,
@@ -881,6 +899,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "pointer_byte_offsets", since = "1.75.0")]
     #[rustc_const_stable(feature = "const_pointer_byte_offsets", since = "1.75.0")]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn byte_offset_from<U: ?Sized>(self, origin: *const U) -> isize {
         // SAFETY: the caller must uphold the safety contract for `offset_from`.
         unsafe { self.cast::<u8>().offset_from(origin.cast::<u8>()) }
@@ -949,6 +968,7 @@ impl<T: ?Sized> *mut T {
     #[rustc_const_stable(feature = "const_ptr_sub_ptr", since = "1.87.0")]
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn offset_from_unsigned(self, origin: *const T) -> usize
     where
         T: Sized,
@@ -971,6 +991,7 @@ impl<T: ?Sized> *mut T {
     #[rustc_const_stable(feature = "const_ptr_sub_ptr", since = "1.87.0")]
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn byte_offset_from_unsigned<U: ?Sized>(self, origin: *mut U) -> usize {
         // SAFETY: the caller must uphold the safety contract for `byte_offset_from_unsigned`.
         unsafe { (self as *const T).byte_offset_from_unsigned(origin) }
@@ -1077,6 +1098,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "pointer_byte_offsets", since = "1.75.0")]
     #[rustc_const_stable(feature = "const_pointer_byte_offsets", since = "1.75.0")]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn byte_add(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `add`.
         unsafe { self.cast::<u8>().add(count).with_metadata_of(self) }
@@ -1131,6 +1153,7 @@ impl<T: ?Sized> *mut T {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn sub(self, count: usize) -> Self
     where
         T: Sized,
@@ -1189,6 +1212,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "pointer_byte_offsets", since = "1.75.0")]
     #[rustc_const_stable(feature = "const_pointer_byte_offsets", since = "1.75.0")]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn byte_sub(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `sub`.
         unsafe { self.cast::<u8>().sub(count).with_metadata_of(self) }
@@ -1246,6 +1270,7 @@ impl<T: ?Sized> *mut T {
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     #[inline(always)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn wrapping_add(self, count: usize) -> Self
     where
         T: Sized,
@@ -1266,6 +1291,7 @@ impl<T: ?Sized> *mut T {
     #[inline(always)]
     #[stable(feature = "pointer_byte_offsets", since = "1.75.0")]
     #[rustc_const_stable(feature = "const_pointer_byte_offsets", since = "1.75.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn wrapping_byte_add(self, count: usize) -> Self {
         self.cast::<u8>().wrapping_add(count).with_metadata_of(self)
     }
@@ -1322,6 +1348,7 @@ impl<T: ?Sized> *mut T {
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     #[inline(always)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn wrapping_sub(self, count: usize) -> Self
     where
         T: Sized,
@@ -1342,6 +1369,7 @@ impl<T: ?Sized> *mut T {
     #[inline(always)]
     #[stable(feature = "pointer_byte_offsets", since = "1.75.0")]
     #[rustc_const_stable(feature = "const_pointer_byte_offsets", since = "1.75.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn wrapping_byte_sub(self, count: usize) -> Self {
         self.cast::<u8>().wrapping_sub(count).with_metadata_of(self)
     }
@@ -1356,6 +1384,7 @@ impl<T: ?Sized> *mut T {
     #[rustc_const_stable(feature = "const_ptr_read", since = "1.71.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn read(self) -> T
     where
         T: Sized,
@@ -1377,6 +1406,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub unsafe fn read_volatile(self) -> T
     where
         T: Sized,
@@ -1397,6 +1427,7 @@ impl<T: ?Sized> *mut T {
     #[rustc_const_stable(feature = "const_ptr_read", since = "1.71.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn read_unaligned(self) -> T
     where
         T: Sized,
@@ -1417,6 +1448,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn copy_to(self, dest: *mut T, count: usize)
     where
         T: Sized,
@@ -1437,6 +1469,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn copy_to_nonoverlapping(self, dest: *mut T, count: usize)
     where
         T: Sized,
@@ -1457,6 +1490,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn copy_from(self, src: *const T, count: usize)
     where
         T: Sized,
@@ -1477,6 +1511,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn copy_from_nonoverlapping(self, src: *const T, count: usize)
     where
         T: Sized,
@@ -1492,6 +1527,7 @@ impl<T: ?Sized> *mut T {
     /// [`ptr::drop_in_place`]: crate::ptr::drop_in_place()
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline(always)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub unsafe fn drop_in_place(self) {
         // SAFETY: the caller must uphold the safety contract for `drop_in_place`.
         unsafe { drop_in_place(self) }
@@ -1507,6 +1543,7 @@ impl<T: ?Sized> *mut T {
     #[rustc_const_stable(feature = "const_ptr_write", since = "1.83.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn write(self, val: T)
     where
         T: Sized,
@@ -1526,6 +1563,7 @@ impl<T: ?Sized> *mut T {
     #[rustc_const_stable(feature = "const_ptr_write", since = "1.83.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn write_bytes(self, val: u8, count: usize)
     where
         T: Sized,
@@ -1547,6 +1585,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub unsafe fn write_volatile(self, val: T)
     where
         T: Sized,
@@ -1567,6 +1606,7 @@ impl<T: ?Sized> *mut T {
     #[rustc_const_stable(feature = "const_ptr_write", since = "1.83.0")]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn write_unaligned(self, val: T)
     where
         T: Sized,
@@ -1584,6 +1624,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[rustc_const_stable(feature = "const_inherent_ptr_replace", since = "CURRENT_RUSTC_VERSION")]
     #[inline(always)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn replace(self, src: T) -> T
     where
         T: Sized,
@@ -1602,6 +1643,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[rustc_const_stable(feature = "const_swap", since = "1.85.0")]
     #[inline(always)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn swap(self, with: *mut T)
     where
         T: Sized,
@@ -1651,6 +1693,7 @@ impl<T: ?Sized> *mut T {
     #[must_use]
     #[inline]
     #[stable(feature = "align_offset", since = "1.36.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn align_offset(self, align: usize) -> usize
     where
         T: Sized,
@@ -1692,6 +1735,7 @@ impl<T: ?Sized> *mut T {
     #[must_use]
     #[inline]
     #[stable(feature = "pointer_is_aligned", since = "1.79.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn is_aligned(self) -> bool
     where
         T: Sized,
@@ -1732,6 +1776,7 @@ impl<T: ?Sized> *mut T {
     #[must_use]
     #[inline]
     #[unstable(feature = "pointer_is_aligned_to", issue = "96284")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn is_aligned_to(self, align: usize) -> bool {
         if !align.is_power_of_two() {
             panic!("is_aligned_to: align is not a power-of-two");
@@ -1761,6 +1806,7 @@ impl<T> *mut [T] {
     #[inline(always)]
     #[stable(feature = "slice_ptr_len", since = "1.79.0")]
     #[rustc_const_stable(feature = "const_slice_ptr_len", since = "1.79.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn len(self) -> usize {
         metadata(self)
     }
@@ -1778,6 +1824,7 @@ impl<T> *mut [T] {
     #[inline(always)]
     #[stable(feature = "slice_ptr_len", since = "1.79.0")]
     #[rustc_const_stable(feature = "const_slice_ptr_len", since = "1.79.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn is_empty(self) -> bool {
         self.len() == 0
     }
@@ -1788,6 +1835,7 @@ impl<T> *mut [T] {
     #[unstable(feature = "slice_as_array", issue = "133508")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_mut_array<const N: usize>(self) -> Option<*mut [T; N]> {
         if self.len() == N {
             let me = self.as_mut_ptr() as *mut [T; N];
@@ -1840,6 +1888,7 @@ impl<T> *mut [T] {
     #[inline(always)]
     #[track_caller]
     #[unstable(feature = "raw_slice_split", issue = "95595")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub unsafe fn split_at_mut(self, mid: usize) -> (*mut [T], *mut [T]) {
         assert!(mid <= self.len());
         // SAFETY: The assert above is only a safety-net as long as `self.len()` is correct
@@ -1883,6 +1932,7 @@ impl<T> *mut [T] {
     /// ```
     #[inline(always)]
     #[unstable(feature = "raw_slice_split", issue = "95595")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub unsafe fn split_at_mut_unchecked(self, mid: usize) -> (*mut [T], *mut [T]) {
         let len = self.len();
         let ptr = self.as_mut_ptr();
@@ -1910,6 +1960,7 @@ impl<T> *mut [T] {
     /// ```
     #[inline(always)]
     #[unstable(feature = "slice_ptr_get", issue = "74265")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_mut_ptr(self) -> *mut T {
         self as *mut T
     }
@@ -1936,6 +1987,7 @@ impl<T> *mut [T] {
     /// ```
     #[unstable(feature = "slice_ptr_get", issue = "74265")]
     #[inline(always)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub unsafe fn get_unchecked_mut<I>(self, index: I) -> *mut I::Output
     where
         I: SliceIndex<[T]>,
@@ -1993,6 +2045,7 @@ impl<T> *mut [T] {
     /// [`is_null`]: #method.is_null-1
     #[inline]
     #[unstable(feature = "ptr_as_uninit", issue = "75402")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn as_uninit_slice<'a>(self) -> Option<&'a [MaybeUninit<T>]> {
         if self.is_null() {
             None
@@ -2051,6 +2104,7 @@ impl<T> *mut [T] {
     /// [`is_null`]: #method.is_null-1
     #[inline]
     #[unstable(feature = "ptr_as_uninit", issue = "75402")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn as_uninit_slice_mut<'a>(self) -> Option<&'a mut [MaybeUninit<T>]> {
         if self.is_null() {
             None
@@ -2078,6 +2132,7 @@ impl<T, const N: usize> *mut [T; N] {
     /// ```
     #[inline]
     #[unstable(feature = "array_ptr_get", issue = "119834")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_mut_ptr(self) -> *mut T {
         self as *mut T
     }
@@ -2098,14 +2153,14 @@ impl<T, const N: usize> *mut [T; N] {
     /// ```
     #[inline]
     #[unstable(feature = "array_ptr_get", issue = "119834")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_mut_slice(self) -> *mut [T] {
         self
     }
 }
 
-/// Pointer equality is by address, as produced by the [`<*mut T>::addr`](pointer::addr) method.
+// /// Pointer equality is by address, as produced by the [`<*mut T>::addr`](pointer::addr) method.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized> PartialEq for *mut T {
     #[inline(always)]
     #[allow(ambiguous_wide_pointer_comparisons)]
@@ -2116,7 +2171,6 @@ impl<T: ?Sized> PartialEq for *mut T {
 
 /// Pointer equality is an equivalence relation.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized> Eq for *mut T {}
 
 /// Pointer comparison is by address, as produced by the [`<*mut T>::addr`](pointer::addr) method.
@@ -2125,6 +2179,7 @@ impl<T: ?Sized> Eq for *mut T {}
 impl<T: ?Sized> Ord for *mut T {
     #[inline]
     #[allow(ambiguous_wide_pointer_comparisons)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn cmp(&self, other: &*mut T) -> Ordering {
         if self < other {
             Less
@@ -2142,30 +2197,35 @@ impl<T: ?Sized> Ord for *mut T {
 impl<T: ?Sized> PartialOrd for *mut T {
     #[inline(always)]
     #[allow(ambiguous_wide_pointer_comparisons)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn partial_cmp(&self, other: &*mut T) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 
     #[inline(always)]
     #[allow(ambiguous_wide_pointer_comparisons)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn lt(&self, other: &*mut T) -> bool {
         *self < *other
     }
 
     #[inline(always)]
     #[allow(ambiguous_wide_pointer_comparisons)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn le(&self, other: &*mut T) -> bool {
         *self <= *other
     }
 
     #[inline(always)]
     #[allow(ambiguous_wide_pointer_comparisons)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn gt(&self, other: &*mut T) -> bool {
         *self > *other
     }
 
     #[inline(always)]
     #[allow(ambiguous_wide_pointer_comparisons)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn ge(&self, other: &*mut T) -> bool {
         *self >= *other
     }
@@ -2175,6 +2235,7 @@ impl<T: ?Sized> PartialOrd for *mut T {
 #[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized + Thin> Default for *mut T {
     /// Returns the default value of [`null_mut()`][crate::ptr::null_mut].
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn default() -> Self {
         crate::ptr::null_mut()
     }

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -1,13 +1,24 @@
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::cmp::Ordering;
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::marker::Unsize;
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::mem::{MaybeUninit, SizedTypeProperties};
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::num::NonZero;
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::ops::{CoerceUnsized, DispatchFromDyn};
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::pin::PinCoerceUnsized;
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::ptr::Unique;
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::slice::{self, SliceIndex};
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::ub_checks::assert_unsafe_precondition;
-use crate::{fmt, hash, intrinsics, mem, ptr};
+#[cfg(not(feature = "ferrocene_certified"))]
+use crate::{fmt, hash, mem, ptr};
+use crate::{intrinsics, mem};
 
 /// `*mut T` but non-zero and [covariant].
 ///
@@ -33,35 +44,35 @@ use crate::{fmt, hash, intrinsics, mem, ptr};
 /// If your type cannot safely be covariant, you must ensure it contains some
 /// additional field to provide invariance. Often this field will be a [`PhantomData`]
 /// type like `PhantomData<Cell<T>>` or `PhantomData<&'a mut T>`.
-///
-/// Notice that `NonNull<T>` has a `From` instance for `&T`. However, this does
-/// not change the fact that mutating through a (pointer derived from a) shared
-/// reference is undefined behavior unless the mutation happens inside an
-/// [`UnsafeCell<T>`]. The same goes for creating a mutable reference from a shared
-/// reference. When using this `From` instance without an `UnsafeCell<T>`,
-/// it is your responsibility to ensure that `as_mut` is never called, and `as_ptr`
-/// is never used for mutation.
-///
-/// # Representation
-///
-/// Thanks to the [null pointer optimization],
-/// `NonNull<T>` and `Option<NonNull<T>>`
-/// are guaranteed to have the same size and alignment:
-///
-/// ```
-/// use std::ptr::NonNull;
-///
-/// assert_eq!(size_of::<NonNull<i16>>(), size_of::<Option<NonNull<i16>>>());
-/// assert_eq!(align_of::<NonNull<i16>>(), align_of::<Option<NonNull<i16>>>());
-///
-/// assert_eq!(size_of::<NonNull<str>>(), size_of::<Option<NonNull<str>>>());
-/// assert_eq!(align_of::<NonNull<str>>(), align_of::<Option<NonNull<str>>>());
-/// ```
+// ///
+// /// Notice that `NonNull<T>` has a `From` instance for `&T`. However, this does
+// /// not change the fact that mutating through a (pointer derived from a) shared
+// /// reference is undefined behavior unless the mutation happens inside an
+// /// [`UnsafeCell<T>`]. The same goes for creating a mutable reference from a shared
+// /// reference. When using this `From` instance without an `UnsafeCell<T>`,
+// /// it is your responsibility to ensure that `as_mut` is never called, and `as_ptr`
+// /// is never used for mutation.
+// ///
+// /// # Representation
+// ///
+// /// Thanks to the [null pointer optimization],
+// /// `NonNull<T>` and `Option<NonNull<T>>`
+// /// are guaranteed to have the same size and alignment:
+// ///
+// /// ```
+// /// use std::ptr::NonNull;
+// ///
+// /// assert_eq!(size_of::<NonNull<i16>>(), size_of::<Option<NonNull<i16>>>());
+// /// assert_eq!(align_of::<NonNull<i16>>(), align_of::<Option<NonNull<i16>>>());
+// ///
+// /// assert_eq!(size_of::<NonNull<str>>(), size_of::<Option<NonNull<str>>>());
+// /// assert_eq!(align_of::<NonNull<str>>(), align_of::<Option<NonNull<str>>>());
+// /// ```
 ///
 /// [covariant]: https://doc.rust-lang.org/reference/subtyping.html
 /// [`PhantomData`]: crate::marker::PhantomData
-/// [`UnsafeCell<T>`]: crate::cell::UnsafeCell
-/// [null pointer optimization]: crate::option#representation
+// /// [`UnsafeCell<T>`]: crate::cell::UnsafeCell
+// /// [null pointer optimization]: crate::option#representation
 #[stable(feature = "nonnull", since = "1.25.0")]
 #[repr(transparent)]
 #[rustc_layout_scalar_valid_range_start(1)]
@@ -76,11 +87,13 @@ pub struct NonNull<T: ?Sized> {
 /// `NonNull` pointers are not `Send` because the data they reference may be aliased.
 // N.B., this impl is unnecessary, but should provide better error messages.
 #[stable(feature = "nonnull", since = "1.25.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized> !Send for NonNull<T> {}
 
 /// `NonNull` pointers are not `Sync` because the data they reference may be aliased.
 // N.B., this impl is unnecessary, but should provide better error messages.
 #[stable(feature = "nonnull", since = "1.25.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized> !Sync for NonNull<T> {}
 
 impl<T: Sized> NonNull<T> {
@@ -92,6 +105,7 @@ impl<T: Sized> NonNull<T> {
     #[unstable(feature = "nonnull_provenance", issue = "135243")]
     #[must_use]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn without_provenance(addr: NonZero<usize>) -> Self {
         let pointer = crate::ptr::without_provenance(addr.get());
         // SAFETY: we know `addr` is non-zero.
@@ -121,6 +135,7 @@ impl<T: Sized> NonNull<T> {
     #[rustc_const_stable(feature = "const_nonnull_dangling", since = "1.36.0")]
     #[must_use]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn dangling() -> Self {
         let align = crate::ptr::Alignment::of::<T>();
         NonNull::without_provenance(align.as_nonzero())
@@ -134,6 +149,7 @@ impl<T: Sized> NonNull<T> {
     /// This is an [Exposed Provenance][crate::ptr#exposed-provenance] API.
     #[unstable(feature = "nonnull_provenance", issue = "135243")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn with_exposed_provenance(addr: NonZero<usize>) -> Self {
         // SAFETY: we know `addr` is non-zero.
         unsafe {
@@ -159,6 +175,7 @@ impl<T: Sized> NonNull<T> {
     #[inline]
     #[must_use]
     #[unstable(feature = "ptr_as_uninit", issue = "75402")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn as_uninit_ref<'a>(self) -> &'a MaybeUninit<T> {
         // SAFETY: the caller must guarantee that `self` meets all the
         // requirements for a reference.
@@ -182,6 +199,7 @@ impl<T: Sized> NonNull<T> {
     #[inline]
     #[must_use]
     #[unstable(feature = "ptr_as_uninit", issue = "75402")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn as_uninit_mut<'a>(self) -> &'a mut MaybeUninit<T> {
         // SAFETY: the caller must guarantee that `self` meets all the
         // requirements for a reference.
@@ -216,6 +234,7 @@ impl<T: ?Sized> NonNull<T> {
     #[stable(feature = "nonnull", since = "1.25.0")]
     #[rustc_const_stable(feature = "const_nonnull_new_unchecked", since = "1.25.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn new_unchecked(ptr: *mut T) -> Self {
         // SAFETY: the caller must guarantee that `ptr` is non-null.
         unsafe {
@@ -252,6 +271,7 @@ impl<T: ?Sized> NonNull<T> {
     #[stable(feature = "nonnull", since = "1.25.0")]
     #[rustc_const_stable(feature = "const_nonnull_new", since = "1.85.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn new(ptr: *mut T) -> Option<Self> {
         if !ptr.is_null() {
             // SAFETY: The pointer is already checked and is not null
@@ -264,6 +284,7 @@ impl<T: ?Sized> NonNull<T> {
     /// Converts a reference to a `NonNull` pointer.
     #[unstable(feature = "non_null_from_ref", issue = "130823")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn from_ref(r: &T) -> Self {
         // SAFETY: A reference cannot be null.
         unsafe { NonNull { pointer: r as *const T } }
@@ -285,6 +306,7 @@ impl<T: ?Sized> NonNull<T> {
     /// [`std::ptr::from_raw_parts`]: crate::ptr::from_raw_parts
     #[unstable(feature = "ptr_metadata", issue = "81513")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn from_raw_parts(
         data_pointer: NonNull<impl super::Thin>,
         metadata: <T as super::Pointee>::Metadata,
@@ -302,6 +324,7 @@ impl<T: ?Sized> NonNull<T> {
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn to_raw_parts(self) -> (NonNull<()>, <T as super::Pointee>::Metadata) {
         (self.cast(), super::metadata(self.as_ptr()))
     }
@@ -314,6 +337,7 @@ impl<T: ?Sized> NonNull<T> {
     #[must_use]
     #[inline]
     #[stable(feature = "strict_provenance", since = "1.84.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn addr(self) -> NonZero<usize> {
         // SAFETY: The pointer is guaranteed by the type to be non-null,
         // meaning that the address will be non-zero.
@@ -327,6 +351,7 @@ impl<T: ?Sized> NonNull<T> {
     ///
     /// This is an [Exposed Provenance][crate::ptr#exposed-provenance] API.
     #[unstable(feature = "nonnull_provenance", issue = "135243")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn expose_provenance(self) -> NonZero<usize> {
         // SAFETY: The pointer is guaranteed by the type to be non-null,
         // meaning that the address will be non-zero.
@@ -342,6 +367,7 @@ impl<T: ?Sized> NonNull<T> {
     #[must_use]
     #[inline]
     #[stable(feature = "strict_provenance", since = "1.84.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn with_addr(self, addr: NonZero<usize>) -> Self {
         // SAFETY: The result of `ptr::from::with_addr` is non-null because `addr` is guaranteed to be non-zero.
         unsafe { NonNull::new_unchecked(self.as_ptr().with_addr(addr.get()) as *mut _) }
@@ -356,6 +382,7 @@ impl<T: ?Sized> NonNull<T> {
     #[must_use]
     #[inline]
     #[stable(feature = "strict_provenance", since = "1.84.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn map_addr(self, f: impl FnOnce(NonZero<usize>) -> NonZero<usize>) -> Self {
         self.with_addr(f(self.addr()))
     }
@@ -421,6 +448,7 @@ impl<T: ?Sized> NonNull<T> {
     #[rustc_const_stable(feature = "const_nonnull_as_ref", since = "1.73.0")]
     #[must_use]
     #[inline(always)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn as_ref<'a>(&self) -> &'a T {
         // SAFETY: the caller must guarantee that `self` meets all the
         // requirements for a reference.
@@ -428,33 +456,34 @@ impl<T: ?Sized> NonNull<T> {
         unsafe { &*self.as_ptr().cast_const() }
     }
 
-    /// Returns a unique reference to the value. If the value may be uninitialized, [`as_uninit_mut`]
-    /// must be used instead.
-    ///
-    /// For the shared counterpart see [`as_ref`].
-    ///
-    /// [`as_uninit_mut`]: NonNull::as_uninit_mut
-    /// [`as_ref`]: NonNull::as_ref
-    ///
-    /// # Safety
-    ///
-    /// When calling this method, you have to ensure that
-    /// the pointer is [convertible to a reference](crate::ptr#pointer-to-reference-conversion).
-    /// # Examples
-    ///
-    /// ```
-    /// use std::ptr::NonNull;
-    ///
-    /// let mut x = 0u32;
-    /// let mut ptr = NonNull::new(&mut x).expect("null pointer");
-    ///
-    /// let x_ref = unsafe { ptr.as_mut() };
-    /// assert_eq!(*x_ref, 0);
-    /// *x_ref += 2;
-    /// assert_eq!(*x_ref, 2);
-    /// ```
-    ///
-    /// [the module documentation]: crate::ptr#safety
+    // /// Returns a unique reference to the value. If the value may be uninitialized, [`as_uninit_mut`]
+    // /// must be used instead.
+    // ///
+    // /// For the shared counterpart see [`as_ref`].
+    // ///
+    // /// [`as_uninit_mut`]: NonNull::as_uninit_mut
+    // /// [`as_ref`]: NonNull::as_ref
+    // ///
+    // /// # Safety
+    // ///
+    // /// When calling this method, you have to ensure that
+    // /// the pointer is [convertible to a reference](crate::ptr#pointer-to-reference-conversion).
+    // /// # Examples
+    // ///
+    // /// ```
+    // /// use std::ptr::NonNull;
+    // ///
+    // /// let mut x = 0u32;
+    // /// let mut ptr = NonNull::new(&mut x).expect("null pointer");
+    // ///
+    // /// let x_ref = unsafe { ptr.as_mut() };
+    // /// assert_eq!(*x_ref, 0);
+    // /// *x_ref += 2;
+    // /// assert_eq!(*x_ref, 2);
+    // /// ```
+    // ///
+    // /// [the module documentation]: crate::ptr#safety
+    /// FIXME(@pvdrz): docs
     #[stable(feature = "nonnull", since = "1.25.0")]
     #[rustc_const_stable(feature = "const_ptr_as_ref", since = "1.83.0")]
     #[must_use]
@@ -529,6 +558,7 @@ impl<T: ?Sized> NonNull<T> {
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "non_null_convenience", since = "1.80.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn offset(self, count: isize) -> Self
     where
         T: Sized,
@@ -555,6 +585,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "non_null_convenience", since = "1.80.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn byte_offset(self, count: isize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `offset` and `byte_offset` has
         // the same safety contract.
@@ -631,6 +662,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "non_null_convenience", since = "1.80.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn byte_add(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `add` and `byte_add` has the same
         // safety contract.
@@ -682,6 +714,7 @@ impl<T: ?Sized> NonNull<T> {
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "non_null_convenience", since = "1.80.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn sub(self, count: usize) -> Self
     where
         T: Sized,
@@ -713,6 +746,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "non_null_convenience", since = "1.80.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn byte_sub(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `sub` and `byte_sub` has the same
         // safety contract.
@@ -811,6 +845,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "non_null_convenience", since = "1.80.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn offset_from(self, origin: NonNull<T>) -> isize
     where
         T: Sized,
@@ -832,6 +867,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "non_null_convenience", since = "1.80.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn byte_offset_from<U: ?Sized>(self, origin: NonNull<U>) -> isize {
         // SAFETY: the caller must uphold the safety contract for `byte_offset_from`.
         unsafe { self.as_ptr().byte_offset_from(origin.as_ptr()) }
@@ -902,6 +938,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "ptr_sub_ptr", since = "1.87.0")]
     #[rustc_const_stable(feature = "const_ptr_sub_ptr", since = "1.87.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn offset_from_unsigned(self, subtracted: NonNull<T>) -> usize
     where
         T: Sized,
@@ -924,6 +961,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "ptr_sub_ptr", since = "1.87.0")]
     #[rustc_const_stable(feature = "const_ptr_sub_ptr", since = "1.87.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn byte_offset_from_unsigned<U: ?Sized>(self, origin: NonNull<U>) -> usize {
         // SAFETY: the caller must uphold the safety contract for `byte_offset_from_unsigned`.
         unsafe { self.as_ptr().byte_offset_from_unsigned(origin.as_ptr()) }
@@ -939,6 +977,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "non_null_convenience", since = "1.80.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn read(self) -> T
     where
         T: Sized,
@@ -960,6 +999,7 @@ impl<T: ?Sized> NonNull<T> {
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub unsafe fn read_volatile(self) -> T
     where
         T: Sized,
@@ -980,6 +1020,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "non_null_convenience", since = "1.80.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn read_unaligned(self) -> T
     where
         T: Sized,
@@ -1000,6 +1041,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.83.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn copy_to(self, dest: NonNull<T>, count: usize)
     where
         T: Sized,
@@ -1020,6 +1062,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.83.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn copy_to_nonoverlapping(self, dest: NonNull<T>, count: usize)
     where
         T: Sized,
@@ -1040,6 +1083,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.83.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn copy_from(self, src: NonNull<T>, count: usize)
     where
         T: Sized,
@@ -1060,6 +1104,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.83.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn copy_from_nonoverlapping(self, src: NonNull<T>, count: usize)
     where
         T: Sized,
@@ -1075,6 +1120,7 @@ impl<T: ?Sized> NonNull<T> {
     /// [`ptr::drop_in_place`]: crate::ptr::drop_in_place()
     #[inline(always)]
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub unsafe fn drop_in_place(self) {
         // SAFETY: the caller must uphold the safety contract for `drop_in_place`.
         unsafe { ptr::drop_in_place(self.as_ptr()) }
@@ -1090,6 +1136,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "const_ptr_write", since = "1.83.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn write(self, val: T)
     where
         T: Sized,
@@ -1109,6 +1156,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "const_ptr_write", since = "1.83.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn write_bytes(self, val: u8, count: usize)
     where
         T: Sized,
@@ -1130,6 +1178,7 @@ impl<T: ?Sized> NonNull<T> {
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub unsafe fn write_volatile(self, val: T)
     where
         T: Sized,
@@ -1150,6 +1199,7 @@ impl<T: ?Sized> NonNull<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "const_ptr_write", since = "1.83.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn write_unaligned(self, val: T)
     where
         T: Sized,
@@ -1167,6 +1217,7 @@ impl<T: ?Sized> NonNull<T> {
     #[inline(always)]
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "const_inherent_ptr_replace", since = "CURRENT_RUSTC_VERSION")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn replace(self, src: T) -> T
     where
         T: Sized,
@@ -1185,6 +1236,7 @@ impl<T: ?Sized> NonNull<T> {
     #[inline(always)]
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_stable(feature = "const_swap", since = "1.85.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn swap(self, with: NonNull<T>)
     where
         T: Sized,
@@ -1242,6 +1294,7 @@ impl<T: ?Sized> NonNull<T> {
     #[inline]
     #[must_use]
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn align_offset(self, align: usize) -> usize
     where
         T: Sized,
@@ -1276,6 +1329,7 @@ impl<T: ?Sized> NonNull<T> {
     #[inline]
     #[must_use]
     #[stable(feature = "pointer_is_aligned", since = "1.79.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn is_aligned(self) -> bool
     where
         T: Sized,
@@ -1316,11 +1370,13 @@ impl<T: ?Sized> NonNull<T> {
     #[inline]
     #[must_use]
     #[unstable(feature = "pointer_is_aligned_to", issue = "96284")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn is_aligned_to(self, align: usize) -> bool {
         self.as_ptr().is_aligned_to(align)
     }
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> NonNull<[T]> {
     /// Creates a non-null raw slice from a thin pointer and a length.
     ///
@@ -1347,6 +1403,7 @@ impl<T> NonNull<[T]> {
     #[rustc_const_stable(feature = "const_slice_from_raw_parts_mut", since = "1.83.0")]
     #[must_use]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn slice_from_raw_parts(data: NonNull<T>, len: usize) -> Self {
         // SAFETY: `data` is a `NonNull` pointer which is necessarily non-null
         unsafe { Self::new_unchecked(super::slice_from_raw_parts_mut(data.as_ptr(), len)) }
@@ -1371,6 +1428,7 @@ impl<T> NonNull<[T]> {
     #[rustc_const_stable(feature = "const_slice_ptr_len_nonnull", since = "1.63.0")]
     #[must_use]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn len(self) -> usize {
         self.as_ptr().len()
     }
@@ -1389,6 +1447,7 @@ impl<T> NonNull<[T]> {
     #[rustc_const_stable(feature = "const_slice_ptr_is_empty_nonnull", since = "1.79.0")]
     #[must_use]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn is_empty(self) -> bool {
         self.len() == 0
     }
@@ -1407,6 +1466,7 @@ impl<T> NonNull<[T]> {
     #[inline]
     #[must_use]
     #[unstable(feature = "slice_ptr_get", issue = "74265")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_non_null_ptr(self) -> NonNull<T> {
         self.cast()
     }
@@ -1426,6 +1486,7 @@ impl<T> NonNull<[T]> {
     #[must_use]
     #[unstable(feature = "slice_ptr_get", issue = "74265")]
     #[rustc_never_returns_null_ptr]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_mut_ptr(self) -> *mut T {
         self.as_non_null_ptr().as_ptr()
     }
@@ -1470,6 +1531,7 @@ impl<T> NonNull<[T]> {
     #[inline]
     #[must_use]
     #[unstable(feature = "ptr_as_uninit", issue = "75402")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn as_uninit_slice<'a>(self) -> &'a [MaybeUninit<T>] {
         // SAFETY: the caller must uphold the safety contract for `as_uninit_slice`.
         unsafe { slice::from_raw_parts(self.cast().as_ptr(), self.len()) }
@@ -1534,6 +1596,7 @@ impl<T> NonNull<[T]> {
     #[inline]
     #[must_use]
     #[unstable(feature = "ptr_as_uninit", issue = "75402")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn as_uninit_slice_mut<'a>(self) -> &'a mut [MaybeUninit<T>] {
         // SAFETY: the caller must uphold the safety contract for `as_uninit_slice_mut`.
         unsafe { slice::from_raw_parts_mut(self.cast().as_ptr(), self.len()) }
@@ -1562,6 +1625,7 @@ impl<T> NonNull<[T]> {
     /// ```
     #[unstable(feature = "slice_ptr_get", issue = "74265")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub unsafe fn get_unchecked_mut<I>(self, index: I) -> NonNull<I::Output>
     where
         I: SliceIndex<[T]>,
@@ -1584,26 +1648,34 @@ impl<T: ?Sized> Clone for NonNull<T> {
 impl<T: ?Sized> Copy for NonNull<T> {}
 
 #[unstable(feature = "coerce_unsized", issue = "18598")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized, U: ?Sized> CoerceUnsized<NonNull<U>> for NonNull<T> where T: Unsize<U> {}
 
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized, U: ?Sized> DispatchFromDyn<NonNull<U>> for NonNull<T> where T: Unsize<U> {}
 
 #[stable(feature = "pin", since = "1.33.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T: ?Sized> PinCoerceUnsized for NonNull<T> {}
 
 #[unstable(feature = "pointer_like_trait", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> core::marker::PointerLike for NonNull<T> {}
 
 #[stable(feature = "nonnull", since = "1.25.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized> fmt::Debug for NonNull<T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Pointer::fmt(&self.as_ptr(), f)
     }
 }
 
 #[stable(feature = "nonnull", since = "1.25.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized> fmt::Pointer for NonNull<T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Pointer::fmt(&self.as_ptr(), f)
     }
@@ -1622,56 +1694,68 @@ impl<T: ?Sized> PartialEq for NonNull<T> {
 }
 
 #[stable(feature = "nonnull", since = "1.25.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized> Ord for NonNull<T> {
     #[inline]
     #[allow(ambiguous_wide_pointer_comparisons)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn cmp(&self, other: &Self) -> Ordering {
         self.as_ptr().cmp(&other.as_ptr())
     }
 }
 
 #[stable(feature = "nonnull", since = "1.25.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized> PartialOrd for NonNull<T> {
     #[inline]
     #[allow(ambiguous_wide_pointer_comparisons)]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.as_ptr().partial_cmp(&other.as_ptr())
     }
 }
 
 #[stable(feature = "nonnull", since = "1.25.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized> hash::Hash for NonNull<T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.as_ptr().hash(state)
     }
 }
 
 #[unstable(feature = "ptr_internals", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized> From<Unique<T>> for NonNull<T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn from(unique: Unique<T>) -> Self {
         unique.as_non_null_ptr()
     }
 }
 
 #[stable(feature = "nonnull", since = "1.25.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized> From<&mut T> for NonNull<T> {
     /// Converts a `&mut T` to a `NonNull<T>`.
     ///
     /// This conversion is safe and infallible since references cannot be null.
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn from(r: &mut T) -> Self {
         NonNull::from_mut(r)
     }
 }
 
 #[stable(feature = "nonnull", since = "1.25.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: ?Sized> From<&T> for NonNull<T> {
     /// Converts a `&T` to a `NonNull<T>`.
     ///
     /// This conversion is safe and infallible since references cannot be null.
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn from(r: &T) -> Self {
         NonNull::from_ref(r)
     }

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -1,27 +1,42 @@
 //! Definitions of a bunch of iterators for `[T]`.
 
 #[macro_use] // import iterator! and forward_iterator!
+
 mod macros;
 
+#[cfg(not(feature = "ferrocene_certified"))]
 use super::{from_raw_parts, from_raw_parts_mut};
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::hint::assert_unchecked;
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::iter::{
     FusedIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce, UncheckedIterator,
 };
 use crate::marker::PhantomData;
-use crate::mem::{self, SizedTypeProperties};
+#[cfg(not(feature = "ferrocene_certified"))]
+use crate::mem;
+use crate::mem::SizedTypeProperties;
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::num::NonZero;
-use crate::ptr::{NonNull, without_provenance, without_provenance_mut};
+#[cfg(not(feature = "ferrocene_certified"))]
+use crate::ptr::without_provenance;
+use crate::ptr::{NonNull, without_provenance_mut};
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::{cmp, fmt};
 
 #[stable(feature = "boxed_slice_into_iter", since = "1.80.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> !Iterator for [T] {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> IntoIterator for &'a [T] {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a T;
+    #[cfg(not(feature = "ferrocene_certified"))]
     type IntoIter = Iter<'a, T>;
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn into_iter(self) -> Iter<'a, T> {
         self.iter()
     }
@@ -66,6 +81,7 @@ impl<'a, T> IntoIterator for &'a mut [T] {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[rustc_diagnostic_item = "SliceIter"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct Iter<'a, T: 'a> {
     /// The pointer to the next element to return, or the past-the-end location
     /// if the iterator is empty.
@@ -80,19 +96,25 @@ pub struct Iter<'a, T: 'a> {
 }
 
 #[stable(feature = "core_impl_debug", since = "1.9.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: fmt::Debug> fmt::Debug for Iter<'_, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Iter").field(&self.as_slice()).finish()
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T: Sync> Sync for Iter<'_, T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T: Sync> Send for Iter<'_, T> {}
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> Iter<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) const fn new(slice: &'a [T]) -> Self {
         let len = slice.len();
         let ptr: NonNull<T> = NonNull::from_ref(slice).cast();
@@ -134,11 +156,13 @@ impl<'a, T> Iter<'a, T> {
     #[must_use]
     #[stable(feature = "iter_to_slice", since = "1.4.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn as_slice(&self) -> &'a [T] {
         self.make_slice()
     }
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 iterator! {struct Iter -> *const T, &'a T, const, {/* no mut */}, as_ref, {
     fn is_sorted_by<F>(self, mut compare: F) -> bool
     where
@@ -150,16 +174,20 @@ iterator! {struct Iter -> *const T, &'a T, const, {/* no mut */}, as_ref, {
 }}
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> Clone for Iter<'_, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn clone(&self) -> Self {
         Iter { ptr: self.ptr, end_or_len: self.end_or_len, _marker: self._marker }
     }
 }
 
 #[stable(feature = "slice_iter_as_ref", since = "1.13.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> AsRef<[T]> for Iter<'_, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn as_ref(&self) -> &[T] {
         self.as_slice()
     }
@@ -205,15 +233,19 @@ pub struct IterMut<'a, T: 'a> {
 }
 
 #[stable(feature = "core_impl_debug", since = "1.9.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: fmt::Debug> fmt::Debug for IterMut<'_, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("IterMut").field(&self.make_slice()).finish()
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T: Sync> Sync for IterMut<'_, T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T: Send> Send for IterMut<'_, T> {}
 
 impl<'a, T> IterMut<'a, T> {
@@ -273,6 +305,7 @@ impl<'a, T> IterMut<'a, T> {
     /// ```
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(feature = "iter_to_slice", since = "1.4.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn into_slice(self) -> &'a mut [T] {
         // SAFETY: the iterator was created from a mutable slice with pointer
         // `self.ptr` and length `len!(self)`. This guarantees that all the prerequisites
@@ -310,6 +343,7 @@ impl<'a, T> IterMut<'a, T> {
     #[must_use]
     #[stable(feature = "slice_iter_mut_as_slice", since = "1.53.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn as_slice(&self) -> &[T] {
         self.make_slice()
     }
@@ -345,6 +379,7 @@ impl<'a, T> IterMut<'a, T> {
     #[must_use]
     // FIXME: Uncomment the `AsMut<[T]>` impl when this gets stabilized.
     #[unstable(feature = "slice_iter_mut_as_mut_slice", issue = "93079")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         // SAFETY: the iterator was created from a mutable slice with pointer
         // `self.ptr` and length `len!(self)`. This guarantees that all the prerequisites
@@ -354,8 +389,10 @@ impl<'a, T> IterMut<'a, T> {
 }
 
 #[stable(feature = "slice_iter_mut_as_slice", since = "1.53.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> AsRef<[T]> for IterMut<'_, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn as_ref(&self) -> &[T] {
         self.as_slice()
     }
@@ -373,9 +410,11 @@ iterator! {struct IterMut -> *mut T, &'a mut T, mut, {mut}, as_mut, {}}
 /// An internal abstraction over the splitting iterators, so that
 /// splitn, splitn_mut etc can be implemented once.
 #[doc(hidden)]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub(super) trait SplitIter: DoubleEndedIterator {
     /// Marks the underlying iterator as complete, extracting the remaining
     /// portion of the slice.
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn finish(&mut self) -> Option<Self::Item>;
 }
 
@@ -398,6 +437,7 @@ pub(super) trait SplitIter: DoubleEndedIterator {
 /// [slices]: slice
 #[stable(feature = "rust1", since = "1.0.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct Split<'a, T: 'a, P>
 where
     P: FnMut(&T) -> bool,
@@ -409,8 +449,10 @@ where
     pub(crate) finished: bool,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P: FnMut(&T) -> bool> Split<'a, T, P> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) fn new(slice: &'a [T], pred: P) -> Self {
         Self { v: slice, pred, finished: false }
     }
@@ -425,16 +467,19 @@ impl<'a, T: 'a, P: FnMut(&T) -> bool> Split<'a, T, P> {
     /// assert_eq!(split.as_slice(), &[3,4,5]);
     /// ```
     #[unstable(feature = "split_as_slice", issue = "96137")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn as_slice(&self) -> &'a [T] {
         if self.finished { &[] } else { &self.v }
     }
 }
 
 #[stable(feature = "core_impl_debug", since = "1.9.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: fmt::Debug, P> fmt::Debug for Split<'_, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Split").field("v", &self.v).field("finished", &self.finished).finish()
     }
@@ -442,23 +487,28 @@ where
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, P> Clone for Split<'_, T, P>
 where
     P: Clone + FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn clone(&self) -> Self {
         Split { v: self.v, pred: self.pred.clone(), finished: self.finished }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> Iterator for Split<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a [T]> {
         if self.finished {
             return None;
@@ -479,6 +529,7 @@ where
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.finished {
             (0, Some(0))
@@ -491,11 +542,13 @@ where
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> DoubleEndedIterator for Split<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a [T]> {
         if self.finished {
             return None;
@@ -516,11 +569,13 @@ where
     }
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> SplitIter for Split<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn finish(&mut self) -> Option<&'a [T]> {
         if self.finished {
             None
@@ -532,6 +587,7 @@ where
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, P> FusedIterator for Split<'_, T, P> where P: FnMut(&T) -> bool {}
 
 /// An iterator over subslices separated by elements that match a predicate
@@ -554,6 +610,7 @@ impl<T, P> FusedIterator for Split<'_, T, P> where P: FnMut(&T) -> bool {}
 /// [slices]: slice
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct SplitInclusive<'a, T: 'a, P>
 where
     P: FnMut(&T) -> bool,
@@ -563,8 +620,10 @@ where
     finished: bool,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P: FnMut(&T) -> bool> SplitInclusive<'a, T, P> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) fn new(slice: &'a [T], pred: P) -> Self {
         let finished = slice.is_empty();
         Self { v: slice, pred, finished }
@@ -572,10 +631,12 @@ impl<'a, T: 'a, P: FnMut(&T) -> bool> SplitInclusive<'a, T, P> {
 }
 
 #[stable(feature = "split_inclusive", since = "1.51.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: fmt::Debug, P> fmt::Debug for SplitInclusive<'_, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SplitInclusive")
             .field("v", &self.v)
@@ -586,23 +647,28 @@ where
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[stable(feature = "split_inclusive", since = "1.51.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, P> Clone for SplitInclusive<'_, T, P>
 where
     P: Clone + FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn clone(&self) -> Self {
         SplitInclusive { v: self.v, pred: self.pred.clone(), finished: self.finished }
     }
 }
 
 #[stable(feature = "split_inclusive", since = "1.51.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> Iterator for SplitInclusive<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a [T]> {
         if self.finished {
             return None;
@@ -619,6 +685,7 @@ where
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.finished {
             (0, Some(0))
@@ -632,11 +699,13 @@ where
 }
 
 #[stable(feature = "split_inclusive", since = "1.51.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> DoubleEndedIterator for SplitInclusive<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a [T]> {
         if self.finished {
             return None;
@@ -657,6 +726,7 @@ where
 }
 
 #[stable(feature = "split_inclusive", since = "1.51.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, P> FusedIterator for SplitInclusive<'_, T, P> where P: FnMut(&T) -> bool {}
 
 /// An iterator over the mutable subslices of the vector which are separated
@@ -675,6 +745,7 @@ impl<T, P> FusedIterator for SplitInclusive<'_, T, P> where P: FnMut(&T) -> bool
 /// [slices]: slice
 #[stable(feature = "rust1", since = "1.0.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct SplitMut<'a, T: 'a, P>
 where
     P: FnMut(&T) -> bool,
@@ -684,28 +755,34 @@ where
     finished: bool,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P: FnMut(&T) -> bool> SplitMut<'a, T, P> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) fn new(slice: &'a mut [T], pred: P) -> Self {
         Self { v: slice, pred, finished: false }
     }
 }
 
 #[stable(feature = "core_impl_debug", since = "1.9.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: fmt::Debug, P> fmt::Debug for SplitMut<'_, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SplitMut").field("v", &self.v).field("finished", &self.finished).finish()
     }
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> SplitIter for SplitMut<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn finish(&mut self) -> Option<&'a mut [T]> {
         if self.finished {
             None
@@ -717,13 +794,16 @@ where
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> Iterator for SplitMut<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a mut [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a mut [T]> {
         if self.finished {
             return None;
@@ -745,6 +825,7 @@ where
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.finished {
             (0, Some(0))
@@ -757,11 +838,13 @@ where
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> DoubleEndedIterator for SplitMut<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a mut [T]> {
         if self.finished {
             return None;
@@ -785,6 +868,7 @@ where
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, P> FusedIterator for SplitMut<'_, T, P> where P: FnMut(&T) -> bool {}
 
 /// An iterator over the mutable subslices of the vector which are separated
@@ -804,6 +888,7 @@ impl<T, P> FusedIterator for SplitMut<'_, T, P> where P: FnMut(&T) -> bool {}
 /// [slices]: slice
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct SplitInclusiveMut<'a, T: 'a, P>
 where
     P: FnMut(&T) -> bool,
@@ -813,8 +898,10 @@ where
     finished: bool,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P: FnMut(&T) -> bool> SplitInclusiveMut<'a, T, P> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) fn new(slice: &'a mut [T], pred: P) -> Self {
         let finished = slice.is_empty();
         Self { v: slice, pred, finished }
@@ -822,10 +909,12 @@ impl<'a, T: 'a, P: FnMut(&T) -> bool> SplitInclusiveMut<'a, T, P> {
 }
 
 #[stable(feature = "split_inclusive", since = "1.51.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: fmt::Debug, P> fmt::Debug for SplitInclusiveMut<'_, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SplitInclusiveMut")
             .field("v", &self.v)
@@ -835,13 +924,16 @@ where
 }
 
 #[stable(feature = "split_inclusive", since = "1.51.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> Iterator for SplitInclusiveMut<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a mut [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a mut [T]> {
         if self.finished {
             return None;
@@ -863,6 +955,7 @@ where
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.finished {
             (0, Some(0))
@@ -876,11 +969,13 @@ where
 }
 
 #[stable(feature = "split_inclusive", since = "1.51.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> DoubleEndedIterator for SplitInclusiveMut<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a mut [T]> {
         if self.finished {
             return None;
@@ -910,6 +1005,7 @@ where
 }
 
 #[stable(feature = "split_inclusive", since = "1.51.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, P> FusedIterator for SplitInclusiveMut<'_, T, P> where P: FnMut(&T) -> bool {}
 
 /// An iterator over subslices separated by elements that match a predicate
@@ -931,6 +1027,7 @@ impl<T, P> FusedIterator for SplitInclusiveMut<'_, T, P> where P: FnMut(&T) -> b
 /// [slices]: slice
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct RSplit<'a, T: 'a, P>
 where
     P: FnMut(&T) -> bool,
@@ -938,18 +1035,22 @@ where
     inner: Split<'a, T, P>,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P: FnMut(&T) -> bool> RSplit<'a, T, P> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) fn new(slice: &'a [T], pred: P) -> Self {
         Self { inner: Split::new(slice, pred) }
     }
 }
 
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: fmt::Debug, P> fmt::Debug for RSplit<'_, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RSplit")
             .field("v", &self.inner.v)
@@ -960,56 +1061,67 @@ where
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, P> Clone for RSplit<'_, T, P>
 where
     P: Clone + FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn clone(&self) -> Self {
         RSplit { inner: self.inner.clone() }
     }
 }
 
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> Iterator for RSplit<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a [T]> {
         self.inner.next_back()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 }
 
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> DoubleEndedIterator for RSplit<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a [T]> {
         self.inner.next()
     }
 }
 
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> SplitIter for RSplit<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn finish(&mut self) -> Option<&'a [T]> {
         self.inner.finish()
     }
 }
 
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, P> FusedIterator for RSplit<'_, T, P> where P: FnMut(&T) -> bool {}
 
 /// An iterator over the subslices of the vector which are separated
@@ -1028,6 +1140,7 @@ impl<T, P> FusedIterator for RSplit<'_, T, P> where P: FnMut(&T) -> bool {}
 /// [slices]: slice
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct RSplitMut<'a, T: 'a, P>
 where
     P: FnMut(&T) -> bool,
@@ -1035,18 +1148,22 @@ where
     inner: SplitMut<'a, T, P>,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P: FnMut(&T) -> bool> RSplitMut<'a, T, P> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) fn new(slice: &'a mut [T], pred: P) -> Self {
         Self { inner: SplitMut::new(slice, pred) }
     }
 }
 
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: fmt::Debug, P> fmt::Debug for RSplitMut<'_, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RSplitMut")
             .field("v", &self.inner.v)
@@ -1056,61 +1173,74 @@ where
 }
 
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> SplitIter for RSplitMut<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn finish(&mut self) -> Option<&'a mut [T]> {
         self.inner.finish()
     }
 }
 
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> Iterator for RSplitMut<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a mut [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a mut [T]> {
         self.inner.next_back()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 }
 
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, P> DoubleEndedIterator for RSplitMut<'a, T, P>
 where
     P: FnMut(&T) -> bool,
 {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a mut [T]> {
         self.inner.next()
     }
 }
 
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, P> FusedIterator for RSplitMut<'_, T, P> where P: FnMut(&T) -> bool {}
 
 /// An private iterator over subslices separated by elements that
 /// match a predicate function, splitting at most a fixed number of
 /// times.
 #[derive(Debug)]
+#[cfg(not(feature = "ferrocene_certified"))]
 struct GenericSplitN<I> {
     iter: I,
     count: usize,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, I: SplitIter<Item = T>> Iterator for GenericSplitN<I> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = T;
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<T> {
         match self.count {
             0 => None,
@@ -1126,6 +1256,7 @@ impl<T, I: SplitIter<Item = T>> Iterator for GenericSplitN<I> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (lower, upper_opt) = self.iter.size_hint();
         (
@@ -1154,6 +1285,7 @@ impl<T, I: SplitIter<Item = T>> Iterator for GenericSplitN<I> {
 /// [slices]: slice
 #[stable(feature = "rust1", since = "1.0.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct SplitN<'a, T: 'a, P>
 where
     P: FnMut(&T) -> bool,
@@ -1161,18 +1293,22 @@ where
     inner: GenericSplitN<Split<'a, T, P>>,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P: FnMut(&T) -> bool> SplitN<'a, T, P> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) fn new(s: Split<'a, T, P>, n: usize) -> Self {
         Self { inner: GenericSplitN { iter: s, count: n } }
     }
 }
 
 #[stable(feature = "core_impl_debug", since = "1.9.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: fmt::Debug, P> fmt::Debug for SplitN<'_, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SplitN").field("inner", &self.inner).finish()
     }
@@ -1198,6 +1334,7 @@ where
 /// [slices]: slice
 #[stable(feature = "rust1", since = "1.0.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct RSplitN<'a, T: 'a, P>
 where
     P: FnMut(&T) -> bool,
@@ -1205,18 +1342,22 @@ where
     inner: GenericSplitN<RSplit<'a, T, P>>,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P: FnMut(&T) -> bool> RSplitN<'a, T, P> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) fn new(s: RSplit<'a, T, P>, n: usize) -> Self {
         Self { inner: GenericSplitN { iter: s, count: n } }
     }
 }
 
 #[stable(feature = "core_impl_debug", since = "1.9.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: fmt::Debug, P> fmt::Debug for RSplitN<'_, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RSplitN").field("inner", &self.inner).finish()
     }
@@ -1238,6 +1379,7 @@ where
 /// [slices]: slice
 #[stable(feature = "rust1", since = "1.0.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct SplitNMut<'a, T: 'a, P>
 where
     P: FnMut(&T) -> bool,
@@ -1245,18 +1387,22 @@ where
     inner: GenericSplitN<SplitMut<'a, T, P>>,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P: FnMut(&T) -> bool> SplitNMut<'a, T, P> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) fn new(s: SplitMut<'a, T, P>, n: usize) -> Self {
         Self { inner: GenericSplitN { iter: s, count: n } }
     }
 }
 
 #[stable(feature = "core_impl_debug", since = "1.9.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: fmt::Debug, P> fmt::Debug for SplitNMut<'_, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SplitNMut").field("inner", &self.inner).finish()
     }
@@ -1279,6 +1425,7 @@ where
 /// [slices]: slice
 #[stable(feature = "rust1", since = "1.0.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct RSplitNMut<'a, T: 'a, P>
 where
     P: FnMut(&T) -> bool,
@@ -1286,26 +1433,34 @@ where
     inner: GenericSplitN<RSplitMut<'a, T, P>>,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P: FnMut(&T) -> bool> RSplitNMut<'a, T, P> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) fn new(s: RSplitMut<'a, T, P>, n: usize) -> Self {
         Self { inner: GenericSplitN { iter: s, count: n } }
     }
 }
 
 #[stable(feature = "core_impl_debug", since = "1.9.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T: fmt::Debug, P> fmt::Debug for RSplitNMut<'_, T, P>
 where
     P: FnMut(&T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RSplitNMut").field("inner", &self.inner).finish()
     }
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 forward_iterator! { SplitN: T, &'a [T] }
+#[cfg(not(feature = "ferrocene_certified"))]
 forward_iterator! { RSplitN: T, &'a [T] }
+#[cfg(not(feature = "ferrocene_certified"))]
 forward_iterator! { SplitNMut: T, &'a mut [T] }
+#[cfg(not(feature = "ferrocene_certified"))]
 forward_iterator! { RSplitNMut: T, &'a mut [T] }
 
 /// An iterator over overlapping subslices of length `size`.
@@ -1328,13 +1483,16 @@ forward_iterator! { RSplitNMut: T, &'a mut [T] }
 #[derive(Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct Windows<'a, T: 'a> {
     v: &'a [T],
     size: NonZero<usize>,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a> Windows<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) const fn new(slice: &'a [T], size: NonZero<usize>) -> Self {
         Self { v: slice, size }
     }
@@ -1342,17 +1500,22 @@ impl<'a, T: 'a> Windows<'a, T> {
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> Clone for Windows<'_, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn clone(&self) -> Self {
         Windows { v: self.v, size: self.size }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> Iterator for Windows<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a [T]> {
         if self.size.get() > self.v.len() {
             None
@@ -1364,6 +1527,7 @@ impl<'a, T> Iterator for Windows<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.size.get() > self.v.len() {
             (0, Some(0))
@@ -1374,11 +1538,13 @@ impl<'a, T> Iterator for Windows<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn count(self) -> usize {
         self.len()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         let size = self.size.get();
         if let Some(rest) = self.v.get(n..)
@@ -1394,6 +1560,7 @@ impl<'a, T> Iterator for Windows<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn last(self) -> Option<Self::Item> {
         if self.size.get() > self.v.len() {
             None
@@ -1403,6 +1570,7 @@ impl<'a, T> Iterator for Windows<'a, T> {
         }
     }
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         // SAFETY: since the caller guarantees that `i` is in bounds,
         // which means that `i` cannot overflow an `isize`, and the
@@ -1413,8 +1581,10 @@ impl<'a, T> Iterator for Windows<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> DoubleEndedIterator for Windows<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a [T]> {
         if self.size.get() > self.v.len() {
             None
@@ -1426,6 +1596,7 @@ impl<'a, T> DoubleEndedIterator for Windows<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         let (end, overflow) = self.v.len().overflowing_sub(n);
         if end < self.size.get() || overflow {
@@ -1440,21 +1611,27 @@ impl<'a, T> DoubleEndedIterator for Windows<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> ExactSizeIterator for Windows<'_, T> {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> TrustedLen for Windows<'_, T> {}
 
 #[stable(feature = "fused", since = "1.26.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> FusedIterator for Windows<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccess for Windows<'a, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for Windows<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
@@ -1482,13 +1659,16 @@ unsafe impl<'a, T> TrustedRandomAccessNoCoerce for Windows<'a, T> {
 #[derive(Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct Chunks<'a, T: 'a> {
     v: &'a [T],
     chunk_size: usize,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a> Chunks<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) const fn new(slice: &'a [T], size: usize) -> Self {
         Self { v: slice, chunk_size: size }
     }
@@ -1496,17 +1676,22 @@ impl<'a, T: 'a> Chunks<'a, T> {
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> Clone for Chunks<'_, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn clone(&self) -> Self {
         Chunks { v: self.v, chunk_size: self.chunk_size }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> Iterator for Chunks<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a [T]> {
         if self.v.is_empty() {
             None
@@ -1519,6 +1704,7 @@ impl<'a, T> Iterator for Chunks<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.v.is_empty() {
             (0, Some(0))
@@ -1531,11 +1717,13 @@ impl<'a, T> Iterator for Chunks<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn count(self) -> usize {
         self.len()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         let (start, overflow) = n.overflowing_mul(self.chunk_size);
         // min(len) makes a wrong start harmless, but enables optimizing this to brachless code
@@ -1551,6 +1739,7 @@ impl<'a, T> Iterator for Chunks<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn last(self) -> Option<Self::Item> {
         if self.v.is_empty() {
             None
@@ -1560,6 +1749,7 @@ impl<'a, T> Iterator for Chunks<'a, T> {
         }
     }
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let start = idx * self.chunk_size;
         // SAFETY: the caller guarantees that `i` is in bounds,
@@ -1577,8 +1767,10 @@ impl<'a, T> Iterator for Chunks<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> DoubleEndedIterator for Chunks<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a [T]> {
         if self.v.is_empty() {
             None
@@ -1606,6 +1798,7 @@ impl<'a, T> DoubleEndedIterator for Chunks<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         let len = self.len();
         if n >= len {
@@ -1625,21 +1818,27 @@ impl<'a, T> DoubleEndedIterator for Chunks<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> ExactSizeIterator for Chunks<'_, T> {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> TrustedLen for Chunks<'_, T> {}
 
 #[stable(feature = "fused", since = "1.26.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> FusedIterator for Chunks<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccess for Chunks<'a, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for Chunks<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
@@ -1663,6 +1862,7 @@ unsafe impl<'a, T> TrustedRandomAccessNoCoerce for Chunks<'a, T> {
 #[derive(Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct ChunksMut<'a, T: 'a> {
     /// # Safety
     /// This slice pointer must point at a valid region of `T` with at least length `v.len()`. Normally,
@@ -1675,18 +1875,23 @@ pub struct ChunksMut<'a, T: 'a> {
     _marker: PhantomData<&'a mut T>,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a> ChunksMut<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) const fn new(slice: &'a mut [T], size: usize) -> Self {
         Self { v: slice, chunk_size: size, _marker: PhantomData }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> Iterator for ChunksMut<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a mut [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a mut [T]> {
         if self.v.is_empty() {
             None
@@ -1701,6 +1906,7 @@ impl<'a, T> Iterator for ChunksMut<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.v.is_empty() {
             (0, Some(0))
@@ -1713,11 +1919,13 @@ impl<'a, T> Iterator for ChunksMut<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn count(self) -> usize {
         self.len()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth(&mut self, n: usize) -> Option<&'a mut [T]> {
         let (start, overflow) = n.overflowing_mul(self.chunk_size);
         if start >= self.v.len() || overflow {
@@ -1739,6 +1947,7 @@ impl<'a, T> Iterator for ChunksMut<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn last(self) -> Option<Self::Item> {
         if self.v.is_empty() {
             None
@@ -1749,6 +1958,7 @@ impl<'a, T> Iterator for ChunksMut<'a, T> {
         }
     }
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let start = idx * self.chunk_size;
         // SAFETY: see comments for `Chunks::__iterator_get_unchecked` and `self.v`.
@@ -1765,8 +1975,10 @@ impl<'a, T> Iterator for ChunksMut<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> DoubleEndedIterator for ChunksMut<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a mut [T]> {
         if self.v.is_empty() {
             None
@@ -1783,6 +1995,7 @@ impl<'a, T> DoubleEndedIterator for ChunksMut<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         let len = self.len();
         if n >= len {
@@ -1806,28 +2019,36 @@ impl<'a, T> DoubleEndedIterator for ChunksMut<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> ExactSizeIterator for ChunksMut<'_, T> {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> TrustedLen for ChunksMut<'_, T> {}
 
 #[stable(feature = "fused", since = "1.26.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> FusedIterator for ChunksMut<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccess for ChunksMut<'a, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for ChunksMut<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> Send for ChunksMut<'_, T> where T: Send {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> Sync for ChunksMut<'_, T> where T: Sync {}
 
 /// An iterator over a slice in (non-overlapping) chunks (`chunk_size` elements at a
@@ -1855,14 +2076,17 @@ unsafe impl<T> Sync for ChunksMut<'_, T> where T: Sync {}
 #[derive(Debug)]
 #[stable(feature = "chunks_exact", since = "1.31.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct ChunksExact<'a, T: 'a> {
     v: &'a [T],
     rem: &'a [T],
     chunk_size: usize,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> ChunksExact<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) const fn new(slice: &'a [T], chunk_size: usize) -> Self {
         let rem = slice.len() % chunk_size;
         let fst_len = slice.len() - rem;
@@ -1890,6 +2114,7 @@ impl<'a, T> ChunksExact<'a, T> {
     /// ```
     #[must_use]
     #[stable(feature = "chunks_exact", since = "1.31.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn remainder(&self) -> &'a [T] {
         self.rem
     }
@@ -1897,17 +2122,22 @@ impl<'a, T> ChunksExact<'a, T> {
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[stable(feature = "chunks_exact", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> Clone for ChunksExact<'_, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn clone(&self) -> Self {
         ChunksExact { v: self.v, rem: self.rem, chunk_size: self.chunk_size }
     }
 }
 
 #[stable(feature = "chunks_exact", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> Iterator for ChunksExact<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a [T]> {
         if self.v.len() < self.chunk_size {
             None
@@ -1919,17 +2149,20 @@ impl<'a, T> Iterator for ChunksExact<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let n = self.v.len() / self.chunk_size;
         (n, Some(n))
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn count(self) -> usize {
         self.len()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         let (start, overflow) = n.overflowing_mul(self.chunk_size);
         if start >= self.v.len() || overflow {
@@ -1943,10 +2176,12 @@ impl<'a, T> Iterator for ChunksExact<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn last(mut self) -> Option<Self::Item> {
         self.next_back()
     }
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let start = idx * self.chunk_size;
         // SAFETY: mostly identical to `Chunks::__iterator_get_unchecked`.
@@ -1955,8 +2190,10 @@ impl<'a, T> Iterator for ChunksExact<'a, T> {
 }
 
 #[stable(feature = "chunks_exact", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> DoubleEndedIterator for ChunksExact<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a [T]> {
         if self.v.len() < self.chunk_size {
             None
@@ -1968,6 +2205,7 @@ impl<'a, T> DoubleEndedIterator for ChunksExact<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         let len = self.len();
         if n >= len {
@@ -1984,25 +2222,32 @@ impl<'a, T> DoubleEndedIterator for ChunksExact<'a, T> {
 }
 
 #[stable(feature = "chunks_exact", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> ExactSizeIterator for ChunksExact<'_, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_empty(&self) -> bool {
         self.v.is_empty()
     }
 }
 
 #[unstable(feature = "trusted_len", issue = "37572")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> TrustedLen for ChunksExact<'_, T> {}
 
 #[stable(feature = "chunks_exact", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> FusedIterator for ChunksExact<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccess for ChunksExact<'a, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for ChunksExact<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
@@ -2028,6 +2273,7 @@ unsafe impl<'a, T> TrustedRandomAccessNoCoerce for ChunksExact<'a, T> {
 #[derive(Debug)]
 #[stable(feature = "chunks_exact", since = "1.31.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct ChunksExactMut<'a, T: 'a> {
     /// # Safety
     /// This slice pointer must point at a valid region of `T` with at least length `v.len()`. Normally,
@@ -2041,8 +2287,10 @@ pub struct ChunksExactMut<'a, T: 'a> {
     _marker: PhantomData<&'a mut T>,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> ChunksExactMut<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) const fn new(slice: &'a mut [T], chunk_size: usize) -> Self {
         let rem = slice.len() % chunk_size;
         let fst_len = slice.len() - rem;
@@ -2056,16 +2304,20 @@ impl<'a, T> ChunksExactMut<'a, T> {
     /// elements.
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(feature = "chunks_exact", since = "1.31.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn into_remainder(self) -> &'a mut [T] {
         self.rem
     }
 }
 
 #[stable(feature = "chunks_exact", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> Iterator for ChunksExactMut<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a mut [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a mut [T]> {
         if self.v.len() < self.chunk_size {
             None
@@ -2079,17 +2331,20 @@ impl<'a, T> Iterator for ChunksExactMut<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let n = self.v.len() / self.chunk_size;
         (n, Some(n))
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn count(self) -> usize {
         self.len()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth(&mut self, n: usize) -> Option<&'a mut [T]> {
         let (start, overflow) = n.overflowing_mul(self.chunk_size);
         if start >= self.v.len() || overflow {
@@ -2104,10 +2359,12 @@ impl<'a, T> Iterator for ChunksExactMut<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn last(mut self) -> Option<Self::Item> {
         self.next_back()
     }
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let start = idx * self.chunk_size;
         // SAFETY: see comments for `Chunks::__iterator_get_unchecked` and `self.v`.
@@ -2116,8 +2373,10 @@ impl<'a, T> Iterator for ChunksExactMut<'a, T> {
 }
 
 #[stable(feature = "chunks_exact", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> DoubleEndedIterator for ChunksExactMut<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a mut [T]> {
         if self.v.len() < self.chunk_size {
             None
@@ -2131,6 +2390,7 @@ impl<'a, T> DoubleEndedIterator for ChunksExactMut<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         let len = self.len();
         if n >= len {
@@ -2151,32 +2411,41 @@ impl<'a, T> DoubleEndedIterator for ChunksExactMut<'a, T> {
 }
 
 #[stable(feature = "chunks_exact", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> ExactSizeIterator for ChunksExactMut<'_, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_empty(&self) -> bool {
         self.v.is_empty()
     }
 }
 
 #[unstable(feature = "trusted_len", issue = "37572")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> TrustedLen for ChunksExactMut<'_, T> {}
 
 #[stable(feature = "chunks_exact", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> FusedIterator for ChunksExactMut<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccess for ChunksExactMut<'a, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for ChunksExactMut<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 #[stable(feature = "chunks_exact", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> Send for ChunksExactMut<'_, T> where T: Send {}
 
 #[stable(feature = "chunks_exact", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> Sync for ChunksExactMut<'_, T> where T: Sync {}
 
 /// A windowed iterator over a slice in overlapping chunks (`N` elements at a
@@ -2202,14 +2471,17 @@ unsafe impl<T> Sync for ChunksExactMut<'_, T> where T: Sync {}
 #[derive(Debug, Clone, Copy)]
 #[unstable(feature = "array_windows", issue = "75027")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct ArrayWindows<'a, T: 'a, const N: usize> {
     slice_head: *const T,
     num: usize,
     marker: PhantomData<&'a [T; N]>,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, const N: usize> ArrayWindows<'a, T, N> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) const fn new(slice: &'a [T]) -> Self {
         let num_windows = slice.len().saturating_sub(N - 1);
         Self { slice_head: slice.as_ptr(), num: num_windows, marker: PhantomData }
@@ -2217,10 +2489,13 @@ impl<'a, T: 'a, const N: usize> ArrayWindows<'a, T, N> {
 }
 
 #[unstable(feature = "array_windows", issue = "75027")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, const N: usize> Iterator for ArrayWindows<'a, T, N> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a [T; N];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<Self::Item> {
         if self.num == 0 {
             return None;
@@ -2237,16 +2512,19 @@ impl<'a, T, const N: usize> Iterator for ArrayWindows<'a, T, N> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.num, Some(self.num))
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn count(self) -> usize {
         self.num
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         if self.num <= n {
             self.num = 0;
@@ -2263,14 +2541,17 @@ impl<'a, T, const N: usize> Iterator for ArrayWindows<'a, T, N> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn last(mut self) -> Option<Self::Item> {
         self.nth(self.num.checked_sub(1)?)
     }
 }
 
 #[unstable(feature = "array_windows", issue = "75027")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, const N: usize> DoubleEndedIterator for ArrayWindows<'a, T, N> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a [T; N]> {
         if self.num == 0 {
             return None;
@@ -2282,6 +2563,7 @@ impl<'a, T, const N: usize> DoubleEndedIterator for ArrayWindows<'a, T, N> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth_back(&mut self, n: usize) -> Option<&'a [T; N]> {
         if self.num <= n {
             self.num = 0;
@@ -2295,7 +2577,9 @@ impl<'a, T, const N: usize> DoubleEndedIterator for ArrayWindows<'a, T, N> {
 }
 
 #[unstable(feature = "array_windows", issue = "75027")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, const N: usize> ExactSizeIterator for ArrayWindows<'_, T, N> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_empty(&self) -> bool {
         self.num == 0
     }
@@ -2328,14 +2612,17 @@ impl<T, const N: usize> ExactSizeIterator for ArrayWindows<'_, T, N> {
 #[derive(Debug)]
 #[unstable(feature = "array_chunks", issue = "74985")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct ArrayChunks<'a, T: 'a, const N: usize> {
     iter: Iter<'a, [T; N]>,
     rem: &'a [T],
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, const N: usize> ArrayChunks<'a, T, N> {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) const fn new(slice: &'a [T]) -> Self {
         let (array_slice, rem) = slice.as_chunks();
         Self { iter: array_slice.iter(), rem }
@@ -2346,6 +2633,7 @@ impl<'a, T, const N: usize> ArrayChunks<'a, T, N> {
     /// elements.
     #[must_use]
     #[unstable(feature = "array_chunks", issue = "74985")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn remainder(&self) -> &'a [T] {
         self.rem
     }
@@ -2353,41 +2641,51 @@ impl<'a, T, const N: usize> ArrayChunks<'a, T, N> {
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[unstable(feature = "array_chunks", issue = "74985")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, const N: usize> Clone for ArrayChunks<'_, T, N> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn clone(&self) -> Self {
         ArrayChunks { iter: self.iter.clone(), rem: self.rem }
     }
 }
 
 #[unstable(feature = "array_chunks", issue = "74985")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, const N: usize> Iterator for ArrayChunks<'a, T, N> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a [T; N];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a [T; N]> {
         self.iter.next()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn count(self) -> usize {
         self.iter.count()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         self.iter.nth(n)
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn last(self) -> Option<Self::Item> {
         self.iter.last()
     }
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     unsafe fn __iterator_get_unchecked(&mut self, i: usize) -> &'a [T; N] {
         // SAFETY: The safety guarantees of `__iterator_get_unchecked` are
         // transferred to the caller.
@@ -2396,38 +2694,48 @@ impl<'a, T, const N: usize> Iterator for ArrayChunks<'a, T, N> {
 }
 
 #[unstable(feature = "array_chunks", issue = "74985")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, const N: usize> DoubleEndedIterator for ArrayChunks<'a, T, N> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a [T; N]> {
         self.iter.next_back()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         self.iter.nth_back(n)
     }
 }
 
 #[unstable(feature = "array_chunks", issue = "74985")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, const N: usize> ExactSizeIterator for ArrayChunks<'_, T, N> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_empty(&self) -> bool {
         self.iter.is_empty()
     }
 }
 
 #[unstable(feature = "trusted_len", issue = "37572")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T, const N: usize> TrustedLen for ArrayChunks<'_, T, N> {}
 
 #[unstable(feature = "array_chunks", issue = "74985")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, const N: usize> FusedIterator for ArrayChunks<'_, T, N> {}
 
 #[doc(hidden)]
 #[unstable(feature = "array_chunks", issue = "74985")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T, const N: usize> TrustedRandomAccess for ArrayChunks<'a, T, N> {}
 
 #[doc(hidden)]
 #[unstable(feature = "array_chunks", issue = "74985")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T, const N: usize> TrustedRandomAccessNoCoerce for ArrayChunks<'a, T, N> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
@@ -2455,14 +2763,17 @@ unsafe impl<'a, T, const N: usize> TrustedRandomAccessNoCoerce for ArrayChunks<'
 #[derive(Debug)]
 #[unstable(feature = "array_chunks", issue = "74985")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct ArrayChunksMut<'a, T: 'a, const N: usize> {
     iter: IterMut<'a, [T; N]>,
     rem: &'a mut [T],
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, const N: usize> ArrayChunksMut<'a, T, N> {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) const fn new(slice: &'a mut [T]) -> Self {
         let (array_slice, rem) = slice.as_chunks_mut();
         Self { iter: array_slice.iter_mut(), rem }
@@ -2473,40 +2784,49 @@ impl<'a, T, const N: usize> ArrayChunksMut<'a, T, N> {
     /// elements.
     #[must_use = "`self` will be dropped if the result is not used"]
     #[unstable(feature = "array_chunks", issue = "74985")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn into_remainder(self) -> &'a mut [T] {
         self.rem
     }
 }
 
 #[unstable(feature = "array_chunks", issue = "74985")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, const N: usize> Iterator for ArrayChunksMut<'a, T, N> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a mut [T; N];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a mut [T; N]> {
         self.iter.next()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn count(self) -> usize {
         self.iter.count()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         self.iter.nth(n)
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn last(self) -> Option<Self::Item> {
         self.iter.last()
     }
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     unsafe fn __iterator_get_unchecked(&mut self, i: usize) -> &'a mut [T; N] {
         // SAFETY: The safety guarantees of `__iterator_get_unchecked` are transferred to
         // the caller.
@@ -2515,38 +2835,48 @@ impl<'a, T, const N: usize> Iterator for ArrayChunksMut<'a, T, N> {
 }
 
 #[unstable(feature = "array_chunks", issue = "74985")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T, const N: usize> DoubleEndedIterator for ArrayChunksMut<'a, T, N> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a mut [T; N]> {
         self.iter.next_back()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         self.iter.nth_back(n)
     }
 }
 
 #[unstable(feature = "array_chunks", issue = "74985")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, const N: usize> ExactSizeIterator for ArrayChunksMut<'_, T, N> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_empty(&self) -> bool {
         self.iter.is_empty()
     }
 }
 
 #[unstable(feature = "trusted_len", issue = "37572")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T, const N: usize> TrustedLen for ArrayChunksMut<'_, T, N> {}
 
 #[unstable(feature = "array_chunks", issue = "74985")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, const N: usize> FusedIterator for ArrayChunksMut<'_, T, N> {}
 
 #[doc(hidden)]
 #[unstable(feature = "array_chunks", issue = "74985")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T, const N: usize> TrustedRandomAccess for ArrayChunksMut<'a, T, N> {}
 
 #[doc(hidden)]
 #[unstable(feature = "array_chunks", issue = "74985")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T, const N: usize> TrustedRandomAccessNoCoerce for ArrayChunksMut<'a, T, N> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
@@ -2574,13 +2904,16 @@ unsafe impl<'a, T, const N: usize> TrustedRandomAccessNoCoerce for ArrayChunksMu
 #[derive(Debug)]
 #[stable(feature = "rchunks", since = "1.31.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct RChunks<'a, T: 'a> {
     v: &'a [T],
     chunk_size: usize,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a> RChunks<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) const fn new(slice: &'a [T], size: usize) -> Self {
         Self { v: slice, chunk_size: size }
     }
@@ -2588,17 +2921,22 @@ impl<'a, T: 'a> RChunks<'a, T> {
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> Clone for RChunks<'_, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn clone(&self) -> Self {
         RChunks { v: self.v, chunk_size: self.chunk_size }
     }
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> Iterator for RChunks<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a [T]> {
         if self.v.is_empty() {
             None
@@ -2617,6 +2955,7 @@ impl<'a, T> Iterator for RChunks<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.v.is_empty() {
             (0, Some(0))
@@ -2629,11 +2968,13 @@ impl<'a, T> Iterator for RChunks<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn count(self) -> usize {
         self.len()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         let (end, overflow) = n.overflowing_mul(self.chunk_size);
         if end >= self.v.len() || overflow {
@@ -2653,6 +2994,7 @@ impl<'a, T> Iterator for RChunks<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn last(self) -> Option<Self::Item> {
         if self.v.is_empty() {
             None
@@ -2663,6 +3005,7 @@ impl<'a, T> Iterator for RChunks<'a, T> {
         }
     }
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let end = self.v.len() - idx * self.chunk_size;
         let start = match end.checked_sub(self.chunk_size) {
@@ -2675,8 +3018,10 @@ impl<'a, T> Iterator for RChunks<'a, T> {
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> DoubleEndedIterator for RChunks<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a [T]> {
         if self.v.is_empty() {
             None
@@ -2691,6 +3036,7 @@ impl<'a, T> DoubleEndedIterator for RChunks<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         let len = self.len();
         if n >= len {
@@ -2709,21 +3055,27 @@ impl<'a, T> DoubleEndedIterator for RChunks<'a, T> {
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> ExactSizeIterator for RChunks<'_, T> {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> TrustedLen for RChunks<'_, T> {}
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> FusedIterator for RChunks<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccess for RChunks<'a, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for RChunks<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
@@ -2747,6 +3099,7 @@ unsafe impl<'a, T> TrustedRandomAccessNoCoerce for RChunks<'a, T> {
 #[derive(Debug)]
 #[stable(feature = "rchunks", since = "1.31.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct RChunksMut<'a, T: 'a> {
     /// # Safety
     /// This slice pointer must point at a valid region of `T` with at least length `v.len()`. Normally,
@@ -2759,18 +3112,23 @@ pub struct RChunksMut<'a, T: 'a> {
     _marker: PhantomData<&'a mut T>,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a> RChunksMut<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) const fn new(slice: &'a mut [T], size: usize) -> Self {
         Self { v: slice, chunk_size: size, _marker: PhantomData }
     }
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> Iterator for RChunksMut<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a mut [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a mut [T]> {
         if self.v.is_empty() {
             None
@@ -2790,6 +3148,7 @@ impl<'a, T> Iterator for RChunksMut<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.v.is_empty() {
             (0, Some(0))
@@ -2802,11 +3161,13 @@ impl<'a, T> Iterator for RChunksMut<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn count(self) -> usize {
         self.len()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth(&mut self, n: usize) -> Option<&'a mut [T]> {
         let (end, overflow) = n.overflowing_mul(self.chunk_size);
         if end >= self.v.len() || overflow {
@@ -2832,6 +3193,7 @@ impl<'a, T> Iterator for RChunksMut<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn last(self) -> Option<Self::Item> {
         if self.v.is_empty() {
             None
@@ -2843,6 +3205,7 @@ impl<'a, T> Iterator for RChunksMut<'a, T> {
         }
     }
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let end = self.v.len() - idx * self.chunk_size;
         let start = match end.checked_sub(self.chunk_size) {
@@ -2856,8 +3219,10 @@ impl<'a, T> Iterator for RChunksMut<'a, T> {
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> DoubleEndedIterator for RChunksMut<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a mut [T]> {
         if self.v.is_empty() {
             None
@@ -2873,6 +3238,7 @@ impl<'a, T> DoubleEndedIterator for RChunksMut<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         let len = self.len();
         if n >= len {
@@ -2895,28 +3261,36 @@ impl<'a, T> DoubleEndedIterator for RChunksMut<'a, T> {
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> ExactSizeIterator for RChunksMut<'_, T> {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> TrustedLen for RChunksMut<'_, T> {}
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> FusedIterator for RChunksMut<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccess for RChunksMut<'a, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for RChunksMut<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> Send for RChunksMut<'_, T> where T: Send {}
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> Sync for RChunksMut<'_, T> where T: Sync {}
 
 /// An iterator over a slice in (non-overlapping) chunks (`chunk_size` elements at a
@@ -2944,14 +3318,17 @@ unsafe impl<T> Sync for RChunksMut<'_, T> where T: Sync {}
 #[derive(Debug)]
 #[stable(feature = "rchunks", since = "1.31.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct RChunksExact<'a, T: 'a> {
     v: &'a [T],
     rem: &'a [T],
     chunk_size: usize,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> RChunksExact<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) const fn new(slice: &'a [T], chunk_size: usize) -> Self {
         let rem = slice.len() % chunk_size;
         // SAFETY: 0 <= rem <= slice.len() by construction above
@@ -2979,6 +3356,7 @@ impl<'a, T> RChunksExact<'a, T> {
     #[must_use]
     #[stable(feature = "rchunks", since = "1.31.0")]
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn remainder(&self) -> &'a [T] {
         self.rem
     }
@@ -2986,17 +3364,22 @@ impl<'a, T> RChunksExact<'a, T> {
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> Clone for RChunksExact<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn clone(&self) -> RChunksExact<'a, T> {
         RChunksExact { v: self.v, rem: self.rem, chunk_size: self.chunk_size }
     }
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> Iterator for RChunksExact<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a [T]> {
         if self.v.len() < self.chunk_size {
             None
@@ -3008,17 +3391,20 @@ impl<'a, T> Iterator for RChunksExact<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let n = self.v.len() / self.chunk_size;
         (n, Some(n))
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn count(self) -> usize {
         self.len()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         let (end, overflow) = n.overflowing_mul(self.chunk_size);
         if end >= self.v.len() || overflow {
@@ -3032,10 +3418,12 @@ impl<'a, T> Iterator for RChunksExact<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn last(mut self) -> Option<Self::Item> {
         self.next_back()
     }
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let end = self.v.len() - idx * self.chunk_size;
         let start = end - self.chunk_size;
@@ -3045,8 +3433,10 @@ impl<'a, T> Iterator for RChunksExact<'a, T> {
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> DoubleEndedIterator for RChunksExact<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a [T]> {
         if self.v.len() < self.chunk_size {
             None
@@ -3058,6 +3448,7 @@ impl<'a, T> DoubleEndedIterator for RChunksExact<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         let len = self.len();
         if n >= len {
@@ -3077,25 +3468,32 @@ impl<'a, T> DoubleEndedIterator for RChunksExact<'a, T> {
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> ExactSizeIterator for RChunksExact<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_empty(&self) -> bool {
         self.v.is_empty()
     }
 }
 
 #[unstable(feature = "trusted_len", issue = "37572")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> TrustedLen for RChunksExact<'_, T> {}
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> FusedIterator for RChunksExact<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccess for RChunksExact<'a, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for RChunksExact<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
@@ -3121,6 +3519,7 @@ unsafe impl<'a, T> TrustedRandomAccessNoCoerce for RChunksExact<'a, T> {
 #[derive(Debug)]
 #[stable(feature = "rchunks", since = "1.31.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct RChunksExactMut<'a, T: 'a> {
     /// # Safety
     /// This slice pointer must point at a valid region of `T` with at least length `v.len()`. Normally,
@@ -3133,8 +3532,10 @@ pub struct RChunksExactMut<'a, T: 'a> {
     chunk_size: usize,
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> RChunksExactMut<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) const fn new(slice: &'a mut [T], chunk_size: usize) -> Self {
         let rem = slice.len() % chunk_size;
         // SAFETY: 0 <= rem <= slice.len() by construction above
@@ -3148,16 +3549,20 @@ impl<'a, T> RChunksExactMut<'a, T> {
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(feature = "rchunks", since = "1.31.0")]
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn into_remainder(self) -> &'a mut [T] {
         self.rem
     }
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> Iterator for RChunksExactMut<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a mut [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<&'a mut [T]> {
         if self.v.len() < self.chunk_size {
             None
@@ -3172,17 +3577,20 @@ impl<'a, T> Iterator for RChunksExactMut<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let n = self.v.len() / self.chunk_size;
         (n, Some(n))
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn count(self) -> usize {
         self.len()
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth(&mut self, n: usize) -> Option<&'a mut [T]> {
         let (end, overflow) = n.overflowing_mul(self.chunk_size);
         if end >= self.v.len() || overflow {
@@ -3198,10 +3606,12 @@ impl<'a, T> Iterator for RChunksExactMut<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn last(mut self) -> Option<Self::Item> {
         self.next_back()
     }
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
         let end = self.v.len() - idx * self.chunk_size;
         let start = end - self.chunk_size;
@@ -3211,8 +3621,10 @@ impl<'a, T> Iterator for RChunksExactMut<'a, T> {
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T> DoubleEndedIterator for RChunksExactMut<'a, T> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<&'a mut [T]> {
         if self.v.len() < self.chunk_size {
             None
@@ -3226,6 +3638,7 @@ impl<'a, T> DoubleEndedIterator for RChunksExactMut<'a, T> {
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         let len = self.len();
         if n >= len {
@@ -3249,51 +3662,66 @@ impl<'a, T> DoubleEndedIterator for RChunksExactMut<'a, T> {
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> ExactSizeIterator for RChunksExactMut<'_, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_empty(&self) -> bool {
         self.v.is_empty()
     }
 }
 
 #[unstable(feature = "trusted_len", issue = "37572")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> TrustedLen for RChunksExactMut<'_, T> {}
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> FusedIterator for RChunksExactMut<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccess for RChunksExactMut<'a, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for RChunksExactMut<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> Send for RChunksExactMut<'_, T> where T: Send {}
 
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<T> Sync for RChunksExactMut<'_, T> where T: Sync {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccess for Iter<'a, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for Iter<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccess for IterMut<'a, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for IterMut<'a, T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
@@ -3305,26 +3733,32 @@ unsafe impl<'a, T> TrustedRandomAccessNoCoerce for IterMut<'a, T> {
 /// [slices]: slice
 #[stable(feature = "slice_group_by", since = "1.77.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct ChunkBy<'a, T: 'a, P> {
     slice: &'a [T],
     predicate: P,
 }
 
 #[stable(feature = "slice_group_by", since = "1.77.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P> ChunkBy<'a, T, P> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) const fn new(slice: &'a [T], predicate: P) -> Self {
         ChunkBy { slice, predicate }
     }
 }
 
 #[stable(feature = "slice_group_by", since = "1.77.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P> Iterator for ChunkBy<'a, T, P>
 where
     P: FnMut(&T, &T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<Self::Item> {
         if self.slice.is_empty() {
             None
@@ -3341,22 +3775,26 @@ where
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.slice.is_empty() { (0, Some(0)) } else { (1, Some(self.slice.len())) }
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn last(mut self) -> Option<Self::Item> {
         self.next_back()
     }
 }
 
 #[stable(feature = "slice_group_by", since = "1.77.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P> DoubleEndedIterator for ChunkBy<'a, T, P>
 where
     P: FnMut(&T, &T) -> bool,
 {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.slice.is_empty() {
             None
@@ -3374,10 +3812,13 @@ where
 }
 
 #[stable(feature = "slice_group_by", since = "1.77.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P> FusedIterator for ChunkBy<'a, T, P> where P: FnMut(&T, &T) -> bool {}
 
 #[stable(feature = "slice_group_by", since = "1.77.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a + fmt::Debug, P> fmt::Debug for ChunkBy<'a, T, P> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ChunkBy").field("slice", &self.slice).finish()
     }
@@ -3392,26 +3833,32 @@ impl<'a, T: 'a + fmt::Debug, P> fmt::Debug for ChunkBy<'a, T, P> {
 /// [slices]: slice
 #[stable(feature = "slice_group_by", since = "1.77.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct ChunkByMut<'a, T: 'a, P> {
     slice: &'a mut [T],
     predicate: P,
 }
 
 #[stable(feature = "slice_group_by", since = "1.77.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P> ChunkByMut<'a, T, P> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub(super) const fn new(slice: &'a mut [T], predicate: P) -> Self {
         ChunkByMut { slice, predicate }
     }
 }
 
 #[stable(feature = "slice_group_by", since = "1.77.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P> Iterator for ChunkByMut<'a, T, P>
 where
     P: FnMut(&T, &T) -> bool,
 {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = &'a mut [T];
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next(&mut self) -> Option<Self::Item> {
         if self.slice.is_empty() {
             None
@@ -3429,22 +3876,26 @@ where
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.slice.is_empty() { (0, Some(0)) } else { (1, Some(self.slice.len())) }
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn last(mut self) -> Option<Self::Item> {
         self.next_back()
     }
 }
 
 #[stable(feature = "slice_group_by", since = "1.77.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P> DoubleEndedIterator for ChunkByMut<'a, T, P>
 where
     P: FnMut(&T, &T) -> bool,
 {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.slice.is_empty() {
             None
@@ -3463,10 +3914,13 @@ where
 }
 
 #[stable(feature = "slice_group_by", since = "1.77.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a, P> FusedIterator for ChunkByMut<'a, T, P> where P: FnMut(&T, &T) -> bool {}
 
 #[stable(feature = "slice_group_by", since = "1.77.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a, T: 'a + fmt::Debug, P> fmt::Debug for ChunkByMut<'a, T, P> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ChunkByMut").field("slice", &self.slice).finish()
     }

--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -7,6 +7,7 @@
 /// Internally, this reads the `end` through a pointer-to-`NonNull` so that
 /// it'll get the appropriate non-null metadata in the backend without needing
 /// to call `assume` manually.
+#[cfg(not(feature = "ferrocene_certified"))]
 macro_rules! if_zst {
     (mut $this:ident, $len:ident => $zst_body:expr, $end:ident => $other_body:expr,) => {{
         #![allow(unused_unsafe)] // we're sometimes used within an unsafe block
@@ -37,6 +38,7 @@ macro_rules! if_zst {
 }
 
 // Inlining is_empty and len makes a huge performance difference
+#[cfg(not(feature = "ferrocene_certified"))]
 macro_rules! is_empty {
     ($self: ident) => {
         if_zst!($self,
@@ -46,6 +48,7 @@ macro_rules! is_empty {
     };
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 macro_rules! len {
     ($self: ident) => {{
         if_zst!($self,
@@ -70,6 +73,7 @@ macro_rules! iterator {
         $into_ref:ident,
         {$($extra:tt)*}
     ) => {
+        #[cfg(not(feature = "ferrocene_certified"))]
         impl<'a, T> $name<'a, T> {
             /// Returns the last element and moves the end of the iterator backwards by 1.
             ///
@@ -135,6 +139,7 @@ macro_rules! iterator {
             }
         }
 
+        #[cfg(not(feature = "ferrocene_certified"))]
         #[stable(feature = "rust1", since = "1.0.0")]
         impl<T> ExactSizeIterator for $name<'_, T> {
             #[inline(always)]
@@ -191,17 +196,20 @@ macro_rules! iterator {
             }
 
             #[inline]
+            #[cfg(not(feature = "ferrocene_certified"))]
             fn size_hint(&self) -> (usize, Option<usize>) {
                 let exact = len!(self);
                 (exact, Some(exact))
             }
 
             #[inline]
+            #[cfg(not(feature = "ferrocene_certified"))]
             fn count(self) -> usize {
                 len!(self)
             }
 
             #[inline]
+            #[cfg(not(feature = "ferrocene_certified"))]
             fn nth(&mut self, n: usize) -> Option<$elem> {
                 if n >= len!(self) {
                     // This iterator is now empty.
@@ -219,6 +227,7 @@ macro_rules! iterator {
             }
 
             #[inline]
+            #[cfg(not(feature = "ferrocene_certified"))]
             fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
                 let advance = cmp::min(len!(self), n);
                 // SAFETY: By construction, `advance` does not exceed `self.len()`.
@@ -227,11 +236,13 @@ macro_rules! iterator {
             }
 
             #[inline]
+            #[cfg(not(feature = "ferrocene_certified"))]
             fn last(mut self) -> Option<$elem> {
                 self.next_back()
             }
 
             #[inline]
+            #[cfg(not(feature = "ferrocene_certified"))]
             fn fold<B, F>(self, init: B, mut f: F) -> B
                 where
                     F: FnMut(B, Self::Item) -> B,
@@ -268,6 +279,7 @@ macro_rules! iterator {
             // because this simple implementation generates less LLVM IR and is
             // faster to compile.
             #[inline]
+            #[cfg(not(feature = "ferrocene_certified"))]
             fn for_each<F>(mut self, mut f: F)
             where
                 Self: Sized,
@@ -282,6 +294,7 @@ macro_rules! iterator {
             // because this simple implementation generates less LLVM IR and is
             // faster to compile.
             #[inline]
+            #[cfg(not(feature = "ferrocene_certified"))]
             fn all<F>(&mut self, mut f: F) -> bool
             where
                 Self: Sized,
@@ -299,6 +312,7 @@ macro_rules! iterator {
             // because this simple implementation generates less LLVM IR and is
             // faster to compile.
             #[inline]
+            #[cfg(not(feature = "ferrocene_certified"))]
             fn any<F>(&mut self, mut f: F) -> bool
             where
                 Self: Sized,
@@ -316,6 +330,7 @@ macro_rules! iterator {
             // because this simple implementation generates less LLVM IR and is
             // faster to compile.
             #[inline]
+            #[cfg(not(feature = "ferrocene_certified"))]
             fn find<P>(&mut self, mut predicate: P) -> Option<Self::Item>
             where
                 Self: Sized,
@@ -333,6 +348,7 @@ macro_rules! iterator {
             // because this simple implementation generates less LLVM IR and is
             // faster to compile.
             #[inline]
+            #[cfg(not(feature = "ferrocene_certified"))]
             fn find_map<B, F>(&mut self, mut f: F) -> Option<B>
             where
                 Self: Sized,
@@ -351,6 +367,7 @@ macro_rules! iterator {
             // faster to compile. Also, the `assume` avoids a bounds check.
             #[inline]
             #[rustc_inherit_overflow_checks]
+            #[cfg(not(feature = "ferrocene_certified"))]
             fn position<P>(&mut self, mut predicate: P) -> Option<usize> where
                 Self: Sized,
                 P: FnMut(Self::Item) -> bool,
@@ -373,6 +390,7 @@ macro_rules! iterator {
             // because this simple implementation generates less LLVM IR and is
             // faster to compile. Also, the `assume` avoids a bounds check.
             #[inline]
+            #[cfg(not(feature = "ferrocene_certified"))]
             fn rposition<P>(&mut self, mut predicate: P) -> Option<usize> where
                 P: FnMut(Self::Item) -> bool,
                 Self: Sized + ExactSizeIterator + DoubleEndedIterator
@@ -392,6 +410,7 @@ macro_rules! iterator {
             }
 
             #[inline]
+            #[cfg(not(feature = "ferrocene_certified"))]
             unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
                 // SAFETY: the caller must guarantee that `i` is in bounds of
                 // the underlying slice, so `i` cannot overflow an `isize`, and
@@ -410,6 +429,7 @@ macro_rules! iterator {
         }
 
         #[stable(feature = "rust1", since = "1.0.0")]
+        #[cfg(not(feature = "ferrocene_certified"))]
         impl<'a, T> DoubleEndedIterator for $name<'a, T> {
             #[inline]
             fn next_back(&mut self) -> Option<$elem> {
@@ -427,6 +447,7 @@ macro_rules! iterator {
             }
 
             #[inline]
+            #[cfg(not(feature = "ferrocene_certified"))]
             fn nth_back(&mut self, n: usize) -> Option<$elem> {
                 if n >= len!(self) {
                     // This iterator is now empty.
@@ -444,6 +465,7 @@ macro_rules! iterator {
             }
 
             #[inline]
+            #[cfg(not(feature = "ferrocene_certified"))]
             fn advance_back_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
                 let advance = cmp::min(len!(self), n);
                 // SAFETY: By construction, `advance` does not exceed `self.len()`.
@@ -453,11 +475,14 @@ macro_rules! iterator {
         }
 
         #[stable(feature = "fused", since = "1.26.0")]
+        #[cfg(not(feature = "ferrocene_certified"))]
         impl<T> FusedIterator for $name<'_, T> {}
 
         #[unstable(feature = "trusted_len", issue = "37572")]
+        #[cfg(not(feature = "ferrocene_certified"))]
         unsafe impl<T> TrustedLen for $name<'_, T> {}
 
+        #[cfg(not(feature = "ferrocene_certified"))]
         impl<'a, T> UncheckedIterator for $name<'a, T> {
             #[inline]
             unsafe fn next_unchecked(&mut self) -> $elem {
@@ -469,6 +494,7 @@ macro_rules! iterator {
         }
 
         #[stable(feature = "default_iters", since = "1.70.0")]
+        #[cfg(not(feature = "ferrocene_certified"))]
         impl<T> Default for $name<'_, T> {
             /// Creates an empty slice iterator.
             ///
@@ -484,6 +510,7 @@ macro_rules! iterator {
     }
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 macro_rules! forward_iterator {
     ($name:ident: $elem:ident, $iter_of:ty) => {
         #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -6,15 +6,25 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::cmp::Ordering::{self, Equal, Greater, Less};
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::intrinsics::{exact_div, unchecked_sub};
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::mem::{self, MaybeUninit, SizedTypeProperties};
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::num::NonZero;
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::ops::{OneSidedRange, OneSidedRangeBound, Range, RangeBounds, RangeInclusive};
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::panic::const_panic;
+use crate::ptr;
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::simd::{self, Simd};
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::ub_checks::assert_unsafe_precondition;
-use crate::{fmt, hint, ptr, range, slice};
+#[cfg(not(feature = "ferrocene_certified"))]
+use crate::{fmt, hint, range, slice};
 
 #[unstable(
     feature = "slice_internals",
@@ -22,6 +32,7 @@ use crate::{fmt, hint, ptr, range, slice};
     reason = "exposed from core to be reused in std; use the memchr crate"
 )]
 /// Pure Rust memchr implementation, taken from rust-memchr
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod memchr;
 
 #[unstable(
@@ -30,50 +41,76 @@ pub mod memchr;
     reason = "exposed from core to be reused in std;"
 )]
 #[doc(hidden)]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod sort;
 
+#[cfg(not(feature = "ferrocene_certified"))]
 mod ascii;
+#[cfg(not(feature = "ferrocene_certified"))]
 mod cmp;
+#[cfg(not(feature = "ferrocene_certified"))]
 pub(crate) mod index;
 mod iter;
+#[cfg(not(feature = "ferrocene_certified"))]
 mod raw;
+#[cfg(not(feature = "ferrocene_certified"))]
 mod rotate;
+#[cfg(not(feature = "ferrocene_certified"))]
 mod specialize;
 
 #[stable(feature = "inherent_ascii_escape", since = "1.60.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use ascii::EscapeAscii;
 #[unstable(feature = "str_internals", issue = "none")]
 #[doc(hidden)]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use ascii::is_ascii_simple;
 #[stable(feature = "slice_get_slice", since = "1.28.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use index::SliceIndex;
 #[unstable(feature = "slice_range", issue = "76393")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use index::{range, try_range};
 #[unstable(feature = "array_windows", issue = "75027")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use iter::ArrayWindows;
+#[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
+pub use iter::Iter;
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use iter::IterMut;
 #[unstable(feature = "array_chunks", issue = "74985")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use iter::{ArrayChunks, ArrayChunksMut};
 #[stable(feature = "slice_group_by", since = "1.77.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use iter::{ChunkBy, ChunkByMut};
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use iter::{Chunks, ChunksMut, Windows};
 #[stable(feature = "chunks_exact", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use iter::{ChunksExact, ChunksExactMut};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use iter::{Iter, IterMut};
 #[stable(feature = "rchunks", since = "1.31.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use iter::{RChunks, RChunksExact, RChunksExactMut, RChunksMut};
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use iter::{RSplit, RSplitMut};
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use iter::{RSplitN, RSplitNMut, Split, SplitMut, SplitN, SplitNMut};
 #[stable(feature = "split_inclusive", since = "1.51.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use iter::{SplitInclusive, SplitInclusiveMut};
 #[stable(feature = "from_ref", since = "1.28.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use raw::{from_mut, from_ref};
 #[unstable(feature = "slice_from_ptr_range", issue = "89792")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use raw::{from_mut_ptr_range, from_ptr_range};
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub use raw::{from_raw_parts, from_raw_parts_mut};
 
 /// Calculates the direction and split point of a one-sided range.
@@ -82,6 +119,7 @@ pub use raw::{from_raw_parts, from_raw_parts_mut};
 /// the direction of the split (front or back) as well as the index at
 /// which to split. Returns `None` if the split index would overflow.
 #[inline]
+#[cfg(not(feature = "ferrocene_certified"))]
 fn split_point_of(range: impl OneSidedRange<usize>) -> Option<(Direction, usize)> {
     use OneSidedRangeBound::{End, EndInclusive, StartInclusive};
 
@@ -92,6 +130,7 @@ fn split_point_of(range: impl OneSidedRange<usize>) -> Option<(Direction, usize)
     })
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 enum Direction {
     Front,
     Back,
@@ -111,7 +150,6 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_slice_len", since = "1.39.0")]
     #[cfg_attr(not(bootstrap), rustc_no_implicit_autorefs)]
     #[inline]
-    #[must_use]
     pub const fn len(&self) -> usize {
         ptr::metadata(self)
     }
@@ -132,6 +170,7 @@ impl<T> [T] {
     #[cfg_attr(not(bootstrap), rustc_no_implicit_autorefs)]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -151,6 +190,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_slice_first_last_not_mut", since = "1.56.0")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn first(&self) -> Option<&T> {
         if let [first, ..] = self { Some(first) } else { None }
     }
@@ -174,6 +214,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_slice_first_last", since = "1.83.0")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn first_mut(&mut self) -> Option<&mut T> {
         if let [first, ..] = self { Some(first) } else { None }
     }
@@ -194,6 +235,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_slice_first_last_not_mut", since = "1.56.0")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_first(&self) -> Option<(&T, &[T])> {
         if let [first, tail @ ..] = self { Some((first, tail)) } else { None }
     }
@@ -216,6 +258,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_slice_first_last", since = "1.83.0")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_first_mut(&mut self) -> Option<(&mut T, &mut [T])> {
         if let [first, tail @ ..] = self { Some((first, tail)) } else { None }
     }
@@ -236,6 +279,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_slice_first_last_not_mut", since = "1.56.0")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_last(&self) -> Option<(&T, &[T])> {
         if let [init @ .., last] = self { Some((last, init)) } else { None }
     }
@@ -258,6 +302,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_slice_first_last", since = "1.83.0")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_last_mut(&mut self) -> Option<(&mut T, &mut [T])> {
         if let [init @ .., last] = self { Some((last, init)) } else { None }
     }
@@ -277,6 +322,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_slice_first_last_not_mut", since = "1.56.0")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn last(&self) -> Option<&T> {
         if let [.., last] = self { Some(last) } else { None }
     }
@@ -300,6 +346,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_slice_first_last", since = "1.83.0")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn last_mut(&mut self) -> Option<&mut T> {
         if let [.., last] = self { Some(last) } else { None }
     }
@@ -323,6 +370,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "slice_first_last_chunk", since = "1.77.0")]
     #[rustc_const_stable(feature = "slice_first_last_chunk", since = "1.77.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn first_chunk<const N: usize>(&self) -> Option<&[T; N]> {
         if self.len() < N {
             None
@@ -353,6 +401,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "slice_first_last_chunk", since = "1.77.0")]
     #[rustc_const_stable(feature = "const_slice_first_last_chunk", since = "1.83.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn first_chunk_mut<const N: usize>(&mut self) -> Option<&mut [T; N]> {
         if self.len() < N {
             None
@@ -383,6 +432,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "slice_first_last_chunk", since = "1.77.0")]
     #[rustc_const_stable(feature = "slice_first_last_chunk", since = "1.77.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_first_chunk<const N: usize>(&self) -> Option<(&[T; N], &[T])> {
         let Some((first, tail)) = self.split_at_checked(N) else { return None };
 
@@ -413,6 +463,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "slice_first_last_chunk", since = "1.77.0")]
     #[rustc_const_stable(feature = "const_slice_first_last_chunk", since = "1.83.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_first_chunk_mut<const N: usize>(
         &mut self,
     ) -> Option<(&mut [T; N], &mut [T])> {
@@ -443,6 +494,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "slice_first_last_chunk", since = "1.77.0")]
     #[rustc_const_stable(feature = "slice_first_last_chunk", since = "1.77.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_last_chunk<const N: usize>(&self) -> Option<(&[T], &[T; N])> {
         let Some(index) = self.len().checked_sub(N) else { return None };
         let (init, last) = self.split_at(index);
@@ -474,6 +526,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "slice_first_last_chunk", since = "1.77.0")]
     #[rustc_const_stable(feature = "const_slice_first_last_chunk", since = "1.83.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_last_chunk_mut<const N: usize>(
         &mut self,
     ) -> Option<(&mut [T], &mut [T; N])> {
@@ -505,6 +558,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "slice_first_last_chunk", since = "1.77.0")]
     #[rustc_const_stable(feature = "const_slice_last_chunk", since = "1.80.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn last_chunk<const N: usize>(&self) -> Option<&[T; N]> {
         // FIXME(const-hack): Without const traits, we need this instead of `get`.
         let Some(index) = self.len().checked_sub(N) else { return None };
@@ -535,6 +589,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "slice_first_last_chunk", since = "1.77.0")]
     #[rustc_const_stable(feature = "const_slice_first_last_chunk", since = "1.83.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn last_chunk_mut<const N: usize>(&mut self) -> Option<&mut [T; N]> {
         // FIXME(const-hack): Without const traits, we need this instead of `get`.
         let Some(index) = self.len().checked_sub(N) else { return None };
@@ -567,6 +622,7 @@ impl<T> [T] {
     #[cfg_attr(not(bootstrap), rustc_no_implicit_autorefs)]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn get<I>(&self, index: I) -> Option<&I::Output>
     where
         I: SliceIndex<Self>,
@@ -593,6 +649,7 @@ impl<T> [T] {
     #[cfg_attr(not(bootstrap), rustc_no_implicit_autorefs)]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn get_mut<I>(&mut self, index: I) -> Option<&mut I::Output>
     where
         I: SliceIndex<Self>,
@@ -631,6 +688,7 @@ impl<T> [T] {
     #[cfg_attr(not(bootstrap), rustc_no_implicit_autorefs)]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub unsafe fn get_unchecked<I>(&self, index: I) -> &I::Output
     where
         I: SliceIndex<Self>,
@@ -674,6 +732,7 @@ impl<T> [T] {
     #[cfg_attr(not(bootstrap), rustc_no_implicit_autorefs)]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub unsafe fn get_unchecked_mut<I>(&mut self, index: I) -> &mut I::Output
     where
         I: SliceIndex<Self>,
@@ -716,6 +775,7 @@ impl<T> [T] {
     #[rustc_as_ptr]
     #[inline(always)]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_ptr(&self) -> *const T {
         self as *const [T] as *const T
     }
@@ -747,6 +807,7 @@ impl<T> [T] {
     #[rustc_as_ptr]
     #[inline(always)]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_mut_ptr(&mut self) -> *mut T {
         self as *mut [T] as *mut T
     }
@@ -783,6 +844,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_ptr_range(&self) -> Range<*const T> {
         let start = self.as_ptr();
         // SAFETY: The `add` here is safe, because:
@@ -826,6 +888,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_mut_ptr_range(&mut self) -> Range<*mut T> {
         let start = self.as_mut_ptr();
         // SAFETY: See as_ptr_range() above for why `add` here is safe.
@@ -839,6 +902,7 @@ impl<T> [T] {
     #[unstable(feature = "slice_as_array", issue = "133508")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_array<const N: usize>(&self) -> Option<&[T; N]> {
         if self.len() == N {
             let ptr = self.as_ptr() as *const [T; N];
@@ -857,6 +921,7 @@ impl<T> [T] {
     #[unstable(feature = "slice_as_array", issue = "133508")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_mut_array<const N: usize>(&mut self) -> Option<&mut [T; N]> {
         if self.len() == N {
             let ptr = self.as_mut_ptr() as *mut [T; N];
@@ -893,6 +958,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_swap", since = "1.85.0")]
     #[inline]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn swap(&mut self, a: usize, b: usize) {
         // FIXME: use swap_unchecked here (https://github.com/rust-lang/rust/pull/88540#issuecomment-944344343)
         // Can't take two mutable loans from one vector, so instead use raw pointers.
@@ -935,6 +1001,7 @@ impl<T> [T] {
     /// [`swap`]: slice::swap
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     #[unstable(feature = "slice_swap_unchecked", issue = "88539")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn swap_unchecked(&mut self, a: usize, b: usize) {
         assert_unsafe_precondition!(
             check_library_ub,
@@ -965,6 +1032,7 @@ impl<T> [T] {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature = "const_slice_reverse", issue = "135120")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn reverse(&mut self) {
         let half_len = self.len() / 2;
         let Range { start, end } = self.as_mut_ptr_range();
@@ -1026,6 +1094,7 @@ impl<T> [T] {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
     #[rustc_diagnostic_item = "slice_iter"]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn iter(&self) -> Iter<'_, T> {
         Iter::new(self)
     }
@@ -1101,6 +1170,7 @@ impl<T> [T] {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn windows(&self, size: usize) -> Windows<'_, T> {
         let size = NonZero::new(size).expect("window size must be non-zero");
         Windows::new(self, size)
@@ -1137,6 +1207,7 @@ impl<T> [T] {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn chunks(&self, chunk_size: usize) -> Chunks<'_, T> {
         assert!(chunk_size != 0, "chunk size must be non-zero");
         Chunks::new(self, chunk_size)
@@ -1177,6 +1248,7 @@ impl<T> [T] {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn chunks_mut(&mut self, chunk_size: usize) -> ChunksMut<'_, T> {
         assert!(chunk_size != 0, "chunk size must be non-zero");
         ChunksMut::new(self, chunk_size)
@@ -1216,6 +1288,7 @@ impl<T> [T] {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn chunks_exact(&self, chunk_size: usize) -> ChunksExact<'_, T> {
         assert!(chunk_size != 0, "chunk size must be non-zero");
         ChunksExact::new(self, chunk_size)
@@ -1260,6 +1333,7 @@ impl<T> [T] {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn chunks_exact_mut(&mut self, chunk_size: usize) -> ChunksExactMut<'_, T> {
         assert!(chunk_size != 0, "chunk size must be non-zero");
         ChunksExactMut::new(self, chunk_size)
@@ -1307,6 +1381,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "slice_as_chunks", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn as_chunks_unchecked<const N: usize>(&self) -> &[[T; N]] {
         assert_unsafe_precondition!(
             check_language_ub,
@@ -1365,6 +1440,7 @@ impl<T> [T] {
     #[inline]
     #[track_caller]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_chunks<const N: usize>(&self) -> (&[[T; N]], &[T]) {
         assert!(N != 0, "chunk size must be non-zero");
         let len_rounded_down = self.len() / N * N;
@@ -1412,6 +1488,7 @@ impl<T> [T] {
     #[inline]
     #[track_caller]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_rchunks<const N: usize>(&self) -> (&[T], &[[T; N]]) {
         assert!(N != 0, "chunk size must be non-zero");
         let len = self.len() / N;
@@ -1453,6 +1530,7 @@ impl<T> [T] {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn array_chunks<const N: usize>(&self) -> ArrayChunks<'_, T, N> {
         assert!(N != 0, "chunk size must be non-zero");
         ArrayChunks::new(self)
@@ -1502,6 +1580,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "slice_as_chunks", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn as_chunks_unchecked_mut<const N: usize>(&mut self) -> &mut [[T; N]] {
         assert_unsafe_precondition!(
             check_language_ub,
@@ -1556,6 +1635,7 @@ impl<T> [T] {
     #[inline]
     #[track_caller]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_chunks_mut<const N: usize>(&mut self) -> (&mut [[T; N]], &mut [T]) {
         assert!(N != 0, "chunk size must be non-zero");
         let len_rounded_down = self.len() / N * N;
@@ -1609,6 +1689,7 @@ impl<T> [T] {
     #[inline]
     #[track_caller]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_rchunks_mut<const N: usize>(&mut self) -> (&mut [T], &mut [[T; N]]) {
         assert!(N != 0, "chunk size must be non-zero");
         let len = self.len() / N;
@@ -1652,6 +1733,7 @@ impl<T> [T] {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn array_chunks_mut<const N: usize>(&mut self) -> ArrayChunksMut<'_, T, N> {
         assert!(N != 0, "chunk size must be non-zero");
         ArrayChunksMut::new(self)
@@ -1686,6 +1768,7 @@ impl<T> [T] {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn array_windows<const N: usize>(&self) -> ArrayWindows<'_, T, N> {
         assert!(N != 0, "window size must be non-zero");
         ArrayWindows::new(self)
@@ -1722,6 +1805,7 @@ impl<T> [T] {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn rchunks(&self, chunk_size: usize) -> RChunks<'_, T> {
         assert!(chunk_size != 0, "chunk size must be non-zero");
         RChunks::new(self, chunk_size)
@@ -1762,6 +1846,7 @@ impl<T> [T] {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn rchunks_mut(&mut self, chunk_size: usize) -> RChunksMut<'_, T> {
         assert!(chunk_size != 0, "chunk size must be non-zero");
         RChunksMut::new(self, chunk_size)
@@ -1803,6 +1888,7 @@ impl<T> [T] {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn rchunks_exact(&self, chunk_size: usize) -> RChunksExact<'_, T> {
         assert!(chunk_size != 0, "chunk size must be non-zero");
         RChunksExact::new(self, chunk_size)
@@ -1848,6 +1934,7 @@ impl<T> [T] {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn rchunks_exact_mut(&mut self, chunk_size: usize) -> RChunksExactMut<'_, T> {
         assert!(chunk_size != 0, "chunk size must be non-zero");
         RChunksExactMut::new(self, chunk_size)
@@ -1888,6 +1975,7 @@ impl<T> [T] {
     #[stable(feature = "slice_group_by", since = "1.77.0")]
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn chunk_by<F>(&self, pred: F) -> ChunkBy<'_, T, F>
     where
         F: FnMut(&T, &T) -> bool,
@@ -1930,6 +2018,7 @@ impl<T> [T] {
     #[stable(feature = "slice_group_by", since = "1.77.0")]
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn chunk_by_mut<F>(&mut self, pred: F) -> ChunkByMut<'_, T, F>
     where
         F: FnMut(&T, &T) -> bool,
@@ -1976,6 +2065,7 @@ impl<T> [T] {
     #[inline]
     #[track_caller]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_at(&self, mid: usize) -> (&[T], &[T]) {
         match self.split_at_checked(mid) {
             Some(pair) => pair,
@@ -2010,6 +2100,7 @@ impl<T> [T] {
     #[track_caller]
     #[must_use]
     #[rustc_const_stable(feature = "const_slice_split_at_mut", since = "1.83.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_at_mut(&mut self, mid: usize) -> (&mut [T], &mut [T]) {
         match self.split_at_mut_checked(mid) {
             Some(pair) => pair,
@@ -2061,6 +2152,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_slice_split_at_unchecked", since = "1.77.0")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn split_at_unchecked(&self, mid: usize) -> (&[T], &[T]) {
         // FIXME(const-hack): the const function `from_raw_parts` is used to make this
         // function const; previously the implementation used
@@ -2114,6 +2206,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_slice_split_at_mut", since = "1.83.0")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const unsafe fn split_at_mut_unchecked(&mut self, mid: usize) -> (&mut [T], &mut [T]) {
         let len = self.len();
         let ptr = self.as_mut_ptr();
@@ -2175,6 +2268,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "split_at_checked", since = "1.80.0")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_at_checked(&self, mid: usize) -> Option<(&[T], &[T])> {
         if mid <= self.len() {
             // SAFETY: `[ptr; mid]` and `[mid; len]` are inside `self`, which
@@ -2214,6 +2308,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_slice_split_at_mut", since = "1.83.0")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_at_mut_checked(&mut self, mid: usize) -> Option<(&mut [T], &mut [T])> {
         if mid <= self.len() {
             // SAFETY: `[ptr; mid]` and `[mid; len]` are inside `self`, which
@@ -2266,6 +2361,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn split<F>(&self, pred: F) -> Split<'_, T, F>
     where
         F: FnMut(&T) -> bool,
@@ -2288,6 +2384,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn split_mut<F>(&mut self, pred: F) -> SplitMut<'_, T, F>
     where
         F: FnMut(&T) -> bool,
@@ -2324,6 +2421,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "split_inclusive", since = "1.51.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn split_inclusive<F>(&self, pred: F) -> SplitInclusive<'_, T, F>
     where
         F: FnMut(&T) -> bool,
@@ -2348,6 +2446,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "split_inclusive", since = "1.51.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn split_inclusive_mut<F>(&mut self, pred: F) -> SplitInclusiveMut<'_, T, F>
     where
         F: FnMut(&T) -> bool,
@@ -2384,6 +2483,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "slice_rsplit", since = "1.27.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn rsplit<F>(&self, pred: F) -> RSplit<'_, T, F>
     where
         F: FnMut(&T) -> bool,
@@ -2410,6 +2510,7 @@ impl<T> [T] {
     ///
     #[stable(feature = "slice_rsplit", since = "1.27.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn rsplit_mut<F>(&mut self, pred: F) -> RSplitMut<'_, T, F>
     where
         F: FnMut(&T) -> bool,
@@ -2438,6 +2539,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn splitn<F>(&self, n: usize, pred: F) -> SplitN<'_, T, F>
     where
         F: FnMut(&T) -> bool,
@@ -2464,6 +2566,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn splitn_mut<F>(&mut self, n: usize, pred: F) -> SplitNMut<'_, T, F>
     where
         F: FnMut(&T) -> bool,
@@ -2493,6 +2596,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn rsplitn<F>(&self, n: usize, pred: F) -> RSplitN<'_, T, F>
     where
         F: FnMut(&T) -> bool,
@@ -2520,6 +2624,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn rsplitn_mut<F>(&mut self, n: usize, pred: F) -> RSplitNMut<'_, T, F>
     where
         F: FnMut(&T) -> bool,
@@ -2547,6 +2652,7 @@ impl<T> [T] {
     /// ```
     #[unstable(feature = "slice_split_once", reason = "newly added", issue = "112811")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn split_once<F>(&self, pred: F) -> Option<(&[T], &[T])>
     where
         F: FnMut(&T) -> bool,
@@ -2575,6 +2681,7 @@ impl<T> [T] {
     /// ```
     #[unstable(feature = "slice_split_once", reason = "newly added", issue = "112811")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn rsplit_once<F>(&self, pred: F) -> Option<(&[T], &[T])>
     where
         F: FnMut(&T) -> bool,
@@ -2611,6 +2718,7 @@ impl<T> [T] {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn contains(&self, x: &T) -> bool
     where
         T: PartialEq,
@@ -2641,6 +2749,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn starts_with(&self, needle: &[T]) -> bool
     where
         T: PartialEq,
@@ -2672,6 +2781,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn ends_with(&self, needle: &[T]) -> bool
     where
         T: PartialEq,
@@ -2704,6 +2814,7 @@ impl<T> [T] {
     /// ```
     #[must_use = "returns the subslice without modifying the original"]
     #[stable(feature = "slice_strip", since = "1.51.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn strip_prefix<P: SlicePattern<Item = T> + ?Sized>(&self, prefix: &P) -> Option<&[T]>
     where
         T: PartialEq,
@@ -2740,6 +2851,7 @@ impl<T> [T] {
     /// ```
     #[must_use = "returns the subslice without modifying the original"]
     #[stable(feature = "slice_strip", since = "1.51.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn strip_suffix<P: SlicePattern<Item = T> + ?Sized>(&self, suffix: &P) -> Option<&[T]>
     where
         T: PartialEq,
@@ -2826,6 +2938,7 @@ impl<T> [T] {
     /// assert_eq!(s, [0, 1, 1, 1, 1, 2, 3, 5, 8, 13, 21, 34, 42, 55]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn binary_search(&self, x: &T) -> Result<usize, usize>
     where
         T: Ord,
@@ -2877,6 +2990,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn binary_search_by<'a, F>(&'a self, mut f: F) -> Result<usize, usize>
     where
         F: FnMut(&'a T) -> Ordering,
@@ -2978,6 +3092,7 @@ impl<T> [T] {
     #[allow(rustdoc::broken_intra_doc_links)]
     #[stable(feature = "slice_binary_search_by_key", since = "1.10.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn binary_search_by_key<'a, B, F>(&'a self, b: &B, mut f: F) -> Result<usize, usize>
     where
         F: FnMut(&'a T) -> B,
@@ -3040,6 +3155,7 @@ impl<T> [T] {
     /// [total order]: https://en.wikipedia.org/wiki/Total_order
     #[stable(feature = "sort_unstable", since = "1.20.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn sort_unstable(&mut self)
     where
         T: Ord,
@@ -3095,6 +3211,7 @@ impl<T> [T] {
     /// [total order]: https://en.wikipedia.org/wiki/Total_order
     #[stable(feature = "sort_unstable", since = "1.20.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn sort_unstable_by<F>(&mut self, mut compare: F)
     where
         F: FnMut(&T, &T) -> Ordering,
@@ -3147,6 +3264,7 @@ impl<T> [T] {
     /// [total order]: https://en.wikipedia.org/wiki/Total_order
     #[stable(feature = "sort_unstable", since = "1.20.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn sort_unstable_by_key<K, F>(&mut self, mut f: F)
     where
         F: FnMut(&T) -> K,
@@ -3210,6 +3328,7 @@ impl<T> [T] {
     /// [total order]: https://en.wikipedia.org/wiki/Total_order
     #[stable(feature = "slice_select_nth_unstable", since = "1.49.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn select_nth_unstable(&mut self, index: usize) -> (&mut [T], &mut T, &mut [T])
     where
         T: Ord,
@@ -3275,6 +3394,7 @@ impl<T> [T] {
     /// [total order]: https://en.wikipedia.org/wiki/Total_order
     #[stable(feature = "slice_select_nth_unstable", since = "1.49.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn select_nth_unstable_by<F>(
         &mut self,
         index: usize,
@@ -3342,6 +3462,7 @@ impl<T> [T] {
     /// [total order]: https://en.wikipedia.org/wiki/Total_order
     #[stable(feature = "slice_select_nth_unstable", since = "1.49.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn select_nth_unstable_by_key<K, F>(
         &mut self,
         index: usize,
@@ -3376,6 +3497,7 @@ impl<T> [T] {
     /// ```
     #[unstable(feature = "slice_partition_dedup", issue = "54279")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn partition_dedup(&mut self) -> (&mut [T], &mut [T])
     where
         T: PartialEq,
@@ -3410,6 +3532,7 @@ impl<T> [T] {
     /// ```
     #[unstable(feature = "slice_partition_dedup", issue = "54279")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn partition_dedup_by<F>(&mut self, mut same_bucket: F) -> (&mut [T], &mut [T])
     where
         F: FnMut(&mut T, &mut T) -> bool,
@@ -3536,6 +3659,7 @@ impl<T> [T] {
     /// ```
     #[unstable(feature = "slice_partition_dedup", issue = "54279")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn partition_dedup_by_key<K, F>(&mut self, mut key: F) -> (&mut [T], &mut [T])
     where
         F: FnMut(&mut T) -> K,
@@ -3577,6 +3701,7 @@ impl<T> [T] {
     /// assert_eq!(a, ['a', 'c', 'd', 'e', 'b', 'f']);
     /// ```
     #[stable(feature = "slice_rotate", since = "1.26.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn rotate_left(&mut self, mid: usize) {
         assert!(mid <= self.len());
         let k = self.len() - mid;
@@ -3622,6 +3747,7 @@ impl<T> [T] {
     /// assert_eq!(a, ['a', 'e', 'b', 'c', 'd', 'f']);
     /// ```
     #[stable(feature = "slice_rotate", since = "1.26.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn rotate_right(&mut self, k: usize) {
         assert!(k <= self.len());
         let mid = self.len() - k;
@@ -3645,6 +3771,7 @@ impl<T> [T] {
     /// ```
     #[doc(alias = "memset")]
     #[stable(feature = "slice_fill", since = "1.50.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn fill(&mut self, value: T)
     where
         T: Clone,
@@ -3653,21 +3780,21 @@ impl<T> [T] {
     }
 
     /// Fills `self` with elements returned by calling a closure repeatedly.
-    ///
-    /// This method uses a closure to create new values. If you'd rather
-    /// [`Clone`] a given value, use [`fill`]. If you want to use the [`Default`]
-    /// trait to generate values, you can pass [`Default::default`] as the
-    /// argument.
-    ///
-    /// [`fill`]: slice::fill
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let mut buf = vec![1; 10];
-    /// buf.fill_with(Default::default);
-    /// assert_eq!(buf, vec![0; 10]);
-    /// ```
+    // ///
+    // /// This method uses a closure to create new values. If you'd rather
+    // /// [`Clone`] a given value, use [`fill`]. If you want to use the [`Default`]
+    // /// trait to generate values, you can pass [`Default::default`] as the
+    // /// argument.
+    // ///
+    // /// [`fill`]: slice::fill
+    // ///
+    // /// # Examples
+    // ///
+    // /// ```
+    // /// let mut buf = vec![1; 10];
+    // /// buf.fill_with(Default::default);
+    // /// assert_eq!(buf, vec![0; 10]);
+    // /// ```
     #[stable(feature = "slice_fill_with", since = "1.51.0")]
     pub fn fill_with<F>(&mut self, mut f: F)
     where
@@ -3732,6 +3859,7 @@ impl<T> [T] {
     /// [`split_at_mut`]: slice::split_at_mut
     #[stable(feature = "clone_from_slice", since = "1.7.0")]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn clone_from_slice(&mut self, src: &[T])
     where
         T: Clone,
@@ -3798,6 +3926,7 @@ impl<T> [T] {
     #[stable(feature = "copy_from_slice", since = "1.9.0")]
     #[rustc_const_stable(feature = "const_copy_from_slice", since = "1.87.0")]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn copy_from_slice(&mut self, src: &[T])
     where
         T: Copy,
@@ -3854,6 +3983,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "copy_within", since = "1.37.0")]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn copy_within<R: RangeBounds<usize>>(&mut self, src: R, dest: usize)
     where
         T: Copy,
@@ -3921,6 +4051,7 @@ impl<T> [T] {
     /// [`split_at_mut`]: slice::split_at_mut
     #[stable(feature = "swap_with_slice", since = "1.27.0")]
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn swap_with_slice(&mut self, other: &mut [T]) {
         assert!(self.len() == other.len(), "destination and source slices have different lengths");
         // SAFETY: `self` is valid for `self.len()` elements by definition, and `src` was
@@ -3932,6 +4063,7 @@ impl<T> [T] {
     }
 
     /// Function to calculate lengths of the middle and trailing slice for `align_to{,_mut}`.
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn align_to_offsets<U>(&self) -> (usize, usize) {
         // What we gonna do about `rest` is figure out what multiple of `U`s we can put in a
         // lowest number of `T`s. And how many `T`s we need for each such "multiple".
@@ -3998,6 +4130,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "slice_align_to", since = "1.30.0")]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub unsafe fn align_to<U>(&self) -> (&[T], &[U], &[T]) {
         // Note that most of this function will be constant-evaluated,
         if U::IS_ZST || T::IS_ZST {
@@ -4063,6 +4196,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "slice_align_to", since = "1.30.0")]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub unsafe fn align_to_mut<U>(&mut self) -> (&mut [T], &mut [U], &mut [T]) {
         // Note that most of this function will be constant-evaluated,
         if U::IS_ZST || T::IS_ZST {
@@ -4154,6 +4288,7 @@ impl<T> [T] {
     /// ```
     #[unstable(feature = "portable_simd", issue = "86656")]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn as_simd<const LANES: usize>(&self) -> (&[T], &[Simd<T, LANES>], &[T])
     where
         Simd<T, LANES>: AsRef<[T; LANES]>,
@@ -4190,6 +4325,7 @@ impl<T> [T] {
     /// method for something like `LANES == 3`.
     #[unstable(feature = "portable_simd", issue = "86656")]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn as_simd_mut<const LANES: usize>(&mut self) -> (&mut [T], &mut [Simd<T, LANES>], &mut [T])
     where
         Simd<T, LANES>: AsMut<[T; LANES]>,
@@ -4229,6 +4365,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "is_sorted", since = "1.82.0")]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn is_sorted(&self) -> bool
     where
         T: PartialOrd,
@@ -4272,6 +4409,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "is_sorted", since = "1.82.0")]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn is_sorted_by<'a, F>(&'a self, mut compare: F) -> bool
     where
         F: FnMut(&'a T, &'a T) -> bool,
@@ -4296,6 +4434,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "is_sorted", since = "1.82.0")]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn is_sorted_by_key<'a, F, K>(&'a self, f: F) -> bool
     where
         F: FnMut(&'a T) -> K,
@@ -4355,6 +4494,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "partition_point", since = "1.52.0")]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn partition_point<P>(&self, mut pred: P) -> usize
     where
         P: FnMut(&T) -> bool,
@@ -4407,6 +4547,7 @@ impl<T> [T] {
     #[inline]
     #[must_use = "method does not modify the slice if the range is out of bounds"]
     #[stable(feature = "slice_take", since = "1.87.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn split_off<'a, R: OneSidedRange<usize>>(
         self: &mut &'a Self,
         range: R,
@@ -4473,6 +4614,7 @@ impl<T> [T] {
     #[inline]
     #[must_use = "method does not modify the slice if the range is out of bounds"]
     #[stable(feature = "slice_take", since = "1.87.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn split_off_mut<'a, R: OneSidedRange<usize>>(
         self: &mut &'a mut Self,
         range: R,
@@ -4511,6 +4653,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "slice_take", since = "1.87.0")]
     #[rustc_const_unstable(feature = "const_split_off_first_last", issue = "138539")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_off_first<'a>(self: &mut &'a Self) -> Option<&'a T> {
         // FIXME(const-hack): Use `?` when available in const instead of `let-else`.
         let Some((first, rem)) = self.split_first() else { return None };
@@ -4536,6 +4679,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "slice_take", since = "1.87.0")]
     #[rustc_const_unstable(feature = "const_split_off_first_last", issue = "138539")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_off_first_mut<'a>(self: &mut &'a mut Self) -> Option<&'a mut T> {
         // FIXME(const-hack): Use `mem::take` and `?` when available in const.
         // Original: `mem::take(self).split_first_mut()?`
@@ -4561,6 +4705,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "slice_take", since = "1.87.0")]
     #[rustc_const_unstable(feature = "const_split_off_first_last", issue = "138539")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_off_last<'a>(self: &mut &'a Self) -> Option<&'a T> {
         // FIXME(const-hack): Use `?` when available in const instead of `let-else`.
         let Some((last, rem)) = self.split_last() else { return None };
@@ -4586,6 +4731,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "slice_take", since = "1.87.0")]
     #[rustc_const_unstable(feature = "const_split_off_first_last", issue = "138539")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn split_off_last_mut<'a>(self: &mut &'a mut Self) -> Option<&'a mut T> {
         // FIXME(const-hack): Use `mem::take` and `?` when available in const.
         // Original: `mem::take(self).split_last_mut()?`
@@ -4642,6 +4788,7 @@ impl<T> [T] {
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     #[stable(feature = "get_many_mut", since = "1.86.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub unsafe fn get_disjoint_unchecked_mut<I, const N: usize>(
         &mut self,
         indices: [I; N],
@@ -4709,6 +4856,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "get_many_mut", since = "1.86.0")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn get_disjoint_mut<I, const N: usize>(
         &mut self,
         indices: [I; N],
@@ -4764,6 +4912,7 @@ impl<T> [T] {
     /// ```
     #[must_use]
     #[unstable(feature = "substr_range", issue = "126769")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn element_offset(&self, element: &T) -> Option<usize> {
         if T::IS_ZST {
             panic!("elements are zero-sized");
@@ -4818,6 +4967,7 @@ impl<T> [T] {
     /// ```
     #[must_use]
     #[unstable(feature = "substr_range", issue = "126769")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn subslice_range(&self, subslice: &[T]) -> Option<Range<usize>> {
         if T::IS_ZST {
             panic!("elements are zero-sized");
@@ -4839,6 +4989,7 @@ impl<T> [T] {
     }
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> [MaybeUninit<T>] {
     /// Transmutes the mutable uninitialized slice to a mutable uninitialized slice of
     /// another type, ensuring alignment of the types is maintained.
@@ -4879,6 +5030,7 @@ impl<T> [MaybeUninit<T>] {
     #[unstable(feature = "align_to_uninit_mut", issue = "139062")]
     #[inline]
     #[must_use]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn align_to_uninit_mut<U>(&mut self) -> (&mut Self, &mut [MaybeUninit<U>], &mut Self) {
         // SAFETY: `MaybeUninit` is transparent. Correct size and alignment are guaranteed by
         // `align_to_mut` itself. Therefore the only thing that we have to ensure for a safe
@@ -4888,6 +5040,7 @@ impl<T> [MaybeUninit<T>] {
     }
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, const N: usize> [[T; N]] {
     /// Takes a `&[[T; N]]`, and flattens it to a `&[T]`.
     ///
@@ -4922,6 +5075,7 @@ impl<T, const N: usize> [[T; N]] {
     /// ```
     #[stable(feature = "slice_flatten", since = "1.80.0")]
     #[rustc_const_stable(feature = "const_slice_flatten", since = "1.87.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_flattened(&self) -> &[T] {
         let len = if T::IS_ZST {
             self.len().checked_mul(N).expect("slice len overflow")
@@ -4964,6 +5118,7 @@ impl<T, const N: usize> [[T; N]] {
     /// ```
     #[stable(feature = "slice_flatten", since = "1.80.0")]
     #[rustc_const_stable(feature = "const_slice_flatten", since = "1.87.0")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub const fn as_flattened_mut(&mut self) -> &mut [T] {
         let len = if T::IS_ZST {
             self.len().checked_mul(N).expect("slice len overflow")
@@ -4977,6 +5132,7 @@ impl<T, const N: usize> [[T; N]] {
     }
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl [f32] {
     /// Sorts the slice of floats.
     ///
@@ -5000,11 +5156,13 @@ impl [f32] {
     /// ```
     #[unstable(feature = "sort_floats", issue = "93396")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn sort_floats(&mut self) {
         self.sort_unstable_by(f32::total_cmp);
     }
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl [f64] {
     /// Sorts the slice of floats.
     ///
@@ -5028,20 +5186,25 @@ impl [f64] {
     /// ```
     #[unstable(feature = "sort_floats", issue = "93396")]
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub fn sort_floats(&mut self) {
         self.sort_unstable_by(f64::total_cmp);
     }
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 trait CloneFromSpec<T> {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn spec_clone_from(&mut self, src: &[T]);
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> CloneFromSpec<T> for [T]
 where
     T: Clone,
 {
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     default fn spec_clone_from(&mut self, src: &[T]) {
         assert!(self.len() == src.len(), "destination and source slices have different lengths");
         // NOTE: We need to explicitly slice them to the same length
@@ -5055,27 +5218,33 @@ where
     }
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> CloneFromSpec<T> for [T]
 where
     T: Copy,
 {
     #[track_caller]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn spec_clone_from(&mut self, src: &[T]) {
         self.copy_from_slice(src);
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> Default for &[T] {
     /// Creates an empty slice.
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn default() -> Self {
         &[]
     }
 }
 
 #[stable(feature = "mut_slice_default", since = "1.5.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> Default for &mut [T] {
     /// Creates a mutable empty slice.
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn default() -> Self {
         &mut []
     }
@@ -5085,29 +5254,37 @@ impl<T> Default for &mut [T] {
 /// Patterns in slices - currently, only used by `strip_prefix` and `strip_suffix`.  At a future
 /// point, we hope to generalise `core::str::Pattern` (which at the time of writing is limited to
 /// `str`) to slices, and then this trait will be replaced or abolished.
+#[cfg(not(feature = "ferrocene_certified"))]
 pub trait SlicePattern {
     /// The element type of the slice being matched on.
     type Item;
 
     /// Currently, the consumers of `SlicePattern` need a slice.
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn as_slice(&self) -> &[Self::Item];
 }
 
 #[stable(feature = "slice_strip", since = "1.51.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T> SlicePattern for [T] {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = T;
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn as_slice(&self) -> &[Self::Item] {
         self
     }
 }
 
 #[stable(feature = "slice_strip", since = "1.51.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<T, const N: usize> SlicePattern for [T; N] {
+    #[cfg(not(feature = "ferrocene_certified"))]
     type Item = T;
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn as_slice(&self) -> &[Self::Item] {
         self
     }
@@ -5118,6 +5295,7 @@ impl<T, const N: usize> SlicePattern for [T; N] {
 /// This will do `binomial(N + 1, 2) = N * (N + 1) / 2 = 0, 1, 3, 6, 10, ..`
 /// comparison operations.
 #[inline]
+#[cfg(not(feature = "ferrocene_certified"))]
 fn get_disjoint_check_valid<I: GetDisjointMutIndex, const N: usize>(
     indices: &[I; N],
     len: usize,
@@ -5155,6 +5333,7 @@ fn get_disjoint_check_valid<I: GetDisjointMutIndex, const N: usize>(
 /// ```
 #[stable(feature = "get_many_mut", since = "1.86.0")]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub enum GetDisjointMutError {
     /// An index provided was out-of-bounds for the slice.
     IndexOutOfBounds,
@@ -5163,7 +5342,9 @@ pub enum GetDisjointMutError {
 }
 
 #[stable(feature = "get_many_mut", since = "1.86.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl fmt::Display for GetDisjointMutError {
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match self {
             GetDisjointMutError::IndexOutOfBounds => "an index is out of bounds",
@@ -5173,21 +5354,29 @@ impl fmt::Display for GetDisjointMutError {
     }
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 mod private_get_disjoint_mut_index {
+    #[cfg(not(feature = "ferrocene_certified"))]
     use super::{Range, RangeInclusive, range};
 
     #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     pub trait Sealed {}
 
     #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     impl Sealed for usize {}
     #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     impl Sealed for Range<usize> {}
     #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     impl Sealed for RangeInclusive<usize> {}
     #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     impl Sealed for range::Range<usize> {}
     #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     impl Sealed for range::RangeInclusive<usize> {}
 }
 
@@ -5198,11 +5387,13 @@ mod private_get_disjoint_mut_index {
 /// If `is_in_bounds()` returns `true` and `is_overlapping()` returns `false`,
 /// it must be safe to index the slice with the indices.
 #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub unsafe trait GetDisjointMutIndex:
     Clone + private_get_disjoint_mut_index::Sealed
 {
     /// Returns `true` if `self` is in bounds for `len` slice elements.
     #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_in_bounds(&self, len: usize) -> bool;
 
     /// Returns `true` if `self` overlaps with `other`.
@@ -5210,18 +5401,22 @@ pub unsafe trait GetDisjointMutIndex:
     /// Note that we don't consider zero-length ranges to overlap at the beginning or the end,
     /// but do consider them to overlap in the middle.
     #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_overlapping(&self, other: &Self) -> bool;
 }
 
 #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
 // SAFETY: We implement `is_in_bounds()` and `is_overlapping()` correctly.
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl GetDisjointMutIndex for usize {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_in_bounds(&self, len: usize) -> bool {
         *self < len
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_overlapping(&self, other: &Self) -> bool {
         *self == *other
     }
@@ -5229,13 +5424,16 @@ unsafe impl GetDisjointMutIndex for usize {
 
 #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
 // SAFETY: We implement `is_in_bounds()` and `is_overlapping()` correctly.
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl GetDisjointMutIndex for Range<usize> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_in_bounds(&self, len: usize) -> bool {
         (self.start <= self.end) & (self.end <= len)
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_overlapping(&self, other: &Self) -> bool {
         (self.start < other.end) & (other.start < self.end)
     }
@@ -5243,13 +5441,16 @@ unsafe impl GetDisjointMutIndex for Range<usize> {
 
 #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
 // SAFETY: We implement `is_in_bounds()` and `is_overlapping()` correctly.
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl GetDisjointMutIndex for RangeInclusive<usize> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_in_bounds(&self, len: usize) -> bool {
         (self.start <= self.end) & (self.end < len)
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_overlapping(&self, other: &Self) -> bool {
         (self.start <= other.end) & (other.start <= self.end)
     }
@@ -5257,13 +5458,16 @@ unsafe impl GetDisjointMutIndex for RangeInclusive<usize> {
 
 #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
 // SAFETY: We implement `is_in_bounds()` and `is_overlapping()` correctly.
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl GetDisjointMutIndex for range::Range<usize> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_in_bounds(&self, len: usize) -> bool {
         Range::from(*self).is_in_bounds(len)
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_overlapping(&self, other: &Self) -> bool {
         Range::from(*self).is_overlapping(&Range::from(*other))
     }
@@ -5271,13 +5475,16 @@ unsafe impl GetDisjointMutIndex for range::Range<usize> {
 
 #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
 // SAFETY: We implement `is_in_bounds()` and `is_overlapping()` correctly.
+#[cfg(not(feature = "ferrocene_certified"))]
 unsafe impl GetDisjointMutIndex for range::RangeInclusive<usize> {
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_in_bounds(&self, len: usize) -> bool {
         RangeInclusive::from(*self).is_in_bounds(len)
     }
 
     #[inline]
+    #[cfg(not(feature = "ferrocene_certified"))]
     fn is_overlapping(&self, other: &Self) -> bool {
         RangeInclusive::from(*self).is_overlapping(&RangeInclusive::from(*other))
     }


### PR DESCRIPTION
This is a minimal effort, meaning that none of the `Iterator` adapters are included on this PR.

Additionally `<[T]>::fill_with` is marked as certified to ensure that `for` loops work.
