### PR TITLE
Do style adjustments

### DIFF
--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -21,7 +21,6 @@ test = false
 bench = false
 
 [features]
-
 # Ferrocene addition: only add the explicit dependency to profiler_builtins when we are building
 # core specifically for profiling.
 ferrocene_inject_profiler_builtins = ["dep:profiler_builtins"]
@@ -37,9 +36,6 @@ optimize_for_size = []
 debug_refcell = []
 # Make `TypeId` store a reference to the name of the type, so that it can print that name.
 debug_typeid = []
-
-# Include uncertified code
-uncertified = []
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -6,16 +6,19 @@
 
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::error::Error;
-#[cfg(not(feature = "ferrocene_certified"))]
-use crate::fmt;
+#[cfg(feature = "ferrocene_certified")]
 use crate::intrinsics::unchecked_sub;
 #[cfg(not(feature = "ferrocene_certified"))]
-use crate::intrinsics::{unchecked_add, unchecked_mul};
+use crate::intrinsics::{unchecked_add, unchecked_mul, unchecked_sub};
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::mem::SizedTypeProperties;
+#[cfg(feature = "ferrocene_certified")]
 use crate::ptr::Alignment;
 #[cfg(not(feature = "ferrocene_certified"))]
-use crate::ptr::NonNull;
+use crate::ptr::{Alignment, NonNull};
+#[cfg(not(feature = "ferrocene_certified"))]
+use crate::{assert_unsafe_precondition, fmt, mem};
+#[cfg(feature = "ferrocene_certified")]
 use crate::{assert_unsafe_precondition, mem};
 
 // While this function is used in one place and its implementation
@@ -127,6 +130,7 @@ impl Layout {
     }
 
     /// Creates a layout, bypassing all checks.
+    // FIXME(pvdrz): fix docs
     // ///
     // /// # Safety
     // ///

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -1,4 +1,5 @@
 //! The `Clone` trait for types that cannot be 'implicitly copied'.
+// FIXME(pvdrz): Fix docs
 // //!
 // //! In Rust, some simple types are "implicitly copyable" and when you
 // //! assign them or pass them as arguments, the receiver will get a copy,
@@ -557,9 +558,13 @@ mod impls {
 
     #[cfg(not(feature = "ferrocene_certified"))]
     impl_clone! {
-        f16 f128
-        char
+        usize u8 u16 u32 u64 u128
+        isize i8 i16 i32 i64 i128
+        f16 f32 f64 f128
+        bool char
     }
+
+    #[cfg(feature = "ferrocene_certified")]
     impl_clone! {
         usize u8 u16 u32 u64 u128
         isize i8 i16 i32 i64 i128

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1,4 +1,5 @@
 //! Utilities for comparing and ordering values.
+// FIXME(pvdrz): fix docs
 // //!
 // //! This module contains various tools for comparing and ordering values. In
 // //! summary:
@@ -34,6 +35,7 @@ use self::Ordering::*;
 use crate::ops::ControlFlow;
 
 /// Trait for comparisons using the equality operator.
+// FIXME(pvdrz): fix docs
 // ///
 // /// Implementing this trait for types provides the `==` and `!=` operators for
 // /// those types.
@@ -277,6 +279,7 @@ pub macro PartialEq($item:item) {
 
 /// Trait for comparisons corresponding to [equivalence relations](
 /// https://en.wikipedia.org/wiki/Equivalence_relation).
+// FIXME(pvdrz): fix docs
 // ///
 // /// The primary difference to [`PartialEq`] is the additional requirement for reflexivity. A type
 // /// that implements [`PartialEq`] guarantees that for all `a`, `b` and `c`:
@@ -719,6 +722,7 @@ impl<T: Clone> Clone for Reverse<T> {
 }
 
 /// Trait for types that form a [total order](https://en.wikipedia.org/wiki/Total_order).
+// FIXME(pvdrz): fix docs
 // ///
 // /// Implementations must be consistent with the [`PartialOrd`] implementation, and ensure `max`,
 // /// `min`, and `clamp` are consistent with `cmp`:
@@ -970,6 +974,7 @@ pub trait Ord: Eq + PartialOrd<Self> {
     ///
     /// By convention, `self.cmp(&other)` returns the ordering matching the expression
     /// `self <operator> other` if true.
+    // FIXME(pvdrz): fix docs
     // ///
     // /// # Examples
     // ///
@@ -988,6 +993,7 @@ pub trait Ord: Eq + PartialOrd<Self> {
     /// Compares and returns the maximum of two values.
     ///
     /// Returns the second argument if the comparison determines them to be equal.
+    // FIXME(pvdrz): fix docs
     // ///
     // /// # Examples
     // ///
@@ -1027,6 +1033,7 @@ pub trait Ord: Eq + PartialOrd<Self> {
     /// Compares and returns the minimum of two values.
     ///
     /// Returns the first argument if the comparison determines them to be equal.
+    // FIXME(pvdrz): fix docs
     // ///
     // /// # Examples
     // ///
@@ -1067,6 +1074,7 @@ pub trait Ord: Eq + PartialOrd<Self> {
     ///
     /// Returns `max` if `self` is greater than `max`, and `min` if `self` is
     /// less than `min`. Otherwise this returns `self`.
+    // FIXME(pvdrz): fix docs
     // ///
     // /// # Panics
     // ///
@@ -1108,6 +1116,7 @@ pub macro Ord($item:item) {
 }
 
 /// Trait for types that form a [partial order](https://en.wikipedia.org/wiki/Partial_order).
+// FIXME(pvdrz): fix docs
 // ///
 // /// The `lt`, `le`, `gt`, and `ge` methods of this trait can be called using the `<`, `<=`, `>`, and
 // /// `>=` operators, respectively.
@@ -1852,8 +1861,10 @@ mod impls {
 
     #[cfg(not(feature = "ferrocene_certified"))]
     partial_eq_impl! {
-        char f16 f128
+        bool char usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f16 f32 f64 f128
     }
+
+    #[cfg(feature = "ferrocene_certified")]
     partial_eq_impl! {
         bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64
     }
@@ -1866,7 +1877,8 @@ mod impls {
     }
 
     #[cfg(not(feature = "ferrocene_certified"))]
-    eq_impl! { () char }
+    eq_impl! { () bool char usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
+    #[cfg(feature = "ferrocene_certified")]
     eq_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 
     #[rustfmt::skip]
@@ -1947,7 +1959,9 @@ mod impls {
     }
 
     #[cfg(not(feature = "ferrocene_certified"))]
-    partial_ord_impl! { f16 f128 }
+    partial_ord_impl! { f16 f32 f64 f128 }
+
+    #[cfg(feature = "ferrocene_certified")]
     partial_ord_impl! { f32 f64 }
 
     macro_rules! ord_impl {
@@ -2015,7 +2029,8 @@ mod impls {
     }
 
     #[cfg(not(feature = "ferrocene_certified"))]
-    ord_impl! { char }
+    ord_impl! { char usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
+    #[cfg(feature = "ferrocene_certified")]
     ord_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 
     #[unstable(feature = "never_type", issue = "35121")]

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -111,6 +111,7 @@ pub const fn identity<T>(x: T) -> T {
 }
 
 /// Used to do a cheap reference-to-reference conversion.
+// FIXME(pvdrz): fix docs
 // ///
 // /// This trait is similar to [`AsMut`] which is used for converting between mutable references.
 // /// If you need to do a costly conversion it is better to implement [`From`] with type
@@ -458,6 +459,7 @@ pub trait Into<T>: Sized {
 
 /// Used to do value-to-value conversions while consuming the input value. It is the reciprocal of
 /// [`Into`].
+// FIXME(pvdrz): fix docs
 // ///
 // /// One should always prefer implementing `From` over [`Into`]
 // /// because implementing `From` automatically provides one with an implementation of [`Into`]
@@ -630,6 +632,7 @@ pub trait TryInto<T>: Sized {
 /// using the [`From`] trait, because an [`i64`] may contain a value
 /// that an [`i32`] cannot represent and so the conversion would lose data.
 /// This might be handled by truncating the [`i64`] to an [`i32`] or by
+// FIXME(pvdrz): fix docs
 // /// simply returning [`i32::MAX`], or by some other method.  The [`From`]
 /// trait is intended for perfect conversions, so the `TryFrom` trait
 /// informs the programmer when a type conversion could go bad and lets
@@ -915,7 +918,7 @@ impl AsMut<str> for str {
 /// the two `impl`s will start to overlap
 /// and therefore will be disallowed by the language’s trait coherence rules.
 #[stable(feature = "convert_infallible", since = "1.34.0")]
-#[cfg_attr(not(feature = "ferrocene_certified"), derive(Copy))]
+#[derive(Copy)]
 pub enum Infallible {}
 
 #[stable(feature = "convert_infallible", since = "1.34.0")]

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -10,6 +10,7 @@ use crate::{intrinsics, ub_checks};
 
 /// Informs the compiler that the site which is calling this function is not
 /// reachable, possibly enabling further optimizations.
+// FIXME(pvdrz): fix docs
 // ///
 // /// # Safety
 // ///

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3076,6 +3076,7 @@ pub const unsafe fn write_via_move<T>(ptr: *mut T, value: T);
 
 /// Returns the value of the discriminant for the variant in 'v';
 /// if `T` has no discriminant, returns `0`.
+// FIXME(pvdrz): fix docs
 // ///
 // /// Note that, unlike most intrinsics, this is safe to call;
 // /// it does not require an `unsafe` block.

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -4,7 +4,7 @@
 #[allow_internal_unstable(edition_panic)]
 #[stable(feature = "core", since = "1.6.0")]
 #[rustc_diagnostic_item = "core_panic_macro"]
-/// FIXME: docs
+/// FIXME(pvdrz): docs
 macro_rules! panic {
     // Expands to either `$crate::panic::panic_2015` or `$crate::panic::panic_2021`
     // depending on the edition of the caller.
@@ -437,6 +437,7 @@ pub macro debug_assert_matches($($arg:tt)*) {
 /// used to add additional checks that must be true for the matched value, otherwise this macro will
 /// return `false`.
 ///
+// FIXME(pvdrz): fix docs
 // /// When testing that a value matches a pattern, it's generally preferable to use
 // /// [`assert_matches!`] as it will print the debug representation of the value if the assertion
 // /// fails.
@@ -919,6 +920,7 @@ pub(crate) mod builtin {
 
     /// Causes compilation to fail with the given error message when encountered.
     ///
+    // FIXME(pvdrz): fix docs
     // /// This macro should be used when a crate uses a conditional compilation strategy to provide
     // /// better error messages for erroneous conditions. It's the compiler-level form of [`panic!`],
     // /// but emits an error during *compilation* rather than at *runtime*.
@@ -959,6 +961,7 @@ pub(crate) mod builtin {
 
     /// Constructs parameters for the other string-formatting macros.
     ///
+    // FIXME(pvdrz): fix docs
     // /// This macro functions by taking a formatting string literal containing
     // /// `{}` for each additional argument passed. `format_args!` prepares the
     // /// additional parameters to ensure the output can be interpreted as a string
@@ -1052,6 +1055,7 @@ pub(crate) mod builtin {
 
     /// Inspects an environment variable at compile time.
     ///
+    // FIXME(pvdrz): fix docs
     // /// This macro will expand to the value of the named environment variable at
     // /// compile time, yielding an expression of type `&'static str`. Use
     // /// [`std::env::var`] instead if you want to read the value at runtime.
@@ -1214,6 +1218,7 @@ pub(crate) mod builtin {
 
     /// Expands to the line number on which it was invoked.
     ///
+    // FIXME(pvdrz): fix docs
     // /// With [`column!`] and [`file!`], these macros provide debugging information for
     // /// developers about the location within the source.
     // ///
@@ -1241,6 +1246,7 @@ pub(crate) mod builtin {
 
     /// Expands to the column number at which it was invoked.
     ///
+    // FIXME(pvdrz): fix docs
     // /// With [`line!`] and [`file!`], these macros provide debugging information for
     // /// developers about the location within the source.
     // ///
@@ -1280,6 +1286,7 @@ pub(crate) mod builtin {
 
     /// Expands to the file name in which it was invoked.
     ///
+    // FIXME(pvdrz): fix docs
     // /// With [`line!`] and [`column!`], these macros provide debugging information for
     // /// developers about the location within the source.
     // ///
@@ -1572,6 +1579,7 @@ pub(crate) mod builtin {
 
     /// Asserts that a boolean expression is `true` at runtime.
     ///
+    // FIXME(pvdrz): fix docs
     // /// This will invoke the [`panic!`] macro if the provided expression cannot be
     // /// evaluated to `true` at runtime.
     // ///

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -76,6 +76,7 @@ macro marker_impls {
 ///
 /// This trait is automatically implemented when the compiler determines it's
 /// appropriate.
+// FIXME(pvdrz): fix docs
 // ///
 // /// An example of a non-`Send` type is the reference-counting pointer
 // /// [`rc::Rc`][`Rc`]. If two threads attempt to clone [`Rc`]s that point to the same
@@ -164,6 +165,7 @@ pub trait Sized {
 }
 
 /// Types that can be "unsized" to a dynamically-sized type.
+// FIXME(pvdrz): fix docs
 // ///
 // /// For example, the sized array type `[i8; 2]` implements `Unsize<[i8]>` and
 // /// `Unsize<dyn fmt::Debug>`.
@@ -318,6 +320,7 @@ marker_impls! {
 /// impl<T: Copy> Copy for MyStruct<T> { }
 /// ```
 ///
+// FIXME(pvdrz): fix docs
 // /// This isn't always desired. For example, shared references (`&T`) can be copied regardless of
 // /// whether `T` is `Copy`. Likewise, a generic struct containing markers such as [`PhantomData`]
 // /// could potentially be duplicated with a bit-wise copy.
@@ -390,6 +393,7 @@ marker_impls! {
 /// mutable reference. Copying [`String`] would duplicate responsibility for managing the
 /// [`String`]'s buffer, leading to a double free.
 ///
+// FIXME(pvdrz): fix docs
 // /// Generalizing the latter case, any type implementing [`Drop`] can't be `Copy`, because it's
 // /// managing some resource besides its own [`size_of::<T>`] bytes.
 ///
@@ -420,6 +424,7 @@ marker_impls! {
 ///
 /// [`Vec<T>`]: ../../std/vec/struct.Vec.html
 /// [`String`]: ../../std/string/struct.String.html
+// FIXME(pvdrz): fix docs
 // /// [`size_of::<T>`]: size_of
 /// [impls]: #implementors
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -453,10 +458,15 @@ pub macro Copy($item:item) {
 marker_impls! {
     #[stable(feature = "rust1", since = "1.0.0")]
     Copy for
-        f16, f128,
-        char,
+        usize, u8, u16, u32, u64, u128,
+        isize, i8, i16, i32, i64, i128,
+        f16, f32, f64, f128,
+        bool, char,
+        {T: ?Sized} *const T,
+        {T: ?Sized} *mut T,
 
 }
+#[cfg(feature = "ferrocene_certified")]
 marker_impls! {
     #[stable(feature = "rust1", since = "1.0.0")]
     Copy for
@@ -503,6 +513,7 @@ pub trait BikeshedGuaranteedNoDrop {}
 /// This trait is automatically implemented when the compiler determines
 /// it's appropriate.
 ///
+// FIXME(pvdrz): fix docs
 // /// The precise definition is: a type `T` is [`Sync`] if and only if `&T` is
 // /// [`Send`]. In other words, if there is no possibility of
 // /// [undefined behavior][ub] (including data races) when passing
@@ -862,6 +873,7 @@ impl<T: ?Sized> Default for PhantomData<T> {
 impl<T: ?Sized> StructuralPartialEq for PhantomData<T> {}
 
 /// Compiler-internal trait used to indicate the type of enum discriminants.
+// FIXME(pvdrz): fix docs
 // ///
 // /// This trait is automatically implemented for every type and does not add any
 // /// guarantees to [`mem::Discriminant`]. It is **undefined behavior** to transmute

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -6,11 +6,12 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::alloc::Layout;
+#[cfg(feature = "ferrocene_certified")]
 use crate::intrinsics;
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::marker::DiscriminantKind;
 #[cfg(not(feature = "ferrocene_certified"))]
-use crate::{clone, cmp, fmt, hash, ptr};
+use crate::{clone, cmp, fmt, hash, intrinsics, ptr};
 
 #[cfg(not(feature = "ferrocene_certified"))]
 mod manually_drop;
@@ -910,6 +911,7 @@ pub const fn replace<T>(dest: &mut T, src: T) -> T {
 /// the function returns.
 ///
 /// [drop]: Drop
+// FIXME(pvdrz): fix docs
 // ///
 // /// # Examples
 // ///

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -25,6 +25,7 @@ macro_rules! int_impl {
         bound_condition = $bound_condition:literal,
     ) => {
         /// The smallest value that can be represented by this integer type
+        // FIXME(pvdrz): fix docs
         // #[doc = concat!("(&minus;2<sup>", $BITS_MINUS_ONE, "</sup>", $bound_condition, ").")]
         // ///
         // /// # Examples
@@ -38,6 +39,7 @@ macro_rules! int_impl {
         pub const MIN: Self = !Self::MAX;
 
         /// The largest value that can be represented by this integer type
+        // FIXME(pvdrz): fix docs
         // #[doc = concat!("(2<sup>", $BITS_MINUS_ONE, "</sup> &minus; 1", $bound_condition, ").")]
         // ///
         // /// # Examples

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -2,6 +2,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+#[cfg(feature = "ferrocene_certified")]
 use crate::intrinsics;
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::panic::const_panic;
@@ -10,7 +11,7 @@ use crate::str::FromStr;
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::ub_checks::assert_unsafe_precondition;
 #[cfg(not(feature = "ferrocene_certified"))]
-use crate::{ascii, mem};
+use crate::{ascii, intrinsics, mem};
 
 // FIXME(const-hack): Used because the `?` operator is not allowed in a const context.
 #[cfg(not(feature = "ferrocene_certified"))]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -24,6 +24,7 @@ macro_rules! uint_impl {
         bound_condition = $bound_condition:literal,
     ) => {
         /// The smallest value that can be represented by this integer type.
+        // FIXME(pvdrz): fix docs
         // ///
         // /// # Examples
         // ///
@@ -36,6 +37,7 @@ macro_rules! uint_impl {
         pub const MIN: Self = 0;
 
         /// The largest value that can be represented by this integer type
+        // FIXME(pvdrz): fix docs
         // #[doc = concat!("(2<sup>", $BITS, "</sup> &minus; 1", $bound_condition, ").")]
         // ///
         // /// # Examples
@@ -60,6 +62,7 @@ macro_rules! uint_impl {
         pub const BITS: u32 = Self::MAX.count_ones();
 
         /// Returns the number of ones in the binary representation of `self`.
+        // FIXME(pvdrz): fix docs
         // ///
         // /// # Examples
         // ///
@@ -3554,6 +3557,7 @@ macro_rules! uint_impl {
         }
 
         /// Returns `true` if and only if `self == 2^k` for some unsigned integer `k`.
+        // FIXME(pvdrz): fix docs
         // ///
         // /// # Examples
         // ///

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -111,7 +111,9 @@ macro_rules! add_impl {
 }
 
 #[cfg(not(feature = "ferrocene_certified"))]
-add_impl! { f16 f128 }
+add_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f16 f32 f64 f128 }
+
+#[cfg(feature = "ferrocene_certified")]
 add_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 
 /// The subtraction operator `-`.
@@ -222,7 +224,9 @@ macro_rules! sub_impl {
 }
 
 #[cfg(not(feature = "ferrocene_certified"))]
-sub_impl! { f16 f128 }
+sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f16 f32 f64 f128 }
+
+#[cfg(feature = "ferrocene_certified")]
 sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 
 /// The multiplication operator `*`.
@@ -354,7 +358,9 @@ macro_rules! mul_impl {
 }
 
 #[cfg(not(feature = "ferrocene_certified"))]
-mul_impl! { f16 f128 }
+mul_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f16 f32 f64 f128 }
+
+#[cfg(feature = "ferrocene_certified")]
 mul_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 
 /// The division operator `/`.
@@ -514,7 +520,9 @@ macro_rules! div_impl_float {
 }
 
 #[cfg(not(feature = "ferrocene_certified"))]
-div_impl_float! { f16 f128 }
+div_impl_float! { f16 f32 f64 f128 }
+
+#[cfg(feature = "ferrocene_certified")]
 div_impl_float! { f32 f64 }
 
 /// The remainder operator `%`.
@@ -633,7 +641,9 @@ macro_rules! rem_impl_float {
 }
 
 #[cfg(not(feature = "ferrocene_certified"))]
-rem_impl_float! { f16 f128 }
+rem_impl_float! { f16 f32 f64 f128 }
+
+#[cfg(feature = "ferrocene_certified")]
 rem_impl_float! { f32 f64 }
 
 /// The unary negation operator `-`.
@@ -710,7 +720,9 @@ macro_rules! neg_impl {
 }
 
 #[cfg(not(feature = "ferrocene_certified"))]
-neg_impl! { f16 f128 }
+neg_impl! { isize i8 i16 i32 i64 i128 f16 f32 f64 f128 }
+
+#[cfg(feature = "ferrocene_certified")]
 neg_impl! { isize i8 i16 i32 i64 i128 f32 f64 }
 
 /// The addition assignment operator `+=`.
@@ -779,7 +791,9 @@ macro_rules! add_assign_impl {
 }
 
 #[cfg(not(feature = "ferrocene_certified"))]
-add_assign_impl! { f16 f128 }
+add_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f16 f32 f64 f128 }
+
+#[cfg(feature = "ferrocene_certified")]
 add_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 
 /// The subtraction assignment operator `-=`.
@@ -848,7 +862,9 @@ macro_rules! sub_assign_impl {
 }
 
 #[cfg(not(feature = "ferrocene_certified"))]
-sub_assign_impl! { f16 f128 }
+sub_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f16 f32 f64 f128 }
+
+#[cfg(feature = "ferrocene_certified")]
 sub_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 
 /// The multiplication assignment operator `*=`.
@@ -908,7 +924,9 @@ macro_rules! mul_assign_impl {
 }
 
 #[cfg(not(feature = "ferrocene_certified"))]
-mul_assign_impl! { f16 f128 }
+mul_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f16 f32 f64 f128 }
+
+#[cfg(feature = "ferrocene_certified")]
 mul_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 
 /// The division assignment operator `/=`.
@@ -967,7 +985,9 @@ macro_rules! div_assign_impl {
 }
 
 #[cfg(not(feature = "ferrocene_certified"))]
-div_assign_impl! { f16 f128 }
+div_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f16 f32 f64 f128 }
+
+#[cfg(feature = "ferrocene_certified")]
 div_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 
 /// The remainder assignment operator `%=`.
@@ -1030,5 +1050,7 @@ macro_rules! rem_assign_impl {
 }
 
 #[cfg(not(feature = "ferrocene_certified"))]
-rem_assign_impl! { f16 f128 }
+rem_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f16 f32 f64 f128 }
+
+#[cfg(feature = "ferrocene_certified")]
 rem_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }

--- a/library/core/src/ops/bit.rs
+++ b/library/core/src/ops/bit.rs
@@ -68,7 +68,7 @@ macro_rules! not_impl {
 not_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 
 #[stable(feature = "not_never", since = "1.60.0")]
-#[cfg(not(feature = "ferrocene_certified"))] /* blocked on ! */
+#[cfg(not(feature = "ferrocene_certified"))] /* FIXME(pvdrz): blocked on ! */
 impl Not for ! {
     type Output = !;
 

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -1,6 +1,7 @@
 use crate::{convert, ops};
 
 /// Used to tell an operation whether it should exit early or go on as usual.
+// FIXME(pvdrz): fix docs
 // ///
 // /// This is used when exposing things (like graph traversals or visitors) where
 // /// you want the user to be able to choose whether to exit early.

--- a/library/core/src/ops/deref.rs
+++ b/library/core/src/ops/deref.rs
@@ -1,4 +1,5 @@
 /// Used for immutable dereferencing operations, like `*v`.
+// FIXME(pvdrz): fix docs
 // ///
 // /// In addition to being used for explicit dereferencing operations with the
 // /// (unary) `*` operator in immutable contexts, `Deref` is also used implicitly
@@ -174,6 +175,7 @@ impl<T: ?Sized> const Deref for &mut T {
 }
 
 /// Used for mutable dereferencing operations, like in `*v = 1;`.
+// FIXME(pvdrz): fix docs
 // ///
 // /// In addition to being used for explicit dereferencing operations with the
 // /// (unary) `*` operator in mutable contexts, `DerefMut` is also used implicitly

--- a/library/core/src/ops/drop.rs
+++ b/library/core/src/ops/drop.rs
@@ -1,4 +1,5 @@
 /// Custom code within the destructor.
+// FIXME(pvdrz): fix docs
 // ///
 // /// When a value is no longer needed, Rust will run a "destructor" on that value.
 // /// The most common way that a value is no longer needed is when it goes out of
@@ -207,6 +208,7 @@
 #[rustc_const_unstable(feature = "const_destruct", issue = "133214")]
 pub trait Drop {
     /// Executes the destructor for this type.
+    // FIXME(pvdrz): fix docs
     // ///
     // /// This method is called implicitly when the value goes out of scope,
     // /// and cannot be called explicitly (this is compiler error [E0040]).

--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -1,4 +1,5 @@
 //! Overloadable operators.
+// FIXME(pvdrz): fix docs
 // //!
 // //! Implementing these traits allows you to overload certain operators.
 // //!

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -4,6 +4,7 @@ use crate::fmt;
 use crate::hash::Hash;
 
 /// An unbounded range (`..`).
+// FIXME(pvdrz): fix docs
 // ///
 // /// `RangeFull` is primarily used as a [slicing index], its shorthand is `..`.
 // /// It cannot serve as an [`Iterator`] because it doesn't have a starting point.
@@ -155,6 +156,7 @@ impl<Idx: PartialOrd<Idx>> Range<Idx> {
 }
 
 /// A range only bounded inclusively below (`start..`).
+// FIXME(pvdrz): fix docs
 // ///
 // /// The `RangeFrom` `start..` contains all values with `x >= start`.
 // ///
@@ -234,6 +236,7 @@ impl<Idx: PartialOrd<Idx>> RangeFrom<Idx> {
 }
 
 /// A range only bounded exclusively above (`..end`).
+// FIXME(pvdrz): fix docs
 // ///
 // /// The `RangeTo` `..end` contains all values with `x < end`.
 // /// It cannot serve as an [`Iterator`] because it doesn't have a starting point.
@@ -318,6 +321,7 @@ impl<Idx: PartialOrd<Idx>> RangeTo<Idx> {
 }
 
 /// A range bounded inclusively below and above (`start..=end`).
+// FIXME(pvdrz): fix docs
 // ///
 // /// The `RangeInclusive` `start..=end` contains all values with `x >= start`
 // /// and `x <= end`. It is empty unless `start <= end`.
@@ -389,6 +393,7 @@ impl<Idx> RangeInclusive<Idx> {
     }
 
     /// Returns the lower bound of the range (inclusive).
+    // FIXME(pvdrz): fix docs
     // ///
     // /// When using an inclusive range for iteration, the values of `start()` and
     // /// [`end()`] are unspecified after the iteration ended. To determine
@@ -414,6 +419,7 @@ impl<Idx> RangeInclusive<Idx> {
     }
 
     /// Returns the upper bound of the range (inclusive).
+    // FIXME(pvdrz): fix docs
     // ///
     // /// When using an inclusive range for iteration, the values of [`start()`]
     // /// and `end()` are unspecified after the iteration ended. To determine
@@ -561,6 +567,7 @@ impl<Idx: PartialOrd<Idx>> RangeInclusive<Idx> {
 }
 
 /// A range only bounded inclusively above (`..=end`).
+// FIXME(pvdrz): fix docs
 // ///
 // /// The `RangeToInclusive` `..=end` contains all values with `x <= end`.
 // /// It cannot serve as an [`Iterator`] because it doesn't have a starting point.

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -1,6 +1,7 @@
 use crate::ops::ControlFlow;
 
 /// The `?` operator and `try {}` blocks.
+// FIXME(pvdrz): fix docs
 // ///
 // /// `try_*` methods typically involve a type implementing this trait.  For
 // /// example, the closures passed to [`Iterator::try_fold`] and

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -578,7 +578,8 @@
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::iter::{self, FusedIterator, TrustedLen};
 #[cfg(not(feature = "ferrocene_certified"))]
-use crate::ops::{self, ControlFlow};
+use crate::ops::{self, ControlFlow, Deref, DerefMut};
+#[cfg(feature = "ferrocene_certified")]
 use crate::ops::{Deref, DerefMut};
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::panicking::{panic, panic_display};
@@ -1082,6 +1083,7 @@ impl<T> Option<T> {
     /// ```
     ///
     /// [default value]: Default::default
+    // FIXME(pvdrz): fix docs
     // /// [`parse`]: str::parse
     // /// [`FromStr`]: crate::str::FromStr
     #[inline]
@@ -1533,6 +1535,7 @@ impl<T> Option<T> {
     ///   value), and
     /// - [`None`] if `predicate` returns `false`.
     ///
+    // FIXME(pvdrz): fix docs
     // /// This function works similar to [`Iterator::filter()`]. You can imagine
     // /// the `Option<T>` being an iterator over one or zero elements. `filter()`
     // /// lets you decide which elements to keep.
@@ -1682,7 +1685,7 @@ impl<T> Option<T> {
     #[must_use = "if you intended to set a value, consider assignment instead"]
     #[inline]
     #[stable(feature = "option_insert", since = "1.53.0")]
-    // Uncertified because it depends on unwrap_unchecked
+    // FIXME(pvdrz): Uncertified because it depends on unwrap_unchecked
     #[cfg(not(feature = "ferrocene_certified"))]
     pub fn insert(&mut self, value: T) -> &mut T {
         *self = Some(value);
@@ -1713,7 +1716,7 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "option_entry", since = "1.20.0")]
-    // Uncertified because it depends on unwrap_unchecked
+    // FIXME(pvdrz): Uncertified because it depends on unwrap_unchecked
     #[cfg(not(feature = "ferrocene_certified"))]
     pub fn get_or_insert(&mut self, value: T) -> &mut T {
         self.get_or_insert_with(|| value)
@@ -1738,7 +1741,7 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "option_get_or_insert_default", since = "1.83.0")]
-    // Uncertified because it depends on unwrap_unchecked
+    // FIXME(pvdrz): Uncertified because it depends on unwrap_unchecked
     #[cfg(not(feature = "ferrocene_certified"))]
     pub fn get_or_insert_default(&mut self) -> &mut T
     where
@@ -1766,7 +1769,7 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "option_entry", since = "1.20.0")]
-    // Uncertified because it depends on unwrap_unchecked
+    // FIXME(pvdrz): Uncertified because it depends on unwrap_unchecked
     #[cfg(not(feature = "ferrocene_certified"))]
     pub fn get_or_insert_with<F>(&mut self, f: F) -> &mut T
     where

--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -4,6 +4,7 @@ use crate::ffi::CStr;
 use crate::fmt;
 
 /// A struct containing information about the location of a panic.
+// FIXME(pvdrz): fix docs
 // ///
 // /// This structure is created by [`PanicHookInfo::location()`] and [`PanicInfo::location()`].
 // ///
@@ -103,6 +104,7 @@ impl<'a> Location<'a> {
     }
 
     /// Returns the name of the source file from which the panic originated.
+    // FIXME(pvdrz): fix docs
     // ///
     // /// # `&str`, not `&Path`
     // ///
@@ -161,6 +163,7 @@ impl<'a> Location<'a> {
     }
 
     /// Returns the line number from which the panic originated.
+    // FIXME(pvdrz): fix docs
     // ///
     // /// # Examples
     // ///
@@ -186,6 +189,7 @@ impl<'a> Location<'a> {
     }
 
     /// Returns the column from which the panic originated.
+    // FIXME(pvdrz): fix docs
     // ///
     // /// # Examples
     // ///

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -79,7 +79,7 @@ pub const fn panic_fmt(fmt: fmt::Arguments<'_>) -> ! {
     unsafe { panic_impl(&pi) }
 }
 
-/// FIXME: This is just a hack so we can get `panic` working.
+/// FIXME(pvdrz): This is just a hack so we can get `panic` working.
 #[inline]
 #[track_caller]
 #[lang = "panic_fmt"] // needed for const-evaluated panics
@@ -135,7 +135,7 @@ pub const fn panic_nounwind_fmt(fmt: fmt::Arguments<'_>, force_no_backtrace: boo
     )
 }
 
-/// FIXME: This is just a hack so we can get `panic_nounwind` working.
+/// FIXME(pvdrz): This is just a hack so we can get `panic_nounwind` working.
 #[inline]
 #[track_caller]
 // This attribute has the key side-effect that if the panic handler ignores `can_unwind`

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -11,9 +11,10 @@
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 #[cfg(not(feature = "ferrocene_certified"))]
-pub use crate::marker::Unpin;
+pub use crate::marker::{Copy, Send, Sized, Sync, Unpin};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
+#[cfg(feature = "ferrocene_certified")]
 pub use crate::marker::{Copy, Send, Sized, Sync};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
@@ -30,9 +31,10 @@ pub use crate::mem::drop;
 #[stable(feature = "size_of_prelude", since = "1.80.0")]
 #[doc(no_inline)]
 #[cfg(not(feature = "ferrocene_certified"))]
-pub use crate::mem::{align_of_val, size_of_val};
+pub use crate::mem::{align_of, align_of_val, size_of, size_of_val};
 #[stable(feature = "size_of_prelude", since = "1.80.0")]
 #[doc(no_inline)]
+#[cfg(feature = "ferrocene_certified")]
 pub use crate::mem::{ size_of, align_of };
 
 // Re-exported types and traits
@@ -41,10 +43,7 @@ pub use crate::mem::{ size_of, align_of };
 pub use crate::clone::Clone;
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use crate::cmp::{Ord, PartialOrd};
-#[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
-pub use crate::cmp::{Eq, PartialEq};
+pub use crate::cmp::{Eq, Ord, PartialEq, PartialOrd};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 pub use crate::convert::{AsMut, AsRef, From, Into};

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -2,6 +2,7 @@
 #[doc(alias = "true")]
 #[doc(alias = "false")]
 /// The boolean type.
+// FIXME(pvdrz): fix docs
 // ///
 // /// The `bool` represents a value, which could only be either [`true`] or [`false`]. If you cast
 // /// a `bool` into an integer, [`true`] will be 1 and [`false`] will be 0.
@@ -626,6 +627,7 @@ mod prim_pointer {}
 #[doc(alias = "[T; N]")]
 /// A fixed-size array, denoted `[T; N]`, for the element type, `T`, and the
 /// non-negative compile-time constant size, `N`.
+// FIXME(pvdrz): fix docs
 // ///
 // /// There are two syntactic forms for creating an array:
 // ///
@@ -1243,6 +1245,7 @@ mod prim_f16 {}
 ///
 /// For more information on floating-point numbers, see [Wikipedia][wikipedia].
 ///
+// FIXME(pvdrz): fix docs
 // /// *[See also the `std::f32::consts` module](crate::f32::consts).*
 // ///
 /// [wikipedia]: https://en.wikipedia.org/wiki/Single-precision_floating-point_format
@@ -1381,6 +1384,7 @@ mod prim_f32 {}
 /// bits. Please see [the documentation for `f32`](prim@f32) or [Wikipedia on double-precision
 /// values][wikipedia] for more information.
 ///
+// FIXME(pvdrz): fix docs
 // /// *[See also the `std::f64::consts` module](crate::f64::consts).*
 // ///
 /// [wikipedia]: https://en.wikipedia.org/wiki/Double-precision_floating-point_format

--- a/library/core/src/ptr/alignment.rs
+++ b/library/core/src/ptr/alignment.rs
@@ -1,9 +1,10 @@
+#[cfg(feature = "ferrocene_certified")]
 use crate::mem;
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::num::NonZero;
 use crate::ub_checks::assert_unsafe_precondition;
 #[cfg(not(feature = "ferrocene_certified"))]
-use crate::{cmp, fmt, hash, num};
+use crate::{cmp, fmt, hash, mem, num};
 
 /// A type storing a `usize` which is a power of two, and thus
 /// represents a possible alignment in the Rust abstract machine.
@@ -11,8 +12,8 @@ use crate::{cmp, fmt, hash, num};
 /// Note that particularly large alignments, while representable in this type,
 /// are likely not to be supported by actual allocators and linkers.
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]
-#[cfg_attr(not(feature = "ferrocene_certified"), derive(PartialEq, Eq))]
-#[derive(Copy, Clone)]
+#[cfg_attr(not(feature = "ferrocene_certified"), derive(Copy, Clone, PartialEq, Eq))]
+#[cfg_attr(feature = "ferrocene_certified", derive(Copy, Clone))]
 #[repr(transparent)]
 pub struct Alignment(AlignmentEnum);
 
@@ -259,8 +260,8 @@ impl Default for Alignment {
 }
 
 #[cfg(target_pointer_width = "16")]
-#[cfg_attr(not(feature = "ferrocene_certified"), derive(PartialEq, Eq))]
-#[derive(Copy, Clone)]
+#[cfg_attr(not(feature = "ferrocene_certified"), derive(Copy, Clone, PartialEq, Eq))]
+#[cfg_attr(feature = "ferrocene_certified", derive(Copy, Clone))]
 #[repr(u16)]
 enum AlignmentEnum {
     _Align1Shl0 = 1 << 0,
@@ -282,8 +283,8 @@ enum AlignmentEnum {
 }
 
 #[cfg(target_pointer_width = "32")]
-#[cfg_attr(not(feature = "ferrocene_certified"), derive(PartialEq, Eq))]
-#[derive(Copy, Clone)]
+#[cfg_attr(not(feature = "ferrocene_certified"), derive(Copy, Clone, PartialEq, Eq))]
+#[cfg_attr(feature = "ferrocene_certified", derive(Copy, Clone))]
 #[repr(u32)]
 enum AlignmentEnum {
     _Align1Shl0 = 1 << 0,
@@ -321,8 +322,8 @@ enum AlignmentEnum {
 }
 
 #[cfg(target_pointer_width = "64")]
-#[cfg_attr(not(feature = "ferrocene_certified"), derive(PartialEq, Eq))]
-#[derive(Copy, Clone)]
+#[cfg_attr(not(feature = "ferrocene_certified"), derive(Copy, Clone, PartialEq, Eq))]
+#[cfg_attr(feature = "ferrocene_certified", derive(Copy, Clone))]
 #[repr(u64)]
 enum AlignmentEnum {
     _Align1Shl0 = 1 << 0,

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -2,14 +2,16 @@ use super::*;
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::cmp::Ordering::{Equal, Greater, Less};
 use crate::intrinsics::const_eval_select;
+#[cfg(feature = "ferrocene_certified")]
 use crate::mem;
 #[cfg(not(feature = "ferrocene_certified"))]
-use crate::mem::SizedTypeProperties;
+use crate::mem::{self, SizedTypeProperties};
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::slice::{self, SliceIndex};
 
 impl<T: ?Sized> *const T {
     /// Returns `true` if the pointer is null.
+    // FIXME(pvdrz): fix docs
     // ///
     // /// Note that unsized types have many possible null pointers, as only the
     // /// raw data pointer is considered, not their length, vtable, etc.
@@ -170,6 +172,7 @@ impl<T: ?Sized> *const T {
     }
 
     /// Gets the "address" portion of the pointer.
+    // FIXME(pvdrz): fix docs
     // ///
     // /// This is similar to `self as usize`, except that the [provenance][crate::ptr#provenance] of
     // /// the pointer is discarded and not [exposed][crate::ptr#exposed-provenance]. This means that
@@ -1447,6 +1450,7 @@ impl<T: ?Sized> *const T {
     ///
     /// For non-`Sized` pointees this operation considers only the data pointer,
     /// ignoring the metadata.
+    // FIXME(pvdrz): fix docs
     // ///
     // /// # Panics
     // ///
@@ -1684,6 +1688,7 @@ impl<T, const N: usize> *const [T; N] {
     }
 }
 
+// FIXME(pvdrz): fix docs
 // /// Pointer equality is by address, as produced by the [`<*const T>::addr`](pointer::addr) method.
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> PartialEq for *const T {

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -4,15 +4,17 @@
 use crate::fmt;
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::hash::{Hash, Hasher};
+#[cfg(feature = "ferrocene_certified")]
 use crate::intrinsics::aggregate_raw_ptr;
 #[cfg(not(feature = "ferrocene_certified"))]
-use crate::intrinsics::ptr_metadata;
+use crate::intrinsics::{aggregate_raw_ptr, ptr_metadata};
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::marker::Freeze;
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::ptr::NonNull;
 
 /// Provides the pointer metadata type of any pointed-to type.
+// FIXME(pvdrz): fix docs
 // ///
 // /// # Pointer metadata
 // ///
@@ -113,6 +115,7 @@ pub const fn metadata<T: ?Sized>(ptr: *const T) -> <T as Pointee>::Metadata {
 }
 
 /// Forms a (possibly-wide) raw pointer from a data pointer and metadata.
+// FIXME(pvdrz): fix docs
 // ///
 // /// This function is safe but the returned pointer is not necessarily safe to dereference.
 // /// For slices, see the documentation of [`slice::from_raw_parts`] for safety requirements.

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1,4 +1,5 @@
 //! Manually manage memory through raw pointers.
+// FIXME(pvdrz): fix docs
 // //!
 // //! *[See also the pointer primitive types](pointer).*
 // //!
@@ -403,13 +404,15 @@ use crate::intrinsics::const_eval_select;
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::marker::FnPtr;
 #[cfg(not(feature = "ferrocene_certified"))]
-use crate::mem::MaybeUninit;
-use crate::mem::SizedTypeProperties;
+use crate::mem::{self, MaybeUninit, SizedTypeProperties};
+#[cfg(feature = "ferrocene_certified")]
+use crate::mem::{self, SizedTypeProperties};
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::num::NonZero;
 #[cfg(not(feature = "ferrocene_certified"))]
-use crate::{fmt, hash};
-use crate::{intrinsics, mem, ub_checks};
+use crate::{fmt, hash, intrinsics, ub_checks};
+#[cfg(feature = "ferrocene_certified")]
+use crate::{intrinsics, ub_checks};
 
 mod alignment;
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]
@@ -418,11 +421,10 @@ pub use alignment::Alignment;
 mod metadata;
 #[unstable(feature = "ptr_metadata", issue = "81513")]
 #[cfg(not(feature = "ferrocene_certified"))]
-pub use metadata::{DynMetadata, metadata};
+pub use metadata::{DynMetadata, Pointee, Thin, from_raw_parts, from_raw_parts_mut, metadata};
 #[unstable(feature = "ptr_metadata", issue = "81513")]
-pub use metadata::{Pointee, Thin};
-#[unstable(feature = "ptr_metadata", issue = "81513")]
-pub use metadata::{from_raw_parts, from_raw_parts_mut};
+#[cfg(feature = "ferrocene_certified")]
+pub use metadata::{Pointee, Thin, from_raw_parts, from_raw_parts_mut};
 
 #[cfg(not(feature = "ferrocene_certified"))]
 mod non_null;
@@ -876,6 +878,7 @@ pub const fn null_mut<T: ?Sized + Thin>() -> *mut T {
 }
 
 /// Creates a pointer with the given address and no [provenance][crate::ptr#provenance].
+// FIXME(pvdrz): fix docs
 // ///
 // /// This is equivalent to `ptr::null().with_addr(addr)`.
 // ///
@@ -915,6 +918,7 @@ pub const fn dangling<T>() -> *const T {
 }
 
 /// Creates a pointer with the given address and no [provenance][crate::ptr#provenance].
+// FIXME(pvdrz): fix docs
 // ///
 // /// This is equivalent to `ptr::null_mut().with_addr(addr)`.
 // ///
@@ -1617,6 +1621,7 @@ pub const unsafe fn replace<T>(dst: *mut T, src: T) -> T {
 
 /// Reads the value from `src` without moving it. This leaves the
 /// memory in `src` unchanged.
+// FIXME(pvdrz): fix docs
 // ///
 // /// # Safety
 // ///
@@ -1871,6 +1876,7 @@ pub const unsafe fn read_unaligned<T>(src: *const T) -> T {
 /// This is appropriate for initializing uninitialized memory, or overwriting
 /// memory that has previously been [`read`] from.
 ///
+// FIXME(pvdrz): fix docs
 // /// # Safety
 // ///
 // /// Behavior is undefined if any of the following conditions are violated:

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -80,6 +80,7 @@
 //! functions that may encounter errors but don't otherwise return a
 //! useful value.
 //!
+// FIXME(pvdrz): fix docs
 // //! Consider the [`write_all`] method defined for I/O types
 // //! by the [`Write`] trait:
 // //!
@@ -90,7 +91,7 @@
 // //!     fn write_all(&mut self, bytes: &[u8]) -> Result<(), io::Error>;
 // //! }
 // //! ```
-//!
+// //!
 // //! *Note: The actual definition of [`Write`] uses [`io::Result`], which
 // //! is just a synonym for <code>[Result]<T, [io::Error]></code>.*
 // //!
@@ -536,7 +537,8 @@
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::iter::{self, FusedIterator, TrustedLen};
 #[cfg(not(feature = "ferrocene_certified"))]
-use crate::ops::{self, ControlFlow};
+use crate::ops::{self, ControlFlow, Deref, DerefMut};
+#[cfg(feature = "ferrocene_certified")]
 use crate::ops::{Deref, DerefMut};
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::{convert, fmt, hint};
@@ -1184,6 +1186,7 @@ impl<T, E> Result<T, E> {
     /// Consumes the `self` argument then, if [`Ok`], returns the contained
     /// value, otherwise if [`Err`], returns the default value for that
     /// type.
+    // FIXME(pvdrz): fix docs
     // ///
     // /// # Examples
     // ///

--- a/library/core/src/ub_checks.rs
+++ b/library/core/src/ub_checks.rs
@@ -4,6 +4,7 @@
 use crate::intrinsics::{self, const_eval_select};
 
 /// Checks that the preconditions of an unsafe function are followed.
+// FIXME(pvdrz): fix docs
 // ///
 // /// The check is enabled at runtime if debug assertions are enabled when the
 // /// caller is monomorphized. In const-eval/Miri checks implemented with this


### PR DESCRIPTION
This includes:
- Leave all import items untouched internally but gated and just add new
  import items.
- Mark all the commented documentation with a `FIXME` so we don't forget
  about it
- Leave all macro calls untouched internally but gated and just add new
  macro calls.

cc @Urhengulas
