### PR TITLE
[1.86] Upload technical report and make 1.86 stable

### DIFF
--- a/ferrocene/ci/channel
+++ b/ferrocene/ci/channel
@@ -1,1 +1,1 @@
-beta
+stable

--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -354,9 +354,9 @@ fi
 #
 # If this is not provided, the report will not be included in the generated
 # documentation. This should only be set in stable, qualified releases.
-#if is_internal; then
-#    add --set ferrocene.technical-report-url="s3://ferrocene-ci-mirrors/manual/tuv-technical-reports/YYYY-MM-DD-ferrocene-YY.MM.N-technical-report.pdf"
-#fi
+if is_internal; then
+   add --set ferrocene.technical-report-url="s3://ferrocene-ci-mirrors/manual/tuv-technical-reports/2025-06-26-ferrocene-25.05.0-technical-report.pdf"
+fi
 
 # When building Ferrocene outside of Ferrous Systems, folks will not have
 # access to the document signature files stored in AWS. In that case, configure


### PR DESCRIPTION
These steps:

* https://public-docs.ferrocene.dev/main/qualification/internal-procedures/release/stable.html#uploading-the-qualification-technical-report
* https://public-docs.ferrocene.dev/main/qualification/internal-procedures/release/stable.html#publishing-a-stable-release