### PR TITLE
Remove upcoming 25.05 tags

### DIFF
--- a/ferrocene/doc/qualification-report/src/rustc/thumbv7em-none-eabi.rst
+++ b/ferrocene/doc/qualification-report/src/rustc/thumbv7em-none-eabi.rst
@@ -5,4 +5,3 @@
    :host: x86_64-unknown-linux-gnu
    :target: thumbv7em-none-eabi
    :bare_metal_test_target: thumbv7em-ferrocenecoretest-eabi
-   :upcoming: 25.05

--- a/ferrocene/doc/qualification-report/src/rustc/thumbv7em-none-eabihf.rst
+++ b/ferrocene/doc/qualification-report/src/rustc/thumbv7em-none-eabihf.rst
@@ -5,4 +5,3 @@
    :host: x86_64-unknown-linux-gnu
    :target: thumbv7em-none-eabihf
    :bare_metal_test_target: thumbv7em-ferrocenecoretest-eabihf
-   :upcoming: 25.05

--- a/ferrocene/doc/user-manual/src/targets/thumbv7em-none-eabi.rst
+++ b/ferrocene/doc/user-manual/src/targets/thumbv7em-none-eabi.rst
@@ -3,7 +3,7 @@
 
 .. _thumbv7em-none-eabi:
 
-:target:`thumbv7em-none-eabi` :upcoming:`25.05`
+:target:`thumbv7em-none-eabi`
 ===============================================
 
 .. note::

--- a/ferrocene/doc/user-manual/src/targets/thumbv7em-none-eabihf.rst
+++ b/ferrocene/doc/user-manual/src/targets/thumbv7em-none-eabihf.rst
@@ -3,7 +3,7 @@
 
 .. _thumbv7em-none-eabihf:
 
-:target:`thumbv7em-none-eabihf` :upcoming:`25.05`
+:target:`thumbv7em-none-eabihf`
 =================================================
 
 .. note::


### PR DESCRIPTION
Remove the upcoming tags for 25.05 since we're now marking it stable (#1539 )