### PR TITLE
Generate docs for certified subset

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -66,6 +66,10 @@ pub mod simd;
 #[cfg(all(target_has_atomic = "8", target_has_atomic = "32", target_has_atomic = "ptr"))]
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::sync::atomic::{self, AtomicBool, AtomicI32, AtomicIsize, AtomicU32, Ordering};
+#[allow(unused_imports)]
+#[cfg(all(target_has_atomic = "8", target_has_atomic = "32", target_has_atomic = "ptr"))]
+#[cfg(feature = "ferrocene_certified")]
+use crate::sync::atomic::{self, AtomicU32, Ordering};
 
 /// A type for atomic ordering parameters for intrinsics. This is a separate type from
 /// `atomic::Ordering` so that we can make it `ConstParamTy` and fix the values used here without a

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -141,8 +141,8 @@
 #![feature(allow_internal_unstable)]
 #![feature(auto_traits)]
 #![cfg_attr(not(feature = "ferrocene_certified"), feature(cfg_sanitize))]
-#![cfg_attr(not(feature = "ferrocene_certified"), feature(cfg_target_has_atomic))]
-#![cfg_attr(not(feature = "ferrocene_certified"), feature(cfg_target_has_atomic_equal_alignment))]
+#![feature(cfg_target_has_atomic)]
+#![feature(cfg_target_has_atomic_equal_alignment)]
 #![feature(cfg_ub_checks)]
 #![cfg_attr(not(feature = "ferrocene_certified"), feature(const_precise_live_drops))]
 #![feature(const_trait_impl)]
@@ -363,7 +363,6 @@ pub mod async_iter;
 #[unstable(feature = "bstr", issue = "134915")]
 #[cfg(not(feature = "ferrocene_certified"))]
 pub mod bstr;
-#[cfg(not(feature = "ferrocene_certified"))]
 pub mod cell;
 #[cfg(not(feature = "ferrocene_certified"))]
 pub mod char;
@@ -390,7 +389,6 @@ pub mod random;
 #[cfg(not(feature = "ferrocene_certified"))]
 pub mod range;
 pub mod result;
-#[cfg(not(feature = "ferrocene_certified"))]
 pub mod sync;
 #[unstable(feature = "unsafe_binders", issue = "130516")]
 #[cfg(not(feature = "ferrocene_certified"))]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -92,6 +92,8 @@
 // Do not check link redundancy on bootstraping phase
 #![allow(rustdoc::redundant_explicit_links)]
 #![warn(rustdoc::unescaped_backticks)]
+// Ferrocene addition
+#![cfg_attr(feature = "ferrocene_certified", allow(rustdoc::broken_intra_doc_links))]
 //
 // Ferrocene addition: We removed the tidy directives for alphabetical ordering to reduce the number
 // of conflicts we have when merging main.
@@ -158,7 +160,7 @@
 #![feature(fundamental)]
 #![cfg_attr(not(feature = "ferrocene_certified"), feature(generic_arg_infer))]
 #![cfg_attr(not(feature = "ferrocene_certified"), feature(if_let_guard))]
-#![cfg_attr(not(feature = "ferrocene_certified"), feature(intra_doc_pointers))]
+#![feature(intra_doc_pointers)]
 #![feature(intrinsics)]
 #![feature(lang_items)]
 #![cfg_attr(not(feature = "ferrocene_certified"), feature(link_llvm_intrinsics))]


### PR DESCRIPTION
- **Expose `sync` and `cell`**
- **Generate documentation even if intra-doc links are broken**
