### PR TITLE
Remove upcoming from 25.05 release

### DIFF
--- a/ferrocene/doc/release-notes/src/25.05.0.rst
+++ b/ferrocene/doc/release-notes/src/25.05.0.rst
@@ -1,8 +1,6 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-:upcoming-release:
-
 Ferrocene 25.05.0
 =================
 


### PR DESCRIPTION
We've released it now! :)

Follows https://public-docs.ferrocene.dev/main/qualification/internal-procedures/release/stable.html#remove-upcoming-notes-in-the-main-branch