### PR TITLE
libcore-cert: Add doc comments back

### DIFF
--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -130,11 +130,11 @@ impl Layout {
     }
 
     /// Creates a layout, bypassing all checks.
-    // ///
-    // /// # Safety
-    // ///
-    // /// This function is unsafe as it does not verify the preconditions from
-    // /// [`Layout::from_size_align`].
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as it does not verify the preconditions from
+    /// [`Layout::from_size_align`].
     #[stable(feature = "alloc_layout", since = "1.28.0")]
     #[rustc_const_stable(feature = "const_alloc_layout_unchecked", since = "1.36.0")]
     #[must_use]

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -130,7 +130,6 @@ impl Layout {
     }
 
     /// Creates a layout, bypassing all checks.
-    // FIXME(pvdrz): fix docs
     // ///
     // /// # Safety
     // ///

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -1,38 +1,38 @@
 //! The `Clone` trait for types that cannot be 'implicitly copied'.
-// //!
-// //! In Rust, some simple types are "implicitly copyable" and when you
-// //! assign them or pass them as arguments, the receiver will get a copy,
-// //! leaving the original value in place. These types do not require
-// //! allocation to copy and do not have finalizers (i.e., they do not
-// //! contain owned boxes or implement [`Drop`]), so the compiler considers
-// //! them cheap and safe to copy. For other types copies must be made
-// //! explicitly, by convention implementing the [`Clone`] trait and calling
-// //! the [`clone`] method.
-// //!
-// //! [`clone`]: Clone::clone
-// //!
-// //! Basic usage example:
-// //!
-// //! ```
-// //! let s = String::new(); // String type implements Clone
-// //! let copy = s.clone(); // so we can clone it
-// //! ```
-// //!
-// //! To easily implement the Clone trait, you can also use
-// //! `#[derive(Clone)]`. Example:
-// //!
-// //! ```
-// //! #[derive(Clone)] // we add the Clone trait to Morpheus struct
-// //! struct Morpheus {
-// //!    blue_pill: f32,
-// //!    red_pill: i64,
-// //! }
-// //!
-// //! fn main() {
-// //!    let f = Morpheus { blue_pill: 0.0, red_pill: 0 };
-// //!    let copy = f.clone(); // and now we can clone it!
-// //! }
-// //! ```
+//!
+//! In Rust, some simple types are "implicitly copyable" and when you
+//! assign them or pass them as arguments, the receiver will get a copy,
+//! leaving the original value in place. These types do not require
+//! allocation to copy and do not have finalizers (i.e., they do not
+//! contain owned boxes or implement [`Drop`]), so the compiler considers
+//! them cheap and safe to copy. For other types copies must be made
+//! explicitly, by convention implementing the [`Clone`] trait and calling
+//! the [`clone`] method.
+//!
+//! [`clone`]: Clone::clone
+//!
+//! Basic usage example:
+//!
+//! ```
+//! let s = String::new(); // String type implements Clone
+//! let copy = s.clone(); // so we can clone it
+//! ```
+//!
+//! To easily implement the Clone trait, you can also use
+//! `#[derive(Clone)]`. Example:
+//!
+//! ```
+//! #[derive(Clone)] // we add the Clone trait to Morpheus struct
+//! struct Morpheus {
+//!    blue_pill: f32,
+//!    red_pill: i64,
+//! }
+//!
+//! fn main() {
+//!    let f = Morpheus { blue_pill: 0.0, red_pill: 0 };
+//!    let copy = f.clone(); // and now we can clone it!
+//! }
+//! ```
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -1,5 +1,4 @@
 //! The `Clone` trait for types that cannot be 'implicitly copied'.
-// FIXME(pvdrz): Fix docs
 // //!
 // //! In Rust, some simple types are "implicitly copyable" and when you
 // //! assign them or pass them as arguments, the receiver will get a copy,

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1,27 +1,27 @@
 //! Utilities for comparing and ordering values.
-// //!
-// //! This module contains various tools for comparing and ordering values. In
-// //! summary:
-// //!
-// //! * [`PartialEq<Rhs>`] overloads the `==` and `!=` operators. In cases where
-// //!   `Rhs` (the right hand side's type) is `Self`, this trait corresponds to a
-// //!   partial equivalence relation.
-// //! * [`Eq`] indicates that the overloaded `==` operator corresponds to an
-// //!   equivalence relation.
-// //! * [`Ord`] and [`PartialOrd`] are traits that allow you to define total and
-// //!   partial orderings between values, respectively. Implementing them overloads
-// //!   the `<`, `<=`, `>`, and `>=` operators.
-// //! * [`Ordering`] is an enum returned by the main functions of [`Ord`] and
-// //!   [`PartialOrd`], and describes an ordering of two values (less, equal, or
-// //!   greater).
-// //! * [`Reverse`] is a struct that allows you to easily reverse an ordering.
-// //! * [`max`] and [`min`] are functions that build off of [`Ord`] and allow you
-// //!   to find the maximum or minimum of two values.
-// //!
-// //! For more details, see the respective documentation of each item in the list.
-// //!
-// //! [`max`]: Ord::max
-// //! [`min`]: Ord::min
+//!
+//! This module contains various tools for comparing and ordering values. In
+//! summary:
+//!
+//! * [`PartialEq<Rhs>`] overloads the `==` and `!=` operators. In cases where
+//!   `Rhs` (the right hand side's type) is `Self`, this trait corresponds to a
+//!   partial equivalence relation.
+//! * [`Eq`] indicates that the overloaded `==` operator corresponds to an
+//!   equivalence relation.
+//! * [`Ord`] and [`PartialOrd`] are traits that allow you to define total and
+//!   partial orderings between values, respectively. Implementing them overloads
+//!   the `<`, `<=`, `>`, and `>=` operators.
+//! * [`Ordering`] is an enum returned by the main functions of [`Ord`] and
+//!   [`PartialOrd`], and describes an ordering of two values (less, equal, or
+//!   greater).
+//! * [`Reverse`] is a struct that allows you to easily reverse an ordering.
+//! * [`max`] and [`min`] are functions that build off of [`Ord`] and allow you
+//!   to find the maximum or minimum of two values.
+//!
+//! For more details, see the respective documentation of each item in the list.
+//!
+//! [`max`]: Ord::max
+//! [`min`]: Ord::min
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -36,210 +36,210 @@ use crate::ops::ControlFlow;
 
 /// Trait for comparisons using the equality operator.
 // FIXME(pvdrz): fix docs
-// ///
-// /// Implementing this trait for types provides the `==` and `!=` operators for
-// /// those types.
-// ///
-// /// `x.eq(y)` can also be written `x == y`, and `x.ne(y)` can be written `x != y`.
-// /// We use the easier-to-read infix notation in the remainder of this documentation.
-// ///
-// /// This trait allows for comparisons using the equality operator, for types
-// /// that do not have a full equivalence relation. For example, in floating point
-// /// numbers `NaN != NaN`, so floating point types implement `PartialEq` but not
-// /// [`trait@Eq`]. Formally speaking, when `Rhs == Self`, this trait corresponds
-// /// to a [partial equivalence relation].
-// ///
-// /// [partial equivalence relation]: https:// //en.wikipedia.org/wiki/Partial_equivalence_relation
-// ///
-// /// Implementations must ensure that `eq` and `ne` are consistent with each other:
-// ///
-// /// - `a != b` if and only if `!(a == b)`.
-// ///
-// /// The default implementation of `ne` provides this consistency and is almost
-// /// always sufficient. It should not be overridden without very good reason.
-// ///
-// /// If [`PartialOrd`] or [`Ord`] are also implemented for `Self` and `Rhs`, their methods must also
-// /// be consistent with `PartialEq` (see the documentation of those traits for the exact
-// /// requirements). It's easy to accidentally make them disagree by deriving some of the traits and
-// /// manually implementing others.
-// ///
-// /// The equality relation `==` must satisfy the following conditions
-// /// (for all `a`, `b`, `c` of type `A`, `B`, `C`):
-// ///
-// /// - **Symmetry**: if `A: PartialEq<B>` and `B: PartialEq<A>`, then **`a == b`
-// ///   implies `b == a`**; and
-// ///
-// /// - **Transitivity**: if `A: PartialEq<B>` and `B: PartialEq<C>` and `A:
-// ///   PartialEq<C>`, then **`a == b` and `b == c` implies `a == c`**.
-// ///   This must also work for longer chains, such as when `A: PartialEq<B>`, `B: PartialEq<C>`,
-// ///   `C: PartialEq<D>`, and `A: PartialEq<D>` all exist.
-// ///
-// /// Note that the `B: PartialEq<A>` (symmetric) and `A: PartialEq<C>`
-// /// (transitive) impls are not forced to exist, but these requirements apply
-// /// whenever they do exist.
-// ///
-// /// Violating these requirements is a logic error. The behavior resulting from a logic error is not
-// /// specified, but users of the trait must ensure that such logic errors do *not* result in
-// /// undefined behavior. This means that `unsafe` code **must not** rely on the correctness of these
-// /// methods.
-// ///
-// /// ## Cross-crate considerations
-// ///
-// /// Upholding the requirements stated above can become tricky when one crate implements `PartialEq`
-// /// for a type of another crate (i.e., to allow comparing one of its own types with a type from the
-// /// standard library). The recommendation is to never implement this trait for a foreign type. In
-// /// other words, such a crate should do `impl PartialEq<ForeignType> for LocalType`, but it should
-// /// *not* do `impl PartialEq<LocalType> for ForeignType`.
-// ///
-// /// This avoids the problem of transitive chains that criss-cross crate boundaries: for all local
-// /// types `T`, you may assume that no other crate will add `impl`s that allow comparing `T == U`. In
-// /// other words, if other crates add `impl`s that allow building longer transitive chains `U1 == ...
-// /// == T == V1 == ...`, then all the types that appear to the right of `T` must be types that the
-// /// crate defining `T` already knows about. This rules out transitive chains where downstream crates
-// /// can add new `impl`s that "stitch together" comparisons of foreign types in ways that violate
-// /// transitivity.
-// ///
-// /// Not having such foreign `impl`s also avoids forward compatibility issues where one crate adding
-// /// more `PartialEq` implementations can cause build failures in downstream crates.
-// ///
+///
+/// Implementing this trait for types provides the `==` and `!=` operators for
+/// those types.
+///
+/// `x.eq(y)` can also be written `x == y`, and `x.ne(y)` can be written `x != y`.
+/// We use the easier-to-read infix notation in the remainder of this documentation.
+///
+/// This trait allows for comparisons using the equality operator, for types
+/// that do not have a full equivalence relation. For example, in floating point
+/// numbers `NaN != NaN`, so floating point types implement `PartialEq` but not
+/// [`trait@Eq`]. Formally speaking, when `Rhs == Self`, this trait corresponds
+/// to a [partial equivalence relation].
+///
+/// [partial equivalence relation]: https:// //en.wikipedia.org/wiki/Partial_equivalence_relation
+///
+/// Implementations must ensure that `eq` and `ne` are consistent with each other:
+///
+/// - `a != b` if and only if `!(a == b)`.
+///
+/// The default implementation of `ne` provides this consistency and is almost
+/// always sufficient. It should not be overridden without very good reason.
+///
+/// If [`PartialOrd`] or [`Ord`] are also implemented for `Self` and `Rhs`, their methods must also
+/// be consistent with `PartialEq` (see the documentation of those traits for the exact
+/// requirements). It's easy to accidentally make them disagree by deriving some of the traits and
+/// manually implementing others.
+///
+/// The equality relation `==` must satisfy the following conditions
+/// (for all `a`, `b`, `c` of type `A`, `B`, `C`):
+///
+/// - **Symmetry**: if `A: PartialEq<B>` and `B: PartialEq<A>`, then **`a == b`
+///   implies `b == a`**; and
+///
+/// - **Transitivity**: if `A: PartialEq<B>` and `B: PartialEq<C>` and `A:
+///   PartialEq<C>`, then **`a == b` and `b == c` implies `a == c`**.
+///   This must also work for longer chains, such as when `A: PartialEq<B>`, `B: PartialEq<C>`,
+///   `C: PartialEq<D>`, and `A: PartialEq<D>` all exist.
+///
+/// Note that the `B: PartialEq<A>` (symmetric) and `A: PartialEq<C>`
+/// (transitive) impls are not forced to exist, but these requirements apply
+/// whenever they do exist.
+///
+/// Violating these requirements is a logic error. The behavior resulting from a logic error is not
+/// specified, but users of the trait must ensure that such logic errors do *not* result in
+/// undefined behavior. This means that `unsafe` code **must not** rely on the correctness of these
+/// methods.
+///
+/// ## Cross-crate considerations
+///
+/// Upholding the requirements stated above can become tricky when one crate implements `PartialEq`
+/// for a type of another crate (i.e., to allow comparing one of its own types with a type from the
+/// standard library). The recommendation is to never implement this trait for a foreign type. In
+/// other words, such a crate should do `impl PartialEq<ForeignType> for LocalType`, but it should
+/// *not* do `impl PartialEq<LocalType> for ForeignType`.
+///
+/// This avoids the problem of transitive chains that criss-cross crate boundaries: for all local
+/// types `T`, you may assume that no other crate will add `impl`s that allow comparing `T == U`. In
+/// other words, if other crates add `impl`s that allow building longer transitive chains `U1 == ...
+/// == T == V1 == ...`, then all the types that appear to the right of `T` must be types that the
+/// crate defining `T` already knows about. This rules out transitive chains where downstream crates
+/// can add new `impl`s that "stitch together" comparisons of foreign types in ways that violate
+/// transitivity.
+///
+/// Not having such foreign `impl`s also avoids forward compatibility issues where one crate adding
+/// more `PartialEq` implementations can cause build failures in downstream crates.
+///
 /// ## Derivable
-// ///
-// /// This trait can be used with `#[derive]`. When `derive`d on structs, two
-// /// instances are equal if all fields are equal, and not equal if any fields
-// /// are not equal. When `derive`d on enums, two instances are equal if they
-// /// are the same variant and all fields are equal.
-// ///
-// /// ## How can I implement `PartialEq`?
-// ///
-// /// An example implementation for a domain in which two books are considered
-// /// the same book if their ISBN matches, even if the formats differ:
-// ///
-// /// ```
-// /// enum BookFormat {
-// ///     Paperback,
-// ///     Hardback,
-// ///     Ebook,
-// /// }
-// ///
-// /// struct Book {
-// ///     isbn: i32,
-// ///     format: BookFormat,
-// /// }
-// ///
-// /// impl PartialEq for Book {
-// ///     fn eq(&self, other: &Self) -> bool {
-// ///         self.isbn == other.isbn
-// ///     }
-// /// }
-// ///
-// /// let b1 = Book { isbn: 3, format: BookFormat::Paperback };
-// /// let b2 = Book { isbn: 3, format: BookFormat::Ebook };
-// /// let b3 = Book { isbn: 10, format: BookFormat::Paperback };
-// ///
-// /// assert!(b1 == b2);
-// /// assert!(b1 != b3);
-// /// ```
-// ///
-// /// ## How can I compare two different types?
-// ///
-// /// The type you can compare with is controlled by `PartialEq`'s type parameter.
-// /// For example, let's tweak our previous code a bit:
-// ///
-// /// ```
-// /// // // The derive implements <BookFormat> == <BookFormat> comparisons
-// /// #[derive(PartialEq)]
-// /// enum BookFormat {
-// ///     Paperback,
-// ///     Hardback,
-// ///     Ebook,
-// /// }
-// ///
-// /// struct Book {
-// ///     isbn: i32,
-// ///     format: BookFormat,
-// /// }
-// ///
-// /// // // Implement <Book> == <BookFormat> comparisons
-// /// impl PartialEq<BookFormat> for Book {
-// ///     fn eq(&self, other: &BookFormat) -> bool {
-// ///         self.format == *other
-// ///     }
-// /// }
-// ///
-// /// // // Implement <BookFormat> == <Book> comparisons
-// /// impl PartialEq<Book> for BookFormat {
-// ///     fn eq(&self, other: &Book) -> bool {
-// ///         *self == other.format
-// ///     }
-// /// }
-// ///
-// /// let b1 = Book { isbn: 3, format: BookFormat::Paperback };
-// ///
-// /// assert!(b1 == BookFormat::Paperback);
-// /// assert!(BookFormat::Ebook != b1);
-// /// ```
-// ///
-// /// By changing `impl PartialEq for Book` to `impl PartialEq<BookFormat> for Book`,
-// /// we allow `BookFormat`s to be compared with `Book`s.
-// ///
-// /// A comparison like the one above, which ignores some fields of the struct,
-// /// can be dangerous. It can easily lead to an unintended violation of the
-// /// requirements for a partial equivalence relation. For example, if we kept
-// /// the above implementation of `PartialEq<Book>` for `BookFormat` and added an
-// /// implementation of `PartialEq<Book>` for `Book` (either via a `#[derive]` or
-// /// via the manual implementation from the first example) then the result would
-// /// violate transitivity:
-// ///
-// /// ```should_panic
-// /// #[derive(PartialEq)]
-// /// enum BookFormat {
-// ///     Paperback,
-// ///     Hardback,
-// ///     Ebook,
-// /// }
-// ///
-// /// #[derive(PartialEq)]
-// /// struct Book {
-// ///     isbn: i32,
-// ///     format: BookFormat,
-// /// }
-// ///
-// /// impl PartialEq<BookFormat> for Book {
-// ///     fn eq(&self, other: &BookFormat) -> bool {
-// ///         self.format == *other
-// ///     }
-// /// }
-// ///
-// /// impl PartialEq<Book> for BookFormat {
-// ///     fn eq(&self, other: &Book) -> bool {
-// ///         *self == other.format
-// ///     }
-// /// }
-// ///
-// /// fn main() {
-// ///     let b1 = Book { isbn: 1, format: BookFormat::Paperback };
-// ///     let b2 = Book { isbn: 2, format: BookFormat::Paperback };
-// ///
-// ///     assert!(b1 == BookFormat::Paperback);
-// ///     assert!(BookFormat::Paperback == b2);
-// ///
-// ///     // // The following should hold by transitivity but doesn't.
-// ///     assert!(b1 == b2); // // <-- PANICS
-// /// }
-// /// ```
-// ///
-// /// # Examples
-// ///
-// /// ```
-// /// let x: u32 = 0;
-// /// let y: u32 = 1;
-// ///
-// /// assert_eq!(x == y, false);
-// /// assert_eq!(x.eq(&y), false);
-// /// ```
-// ///
-// /// [`eq`]: PartialEq::eq
-// /// [`ne`]: PartialEq::ne
+///
+/// This trait can be used with `#[derive]`. When `derive`d on structs, two
+/// instances are equal if all fields are equal, and not equal if any fields
+/// are not equal. When `derive`d on enums, two instances are equal if they
+/// are the same variant and all fields are equal.
+///
+/// ## How can I implement `PartialEq`?
+///
+/// An example implementation for a domain in which two books are considered
+/// the same book if their ISBN matches, even if the formats differ:
+///
+/// ```
+/// enum BookFormat {
+///     Paperback,
+///     Hardback,
+///     Ebook,
+/// }
+///
+/// struct Book {
+///     isbn: i32,
+///     format: BookFormat,
+/// }
+///
+/// impl PartialEq for Book {
+///     fn eq(&self, other: &Self) -> bool {
+///         self.isbn == other.isbn
+///     }
+/// }
+///
+/// let b1 = Book { isbn: 3, format: BookFormat::Paperback };
+/// let b2 = Book { isbn: 3, format: BookFormat::Ebook };
+/// let b3 = Book { isbn: 10, format: BookFormat::Paperback };
+///
+/// assert!(b1 == b2);
+/// assert!(b1 != b3);
+/// ```
+///
+/// ## How can I compare two different types?
+///
+/// The type you can compare with is controlled by `PartialEq`'s type parameter.
+/// For example, let's tweak our previous code a bit:
+///
+/// ```
+/// // // The derive implements <BookFormat> == <BookFormat> comparisons
+/// #[derive(PartialEq)]
+/// enum BookFormat {
+///     Paperback,
+///     Hardback,
+///     Ebook,
+/// }
+///
+/// struct Book {
+///     isbn: i32,
+///     format: BookFormat,
+/// }
+///
+/// // // Implement <Book> == <BookFormat> comparisons
+/// impl PartialEq<BookFormat> for Book {
+///     fn eq(&self, other: &BookFormat) -> bool {
+///         self.format == *other
+///     }
+/// }
+///
+/// // // Implement <BookFormat> == <Book> comparisons
+/// impl PartialEq<Book> for BookFormat {
+///     fn eq(&self, other: &Book) -> bool {
+///         *self == other.format
+///     }
+/// }
+///
+/// let b1 = Book { isbn: 3, format: BookFormat::Paperback };
+///
+/// assert!(b1 == BookFormat::Paperback);
+/// assert!(BookFormat::Ebook != b1);
+/// ```
+///
+/// By changing `impl PartialEq for Book` to `impl PartialEq<BookFormat> for Book`,
+/// we allow `BookFormat`s to be compared with `Book`s.
+///
+/// A comparison like the one above, which ignores some fields of the struct,
+/// can be dangerous. It can easily lead to an unintended violation of the
+/// requirements for a partial equivalence relation. For example, if we kept
+/// the above implementation of `PartialEq<Book>` for `BookFormat` and added an
+/// implementation of `PartialEq<Book>` for `Book` (either via a `#[derive]` or
+/// via the manual implementation from the first example) then the result would
+/// violate transitivity:
+///
+/// ```should_panic
+/// #[derive(PartialEq)]
+/// enum BookFormat {
+///     Paperback,
+///     Hardback,
+///     Ebook,
+/// }
+///
+/// #[derive(PartialEq)]
+/// struct Book {
+///     isbn: i32,
+///     format: BookFormat,
+/// }
+///
+/// impl PartialEq<BookFormat> for Book {
+///     fn eq(&self, other: &BookFormat) -> bool {
+///         self.format == *other
+///     }
+/// }
+///
+/// impl PartialEq<Book> for BookFormat {
+///     fn eq(&self, other: &Book) -> bool {
+///         *self == other.format
+///     }
+/// }
+///
+/// fn main() {
+///     let b1 = Book { isbn: 1, format: BookFormat::Paperback };
+///     let b2 = Book { isbn: 2, format: BookFormat::Paperback };
+///
+///     assert!(b1 == BookFormat::Paperback);
+///     assert!(BookFormat::Paperback == b2);
+///
+///     // // The following should hold by transitivity but doesn't.
+///     assert!(b1 == b2); // // <-- PANICS
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```
+/// let x: u32 = 0;
+/// let y: u32 = 1;
+///
+/// assert_eq!(x == y, false);
+/// assert_eq!(x.eq(&y), false);
+/// ```
+///
+/// [`eq`]: PartialEq::eq
+/// [`ne`]: PartialEq::ne
 #[lang = "eq"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(alias = "==")]
@@ -280,59 +280,59 @@ pub macro PartialEq($item:item) {
 /// Trait for comparisons corresponding to [equivalence relations](
 /// https://en.wikipedia.org/wiki/Equivalence_relation).
 // FIXME(pvdrz): fix docs
-// ///
-// /// The primary difference to [`PartialEq`] is the additional requirement for reflexivity. A type
-// /// that implements [`PartialEq`] guarantees that for all `a`, `b` and `c`:
-// ///
-// /// - symmetric: `a == b` implies `b == a` and `a != b` implies `!(a == b)`
-// /// - transitive: `a == b` and `b == c` implies `a == c`
-// ///
-// /// `Eq`, which builds on top of [`PartialEq`] also implies:
-// ///
-// /// - reflexive: `a == a`
-// ///
-// /// This property cannot be checked by the compiler, and therefore `Eq` is a trait without methods.
-// ///
-// /// Violating this property is a logic error. The behavior resulting from a logic error is not
-// /// specified, but users of the trait must ensure that such logic errors do *not* result in
-// /// undefined behavior. This means that `unsafe` code **must not** rely on the correctness of these
-// /// methods.
-// ///
-// /// Floating point types such as [`f32`] and [`f64`] implement only [`PartialEq`] but *not* `Eq`
-// /// because `NaN` != `NaN`.
-// ///
-// /// ## Derivable
-// ///
-// /// This trait can be used with `#[derive]`. When `derive`d, because `Eq` has no extra methods, it
-// /// is only informing the compiler that this is an equivalence relation rather than a partial
-// /// equivalence relation. Note that the `derive` strategy requires all fields are `Eq`, which isn't
-// /// always desired.
-// ///
-// /// ## How can I implement `Eq`?
-// ///
-// /// If you cannot use the `derive` strategy, specify that your type implements `Eq`, which has no
-// /// extra methods:
-// ///
-// /// ```
-// /// enum BookFormat {
-// ///     Paperback,
-// ///     Hardback,
-// ///     Ebook,
-// /// }
-// ///
-// /// struct Book {
-// ///     isbn: i32,
-// ///     format: BookFormat,
-// /// }
-// ///
-// /// impl PartialEq for Book {
-// ///     fn eq(&self, other: &Self) -> bool {
-// ///         self.isbn == other.isbn
-// ///     }
-// /// }
-// ///
-// /// impl Eq for Book {}
-// /// ```
+///
+/// The primary difference to [`PartialEq`] is the additional requirement for reflexivity. A type
+/// that implements [`PartialEq`] guarantees that for all `a`, `b` and `c`:
+///
+/// - symmetric: `a == b` implies `b == a` and `a != b` implies `!(a == b)`
+/// - transitive: `a == b` and `b == c` implies `a == c`
+///
+/// `Eq`, which builds on top of [`PartialEq`] also implies:
+///
+/// - reflexive: `a == a`
+///
+/// This property cannot be checked by the compiler, and therefore `Eq` is a trait without methods.
+///
+/// Violating this property is a logic error. The behavior resulting from a logic error is not
+/// specified, but users of the trait must ensure that such logic errors do *not* result in
+/// undefined behavior. This means that `unsafe` code **must not** rely on the correctness of these
+/// methods.
+///
+/// Floating point types such as [`f32`] and [`f64`] implement only [`PartialEq`] but *not* `Eq`
+/// because `NaN` != `NaN`.
+///
+/// ## Derivable
+///
+/// This trait can be used with `#[derive]`. When `derive`d, because `Eq` has no extra methods, it
+/// is only informing the compiler that this is an equivalence relation rather than a partial
+/// equivalence relation. Note that the `derive` strategy requires all fields are `Eq`, which isn't
+/// always desired.
+///
+/// ## How can I implement `Eq`?
+///
+/// If you cannot use the `derive` strategy, specify that your type implements `Eq`, which has no
+/// extra methods:
+///
+/// ```
+/// enum BookFormat {
+///     Paperback,
+///     Hardback,
+///     Ebook,
+/// }
+///
+/// struct Book {
+///     isbn: i32,
+///     format: BookFormat,
+/// }
+///
+/// impl PartialEq for Book {
+///     fn eq(&self, other: &Self) -> bool {
+///         self.isbn == other.isbn
+///     }
+/// }
+///
+/// impl Eq for Book {}
+/// ```
 #[doc(alias = "==")]
 #[doc(alias = "!=")]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -723,246 +723,246 @@ impl<T: Clone> Clone for Reverse<T> {
 
 /// Trait for types that form a [total order](https://en.wikipedia.org/wiki/Total_order).
 // FIXME(pvdrz): fix docs
-// ///
-// /// Implementations must be consistent with the [`PartialOrd`] implementation, and ensure `max`,
-// /// `min`, and `clamp` are consistent with `cmp`:
-// ///
-// /// - `partial_cmp(a, b) == Some(cmp(a, b))`.
-// /// - `max(a, b) == max_by(a, b, cmp)` (ensured by the default implementation).
-// /// - `min(a, b) == min_by(a, b, cmp)` (ensured by the default implementation).
-// /// - For `a.clamp(min, max)`, see the [method docs](#method.clamp) (ensured by the default
-// ///   implementation).
-// ///
-// /// Violating these requirements is a logic error. The behavior resulting from a logic error is not
-// /// specified, but users of the trait must ensure that such logic errors do *not* result in
-// /// undefined behavior. This means that `unsafe` code **must not** rely on the correctness of these
-// /// methods.
-// ///
-// /// ## Corollaries
-// ///
-// /// From the above and the requirements of `PartialOrd`, it follows that for all `a`, `b` and `c`:
-// ///
-// /// - exactly one of `a < b`, `a == b` or `a > b` is true; and
-// /// - `<` is transitive: `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and
-// ///   `>`.
-// ///
-// /// Mathematically speaking, the `<` operator defines a strict [weak order]. In cases where `==`
-// /// conforms to mathematical equality, it also defines a strict [total order].
-// ///
-// /// [weak order]: https://en.wikipedia.org/wiki/Weak_ordering
-// /// [total order]: https://en.wikipedia.org/wiki/Total_order
-// ///
+///
+/// Implementations must be consistent with the [`PartialOrd`] implementation, and ensure `max`,
+/// `min`, and `clamp` are consistent with `cmp`:
+///
+/// - `partial_cmp(a, b) == Some(cmp(a, b))`.
+/// - `max(a, b) == max_by(a, b, cmp)` (ensured by the default implementation).
+/// - `min(a, b) == min_by(a, b, cmp)` (ensured by the default implementation).
+/// - For `a.clamp(min, max)`, see the [method docs](#method.clamp) (ensured by the default
+///   implementation).
+///
+/// Violating these requirements is a logic error. The behavior resulting from a logic error is not
+/// specified, but users of the trait must ensure that such logic errors do *not* result in
+/// undefined behavior. This means that `unsafe` code **must not** rely on the correctness of these
+/// methods.
+///
+/// ## Corollaries
+///
+/// From the above and the requirements of `PartialOrd`, it follows that for all `a`, `b` and `c`:
+///
+/// - exactly one of `a < b`, `a == b` or `a > b` is true; and
+/// - `<` is transitive: `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and
+///   `>`.
+///
+/// Mathematically speaking, the `<` operator defines a strict [weak order]. In cases where `==`
+/// conforms to mathematical equality, it also defines a strict [total order].
+///
+/// [weak order]: https://en.wikipedia.org/wiki/Weak_ordering
+/// [total order]: https://en.wikipedia.org/wiki/Total_order
+///
 /// ## Derivable
-// ///
-// /// This trait can be used with `#[derive]`.
-// ///
-// /// When `derive`d on structs, it will produce a
-// /// [lexicographic](https://en.wikipedia.org/wiki/Lexicographic_order) ordering based on the
-// /// top-to-bottom declaration order of the struct's members.
-// ///
-// /// When `derive`d on enums, variants are ordered primarily by their discriminants. Secondarily,
-// /// they are ordered by their fields. By default, the discriminant is smallest for variants at the
-// /// top, and largest for variants at the bottom. Here's an example:
-// ///
-// /// ```
-// /// #[derive(PartialEq, Eq, PartialOrd, Ord)]
-// /// enum E {
-// ///     Top,
-// ///     Bottom,
-// /// }
-// ///
-// /// assert!(E::Top < E::Bottom);
-// /// ```
-// ///
-// /// However, manually setting the discriminants can override this default behavior:
-// ///
-// /// ```
-// /// #[derive(PartialEq, Eq, PartialOrd, Ord)]
-// /// enum E {
-// ///     Top = 2,
-// ///     Bottom = 1,
-// /// }
-// ///
-// /// assert!(E::Bottom < E::Top);
-// /// ```
-// ///
+///
+/// This trait can be used with `#[derive]`.
+///
+/// When `derive`d on structs, it will produce a
+/// [lexicographic](https://en.wikipedia.org/wiki/Lexicographic_order) ordering based on the
+/// top-to-bottom declaration order of the struct's members.
+///
+/// When `derive`d on enums, variants are ordered primarily by their discriminants. Secondarily,
+/// they are ordered by their fields. By default, the discriminant is smallest for variants at the
+/// top, and largest for variants at the bottom. Here's an example:
+///
+/// ```
+/// #[derive(PartialEq, Eq, PartialOrd, Ord)]
+/// enum E {
+///     Top,
+///     Bottom,
+/// }
+///
+/// assert!(E::Top < E::Bottom);
+/// ```
+///
+/// However, manually setting the discriminants can override this default behavior:
+///
+/// ```
+/// #[derive(PartialEq, Eq, PartialOrd, Ord)]
+/// enum E {
+///     Top = 2,
+///     Bottom = 1,
+/// }
+///
+/// assert!(E::Bottom < E::Top);
+/// ```
+///
 /// ## Lexicographical comparison
-// ///
-// /// Lexicographical comparison is an operation with the following properties:
-// ///  - Two sequences are compared element by element.
-// ///  - The first mismatching element defines which sequence is lexicographically less or greater
-// ///    than the other.
-// ///  - If one sequence is a prefix of another, the shorter sequence is lexicographically less than
-// ///    the other.
-// ///  - If two sequences have equivalent elements and are of the same length, then the sequences are
-// ///    lexicographically equal.
-// ///  - An empty sequence is lexicographically less than any non-empty sequence.
-// ///  - Two empty sequences are lexicographically equal.
-// ///
-// /// ## How can I implement `Ord`?
-// ///
-// /// `Ord` requires that the type also be [`PartialOrd`], [`PartialEq`], and [`Eq`].
-// ///
-// /// Because `Ord` implies a stronger ordering relationship than [`PartialOrd`], and both `Ord` and
-// /// [`PartialOrd`] must agree, you must choose how to implement `Ord` **first**. You can choose to
-// /// derive it, or implement it manually. If you derive it, you should derive all four traits. If you
-// /// implement it manually, you should manually implement all four traits, based on the
-// /// implementation of `Ord`.
-// ///
-// /// Here's an example where you want to define the `Character` comparison by `health` and
-// /// `experience` only, disregarding the field `mana`:
-// ///
-// /// ```
-// /// use std::cmp::Ordering;
-// ///
-// /// struct Character {
-// ///     health: u32,
-// ///     experience: u32,
-// ///     mana: f32,
-// /// }
-// ///
-// /// impl Ord for Character {
-// ///     fn cmp(&self, other: &Self) -> Ordering {
-// ///         self.experience
-// ///             .cmp(&other.experience)
-// ///             .then(self.health.cmp(&other.health))
-// ///     }
-// /// }
-// ///
-// /// impl PartialOrd for Character {
-// ///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-// ///         Some(self.cmp(other))
-// ///     }
-// /// }
-// ///
-// /// impl PartialEq for Character {
-// ///     fn eq(&self, other: &Self) -> bool {
-// ///         self.health == other.health && self.experience == other.experience
-// ///     }
-// /// }
-// ///
-// /// impl Eq for Character {}
-// /// ```
-// ///
-// /// If all you need is to `slice::sort` a type by a field value, it can be simpler to use
-// /// `slice::sort_by_key`.
-// ///
-// /// ## Examples of incorrect `Ord` implementations
-// ///
-// /// ```
-// /// use std::cmp::Ordering;
-// ///
-// /// #[derive(Debug)]
-// /// struct Character {
-// ///     health: f32,
-// /// }
-// ///
-// /// impl Ord for Character {
-// ///     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-// ///         if self.health < other.health {
-// ///             Ordering::Less
-// ///         } else if self.health > other.health {
-// ///             Ordering::Greater
-// ///         } else {
-// ///             Ordering::Equal
-// ///         }
-// ///     }
-// /// }
-// ///
-// /// impl PartialOrd for Character {
-// ///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-// ///         Some(self.cmp(other))
-// ///     }
-// /// }
-// ///
-// /// impl PartialEq for Character {
-// ///     fn eq(&self, other: &Self) -> bool {
-// ///         self.health == other.health
-// ///     }
-// /// }
-// ///
-// /// impl Eq for Character {}
-// ///
-// /// let a = Character { health: 4.5 };
-// /// let b = Character { health: f32::NAN };
-// ///
-// /// // Mistake: floating-point values do not form a total order and using the built-in comparison
-// /// // operands to implement `Ord` irregardless of that reality does not change it. Use
-// /// // `f32::total_cmp` if you need a total order for floating-point values.
-// ///
-// /// // Reflexivity requirement of `Ord` is not given.
-// /// assert!(a == a);
-// /// assert!(b != b);
-// ///
-// /// // Antisymmetry requirement of `Ord` is not given. Only one of a < c and c < a is allowed to be
-// /// // true, not both or neither.
-// /// assert_eq!((a < b) as u8 + (b < a) as u8, 0);
-// /// ```
-// ///
-// /// ```
-// /// use std::cmp::Ordering;
-// ///
-// /// #[derive(Debug)]
-// /// struct Character {
-// ///     health: u32,
-// ///     experience: u32,
-// /// }
-// ///
-// /// impl PartialOrd for Character {
-// ///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-// ///         Some(self.cmp(other))
-// ///     }
-// /// }
-// ///
-// /// impl Ord for Character {
-// ///     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-// ///         if self.health < 50 {
-// ///             self.health.cmp(&other.health)
-// ///         } else {
-// ///             self.experience.cmp(&other.experience)
-// ///         }
-// ///     }
-// /// }
-// ///
-// /// // For performance reasons implementing `PartialEq` this way is not the idiomatic way, but it
-// /// // ensures consistent behavior between `PartialEq`, `PartialOrd` and `Ord` in this example.
-// /// impl PartialEq for Character {
-// ///     fn eq(&self, other: &Self) -> bool {
-// ///         self.cmp(other) == Ordering::Equal
-// ///     }
-// /// }
-// ///
-// /// impl Eq for Character {}
-// ///
-// /// let a = Character {
-// ///     health: 3,
-// ///     experience: 5,
-// /// };
-// /// let b = Character {
-// ///     health: 10,
-// ///     experience: 77,
-// /// };
-// /// let c = Character {
-// ///     health: 143,
-// ///     experience: 2,
-// /// };
-// ///
-// /// // Mistake: The implementation of `Ord` compares different fields depending on the value of
-// /// // `self.health`, the resulting order is not total.
-// ///
-// /// // Transitivity requirement of `Ord` is not given. If a is smaller than b and b is smaller than
-// /// // c, by transitive property a must also be smaller than c.
-// /// assert!(a < b && b < c && c < a);
-// ///
-// /// // Antisymmetry requirement of `Ord` is not given. Only one of a < c and c < a is allowed to be
-// /// // true, not both or neither.
-// /// assert_eq!((a < c) as u8 + (c < a) as u8, 2);
-// /// ```
-// ///
-// /// The documentation of [`PartialOrd`] contains further examples, for example it's wrong for
-// /// [`PartialOrd`] and [`PartialEq`] to disagree.
-// ///
-// /// [`cmp`]: Ord::cmp
+///
+/// Lexicographical comparison is an operation with the following properties:
+///  - Two sequences are compared element by element.
+///  - The first mismatching element defines which sequence is lexicographically less or greater
+///    than the other.
+///  - If one sequence is a prefix of another, the shorter sequence is lexicographically less than
+///    the other.
+///  - If two sequences have equivalent elements and are of the same length, then the sequences are
+///    lexicographically equal.
+///  - An empty sequence is lexicographically less than any non-empty sequence.
+///  - Two empty sequences are lexicographically equal.
+///
+/// ## How can I implement `Ord`?
+///
+/// `Ord` requires that the type also be [`PartialOrd`], [`PartialEq`], and [`Eq`].
+///
+/// Because `Ord` implies a stronger ordering relationship than [`PartialOrd`], and both `Ord` and
+/// [`PartialOrd`] must agree, you must choose how to implement `Ord` **first**. You can choose to
+/// derive it, or implement it manually. If you derive it, you should derive all four traits. If you
+/// implement it manually, you should manually implement all four traits, based on the
+/// implementation of `Ord`.
+///
+/// Here's an example where you want to define the `Character` comparison by `health` and
+/// `experience` only, disregarding the field `mana`:
+///
+/// ```
+/// use std::cmp::Ordering;
+///
+/// struct Character {
+///     health: u32,
+///     experience: u32,
+///     mana: f32,
+/// }
+///
+/// impl Ord for Character {
+///     fn cmp(&self, other: &Self) -> Ordering {
+///         self.experience
+///             .cmp(&other.experience)
+///             .then(self.health.cmp(&other.health))
+///     }
+/// }
+///
+/// impl PartialOrd for Character {
+///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+///         Some(self.cmp(other))
+///     }
+/// }
+///
+/// impl PartialEq for Character {
+///     fn eq(&self, other: &Self) -> bool {
+///         self.health == other.health && self.experience == other.experience
+///     }
+/// }
+///
+/// impl Eq for Character {}
+/// ```
+///
+/// If all you need is to `slice::sort` a type by a field value, it can be simpler to use
+/// `slice::sort_by_key`.
+///
+/// ## Examples of incorrect `Ord` implementations
+///
+/// ```
+/// use std::cmp::Ordering;
+///
+/// #[derive(Debug)]
+/// struct Character {
+///     health: f32,
+/// }
+///
+/// impl Ord for Character {
+///     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+///         if self.health < other.health {
+///             Ordering::Less
+///         } else if self.health > other.health {
+///             Ordering::Greater
+///         } else {
+///             Ordering::Equal
+///         }
+///     }
+/// }
+///
+/// impl PartialOrd for Character {
+///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+///         Some(self.cmp(other))
+///     }
+/// }
+///
+/// impl PartialEq for Character {
+///     fn eq(&self, other: &Self) -> bool {
+///         self.health == other.health
+///     }
+/// }
+///
+/// impl Eq for Character {}
+///
+/// let a = Character { health: 4.5 };
+/// let b = Character { health: f32::NAN };
+///
+/// // Mistake: floating-point values do not form a total order and using the built-in comparison
+/// // operands to implement `Ord` irregardless of that reality does not change it. Use
+/// // `f32::total_cmp` if you need a total order for floating-point values.
+///
+/// // Reflexivity requirement of `Ord` is not given.
+/// assert!(a == a);
+/// assert!(b != b);
+///
+/// // Antisymmetry requirement of `Ord` is not given. Only one of a < c and c < a is allowed to be
+/// // true, not both or neither.
+/// assert_eq!((a < b) as u8 + (b < a) as u8, 0);
+/// ```
+///
+/// ```
+/// use std::cmp::Ordering;
+///
+/// #[derive(Debug)]
+/// struct Character {
+///     health: u32,
+///     experience: u32,
+/// }
+///
+/// impl PartialOrd for Character {
+///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+///         Some(self.cmp(other))
+///     }
+/// }
+///
+/// impl Ord for Character {
+///     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+///         if self.health < 50 {
+///             self.health.cmp(&other.health)
+///         } else {
+///             self.experience.cmp(&other.experience)
+///         }
+///     }
+/// }
+///
+/// // For performance reasons implementing `PartialEq` this way is not the idiomatic way, but it
+/// // ensures consistent behavior between `PartialEq`, `PartialOrd` and `Ord` in this example.
+/// impl PartialEq for Character {
+///     fn eq(&self, other: &Self) -> bool {
+///         self.cmp(other) == Ordering::Equal
+///     }
+/// }
+///
+/// impl Eq for Character {}
+///
+/// let a = Character {
+///     health: 3,
+///     experience: 5,
+/// };
+/// let b = Character {
+///     health: 10,
+///     experience: 77,
+/// };
+/// let c = Character {
+///     health: 143,
+///     experience: 2,
+/// };
+///
+/// // Mistake: The implementation of `Ord` compares different fields depending on the value of
+/// // `self.health`, the resulting order is not total.
+///
+/// // Transitivity requirement of `Ord` is not given. If a is smaller than b and b is smaller than
+/// // c, by transitive property a must also be smaller than c.
+/// assert!(a < b && b < c && c < a);
+///
+/// // Antisymmetry requirement of `Ord` is not given. Only one of a < c and c < a is allowed to be
+/// // true, not both or neither.
+/// assert_eq!((a < c) as u8 + (c < a) as u8, 2);
+/// ```
+///
+/// The documentation of [`PartialOrd`] contains further examples, for example it's wrong for
+/// [`PartialOrd`] and [`PartialEq`] to disagree.
+///
+/// [`cmp`]: Ord::cmp
 #[doc(alias = "<")]
 #[doc(alias = ">")]
 #[doc(alias = "<=")]
@@ -1117,235 +1117,235 @@ pub macro Ord($item:item) {
 
 /// Trait for types that form a [partial order](https://en.wikipedia.org/wiki/Partial_order).
 // FIXME(pvdrz): fix docs
-// ///
-// /// The `lt`, `le`, `gt`, and `ge` methods of this trait can be called using the `<`, `<=`, `>`, and
-// /// `>=` operators, respectively.
-// ///
-// /// This trait should **only** contain the comparison logic for a type **if one plans on only
-// /// implementing `PartialOrd` but not [`Ord`]**. Otherwise the comparison logic should be in [`Ord`]
-// /// and this trait implemented with `Some(self.cmp(other))`.
-// ///
-// /// The methods of this trait must be consistent with each other and with those of [`PartialEq`].
-// /// The following conditions must hold:
-// ///
-// /// 1. `a == b` if and only if `partial_cmp(a, b) == Some(Equal)`.
-// /// 2. `a < b` if and only if `partial_cmp(a, b) == Some(Less)`
-// /// 3. `a > b` if and only if `partial_cmp(a, b) == Some(Greater)`
-// /// 4. `a <= b` if and only if `a < b || a == b`
-// /// 5. `a >= b` if and only if `a > b || a == b`
-// /// 6. `a != b` if and only if `!(a == b)`.
-// ///
-// /// Conditions 2–5 above are ensured by the default implementation. Condition 6 is already ensured
-// /// by [`PartialEq`].
-// ///
-// /// If [`Ord`] is also implemented for `Self` and `Rhs`, it must also be consistent with
-// /// `partial_cmp` (see the documentation of that trait for the exact requirements). It's easy to
-// /// accidentally make them disagree by deriving some of the traits and manually implementing others.
-// ///
-// /// The comparison relations must satisfy the following conditions (for all `a`, `b`, `c` of type
-// /// `A`, `B`, `C`):
-// ///
-// /// - **Transitivity**: if `A: PartialOrd<B>` and `B: PartialOrd<C>` and `A: PartialOrd<C>`, then `a
-// ///   < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`. This must also
-// ///   work for longer chains, such as when `A: PartialOrd<B>`, `B: PartialOrd<C>`, `C:
-// ///   PartialOrd<D>`, and `A: PartialOrd<D>` all exist.
-// /// - **Duality**: if `A: PartialOrd<B>` and `B: PartialOrd<A>`, then `a < b` if and only if `b >
-// ///   a`.
-// ///
-// /// Note that the `B: PartialOrd<A>` (dual) and `A: PartialOrd<C>` (transitive) impls are not forced
-// /// to exist, but these requirements apply whenever they do exist.
-// ///
-// /// Violating these requirements is a logic error. The behavior resulting from a logic error is not
-// /// specified, but users of the trait must ensure that such logic errors do *not* result in
-// /// undefined behavior. This means that `unsafe` code **must not** rely on the correctness of these
-// /// methods.
-// ///
-// /// ## Cross-crate considerations
-// ///
-// /// Upholding the requirements stated above can become tricky when one crate implements `PartialOrd`
-// /// for a type of another crate (i.e., to allow comparing one of its own types with a type from the
-// /// standard library). The recommendation is to never implement this trait for a foreign type. In
-// /// other words, such a crate should do `impl PartialOrd<ForeignType> for LocalType`, but it should
-// /// *not* do `impl PartialOrd<LocalType> for ForeignType`.
-// ///
-// /// This avoids the problem of transitive chains that criss-cross crate boundaries: for all local
-// /// types `T`, you may assume that no other crate will add `impl`s that allow comparing `T < U`. In
-// /// other words, if other crates add `impl`s that allow building longer transitive chains `U1 < ...
-// /// < T < V1 < ...`, then all the types that appear to the right of `T` must be types that the crate
-// /// defining `T` already knows about. This rules out transitive chains where downstream crates can
-// /// add new `impl`s that "stitch together" comparisons of foreign types in ways that violate
-// /// transitivity.
-// ///
-// /// Not having such foreign `impl`s also avoids forward compatibility issues where one crate adding
-// /// more `PartialOrd` implementations can cause build failures in downstream crates.
-// ///
-// /// ## Corollaries
-// ///
-// /// The following corollaries follow from the above requirements:
-// ///
-// /// - irreflexivity of `<` and `>`: `!(a < a)`, `!(a > a)`
-// /// - transitivity of `>`: if `a > b` and `b > c` then `a > c`
-// /// - duality of `partial_cmp`: `partial_cmp(a, b) == partial_cmp(b, a).map(Ordering::reverse)`
-// ///
-// /// ## Strict and non-strict partial orders
-// ///
-// /// The `<` and `>` operators behave according to a *strict* partial order. However, `<=` and `>=`
-// /// do **not** behave according to a *non-strict* partial order. That is because mathematically, a
-// /// non-strict partial order would require reflexivity, i.e. `a <= a` would need to be true for
-// /// every `a`. This isn't always the case for types that implement `PartialOrd`, for example:
-// ///
-// /// ```
-// /// let a = f64::sqrt(-1.0);
-// /// assert_eq!(a <= a, false);
-// /// ```
-// ///
+///
+/// The `lt`, `le`, `gt`, and `ge` methods of this trait can be called using the `<`, `<=`, `>`, and
+/// `>=` operators, respectively.
+///
+/// This trait should **only** contain the comparison logic for a type **if one plans on only
+/// implementing `PartialOrd` but not [`Ord`]**. Otherwise the comparison logic should be in [`Ord`]
+/// and this trait implemented with `Some(self.cmp(other))`.
+///
+/// The methods of this trait must be consistent with each other and with those of [`PartialEq`].
+/// The following conditions must hold:
+///
+/// 1. `a == b` if and only if `partial_cmp(a, b) == Some(Equal)`.
+/// 2. `a < b` if and only if `partial_cmp(a, b) == Some(Less)`
+/// 3. `a > b` if and only if `partial_cmp(a, b) == Some(Greater)`
+/// 4. `a <= b` if and only if `a < b || a == b`
+/// 5. `a >= b` if and only if `a > b || a == b`
+/// 6. `a != b` if and only if `!(a == b)`.
+///
+/// Conditions 2–5 above are ensured by the default implementation. Condition 6 is already ensured
+/// by [`PartialEq`].
+///
+/// If [`Ord`] is also implemented for `Self` and `Rhs`, it must also be consistent with
+/// `partial_cmp` (see the documentation of that trait for the exact requirements). It's easy to
+/// accidentally make them disagree by deriving some of the traits and manually implementing others.
+///
+/// The comparison relations must satisfy the following conditions (for all `a`, `b`, `c` of type
+/// `A`, `B`, `C`):
+///
+/// - **Transitivity**: if `A: PartialOrd<B>` and `B: PartialOrd<C>` and `A: PartialOrd<C>`, then `a
+///   < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`. This must also
+///   work for longer chains, such as when `A: PartialOrd<B>`, `B: PartialOrd<C>`, `C:
+///   PartialOrd<D>`, and `A: PartialOrd<D>` all exist.
+/// - **Duality**: if `A: PartialOrd<B>` and `B: PartialOrd<A>`, then `a < b` if and only if `b >
+///   a`.
+///
+/// Note that the `B: PartialOrd<A>` (dual) and `A: PartialOrd<C>` (transitive) impls are not forced
+/// to exist, but these requirements apply whenever they do exist.
+///
+/// Violating these requirements is a logic error. The behavior resulting from a logic error is not
+/// specified, but users of the trait must ensure that such logic errors do *not* result in
+/// undefined behavior. This means that `unsafe` code **must not** rely on the correctness of these
+/// methods.
+///
+/// ## Cross-crate considerations
+///
+/// Upholding the requirements stated above can become tricky when one crate implements `PartialOrd`
+/// for a type of another crate (i.e., to allow comparing one of its own types with a type from the
+/// standard library). The recommendation is to never implement this trait for a foreign type. In
+/// other words, such a crate should do `impl PartialOrd<ForeignType> for LocalType`, but it should
+/// *not* do `impl PartialOrd<LocalType> for ForeignType`.
+///
+/// This avoids the problem of transitive chains that criss-cross crate boundaries: for all local
+/// types `T`, you may assume that no other crate will add `impl`s that allow comparing `T < U`. In
+/// other words, if other crates add `impl`s that allow building longer transitive chains `U1 < ...
+/// < T < V1 < ...`, then all the types that appear to the right of `T` must be types that the crate
+/// defining `T` already knows about. This rules out transitive chains where downstream crates can
+/// add new `impl`s that "stitch together" comparisons of foreign types in ways that violate
+/// transitivity.
+///
+/// Not having such foreign `impl`s also avoids forward compatibility issues where one crate adding
+/// more `PartialOrd` implementations can cause build failures in downstream crates.
+///
+/// ## Corollaries
+///
+/// The following corollaries follow from the above requirements:
+///
+/// - irreflexivity of `<` and `>`: `!(a < a)`, `!(a > a)`
+/// - transitivity of `>`: if `a > b` and `b > c` then `a > c`
+/// - duality of `partial_cmp`: `partial_cmp(a, b) == partial_cmp(b, a).map(Ordering::reverse)`
+///
+/// ## Strict and non-strict partial orders
+///
+/// The `<` and `>` operators behave according to a *strict* partial order. However, `<=` and `>=`
+/// do **not** behave according to a *non-strict* partial order. That is because mathematically, a
+/// non-strict partial order would require reflexivity, i.e. `a <= a` would need to be true for
+/// every `a`. This isn't always the case for types that implement `PartialOrd`, for example:
+///
+/// ```
+/// let a = f64::sqrt(-1.0);
+/// assert_eq!(a <= a, false);
+/// ```
+///
 /// ## Derivable
-// ///
-// /// This trait can be used with `#[derive]`.
-// ///
-// /// When `derive`d on structs, it will produce a
-// /// [lexicographic](https://en.wikipedia.org/wiki/Lexicographic_order) ordering based on the
-// /// top-to-bottom declaration order of the struct's members.
-// ///
-// /// When `derive`d on enums, variants are primarily ordered by their discriminants. Secondarily,
-// /// they are ordered by their fields. By default, the discriminant is smallest for variants at the
-// /// top, and largest for variants at the bottom. Here's an example:
-// ///
-// /// ```
-// /// #[derive(PartialEq, PartialOrd)]
-// /// enum E {
-// ///     Top,
-// ///     Bottom,
-// /// }
-// ///
-// /// assert!(E::Top < E::Bottom);
-// /// ```
-// ///
-// /// However, manually setting the discriminants can override this default behavior:
-// ///
-// /// ```
-// /// #[derive(PartialEq, PartialOrd)]
-// /// enum E {
-// ///     Top = 2,
-// ///     Bottom = 1,
-// /// }
-// ///
-// /// assert!(E::Bottom < E::Top);
-// /// ```
-// ///
-// /// ## How can I implement `PartialOrd`?
-// ///
-// /// `PartialOrd` only requires implementation of the [`partial_cmp`] method, with the others
-// /// generated from default implementations.
-// ///
-// /// However it remains possible to implement the others separately for types which do not have a
-// /// total order. For example, for floating point numbers, `NaN < 0 == false` and `NaN >= 0 == false`
-// /// (cf. IEEE 754-2008 section 5.11).
-// ///
-// /// `PartialOrd` requires your type to be [`PartialEq`].
-// ///
-// /// If your type is [`Ord`], you can implement [`partial_cmp`] by using [`cmp`]:
-// ///
-// /// ```
-// /// use std::cmp::Ordering;
-// ///
-// /// struct Person {
-// ///     id: u32,
-// ///     name: String,
-// ///     height: u32,
-// /// }
-// ///
-// /// impl PartialOrd for Person {
-// ///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-// ///         Some(self.cmp(other))
-// ///     }
-// /// }
-// ///
-// /// impl Ord for Person {
-// ///     fn cmp(&self, other: &Self) -> Ordering {
-// ///         self.height.cmp(&other.height)
-// ///     }
-// /// }
-// ///
-// /// impl PartialEq for Person {
-// ///     fn eq(&self, other: &Self) -> bool {
-// ///         self.height == other.height
-// ///     }
-// /// }
-// ///
-// /// impl Eq for Person {}
-// /// ```
-// ///
-// /// You may also find it useful to use [`partial_cmp`] on your type's fields. Here is an example of
-// /// `Person` types who have a floating-point `height` field that is the only field to be used for
-// /// sorting:
-// ///
-// /// ```
-// /// use std::cmp::Ordering;
-// ///
-// /// struct Person {
-// ///     id: u32,
-// ///     name: String,
-// ///     height: f64,
-// /// }
-// ///
-// /// impl PartialOrd for Person {
-// ///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-// ///         self.height.partial_cmp(&other.height)
-// ///     }
-// /// }
-// ///
-// /// impl PartialEq for Person {
-// ///     fn eq(&self, other: &Self) -> bool {
-// ///         self.height == other.height
-// ///     }
-// /// }
-// /// ```
-// ///
-// /// ## Examples of incorrect `PartialOrd` implementations
-// ///
-// /// ```
-// /// use std::cmp::Ordering;
-// ///
-// /// #[derive(PartialEq, Debug)]
-// /// struct Character {
-// ///     health: u32,
-// ///     experience: u32,
-// /// }
-// ///
-// /// impl PartialOrd for Character {
-// ///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-// ///         Some(self.health.cmp(&other.health))
-// ///     }
-// /// }
-// ///
-// /// let a = Character {
-// ///     health: 10,
-// ///     experience: 5,
-// /// };
-// /// let b = Character {
-// ///     health: 10,
-// ///     experience: 77,
-// /// };
-// ///
-// /// // Mistake: `PartialEq` and `PartialOrd` disagree with each other.
-// ///
-// /// assert_eq!(a.partial_cmp(&b).unwrap(), Ordering::Equal); // a == b according to `PartialOrd`.
-// /// assert_ne!(a, b); // a != b according to `PartialEq`.
-// /// ```
-// ///
-// /// # Examples
-// ///
-// /// ```
-// /// let x: u32 = 0;
-// /// let y: u32 = 1;
-// ///
-// /// assert_eq!(x < y, true);
-// /// assert_eq!(x.lt(&y), true);
-// /// ```
-// ///
-// /// [`partial_cmp`]: PartialOrd::partial_cmp
-// /// [`cmp`]: Ord::cmp
+///
+/// This trait can be used with `#[derive]`.
+///
+/// When `derive`d on structs, it will produce a
+/// [lexicographic](https://en.wikipedia.org/wiki/Lexicographic_order) ordering based on the
+/// top-to-bottom declaration order of the struct's members.
+///
+/// When `derive`d on enums, variants are primarily ordered by their discriminants. Secondarily,
+/// they are ordered by their fields. By default, the discriminant is smallest for variants at the
+/// top, and largest for variants at the bottom. Here's an example:
+///
+/// ```
+/// #[derive(PartialEq, PartialOrd)]
+/// enum E {
+///     Top,
+///     Bottom,
+/// }
+///
+/// assert!(E::Top < E::Bottom);
+/// ```
+///
+/// However, manually setting the discriminants can override this default behavior:
+///
+/// ```
+/// #[derive(PartialEq, PartialOrd)]
+/// enum E {
+///     Top = 2,
+///     Bottom = 1,
+/// }
+///
+/// assert!(E::Bottom < E::Top);
+/// ```
+///
+/// ## How can I implement `PartialOrd`?
+///
+/// `PartialOrd` only requires implementation of the [`partial_cmp`] method, with the others
+/// generated from default implementations.
+///
+/// However it remains possible to implement the others separately for types which do not have a
+/// total order. For example, for floating point numbers, `NaN < 0 == false` and `NaN >= 0 == false`
+/// (cf. IEEE 754-2008 section 5.11).
+///
+/// `PartialOrd` requires your type to be [`PartialEq`].
+///
+/// If your type is [`Ord`], you can implement [`partial_cmp`] by using [`cmp`]:
+///
+/// ```
+/// use std::cmp::Ordering;
+///
+/// struct Person {
+///     id: u32,
+///     name: String,
+///     height: u32,
+/// }
+///
+/// impl PartialOrd for Person {
+///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+///         Some(self.cmp(other))
+///     }
+/// }
+///
+/// impl Ord for Person {
+///     fn cmp(&self, other: &Self) -> Ordering {
+///         self.height.cmp(&other.height)
+///     }
+/// }
+///
+/// impl PartialEq for Person {
+///     fn eq(&self, other: &Self) -> bool {
+///         self.height == other.height
+///     }
+/// }
+///
+/// impl Eq for Person {}
+/// ```
+///
+/// You may also find it useful to use [`partial_cmp`] on your type's fields. Here is an example of
+/// `Person` types who have a floating-point `height` field that is the only field to be used for
+/// sorting:
+///
+/// ```
+/// use std::cmp::Ordering;
+///
+/// struct Person {
+///     id: u32,
+///     name: String,
+///     height: f64,
+/// }
+///
+/// impl PartialOrd for Person {
+///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+///         self.height.partial_cmp(&other.height)
+///     }
+/// }
+///
+/// impl PartialEq for Person {
+///     fn eq(&self, other: &Self) -> bool {
+///         self.height == other.height
+///     }
+/// }
+/// ```
+///
+/// ## Examples of incorrect `PartialOrd` implementations
+///
+/// ```
+/// use std::cmp::Ordering;
+///
+/// #[derive(PartialEq, Debug)]
+/// struct Character {
+///     health: u32,
+///     experience: u32,
+/// }
+///
+/// impl PartialOrd for Character {
+///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+///         Some(self.health.cmp(&other.health))
+///     }
+/// }
+///
+/// let a = Character {
+///     health: 10,
+///     experience: 5,
+/// };
+/// let b = Character {
+///     health: 10,
+///     experience: 77,
+/// };
+///
+/// // Mistake: `PartialEq` and `PartialOrd` disagree with each other.
+///
+/// assert_eq!(a.partial_cmp(&b).unwrap(), Ordering::Equal); // a == b according to `PartialOrd`.
+/// assert_ne!(a, b); // a != b according to `PartialEq`.
+/// ```
+///
+/// # Examples
+///
+/// ```
+/// let x: u32 = 0;
+/// let y: u32 = 1;
+///
+/// assert_eq!(x < y, true);
+/// assert_eq!(x.lt(&y), true);
+/// ```
+///
+/// [`partial_cmp`]: PartialOrd::partial_cmp
+/// [`cmp`]: Ord::cmp
 #[lang = "partial_ord"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(alias = ">")]

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -970,16 +970,16 @@ pub trait Ord: Eq + PartialOrd<Self> {
     ///
     /// By convention, `self.cmp(&other)` returns the ordering matching the expression
     /// `self <operator> other` if true.
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```
-    // /// use std::cmp::Ordering;
-    // ///
-    // /// assert_eq!(5.cmp(&10), Ordering::Less);
-    // /// assert_eq!(10.cmp(&5), Ordering::Greater);
-    // /// assert_eq!(5.cmp(&5), Ordering::Equal);
-    // /// ```
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::cmp::Ordering;
+    ///
+    /// assert_eq!(5.cmp(&10), Ordering::Less);
+    /// assert_eq!(10.cmp(&5), Ordering::Greater);
+    /// assert_eq!(5.cmp(&5), Ordering::Equal);
+    /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_diagnostic_item = "ord_cmp_method"]
@@ -988,31 +988,31 @@ pub trait Ord: Eq + PartialOrd<Self> {
     /// Compares and returns the maximum of two values.
     ///
     /// Returns the second argument if the comparison determines them to be equal.
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```
-    // /// assert_eq!(1.max(2), 2);
-    // /// assert_eq!(2.max(2), 2);
-    // /// ```
-    // /// ```
-    // /// use std::cmp::Ordering;
-    // ///
-    // /// #[derive(Eq)]
-    // /// struct Equal(&'static str);
-    // ///
-    // /// impl PartialEq for Equal {
-    // ///     fn eq(&self, other: &Self) -> bool { true }
-    // /// }
-    // /// impl PartialOrd for Equal {
-    // ///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(Ordering::Equal) }
-    // /// }
-    // /// impl Ord for Equal {
-    // ///     fn cmp(&self, other: &Self) -> Ordering { Ordering::Equal }
-    // /// }
-    // ///
-    // /// assert_eq!(Equal("self").max(Equal("other")).0, "other");
-    // /// ```
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert_eq!(1.max(2), 2);
+    /// assert_eq!(2.max(2), 2);
+    /// ```
+    /// ```
+    /// use std::cmp::Ordering;
+    ///
+    /// #[derive(Eq)]
+    /// struct Equal(&'static str);
+    ///
+    /// impl PartialEq for Equal {
+    ///     fn eq(&self, other: &Self) -> bool { true }
+    /// }
+    /// impl PartialOrd for Equal {
+    ///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(Ordering::Equal) }
+    /// }
+    /// impl Ord for Equal {
+    ///     fn cmp(&self, other: &Self) -> Ordering { Ordering::Equal }
+    /// }
+    ///
+    /// assert_eq!(Equal("self").max(Equal("other")).0, "other");
+    /// ```
     #[stable(feature = "ord_max_min", since = "1.21.0")]
     #[inline]
     #[must_use]
@@ -1027,31 +1027,31 @@ pub trait Ord: Eq + PartialOrd<Self> {
     /// Compares and returns the minimum of two values.
     ///
     /// Returns the first argument if the comparison determines them to be equal.
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```
-    // /// assert_eq!(1.min(2), 1);
-    // /// assert_eq!(2.min(2), 2);
-    // /// ```
-    // /// ```
-    // /// use std::cmp::Ordering;
-    // ///
-    // /// #[derive(Eq)]
-    // /// struct Equal(&'static str);
-    // ///
-    // /// impl PartialEq for Equal {
-    // ///     fn eq(&self, other: &Self) -> bool { true }
-    // /// }
-    // /// impl PartialOrd for Equal {
-    // ///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(Ordering::Equal) }
-    // /// }
-    // /// impl Ord for Equal {
-    // ///     fn cmp(&self, other: &Self) -> Ordering { Ordering::Equal }
-    // /// }
-    // ///
-    // /// assert_eq!(Equal("self").min(Equal("other")).0, "self");
-    // /// ```
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert_eq!(1.min(2), 1);
+    /// assert_eq!(2.min(2), 2);
+    /// ```
+    /// ```
+    /// use std::cmp::Ordering;
+    ///
+    /// #[derive(Eq)]
+    /// struct Equal(&'static str);
+    ///
+    /// impl PartialEq for Equal {
+    ///     fn eq(&self, other: &Self) -> bool { true }
+    /// }
+    /// impl PartialOrd for Equal {
+    ///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(Ordering::Equal) }
+    /// }
+    /// impl Ord for Equal {
+    ///     fn cmp(&self, other: &Self) -> Ordering { Ordering::Equal }
+    /// }
+    ///
+    /// assert_eq!(Equal("self").min(Equal("other")).0, "self");
+    /// ```
     #[stable(feature = "ord_max_min", since = "1.21.0")]
     #[inline]
     #[must_use]
@@ -1067,18 +1067,18 @@ pub trait Ord: Eq + PartialOrd<Self> {
     ///
     /// Returns `max` if `self` is greater than `max`, and `min` if `self` is
     /// less than `min`. Otherwise this returns `self`.
-    // ///
-    // /// # Panics
-    // ///
-    // /// Panics if `min > max`.
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```
-    // /// assert_eq!((-3).clamp(-2, 1), -2);
-    // /// assert_eq!(0.clamp(-2, 1), 0);
-    // /// assert_eq!(2.clamp(-2, 1), 1);
-    // /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `min > max`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert_eq!((-3).clamp(-2, 1), -2);
+    /// assert_eq!(0.clamp(-2, 1), 0);
+    /// assert_eq!(2.clamp(-2, 1), 1);
+    /// ```
     #[must_use]
     #[inline]
     #[stable(feature = "clamp", since = "1.50.0")]

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1,5 +1,4 @@
 //! Utilities for comparing and ordering values.
-// FIXME(pvdrz): fix docs
 // //!
 // //! This module contains various tools for comparing and ordering values. In
 // //! summary:
@@ -35,7 +34,6 @@ use self::Ordering::*;
 use crate::ops::ControlFlow;
 
 /// Trait for comparisons using the equality operator.
-// FIXME(pvdrz): fix docs
 ///
 /// Implementing this trait for types provides the `==` and `!=` operators for
 /// those types.
@@ -279,7 +277,6 @@ pub macro PartialEq($item:item) {
 
 /// Trait for comparisons corresponding to [equivalence relations](
 /// https://en.wikipedia.org/wiki/Equivalence_relation).
-// FIXME(pvdrz): fix docs
 ///
 /// The primary difference to [`PartialEq`] is the additional requirement for reflexivity. A type
 /// that implements [`PartialEq`] guarantees that for all `a`, `b` and `c`:
@@ -722,7 +719,6 @@ impl<T: Clone> Clone for Reverse<T> {
 }
 
 /// Trait for types that form a [total order](https://en.wikipedia.org/wiki/Total_order).
-// FIXME(pvdrz): fix docs
 ///
 /// Implementations must be consistent with the [`PartialOrd`] implementation, and ensure `max`,
 /// `min`, and `clamp` are consistent with `cmp`:
@@ -974,7 +970,6 @@ pub trait Ord: Eq + PartialOrd<Self> {
     ///
     /// By convention, `self.cmp(&other)` returns the ordering matching the expression
     /// `self <operator> other` if true.
-    // FIXME(pvdrz): fix docs
     // ///
     // /// # Examples
     // ///
@@ -993,7 +988,6 @@ pub trait Ord: Eq + PartialOrd<Self> {
     /// Compares and returns the maximum of two values.
     ///
     /// Returns the second argument if the comparison determines them to be equal.
-    // FIXME(pvdrz): fix docs
     // ///
     // /// # Examples
     // ///
@@ -1033,7 +1027,6 @@ pub trait Ord: Eq + PartialOrd<Self> {
     /// Compares and returns the minimum of two values.
     ///
     /// Returns the first argument if the comparison determines them to be equal.
-    // FIXME(pvdrz): fix docs
     // ///
     // /// # Examples
     // ///
@@ -1074,7 +1067,6 @@ pub trait Ord: Eq + PartialOrd<Self> {
     ///
     /// Returns `max` if `self` is greater than `max`, and `min` if `self` is
     /// less than `min`. Otherwise this returns `self`.
-    // FIXME(pvdrz): fix docs
     // ///
     // /// # Panics
     // ///
@@ -1116,7 +1108,6 @@ pub macro Ord($item:item) {
 }
 
 /// Trait for types that form a [partial order](https://en.wikipedia.org/wiki/Partial_order).
-// FIXME(pvdrz): fix docs
 ///
 /// The `lt`, `le`, `gt`, and `ge` methods of this trait can be called using the `<`, `<=`, `>`, and
 /// `>=` operators, respectively.

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -111,7 +111,6 @@ pub const fn identity<T>(x: T) -> T {
 }
 
 /// Used to do a cheap reference-to-reference conversion.
-// FIXME(pvdrz): fix docs
 ///
 /// This trait is similar to [`AsMut`] which is used for converting between mutable references.
 /// If you need to do a costly conversion it is better to implement [`From`] with type
@@ -459,7 +458,6 @@ pub trait Into<T>: Sized {
 
 /// Used to do value-to-value conversions while consuming the input value. It is the reciprocal of
 /// [`Into`].
-// FIXME(pvdrz): fix docs
 ///
 /// One should always prefer implementing `From` over [`Into`]
 /// because implementing `From` automatically provides one with an implementation of [`Into`]
@@ -632,7 +630,6 @@ pub trait TryInto<T>: Sized {
 /// using the [`From`] trait, because an [`i64`] may contain a value
 /// that an [`i32`] cannot represent and so the conversion would lose data.
 /// This might be handled by truncating the [`i64`] to an [`i32`] or by
-// FIXME(pvdrz): fix docs
 /// simply returning [`i32::MAX`], or by some other method.  The [`From`]
 /// trait is intended for perfect conversions, so the `TryFrom` trait
 /// informs the programmer when a type conversion could go bad and lets

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -112,113 +112,113 @@ pub const fn identity<T>(x: T) -> T {
 
 /// Used to do a cheap reference-to-reference conversion.
 // FIXME(pvdrz): fix docs
-// ///
-// /// This trait is similar to [`AsMut`] which is used for converting between mutable references.
-// /// If you need to do a costly conversion it is better to implement [`From`] with type
-// /// `&T` or write a custom function.
-// ///
-// /// # Relation to `Borrow`
-// ///
-// /// `AsRef` has the same signature as [`Borrow`], but [`Borrow`] is different in a few aspects:
-// ///
-// /// - Unlike `AsRef`, [`Borrow`] has a blanket impl for any `T`, and can be used to accept either
-// ///   a reference or a value. (See also note on `AsRef`'s reflexibility below.)
-// /// - [`Borrow`] also requires that [`Hash`], [`Eq`] and [`Ord`] for a borrowed value are
-// ///   equivalent to those of the owned value. For this reason, if you want to
-// ///   borrow only a single field of a struct you can implement `AsRef`, but not [`Borrow`].
-// ///
-// /// **Note: This trait must not fail**. If the conversion can fail, use a
-// /// dedicated method which returns an [`Option<T>`] or a [`Result<T, E>`].
-// ///
-// /// # Generic Implementations
-// ///
-// /// `AsRef` auto-dereferences if the inner type is a reference or a mutable reference
-// /// (e.g.: `foo.as_ref()` will work the same if `foo` has type `&mut Foo` or `&&mut Foo`).
-// ///
-// /// Note that due to historic reasons, the above currently does not hold generally for all
-// /// [dereferenceable types], e.g. `foo.as_ref()` will *not* work the same as
-// /// `Box::new(foo).as_ref()`. Instead, many smart pointers provide an `as_ref` implementation which
-// /// simply returns a reference to the [pointed-to value] (but do not perform a cheap
-// /// reference-to-reference conversion for that value). However, [`AsRef::as_ref`] should not be
-// /// used for the sole purpose of dereferencing; instead ['`Deref` coercion'] can be used:
-// ///
-// /// [dereferenceable types]: core::ops::Deref
-// /// [pointed-to value]: core::ops::Deref::Target
-// /// ['`Deref` coercion']: core::ops::Deref#deref-coercion
-// ///
-// /// ```
-// /// let x = Box::new(5i32);
-// /// // Avoid this:
-// /// // let y: &i32 = x.as_ref();
-// /// // Better just write:
-// /// let y: &i32 = &x;
-// /// ```
-// ///
-// /// Types which implement [`Deref`] should consider implementing `AsRef<T>` as follows:
-// ///
-// /// [`Deref`]: core::ops::Deref
-// ///
-// /// ```
-// /// # use core::ops::Deref;
-// /// # struct SomeType;
-// /// # impl Deref for SomeType {
-// /// #     type Target = [u8];
-// /// #     fn deref(&self) -> &[u8] {
-// /// #         &[]
-// /// #     }
-// /// # }
-// /// impl<T> AsRef<T> for SomeType
-// /// where
-// ///     T: ?Sized,
-// ///     <SomeType as Deref>::Target: AsRef<T>,
-// /// {
-// ///     fn as_ref(&self) -> &T {
-// ///         self.deref().as_ref()
-// ///     }
-// /// }
-// /// ```
-// ///
-// /// # Reflexivity
-// ///
-// /// Ideally, `AsRef` would be reflexive, i.e. there would be an `impl<T: ?Sized> AsRef<T> for T`
-// /// with [`as_ref`] simply returning its argument unchanged.
-// /// Such a blanket implementation is currently *not* provided due to technical restrictions of
-// /// Rust's type system (it would be overlapping with another existing blanket implementation for
-// /// `&T where T: AsRef<U>` which allows `AsRef` to auto-dereference, see "Generic Implementations"
-// /// above).
-// ///
-// /// [`as_ref`]: AsRef::as_ref
-// ///
-// /// A trivial implementation of `AsRef<T> for T` must be added explicitly for a particular type `T`
-// /// where needed or desired. Note, however, that not all types from `std` contain such an
-// /// implementation, and those cannot be added by external code due to orphan rules.
-// ///
-// /// # Examples
-// ///
-// /// By using trait bounds we can accept arguments of different types as long as they can be
-// /// converted to the specified type `T`.
-// ///
-// /// For example: By creating a generic function that takes an `AsRef<str>` we express that we
-// /// want to accept all references that can be converted to [`&str`] as an argument.
-// /// Since both [`String`] and [`&str`] implement `AsRef<str>` we can accept both as input argument.
-// ///
-// /// [`&str`]: primitive@str
-// /// [`Borrow`]: crate::borrow::Borrow
-// /// [`Eq`]: crate::cmp::Eq
-// /// [`Ord`]: crate::cmp::Ord
-// /// [`String`]: ../../std/string/struct.String.html
-// ///
-// /// ```
-// /// fn is_hello<T: AsRef<str>>(s: T) {
-// ///    assert_eq!("hello", s.as_ref());
-// /// }
-// ///
-// /// let s = "hello";
-// /// is_hello(s);
-// ///
-// /// let s = "hello".to_string();
-// /// is_hello(s);
-// /// ```
+///
+/// This trait is similar to [`AsMut`] which is used for converting between mutable references.
+/// If you need to do a costly conversion it is better to implement [`From`] with type
+/// `&T` or write a custom function.
+///
+/// # Relation to `Borrow`
+///
+/// `AsRef` has the same signature as [`Borrow`], but [`Borrow`] is different in a few aspects:
+///
+/// - Unlike `AsRef`, [`Borrow`] has a blanket impl for any `T`, and can be used to accept either
+///   a reference or a value. (See also note on `AsRef`'s reflexibility below.)
+/// - [`Borrow`] also requires that [`Hash`], [`Eq`] and [`Ord`] for a borrowed value are
+///   equivalent to those of the owned value. For this reason, if you want to
+///   borrow only a single field of a struct you can implement `AsRef`, but not [`Borrow`].
+///
+/// **Note: This trait must not fail**. If the conversion can fail, use a
+/// dedicated method which returns an [`Option<T>`] or a [`Result<T, E>`].
+///
+/// # Generic Implementations
+///
+/// `AsRef` auto-dereferences if the inner type is a reference or a mutable reference
+/// (e.g.: `foo.as_ref()` will work the same if `foo` has type `&mut Foo` or `&&mut Foo`).
+///
+/// Note that due to historic reasons, the above currently does not hold generally for all
+/// [dereferenceable types], e.g. `foo.as_ref()` will *not* work the same as
+/// `Box::new(foo).as_ref()`. Instead, many smart pointers provide an `as_ref` implementation which
+/// simply returns a reference to the [pointed-to value] (but do not perform a cheap
+/// reference-to-reference conversion for that value). However, [`AsRef::as_ref`] should not be
+/// used for the sole purpose of dereferencing; instead ['`Deref` coercion'] can be used:
+///
+/// [dereferenceable types]: core::ops::Deref
+/// [pointed-to value]: core::ops::Deref::Target
+/// ['`Deref` coercion']: core::ops::Deref#deref-coercion
+///
+/// ```
+/// let x = Box::new(5i32);
+/// // Avoid this:
+/// // let y: &i32 = x.as_ref();
+/// // Better just write:
+/// let y: &i32 = &x;
+/// ```
+///
+/// Types which implement [`Deref`] should consider implementing `AsRef<T>` as follows:
+///
+/// [`Deref`]: core::ops::Deref
+///
+/// ```
+/// # use core::ops::Deref;
+/// # struct SomeType;
+/// # impl Deref for SomeType {
+/// #     type Target = [u8];
+/// #     fn deref(&self) -> &[u8] {
+/// #         &[]
+/// #     }
+/// # }
+/// impl<T> AsRef<T> for SomeType
+/// where
+///     T: ?Sized,
+///     <SomeType as Deref>::Target: AsRef<T>,
+/// {
+///     fn as_ref(&self) -> &T {
+///         self.deref().as_ref()
+///     }
+/// }
+/// ```
+///
+/// # Reflexivity
+///
+/// Ideally, `AsRef` would be reflexive, i.e. there would be an `impl<T: ?Sized> AsRef<T> for T`
+/// with [`as_ref`] simply returning its argument unchanged.
+/// Such a blanket implementation is currently *not* provided due to technical restrictions of
+/// Rust's type system (it would be overlapping with another existing blanket implementation for
+/// `&T where T: AsRef<U>` which allows `AsRef` to auto-dereference, see "Generic Implementations"
+/// above).
+///
+/// [`as_ref`]: AsRef::as_ref
+///
+/// A trivial implementation of `AsRef<T> for T` must be added explicitly for a particular type `T`
+/// where needed or desired. Note, however, that not all types from `std` contain such an
+/// implementation, and those cannot be added by external code due to orphan rules.
+///
+/// # Examples
+///
+/// By using trait bounds we can accept arguments of different types as long as they can be
+/// converted to the specified type `T`.
+///
+/// For example: By creating a generic function that takes an `AsRef<str>` we express that we
+/// want to accept all references that can be converted to [`&str`] as an argument.
+/// Since both [`String`] and [`&str`] implement `AsRef<str>` we can accept both as input argument.
+///
+/// [`&str`]: primitive@str
+/// [`Borrow`]: crate::borrow::Borrow
+/// [`Eq`]: crate::cmp::Eq
+/// [`Ord`]: crate::cmp::Ord
+/// [`String`]: ../../std/string/struct.String.html
+///
+/// ```
+/// fn is_hello<T: AsRef<str>>(s: T) {
+///    assert_eq!("hello", s.as_ref());
+/// }
+///
+/// let s = "hello";
+/// is_hello(s);
+///
+/// let s = "hello".to_string();
+/// is_hello(s);
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "AsRef"]
 pub trait AsRef<T: ?Sized> {
@@ -460,125 +460,125 @@ pub trait Into<T>: Sized {
 /// Used to do value-to-value conversions while consuming the input value. It is the reciprocal of
 /// [`Into`].
 // FIXME(pvdrz): fix docs
-// ///
-// /// One should always prefer implementing `From` over [`Into`]
-// /// because implementing `From` automatically provides one with an implementation of [`Into`]
-// /// thanks to the blanket implementation in the standard library.
-// ///
-// /// Only implement [`Into`] when targeting a version prior to Rust 1.41 and converting to a type
-// /// outside the current crate.
-// /// `From` was not able to do these types of conversions in earlier versions because of Rust's
-// /// orphaning rules.
-// /// See [`Into`] for more details.
-// ///
-// /// Prefer using [`Into`] over [`From`] when specifying trait bounds on a generic function
-// /// to ensure that types that only implement [`Into`] can be used as well.
-// ///
-// /// The `From` trait is also very useful when performing error handling. When constructing a function
-// /// that is capable of failing, the return type will generally be of the form `Result<T, E>`.
-// /// `From` simplifies error handling by allowing a function to return a single error type
-// /// that encapsulates multiple error types. See the "Examples" section and [the book][book] for more
-// /// details.
-// ///
-// /// **Note: This trait must not fail**. The `From` trait is intended for perfect conversions.
-// /// If the conversion can fail or is not perfect, use [`TryFrom`].
-// ///
-// /// # Generic Implementations
-// ///
-// /// - `From<T> for U` implies [`Into`]`<U> for T`
-// /// - `From` is reflexive, which means that `From<T> for T` is implemented
-// ///
-// /// # When to implement `From`
-// ///
-// /// While there's no technical restrictions on which conversions can be done using
-// /// a `From` implementation, the general expectation is that the conversions
-// /// should typically be restricted as follows:
-// ///
-// /// * The conversion is *infallible*: if the conversion can fail, use [`TryFrom`]
-// ///   instead; don't provide a `From` impl that panics.
-// ///
-// /// * The conversion is *lossless*: semantically, it should not lose or discard
-// ///   information. For example, `i32: From<u16>` exists, where the original
-// ///   value can be recovered using `u16: TryFrom<i32>`.  And `String: From<&str>`
-// ///   exists, where you can get something equivalent to the original value via
-// ///   `Deref`.  But `From` cannot be used to convert from `u32` to `u16`, since
-// ///   that cannot succeed in a lossless way.  (There's some wiggle room here for
-// ///   information not considered semantically relevant.  For example,
-// ///   `Box<[T]>: From<Vec<T>>` exists even though it might not preserve capacity,
-// ///   like how two vectors can be equal despite differing capacities.)
-// ///
-// /// * The conversion is *value-preserving*: the conceptual kind and meaning of
-// ///   the resulting value is the same, even though the Rust type and technical
-// ///   representation might be different.  For example `-1_i8 as u8` is *lossless*,
-// ///   since `as` casting back can recover the original value, but that conversion
-// ///   is *not* available via `From` because `-1` and `255` are different conceptual
-// ///   values (despite being identical bit patterns technically).  But
-// ///   `f32: From<i16>` *is* available because `1_i16` and `1.0_f32` are conceptually
-// ///   the same real number (despite having very different bit patterns technically).
-// ///   `String: From<char>` is available because they're both *text*, but
-// ///   `String: From<u32>` is *not* available, since `1` (a number) and `"1"`
-// ///   (text) are too different.  (Converting values to text is instead covered
-// ///   by the [`Display`](crate::fmt::Display) trait.)
-// ///
-// /// * The conversion is *obvious*: it's the only reasonable conversion between
-// ///   the two types.  Otherwise it's better to have it be a named method or
-// ///   constructor, like how [`str::as_bytes`] is a method and how integers have
-// ///   methods like [`u32::from_ne_bytes`], [`u32::from_le_bytes`], and
-// ///   [`u32::from_be_bytes`], none of which are `From` implementations.  Whereas
-// ///   there's only one reasonable way to wrap an [`Ipv6Addr`](crate::net::Ipv6Addr)
-// ///   into an [`IpAddr`](crate::net::IpAddr), thus `IpAddr: From<Ipv6Addr>` exists.
-// ///
-// /// # Examples
-// ///
-// /// [`String`] implements `From<&str>`:
-// ///
-// /// An explicit conversion from a `&str` to a String is done as follows:
-// ///
-// /// ```
-// /// let string = "hello".to_string();
-// /// let other_string = String::from("hello");
-// ///
-// /// assert_eq!(string, other_string);
-// /// ```
-// ///
-// /// While performing error handling it is often useful to implement `From` for your own error type.
-// /// By converting underlying error types to our own custom error type that encapsulates the
-// /// underlying error type, we can return a single error type without losing information on the
-// /// underlying cause. The '?' operator automatically converts the underlying error type to our
-// /// custom error type with `From::from`.
-// ///
-// /// ```
-// /// use std::fs;
-// /// use std::io;
-// /// use std::num;
-// ///
-// /// enum CliError {
-// ///     IoError(io::Error),
-// ///     ParseError(num::ParseIntError),
-// /// }
-// ///
-// /// impl From<io::Error> for CliError {
-// ///     fn from(error: io::Error) -> Self {
-// ///         CliError::IoError(error)
-// ///     }
-// /// }
-// ///
-// /// impl From<num::ParseIntError> for CliError {
-// ///     fn from(error: num::ParseIntError) -> Self {
-// ///         CliError::ParseError(error)
-// ///     }
-// /// }
-// ///
-// /// fn open_and_parse_file(file_name: &str) -> Result<i32, CliError> {
-// ///     let mut contents = fs::read_to_string(&file_name)?;
-// ///     let num: i32 = contents.trim().parse()?;
-// ///     Ok(num)
-// /// }
-// /// ```
-// ///
-// /// [`String`]: ../../std/string/struct.String.html
-// /// [`from`]: From::from
-// /// [book]: ../../book/ch09-00-error-handling.html
+///
+/// One should always prefer implementing `From` over [`Into`]
+/// because implementing `From` automatically provides one with an implementation of [`Into`]
+/// thanks to the blanket implementation in the standard library.
+///
+/// Only implement [`Into`] when targeting a version prior to Rust 1.41 and converting to a type
+/// outside the current crate.
+/// `From` was not able to do these types of conversions in earlier versions because of Rust's
+/// orphaning rules.
+/// See [`Into`] for more details.
+///
+/// Prefer using [`Into`] over [`From`] when specifying trait bounds on a generic function
+/// to ensure that types that only implement [`Into`] can be used as well.
+///
+/// The `From` trait is also very useful when performing error handling. When constructing a function
+/// that is capable of failing, the return type will generally be of the form `Result<T, E>`.
+/// `From` simplifies error handling by allowing a function to return a single error type
+/// that encapsulates multiple error types. See the "Examples" section and [the book][book] for more
+/// details.
+///
+/// **Note: This trait must not fail**. The `From` trait is intended for perfect conversions.
+/// If the conversion can fail or is not perfect, use [`TryFrom`].
+///
+/// # Generic Implementations
+///
+/// - `From<T> for U` implies [`Into`]`<U> for T`
+/// - `From` is reflexive, which means that `From<T> for T` is implemented
+///
+/// # When to implement `From`
+///
+/// While there's no technical restrictions on which conversions can be done using
+/// a `From` implementation, the general expectation is that the conversions
+/// should typically be restricted as follows:
+///
+/// * The conversion is *infallible*: if the conversion can fail, use [`TryFrom`]
+///   instead; don't provide a `From` impl that panics.
+///
+/// * The conversion is *lossless*: semantically, it should not lose or discard
+///   information. For example, `i32: From<u16>` exists, where the original
+///   value can be recovered using `u16: TryFrom<i32>`.  And `String: From<&str>`
+///   exists, where you can get something equivalent to the original value via
+///   `Deref`.  But `From` cannot be used to convert from `u32` to `u16`, since
+///   that cannot succeed in a lossless way.  (There's some wiggle room here for
+///   information not considered semantically relevant.  For example,
+///   `Box<[T]>: From<Vec<T>>` exists even though it might not preserve capacity,
+///   like how two vectors can be equal despite differing capacities.)
+///
+/// * The conversion is *value-preserving*: the conceptual kind and meaning of
+///   the resulting value is the same, even though the Rust type and technical
+///   representation might be different.  For example `-1_i8 as u8` is *lossless*,
+///   since `as` casting back can recover the original value, but that conversion
+///   is *not* available via `From` because `-1` and `255` are different conceptual
+///   values (despite being identical bit patterns technically).  But
+///   `f32: From<i16>` *is* available because `1_i16` and `1.0_f32` are conceptually
+///   the same real number (despite having very different bit patterns technically).
+///   `String: From<char>` is available because they're both *text*, but
+///   `String: From<u32>` is *not* available, since `1` (a number) and `"1"`
+///   (text) are too different.  (Converting values to text is instead covered
+///   by the [`Display`](crate::fmt::Display) trait.)
+///
+/// * The conversion is *obvious*: it's the only reasonable conversion between
+///   the two types.  Otherwise it's better to have it be a named method or
+///   constructor, like how [`str::as_bytes`] is a method and how integers have
+///   methods like [`u32::from_ne_bytes`], [`u32::from_le_bytes`], and
+///   [`u32::from_be_bytes`], none of which are `From` implementations.  Whereas
+///   there's only one reasonable way to wrap an [`Ipv6Addr`](crate::net::Ipv6Addr)
+///   into an [`IpAddr`](crate::net::IpAddr), thus `IpAddr: From<Ipv6Addr>` exists.
+///
+/// # Examples
+///
+/// [`String`] implements `From<&str>`:
+///
+/// An explicit conversion from a `&str` to a String is done as follows:
+///
+/// ```
+/// let string = "hello".to_string();
+/// let other_string = String::from("hello");
+///
+/// assert_eq!(string, other_string);
+/// ```
+///
+/// While performing error handling it is often useful to implement `From` for your own error type.
+/// By converting underlying error types to our own custom error type that encapsulates the
+/// underlying error type, we can return a single error type without losing information on the
+/// underlying cause. The '?' operator automatically converts the underlying error type to our
+/// custom error type with `From::from`.
+///
+/// ```
+/// use std::fs;
+/// use std::io;
+/// use std::num;
+///
+/// enum CliError {
+///     IoError(io::Error),
+///     ParseError(num::ParseIntError),
+/// }
+///
+/// impl From<io::Error> for CliError {
+///     fn from(error: io::Error) -> Self {
+///         CliError::IoError(error)
+///     }
+/// }
+///
+/// impl From<num::ParseIntError> for CliError {
+///     fn from(error: num::ParseIntError) -> Self {
+///         CliError::ParseError(error)
+///     }
+/// }
+///
+/// fn open_and_parse_file(file_name: &str) -> Result<i32, CliError> {
+///     let mut contents = fs::read_to_string(&file_name)?;
+///     let num: i32 = contents.trim().parse()?;
+///     Ok(num)
+/// }
+/// ```
+///
+/// [`String`]: ../../std/string/struct.String.html
+/// [`from`]: From::from
+/// [book]: ../../book/ch09-00-error-handling.html
 #[rustc_diagnostic_item = "From"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_on_unimplemented(on(
@@ -633,7 +633,7 @@ pub trait TryInto<T>: Sized {
 /// that an [`i32`] cannot represent and so the conversion would lose data.
 /// This might be handled by truncating the [`i64`] to an [`i32`] or by
 // FIXME(pvdrz): fix docs
-// /// simply returning [`i32::MAX`], or by some other method.  The [`From`]
+/// simply returning [`i32::MAX`], or by some other method.  The [`From`]
 /// trait is intended for perfect conversions, so the `TryFrom` trait
 /// informs the programmer when a type conversion could go bad and lets
 /// them decide how to handle it.

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -11,92 +11,92 @@ use crate::{intrinsics, ub_checks};
 /// Informs the compiler that the site which is calling this function is not
 /// reachable, possibly enabling further optimizations.
 // FIXME(pvdrz): fix docs
-// ///
-// /// # Safety
-// ///
-// /// Reaching this function is *Undefined Behavior*.
-// ///
-// /// As the compiler assumes that all forms of Undefined Behavior can never
-// /// happen, it will eliminate all branches in the surrounding code that it can
-// /// determine will invariably lead to a call to `unreachable_unchecked()`.
-// ///
-// /// If the assumptions embedded in using this function turn out to be wrong -
-// /// that is, if the site which is calling `unreachable_unchecked()` is actually
-// /// reachable at runtime - the compiler may have generated nonsensical machine
-// /// instructions for this situation, including in seemingly unrelated code,
-// /// causing difficult-to-debug problems.
-// ///
-// /// Use this function sparingly. Consider using the [`unreachable!`] macro,
-// /// which may prevent some optimizations but will safely panic in case it is
-// /// actually reached at runtime. Benchmark your code to find out if using
-// /// `unreachable_unchecked()` comes with a performance benefit.
-// ///
-// /// # Examples
-// ///
-// /// `unreachable_unchecked()` can be used in situations where the compiler
-// /// can't prove invariants that were previously established. Such situations
-// /// have a higher chance of occurring if those invariants are upheld by
-// /// external code that the compiler can't analyze.
-// /// ```
-// /// fn prepare_inputs(divisors: &mut Vec<u32>) {
-// ///     // Note to future-self when making changes: The invariant established
-// ///     // here is NOT checked in `do_computation()`; if this changes, you HAVE
-// ///     // to change `do_computation()`.
-// ///     divisors.retain(|divisor| *divisor != 0)
-// /// }
-// ///
-// /// /// # Safety
-// /// /// All elements of `divisor` must be non-zero.
-// /// unsafe fn do_computation(i: u32, divisors: &[u32]) -> u32 {
-// ///     divisors.iter().fold(i, |acc, divisor| {
-// ///         // Convince the compiler that a division by zero can't happen here
-// ///         // and a check is not needed below.
-// ///         if *divisor == 0 {
-// ///             // Safety: `divisor` can't be zero because of `prepare_inputs`,
-// ///             // but the compiler does not know about this. We *promise*
-// ///             // that we always call `prepare_inputs`.
-// ///             unsafe { std::hint::unreachable_unchecked() }
-// ///         }
-// ///         // The compiler would normally introduce a check here that prevents
-// ///         // a division by zero. However, if `divisor` was zero, the branch
-// ///         // above would reach what we explicitly marked as unreachable.
-// ///         // The compiler concludes that `divisor` can't be zero at this point
-// ///         // and removes the - now proven useless - check.
-// ///         acc / divisor
-// ///     })
-// /// }
-// ///
-// /// let mut divisors = vec![2, 0, 4];
-// /// prepare_inputs(&mut divisors);
-// /// let result = unsafe {
-// ///     // Safety: prepare_inputs() guarantees that divisors is non-zero
-// ///     do_computation(100, &divisors)
-// /// };
-// /// assert_eq!(result, 12);
-// ///
-// /// ```
-// ///
-// /// While using `unreachable_unchecked()` is perfectly sound in the following
-// /// example, as the compiler is able to prove that a division by zero is not
-// /// possible, benchmarking reveals that `unreachable_unchecked()` provides
-// /// no benefit over using [`unreachable!`], while the latter does not introduce
-// /// the possibility of Undefined Behavior.
-// ///
-// /// ```
-// /// fn div_1(a: u32, b: u32) -> u32 {
-// ///     use std::hint::unreachable_unchecked;
-// ///
-// ///     // `b.saturating_add(1)` is always positive (not zero),
-// ///     // hence `checked_div` will never return `None`.
-// ///     // Therefore, the else branch is unreachable.
-// ///     a.checked_div(b.saturating_add(1))
-// ///         .unwrap_or_else(|| unsafe { unreachable_unchecked() })
-// /// }
-// ///
-// /// assert_eq!(div_1(7, 0), 7);
-// /// assert_eq!(div_1(9, 1), 4);
-// /// assert_eq!(div_1(11, u32::MAX), 0);
-// /// ```
+///
+/// # Safety
+///
+/// Reaching this function is *Undefined Behavior*.
+///
+/// As the compiler assumes that all forms of Undefined Behavior can never
+/// happen, it will eliminate all branches in the surrounding code that it can
+/// determine will invariably lead to a call to `unreachable_unchecked()`.
+///
+/// If the assumptions embedded in using this function turn out to be wrong -
+/// that is, if the site which is calling `unreachable_unchecked()` is actually
+/// reachable at runtime - the compiler may have generated nonsensical machine
+/// instructions for this situation, including in seemingly unrelated code,
+/// causing difficult-to-debug problems.
+///
+/// Use this function sparingly. Consider using the [`unreachable!`] macro,
+/// which may prevent some optimizations but will safely panic in case it is
+/// actually reached at runtime. Benchmark your code to find out if using
+/// `unreachable_unchecked()` comes with a performance benefit.
+///
+/// # Examples
+///
+/// `unreachable_unchecked()` can be used in situations where the compiler
+/// can't prove invariants that were previously established. Such situations
+/// have a higher chance of occurring if those invariants are upheld by
+/// external code that the compiler can't analyze.
+/// ```
+/// fn prepare_inputs(divisors: &mut Vec<u32>) {
+///     // Note to future-self when making changes: The invariant established
+///     // here is NOT checked in `do_computation()`; if this changes, you HAVE
+///     // to change `do_computation()`.
+///     divisors.retain(|divisor| *divisor != 0)
+/// }
+///
+/// /// # Safety
+/// /// All elements of `divisor` must be non-zero.
+/// unsafe fn do_computation(i: u32, divisors: &[u32]) -> u32 {
+///     divisors.iter().fold(i, |acc, divisor| {
+///         // Convince the compiler that a division by zero can't happen here
+///         // and a check is not needed below.
+///         if *divisor == 0 {
+///             // Safety: `divisor` can't be zero because of `prepare_inputs`,
+///             // but the compiler does not know about this. We *promise*
+///             // that we always call `prepare_inputs`.
+///             unsafe { std::hint::unreachable_unchecked() }
+///         }
+///         // The compiler would normally introduce a check here that prevents
+///         // a division by zero. However, if `divisor` was zero, the branch
+///         // above would reach what we explicitly marked as unreachable.
+///         // The compiler concludes that `divisor` can't be zero at this point
+///         // and removes the - now proven useless - check.
+///         acc / divisor
+///     })
+/// }
+///
+/// let mut divisors = vec![2, 0, 4];
+/// prepare_inputs(&mut divisors);
+/// let result = unsafe {
+///     // Safety: prepare_inputs() guarantees that divisors is non-zero
+///     do_computation(100, &divisors)
+/// };
+/// assert_eq!(result, 12);
+///
+/// ```
+///
+/// While using `unreachable_unchecked()` is perfectly sound in the following
+/// example, as the compiler is able to prove that a division by zero is not
+/// possible, benchmarking reveals that `unreachable_unchecked()` provides
+/// no benefit over using [`unreachable!`], while the latter does not introduce
+/// the possibility of Undefined Behavior.
+///
+/// ```
+/// fn div_1(a: u32, b: u32) -> u32 {
+///     use std::hint::unreachable_unchecked;
+///
+///     // `b.saturating_add(1)` is always positive (not zero),
+///     // hence `checked_div` will never return `None`.
+///     // Therefore, the else branch is unreachable.
+///     a.checked_div(b.saturating_add(1))
+///         .unwrap_or_else(|| unsafe { unreachable_unchecked() })
+/// }
+///
+/// assert_eq!(div_1(7, 0), 7);
+/// assert_eq!(div_1(9, 1), 4);
+/// assert_eq!(div_1(11, u32::MAX), 0);
+/// ```
 #[inline]
 #[stable(feature = "unreachable", since = "1.27.0")]
 #[rustc_const_stable(feature = "const_unreachable_unchecked", since = "1.57.0")]

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -10,7 +10,6 @@ use crate::{intrinsics, ub_checks};
 
 /// Informs the compiler that the site which is calling this function is not
 /// reachable, possibly enabling further optimizations.
-// FIXME(pvdrz): fix docs
 ///
 /// # Safety
 ///

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2928,9 +2928,9 @@ pub const unsafe fn unchecked_add<T: Copy>(x: T, y: T) -> T;
 
 /// Returns the result of an unchecked subtraction, resulting in
 /// undefined behavior when `x - y > T::MAX` or `x - y < T::MIN`.
-// ///
-// /// The stable counterpart of this intrinsic is `unchecked_sub` on the various
-// /// integer types, such as [`u16::unchecked_sub`] and [`i64::unchecked_sub`].
+///
+/// The stable counterpart of this intrinsic is `unchecked_sub` on the various
+/// integer types, such as [`u16::unchecked_sub`] and [`i64::unchecked_sub`].
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
@@ -3081,13 +3081,13 @@ pub const unsafe fn write_via_move<T>(ptr: *mut T, value: T);
 /// Returns the value of the discriminant for the variant in 'v';
 /// if `T` has no discriminant, returns `0`.
 // FIXME(pvdrz): fix docs
-// ///
-// /// Note that, unlike most intrinsics, this is safe to call;
-// /// it does not require an `unsafe` block.
-// /// Therefore, implementations must not require the user to uphold
-// /// any safety invariants.
-// ///
-// /// The stabilized version of this intrinsic is [`core::mem::discriminant`].
+///
+/// Note that, unlike most intrinsics, this is safe to call;
+/// it does not require an `unsafe` block.
+/// Therefore, implementations must not require the user to uphold
+/// any safety invariants.
+///
+/// The stabilized version of this intrinsic is [`core::mem::discriminant`].
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3080,7 +3080,6 @@ pub const unsafe fn write_via_move<T>(ptr: *mut T, value: T);
 
 /// Returns the value of the discriminant for the variant in 'v';
 /// if `T` has no discriminant, returns `0`.
-// FIXME(pvdrz): fix docs
 ///
 /// Note that, unlike most intrinsics, this is safe to call;
 /// it does not require an `unsafe` block.

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -919,37 +919,37 @@ pub(crate) mod builtin {
 
     /// Causes compilation to fail with the given error message when encountered.
     ///
-    // /// This macro should be used when a crate uses a conditional compilation strategy to provide
-    // /// better error messages for erroneous conditions. It's the compiler-level form of [`panic!`],
-    // /// but emits an error during *compilation* rather than at *runtime*.
-    // ///
-    // /// # Examples
-    // ///
-    // /// Two such examples are macros and `#[cfg]` environments.
-    // ///
-    // /// Emit a better compiler error if a macro is passed invalid values. Without the final branch,
-    // /// the compiler would still emit an error, but the error's message would not mention the two
-    // /// valid values.
-    // ///
-    // /// ```compile_fail
-    // /// macro_rules! give_me_foo_or_bar {
-    // ///     (foo) => {};
-    // ///     (bar) => {};
-    // ///     ($x:ident) => {
-    // ///         compile_error!("This macro only accepts `foo` or `bar`");
-    // ///     }
-    // /// }
-    // ///
-    // /// give_me_foo_or_bar!(neither);
-    // /// // ^ will fail at compile time with message "This macro only accepts `foo` or `bar`"
-    // /// ```
-    // ///
-    // /// Emit a compiler error if one of a number of features isn't available.
-    // ///
-    // /// ```compile_fail
-    // /// #[cfg(not(any(feature = "foo", feature = "bar")))]
-    // /// compile_error!("Either feature \"foo\" or \"bar\" must be enabled for this crate.");
-    // /// ```
+    /// This macro should be used when a crate uses a conditional compilation strategy to provide
+    /// better error messages for erroneous conditions. It's the compiler-level form of [`panic!`],
+    /// but emits an error during *compilation* rather than at *runtime*.
+    ///
+    /// # Examples
+    ///
+    /// Two such examples are macros and `#[cfg]` environments.
+    ///
+    /// Emit a better compiler error if a macro is passed invalid values. Without the final branch,
+    /// the compiler would still emit an error, but the error's message would not mention the two
+    /// valid values.
+    ///
+    /// ```compile_fail
+    /// macro_rules! give_me_foo_or_bar {
+    ///     (foo) => {};
+    ///     (bar) => {};
+    ///     ($x:ident) => {
+    ///         compile_error!("This macro only accepts `foo` or `bar`");
+    ///     }
+    /// }
+    ///
+    /// give_me_foo_or_bar!(neither);
+    /// // ^ will fail at compile time with message "This macro only accepts `foo` or `bar`"
+    /// ```
+    ///
+    /// Emit a compiler error if one of a number of features isn't available.
+    ///
+    /// ```compile_fail
+    /// #[cfg(not(any(feature = "foo", feature = "bar")))]
+    /// compile_error!("Either feature \"foo\" or \"bar\" must be enabled for this crate.");
+    /// ```
     #[stable(feature = "compile_error_macro", since = "1.20.0")]
     #[rustc_builtin_macro]
     #[macro_export]
@@ -959,57 +959,57 @@ pub(crate) mod builtin {
 
     /// Constructs parameters for the other string-formatting macros.
     ///
-    // /// This macro functions by taking a formatting string literal containing
-    // /// `{}` for each additional argument passed. `format_args!` prepares the
-    // /// additional parameters to ensure the output can be interpreted as a string
-    // /// and canonicalizes the arguments into a single type. Any value that implements
-    // /// the [`Display`] trait can be passed to `format_args!`, as can any
-    // /// [`Debug`] implementation be passed to a `{:?}` within the formatting string.
-    // ///
-    // /// This macro produces a value of type [`fmt::Arguments`]. This value can be
-    // /// passed to the macros within [`std::fmt`] for performing useful redirection.
-    // /// All other formatting macros ([`format!`], [`write!`], [`println!`], etc) are
-    // /// proxied through this one. `format_args!`, unlike its derived macros, avoids
-    // /// heap allocations.
-    // ///
-    // /// You can use the [`fmt::Arguments`] value that `format_args!` returns
-    // /// in `Debug` and `Display` contexts as seen below. The example also shows
-    // /// that `Debug` and `Display` format to the same thing: the interpolated
-    // /// format string in `format_args!`.
-    // ///
-    // /// ```rust
-    // /// let debug = format!("{:?}", format_args!("{} foo {:?}", 1, 2));
-    // /// let display = format!("{}", format_args!("{} foo {:?}", 1, 2));
-    // /// assert_eq!("1 foo 2", display);
-    // /// assert_eq!(display, debug);
-    // /// ```
-    // ///
-    // /// See [the formatting documentation in `std::fmt`](../std/fmt/index.html)
-    // /// for details of the macro argument syntax, and further information.
-    // ///
-    // /// [`Display`]: crate::fmt::Display
-    // /// [`Debug`]: crate::fmt::Debug
-    // /// [`fmt::Arguments`]: crate::fmt::Arguments
-    // /// [`std::fmt`]: ../std/fmt/index.html
-    // /// [`format!`]: ../std/macro.format.html
-    // /// [`println!`]: ../std/macro.println.html
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```
-    // /// use std::fmt;
-    // ///
-    // /// let s = fmt::format(format_args!("hello {}", "world"));
-    // /// assert_eq!(s, format!("hello {}", "world"));
-    // /// ```
-    // ///
-    // /// # Lifetime limitation
-    // ///
-    // /// Except when no formatting arguments are used,
-    // /// the produced `fmt::Arguments` value borrows temporary values,
-    // /// which means it can only be used within the same expression
-    // /// and cannot be stored for later use.
-    // /// This is a known limitation, see [#92698](https://github.com/rust-lang/rust/issues/92698).
+    /// This macro functions by taking a formatting string literal containing
+    /// `{}` for each additional argument passed. `format_args!` prepares the
+    /// additional parameters to ensure the output can be interpreted as a string
+    /// and canonicalizes the arguments into a single type. Any value that implements
+    /// the [`Display`] trait can be passed to `format_args!`, as can any
+    /// [`Debug`] implementation be passed to a `{:?}` within the formatting string.
+    ///
+    /// This macro produces a value of type [`fmt::Arguments`]. This value can be
+    /// passed to the macros within [`std::fmt`] for performing useful redirection.
+    /// All other formatting macros ([`format!`], [`write!`], [`println!`], etc) are
+    /// proxied through this one. `format_args!`, unlike its derived macros, avoids
+    /// heap allocations.
+    ///
+    /// You can use the [`fmt::Arguments`] value that `format_args!` returns
+    /// in `Debug` and `Display` contexts as seen below. The example also shows
+    /// that `Debug` and `Display` format to the same thing: the interpolated
+    /// format string in `format_args!`.
+    ///
+    /// ```rust
+    /// let debug = format!("{:?}", format_args!("{} foo {:?}", 1, 2));
+    /// let display = format!("{}", format_args!("{} foo {:?}", 1, 2));
+    /// assert_eq!("1 foo 2", display);
+    /// assert_eq!(display, debug);
+    /// ```
+    ///
+    /// See [the formatting documentation in `std::fmt`](../std/fmt/index.html)
+    /// for details of the macro argument syntax, and further information.
+    ///
+    /// [`Display`]: crate::fmt::Display
+    /// [`Debug`]: crate::fmt::Debug
+    /// [`fmt::Arguments`]: crate::fmt::Arguments
+    /// [`std::fmt`]: ../std/fmt/index.html
+    /// [`format!`]: ../std/macro.format.html
+    /// [`println!`]: ../std/macro.println.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::fmt;
+    ///
+    /// let s = fmt::format(format_args!("hello {}", "world"));
+    /// assert_eq!(s, format!("hello {}", "world"));
+    /// ```
+    ///
+    /// # Lifetime limitation
+    ///
+    /// Except when no formatting arguments are used,
+    /// the produced `fmt::Arguments` value borrows temporary values,
+    /// which means it can only be used within the same expression
+    /// and cannot be stored for later use.
+    /// This is a known limitation, see [#92698](https://github.com/rust-lang/rust/issues/92698).
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_diagnostic_item = "format_args_macro"]
     #[allow_internal_unsafe]
@@ -1052,37 +1052,37 @@ pub(crate) mod builtin {
 
     /// Inspects an environment variable at compile time.
     ///
-    // /// This macro will expand to the value of the named environment variable at
-    // /// compile time, yielding an expression of type `&'static str`. Use
-    // /// [`std::env::var`] instead if you want to read the value at runtime.
-    // ///
-    // /// [`std::env::var`]: ../std/env/fn.var.html
-    // ///
-    // /// If the environment variable is not defined, then a compilation error
-    // /// will be emitted. To not emit a compile error, use the [`option_env!`]
-    // /// macro instead. A compilation error will also be emitted if the
-    // /// environment variable is not a valid Unicode string.
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```
-    // /// let path: &'static str = env!("PATH");
-    // /// println!("the $PATH variable at the time of compiling was: {path}");
-    // /// ```
-    // ///
-    // /// You can customize the error message by passing a string as the second
-    // /// parameter:
-    // ///
-    // /// ```compile_fail
-    // /// let doc: &'static str = env!("documentation", "what's that?!");
-    // /// ```
-    // ///
-    // /// If the `documentation` environment variable is not defined, you'll get
-    // /// the following error:
-    // ///
-    // /// ```text
-    // /// error: what's that?!
-    // /// ```
+    /// This macro will expand to the value of the named environment variable at
+    /// compile time, yielding an expression of type `&'static str`. Use
+    /// [`std::env::var`] instead if you want to read the value at runtime.
+    ///
+    /// [`std::env::var`]: ../std/env/fn.var.html
+    ///
+    /// If the environment variable is not defined, then a compilation error
+    /// will be emitted. To not emit a compile error, use the [`option_env!`]
+    /// macro instead. A compilation error will also be emitted if the
+    /// environment variable is not a valid Unicode string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let path: &'static str = env!("PATH");
+    /// println!("the $PATH variable at the time of compiling was: {path}");
+    /// ```
+    ///
+    /// You can customize the error message by passing a string as the second
+    /// parameter:
+    ///
+    /// ```compile_fail
+    /// let doc: &'static str = env!("documentation", "what's that?!");
+    /// ```
+    ///
+    /// If the `documentation` environment variable is not defined, you'll get
+    /// the following error:
+    ///
+    /// ```text
+    /// error: what's that?!
+    /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     #[macro_export]
@@ -1214,22 +1214,22 @@ pub(crate) mod builtin {
 
     /// Expands to the line number on which it was invoked.
     ///
-    // /// With [`column!`] and [`file!`], these macros provide debugging information for
-    // /// developers about the location within the source.
-    // ///
-    // /// The expanded expression has type `u32` and is 1-based, so the first line
-    // /// in each file evaluates to 1, the second to 2, etc. This is consistent
-    // /// with error messages by common compilers or popular editors.
-    // /// The returned line is *not necessarily* the line of the `line!` invocation itself,
-    // /// but rather the first macro invocation leading up to the invocation
-    // /// of the `line!` macro.
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```
-    // /// let current_line = line!();
-    // /// println!("defined on line: {current_line}");
-    // /// ```
+    /// With [`column!`] and [`file!`], these macros provide debugging information for
+    /// developers about the location within the source.
+    ///
+    /// The expanded expression has type `u32` and is 1-based, so the first line
+    /// in each file evaluates to 1, the second to 2, etc. This is consistent
+    /// with error messages by common compilers or popular editors.
+    /// The returned line is *not necessarily* the line of the `line!` invocation itself,
+    /// but rather the first macro invocation leading up to the invocation
+    /// of the `line!` macro.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let current_line = line!();
+    /// println!("defined on line: {current_line}");
+    /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     #[macro_export]
@@ -1241,34 +1241,34 @@ pub(crate) mod builtin {
 
     /// Expands to the column number at which it was invoked.
     ///
-    // /// With [`line!`] and [`file!`], these macros provide debugging information for
-    // /// developers about the location within the source.
-    // ///
-    // /// The expanded expression has type `u32` and is 1-based, so the first column
-    // /// in each line evaluates to 1, the second to 2, etc. This is consistent
-    // /// with error messages by common compilers or popular editors.
-    // /// The returned column is *not necessarily* the line of the `column!` invocation itself,
-    // /// but rather the first macro invocation leading up to the invocation
-    // /// of the `column!` macro.
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```
-    // /// let current_col = column!();
-    // /// println!("defined on column: {current_col}");
-    // /// ```
-    // ///
-    // /// `column!` counts Unicode code points, not bytes or graphemes. As a result, the first two
-    // /// invocations return the same value, but the third does not.
-    // ///
-    // /// ```
-    // /// let a = ("foobar", column!()).1;
-    // /// let b = ("人之初性本善", column!()).1;
-    // /// let c = ("f̅o̅o̅b̅a̅r̅", column!()).1; // Uses combining overline (U+0305)
-    // ///
-    // /// assert_eq!(a, b);
-    // /// assert_ne!(b, c);
-    // /// ```
+    /// With [`line!`] and [`file!`], these macros provide debugging information for
+    /// developers about the location within the source.
+    ///
+    /// The expanded expression has type `u32` and is 1-based, so the first column
+    /// in each line evaluates to 1, the second to 2, etc. This is consistent
+    /// with error messages by common compilers or popular editors.
+    /// The returned column is *not necessarily* the line of the `column!` invocation itself,
+    /// but rather the first macro invocation leading up to the invocation
+    /// of the `column!` macro.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let current_col = column!();
+    /// println!("defined on column: {current_col}");
+    /// ```
+    ///
+    /// `column!` counts Unicode code points, not bytes or graphemes. As a result, the first two
+    /// invocations return the same value, but the third does not.
+    ///
+    /// ```
+    /// let a = ("foobar", column!()).1;
+    /// let b = ("人之初性本善", column!()).1;
+    /// let c = ("f̅o̅o̅b̅a̅r̅", column!()).1; // Uses combining overline (U+0305)
+    ///
+    /// assert_eq!(a, b);
+    /// assert_ne!(b, c);
+    /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     #[macro_export]
@@ -1280,20 +1280,20 @@ pub(crate) mod builtin {
 
     /// Expands to the file name in which it was invoked.
     ///
-    // /// With [`line!`] and [`column!`], these macros provide debugging information for
-    // /// developers about the location within the source.
-    // ///
-    // /// The expanded expression has type `&'static str`, and the returned file
-    // /// is not the invocation of the `file!` macro itself, but rather the
-    // /// first macro invocation leading up to the invocation of the `file!`
-    // /// macro.
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```
-    // /// let this_file = file!();
-    // /// println!("defined in file: {this_file}");
-    // /// ```
+    /// With [`line!`] and [`column!`], these macros provide debugging information for
+    /// developers about the location within the source.
+    ///
+    /// The expanded expression has type `&'static str`, and the returned file
+    /// is not the invocation of the `file!` macro itself, but rather the
+    /// first macro invocation leading up to the invocation of the `file!`
+    /// macro.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let this_file = file!();
+    /// println!("defined in file: {this_file}");
+    /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     #[macro_export]
@@ -1572,48 +1572,48 @@ pub(crate) mod builtin {
 
     /// Asserts that a boolean expression is `true` at runtime.
     ///
-    // /// This will invoke the [`panic!`] macro if the provided expression cannot be
-    // /// evaluated to `true` at runtime.
-    // ///
-    // /// # Uses
-    // ///
-    // /// Assertions are always checked in both debug and release builds, and cannot
-    // /// be disabled. See [`debug_assert!`] for assertions that are not enabled in
-    // /// release builds by default.
-    // ///
-    // /// Unsafe code may rely on `assert!` to enforce run-time invariants that, if
-    // /// violated could lead to unsafety.
-    // ///
-    // /// Other use-cases of `assert!` include testing and enforcing run-time
-    // /// invariants in safe code (whose violation cannot result in unsafety).
-    // ///
-    // /// # Custom Messages
-    // ///
-    // /// This macro has a second form, where a custom panic message can
-    // /// be provided with or without arguments for formatting. See [`std::fmt`]
-    // /// for syntax for this form. Expressions used as format arguments will only
-    // /// be evaluated if the assertion fails.
-    // ///
-    // /// [`std::fmt`]: ../std/fmt/index.html
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```
-    // /// // the panic message for these assertions is the stringified value of the
-    // /// // expression given.
-    // /// assert!(true);
-    // ///
-    // /// fn some_computation() -> bool { true } // a very simple function
-    // ///
-    // /// assert!(some_computation());
-    // ///
-    // /// // assert with a custom message
-    // /// let x = true;
-    // /// assert!(x, "x wasn't true!");
-    // ///
-    // /// let a = 3; let b = 27;
-    // /// assert!(a + b == 30, "a = {}, b = {}", a, b);
-    // /// ```
+    /// This will invoke the [`panic!`] macro if the provided expression cannot be
+    /// evaluated to `true` at runtime.
+    ///
+    /// # Uses
+    ///
+    /// Assertions are always checked in both debug and release builds, and cannot
+    /// be disabled. See [`debug_assert!`] for assertions that are not enabled in
+    /// release builds by default.
+    ///
+    /// Unsafe code may rely on `assert!` to enforce run-time invariants that, if
+    /// violated could lead to unsafety.
+    ///
+    /// Other use-cases of `assert!` include testing and enforcing run-time
+    /// invariants in safe code (whose violation cannot result in unsafety).
+    ///
+    /// # Custom Messages
+    ///
+    /// This macro has a second form, where a custom panic message can
+    /// be provided with or without arguments for formatting. See [`std::fmt`]
+    /// for syntax for this form. Expressions used as format arguments will only
+    /// be evaluated if the assertion fails.
+    ///
+    /// [`std::fmt`]: ../std/fmt/index.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // the panic message for these assertions is the stringified value of the
+    /// // expression given.
+    /// assert!(true);
+    ///
+    /// fn some_computation() -> bool { true } // a very simple function
+    ///
+    /// assert!(some_computation());
+    ///
+    /// // assert with a custom message
+    /// let x = true;
+    /// assert!(x, "x wasn't true!");
+    ///
+    /// let a = 3; let b = 27;
+    /// assert!(a + b == 30, "a = {}, b = {}", a, b);
+    /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     #[macro_export]

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -437,7 +437,6 @@ pub macro debug_assert_matches($($arg:tt)*) {
 /// used to add additional checks that must be true for the matched value, otherwise this macro will
 /// return `false`.
 ///
-// FIXME(pvdrz): fix docs
 /// When testing that a value matches a pattern, it's generally preferable to use
 /// [`assert_matches!`] as it will print the debug representation of the value if the assertion
 /// fails.
@@ -920,7 +919,6 @@ pub(crate) mod builtin {
 
     /// Causes compilation to fail with the given error message when encountered.
     ///
-    // FIXME(pvdrz): fix docs
     // /// This macro should be used when a crate uses a conditional compilation strategy to provide
     // /// better error messages for erroneous conditions. It's the compiler-level form of [`panic!`],
     // /// but emits an error during *compilation* rather than at *runtime*.
@@ -961,7 +959,6 @@ pub(crate) mod builtin {
 
     /// Constructs parameters for the other string-formatting macros.
     ///
-    // FIXME(pvdrz): fix docs
     // /// This macro functions by taking a formatting string literal containing
     // /// `{}` for each additional argument passed. `format_args!` prepares the
     // /// additional parameters to ensure the output can be interpreted as a string
@@ -1055,7 +1052,6 @@ pub(crate) mod builtin {
 
     /// Inspects an environment variable at compile time.
     ///
-    // FIXME(pvdrz): fix docs
     // /// This macro will expand to the value of the named environment variable at
     // /// compile time, yielding an expression of type `&'static str`. Use
     // /// [`std::env::var`] instead if you want to read the value at runtime.
@@ -1218,7 +1214,6 @@ pub(crate) mod builtin {
 
     /// Expands to the line number on which it was invoked.
     ///
-    // FIXME(pvdrz): fix docs
     // /// With [`column!`] and [`file!`], these macros provide debugging information for
     // /// developers about the location within the source.
     // ///
@@ -1246,7 +1241,6 @@ pub(crate) mod builtin {
 
     /// Expands to the column number at which it was invoked.
     ///
-    // FIXME(pvdrz): fix docs
     // /// With [`line!`] and [`file!`], these macros provide debugging information for
     // /// developers about the location within the source.
     // ///
@@ -1286,7 +1280,6 @@ pub(crate) mod builtin {
 
     /// Expands to the file name in which it was invoked.
     ///
-    // FIXME(pvdrz): fix docs
     // /// With [`line!`] and [`column!`], these macros provide debugging information for
     // /// developers about the location within the source.
     // ///
@@ -1579,7 +1572,6 @@ pub(crate) mod builtin {
 
     /// Asserts that a boolean expression is `true` at runtime.
     ///
-    // FIXME(pvdrz): fix docs
     // /// This will invoke the [`panic!`] macro if the provided expression cannot be
     // /// evaluated to `true` at runtime.
     // ///

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -438,19 +438,19 @@ pub macro debug_assert_matches($($arg:tt)*) {
 /// return `false`.
 ///
 // FIXME(pvdrz): fix docs
-// /// When testing that a value matches a pattern, it's generally preferable to use
-// /// [`assert_matches!`] as it will print the debug representation of the value if the assertion
-// /// fails.
-// ///
-// /// # Examples
-// ///
-// /// ```
-// /// let foo = 'f';
-// /// assert!(matches!(foo, 'A'..='Z' | 'a'..='z'));
-// ///
-// /// let bar = Some(4);
-// /// assert!(matches!(bar, Some(x) if x > 2));
-// /// ```
+/// When testing that a value matches a pattern, it's generally preferable to use
+/// [`assert_matches!`] as it will print the debug representation of the value if the assertion
+/// fails.
+///
+/// # Examples
+///
+/// ```
+/// let foo = 'f';
+/// assert!(matches!(foo, 'A'..='Z' | 'a'..='z'));
+///
+/// let bar = Some(4);
+/// assert!(matches!(bar, Some(x) if x > 2));
+/// ```
 #[macro_export]
 #[stable(feature = "matches_macro", since = "1.42.0")]
 #[rustc_diagnostic_item = "matches_macro"]

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -77,19 +77,19 @@ macro marker_impls {
 /// This trait is automatically implemented when the compiler determines it's
 /// appropriate.
 // FIXME(pvdrz): fix docs
-// ///
-// /// An example of a non-`Send` type is the reference-counting pointer
-// /// [`rc::Rc`][`Rc`]. If two threads attempt to clone [`Rc`]s that point to the same
-// /// reference-counted value, they might try to update the reference count at the
-// /// same time, which is [undefined behavior][ub] because [`Rc`] doesn't use atomic
-// /// operations. Its cousin [`sync::Arc`][arc] does use atomic operations (incurring
-// /// some overhead) and thus is `Send`.
-// ///
-// /// See [the Nomicon](../../nomicon/send-and-sync.html) and the [`Sync`] trait for more details.
-// ///
-// /// [`Rc`]: ../../std/rc/struct.Rc.html
-// /// [arc]: ../../std/sync/struct.Arc.html
-// /// [ub]: ../../reference/behavior-considered-undefined.html
+///
+/// An example of a non-`Send` type is the reference-counting pointer
+/// [`rc::Rc`][`Rc`]. If two threads attempt to clone [`Rc`]s that point to the same
+/// reference-counted value, they might try to update the reference count at the
+/// same time, which is [undefined behavior][ub] because [`Rc`] doesn't use atomic
+/// operations. Its cousin [`sync::Arc`][arc] does use atomic operations (incurring
+/// some overhead) and thus is `Send`.
+///
+/// See [the Nomicon](../../nomicon/send-and-sync.html) and the [`Sync`] trait for more details.
+///
+/// [`Rc`]: ../../std/rc/struct.Rc.html
+/// [arc]: ../../std/sync/struct.Arc.html
+/// [ub]: ../../reference/behavior-considered-undefined.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "Send"]
 #[diagnostic::on_unimplemented(
@@ -166,37 +166,37 @@ pub trait Sized {
 
 /// Types that can be "unsized" to a dynamically-sized type.
 // FIXME(pvdrz): fix docs
-// ///
-// /// For example, the sized array type `[i8; 2]` implements `Unsize<[i8]>` and
-// /// `Unsize<dyn fmt::Debug>`.
-// ///
-// /// All implementations of `Unsize` are provided automatically by the compiler.
-// /// Those implementations are:
-// ///
-// /// - Arrays `[T; N]` implement `Unsize<[T]>`.
-// /// - A type implements `Unsize<dyn Trait + 'a>` if all of these conditions are met:
-// ///   - The type implements `Trait`.
-// ///   - `Trait` is dyn-compatible[^1].
-// ///   - The type is sized.
-// ///   - The type outlives `'a`.
-// /// - Structs `Foo<..., T1, ..., Tn, ...>` implement `Unsize<Foo<..., U1, ..., Un, ...>>`
-// /// where any number of (type and const) parameters may be changed if all of these conditions
-// /// are met:
-// ///   - Only the last field of `Foo` has a type involving the parameters `T1`, ..., `Tn`.
-// ///   - All other parameters of the struct are equal.
-// ///   - `Field<T1, ..., Tn>: Unsize<Field<U1, ..., Un>>`, where `Field<...>` stands for the actual
-// ///     type of the struct's last field.
-// ///
-// /// `Unsize` is used along with [`ops::CoerceUnsized`] to allow
-// /// "user-defined" containers such as [`Rc`] to contain dynamically-sized
-// /// types. See the [DST coercion RFC][RFC982] and [the nomicon entry on coercion][nomicon-coerce]
-// /// for more details.
-// ///
-// /// [`ops::CoerceUnsized`]: crate::ops::CoerceUnsized
-// /// [`Rc`]: ../../std/rc/struct.Rc.html
-// /// [RFC982]: https://github.com/rust-lang/rfcs/blob/master/text/0982-dst-coercion.md
-// /// [nomicon-coerce]: ../../nomicon/coercions.html
-// /// [^1]: Formerly known as *object safe*.
+///
+/// For example, the sized array type `[i8; 2]` implements `Unsize<[i8]>` and
+/// `Unsize<dyn fmt::Debug>`.
+///
+/// All implementations of `Unsize` are provided automatically by the compiler.
+/// Those implementations are:
+///
+/// - Arrays `[T; N]` implement `Unsize<[T]>`.
+/// - A type implements `Unsize<dyn Trait + 'a>` if all of these conditions are met:
+///   - The type implements `Trait`.
+///   - `Trait` is dyn-compatible[^1].
+///   - The type is sized.
+///   - The type outlives `'a`.
+/// - Structs `Foo<..., T1, ..., Tn, ...>` implement `Unsize<Foo<..., U1, ..., Un, ...>>`
+/// where any number of (type and const) parameters may be changed if all of these conditions
+/// are met:
+///   - Only the last field of `Foo` has a type involving the parameters `T1`, ..., `Tn`.
+///   - All other parameters of the struct are equal.
+///   - `Field<T1, ..., Tn>: Unsize<Field<U1, ..., Un>>`, where `Field<...>` stands for the actual
+///     type of the struct's last field.
+///
+/// `Unsize` is used along with [`ops::CoerceUnsized`] to allow
+/// "user-defined" containers such as [`Rc`] to contain dynamically-sized
+/// types. See the [DST coercion RFC][RFC982] and [the nomicon entry on coercion][nomicon-coerce]
+/// for more details.
+///
+/// [`ops::CoerceUnsized`]: crate::ops::CoerceUnsized
+/// [`Rc`]: ../../std/rc/struct.Rc.html
+/// [RFC982]: https://github.com/rust-lang/rfcs/blob/master/text/0982-dst-coercion.md
+/// [nomicon-coerce]: ../../nomicon/coercions.html
+/// [^1]: Formerly known as *object safe*.
 #[unstable(feature = "unsize", issue = "18598")]
 #[lang = "unsize"]
 #[rustc_deny_explicit_impl]
@@ -321,9 +321,9 @@ marker_impls! {
 /// ```
 ///
 // FIXME(pvdrz): fix docs
-// /// This isn't always desired. For example, shared references (`&T`) can be copied regardless of
-// /// whether `T` is `Copy`. Likewise, a generic struct containing markers such as [`PhantomData`]
-// /// could potentially be duplicated with a bit-wise copy.
+/// This isn't always desired. For example, shared references (`&T`) can be copied regardless of
+/// whether `T` is `Copy`. Likewise, a generic struct containing markers such as [`PhantomData`]
+/// could potentially be duplicated with a bit-wise copy.
 ///
 /// ## What's the difference between `Copy` and `Clone`?
 ///
@@ -394,8 +394,8 @@ marker_impls! {
 /// [`String`]'s buffer, leading to a double free.
 ///
 // FIXME(pvdrz): fix docs
-// /// Generalizing the latter case, any type implementing [`Drop`] can't be `Copy`, because it's
-// /// managing some resource besides its own [`size_of::<T>`] bytes.
+/// Generalizing the latter case, any type implementing [`Drop`] can't be `Copy`, because it's
+/// managing some resource besides its own [`size_of::<T>`] bytes.
 ///
 /// If you try to implement `Copy` on a struct or enum containing non-`Copy` data, you will get
 /// the error [E0204].
@@ -425,7 +425,7 @@ marker_impls! {
 /// [`Vec<T>`]: ../../std/vec/struct.Vec.html
 /// [`String`]: ../../std/string/struct.String.html
 // FIXME(pvdrz): fix docs
-// /// [`size_of::<T>`]: size_of
+/// [`size_of::<T>`]: size_of
 /// [impls]: #implementors
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "copy"]
@@ -514,71 +514,71 @@ pub trait BikeshedGuaranteedNoDrop {}
 /// it's appropriate.
 ///
 // FIXME(pvdrz): fix docs
-// /// The precise definition is: a type `T` is [`Sync`] if and only if `&T` is
-// /// [`Send`]. In other words, if there is no possibility of
-// /// [undefined behavior][ub] (including data races) when passing
-// /// `&T` references between threads.
-// ///
-// /// As one would expect, primitive types like [`u8`] and [`f64`]
-// /// are all [`Sync`], and so are simple aggregate types containing them,
-// /// like tuples, structs and enums. More examples of basic [`Sync`]
-// /// types include "immutable" types like `&T`, and those with simple
-// /// inherited mutability, such as [`Box<T>`][box], [`Vec<T>`][vec] and
-// /// most other collection types. (Generic parameters need to be [`Sync`]
-// /// for their container to be [`Sync`].)
-// ///
-// /// A somewhat surprising consequence of the definition is that `&mut T`
-// /// is `Sync` (if `T` is `Sync`) even though it seems like that might
-// /// provide unsynchronized mutation. The trick is that a mutable
-// /// reference behind a shared reference (that is, `& &mut T`)
-// /// becomes read-only, as if it were a `& &T`. Hence there is no risk
-// /// of a data race.
-// ///
-// /// A shorter overview of how [`Sync`] and [`Send`] relate to referencing:
-// /// * `&T` is [`Send`] if and only if `T` is [`Sync`]
-// /// * `&mut T` is [`Send`] if and only if `T` is [`Send`]
-// /// * `&T` and `&mut T` are [`Sync`] if and only if `T` is [`Sync`]
-// ///
-// /// Types that are not `Sync` are those that have "interior
-// /// mutability" in a non-thread-safe form, such as [`Cell`][cell]
-// /// and [`RefCell`][refcell]. These types allow for mutation of
-// /// their contents even through an immutable, shared reference. For
-// /// example the `set` method on [`Cell<T>`][cell] takes `&self`, so it requires
-// /// only a shared reference [`&Cell<T>`][cell]. The method performs no
-// /// synchronization, thus [`Cell`][cell] cannot be `Sync`.
-// ///
-// /// Another example of a non-`Sync` type is the reference-counting
-// /// pointer [`Rc`][rc]. Given any reference [`&Rc<T>`][rc], you can clone
-// /// a new [`Rc<T>`][rc], modifying the reference counts in a non-atomic way.
-// ///
-// /// For cases when one does need thread-safe interior mutability,
-// /// Rust provides [atomic data types], as well as explicit locking via
-// /// [`sync::Mutex`][mutex] and [`sync::RwLock`][rwlock]. These types
-// /// ensure that any mutation cannot cause data races, hence the types
-// /// are `Sync`. Likewise, [`sync::Arc`][arc] provides a thread-safe
-// /// analogue of [`Rc`][rc].
-// ///
-// /// Any types with interior mutability must also use the
-// /// [`cell::UnsafeCell`][unsafecell] wrapper around the value(s) which
-// /// can be mutated through a shared reference. Failing to doing this is
-// /// [undefined behavior][ub]. For example, [`transmute`][transmute]-ing
-// /// from `&T` to `&mut T` is invalid.
-// ///
-// /// See [the Nomicon][nomicon-send-and-sync] for more details about `Sync`.
-// ///
-// /// [box]: ../../std/boxed/struct.Box.html
-// /// [vec]: ../../std/vec/struct.Vec.html
-// /// [cell]: crate::cell::Cell
-// /// [refcell]: crate::cell::RefCell
-// /// [rc]: ../../std/rc/struct.Rc.html
-// /// [arc]: ../../std/sync/struct.Arc.html
-// /// [atomic data types]: crate::sync::atomic
-// /// [mutex]: ../../std/sync/struct.Mutex.html
-// /// [rwlock]: ../../std/sync/struct.RwLock.html
-// /// [unsafecell]: crate::cell::UnsafeCell
-// /// [ub]: ../../reference/behavior-considered-undefined.html
-// /// [transmute]: crate::mem::transmute
-// /// [nomicon-send-and-sync]: ../../nomicon/send-and-sync.html
+/// The precise definition is: a type `T` is [`Sync`] if and only if `&T` is
+/// [`Send`]. In other words, if there is no possibility of
+/// [undefined behavior][ub] (including data races) when passing
+/// `&T` references between threads.
+///
+/// As one would expect, primitive types like [`u8`] and [`f64`]
+/// are all [`Sync`], and so are simple aggregate types containing them,
+/// like tuples, structs and enums. More examples of basic [`Sync`]
+/// types include "immutable" types like `&T`, and those with simple
+/// inherited mutability, such as [`Box<T>`][box], [`Vec<T>`][vec] and
+/// most other collection types. (Generic parameters need to be [`Sync`]
+/// for their container to be [`Sync`].)
+///
+/// A somewhat surprising consequence of the definition is that `&mut T`
+/// is `Sync` (if `T` is `Sync`) even though it seems like that might
+/// provide unsynchronized mutation. The trick is that a mutable
+/// reference behind a shared reference (that is, `& &mut T`)
+/// becomes read-only, as if it were a `& &T`. Hence there is no risk
+/// of a data race.
+///
+/// A shorter overview of how [`Sync`] and [`Send`] relate to referencing:
+/// * `&T` is [`Send`] if and only if `T` is [`Sync`]
+/// * `&mut T` is [`Send`] if and only if `T` is [`Send`]
+/// * `&T` and `&mut T` are [`Sync`] if and only if `T` is [`Sync`]
+///
+/// Types that are not `Sync` are those that have "interior
+/// mutability" in a non-thread-safe form, such as [`Cell`][cell]
+/// and [`RefCell`][refcell]. These types allow for mutation of
+/// their contents even through an immutable, shared reference. For
+/// example the `set` method on [`Cell<T>`][cell] takes `&self`, so it requires
+/// only a shared reference [`&Cell<T>`][cell]. The method performs no
+/// synchronization, thus [`Cell`][cell] cannot be `Sync`.
+///
+/// Another example of a non-`Sync` type is the reference-counting
+/// pointer [`Rc`][rc]. Given any reference [`&Rc<T>`][rc], you can clone
+/// a new [`Rc<T>`][rc], modifying the reference counts in a non-atomic way.
+///
+/// For cases when one does need thread-safe interior mutability,
+/// Rust provides [atomic data types], as well as explicit locking via
+/// [`sync::Mutex`][mutex] and [`sync::RwLock`][rwlock]. These types
+/// ensure that any mutation cannot cause data races, hence the types
+/// are `Sync`. Likewise, [`sync::Arc`][arc] provides a thread-safe
+/// analogue of [`Rc`][rc].
+///
+/// Any types with interior mutability must also use the
+/// [`cell::UnsafeCell`][unsafecell] wrapper around the value(s) which
+/// can be mutated through a shared reference. Failing to doing this is
+/// [undefined behavior][ub]. For example, [`transmute`][transmute]-ing
+/// from `&T` to `&mut T` is invalid.
+///
+/// See [the Nomicon][nomicon-send-and-sync] for more details about `Sync`.
+///
+/// [box]: ../../std/boxed/struct.Box.html
+/// [vec]: ../../std/vec/struct.Vec.html
+/// [cell]: crate::cell::Cell
+/// [refcell]: crate::cell::RefCell
+/// [rc]: ../../std/rc/struct.Rc.html
+/// [arc]: ../../std/sync/struct.Arc.html
+/// [atomic data types]: crate::sync::atomic
+/// [mutex]: ../../std/sync/struct.Mutex.html
+/// [rwlock]: ../../std/sync/struct.RwLock.html
+/// [unsafecell]: crate::cell::UnsafeCell
+/// [ub]: ../../reference/behavior-considered-undefined.html
+/// [transmute]: crate::mem::transmute
+/// [nomicon-send-and-sync]: ../../nomicon/send-and-sync.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "Sync"]
 #[lang = "sync"]
@@ -874,12 +874,12 @@ impl<T: ?Sized> StructuralPartialEq for PhantomData<T> {}
 
 /// Compiler-internal trait used to indicate the type of enum discriminants.
 // FIXME(pvdrz): fix docs
-// ///
-// /// This trait is automatically implemented for every type and does not add any
-// /// guarantees to [`mem::Discriminant`]. It is **undefined behavior** to transmute
-// /// between `DiscriminantKind::Discriminant` and `mem::Discriminant`.
-// ///
-// /// [`mem::Discriminant`]: crate::mem::Discriminant
+///
+/// This trait is automatically implemented for every type and does not add any
+/// guarantees to [`mem::Discriminant`]. It is **undefined behavior** to transmute
+/// between `DiscriminantKind::Discriminant` and `mem::Discriminant`.
+///
+/// [`mem::Discriminant`]: crate::mem::Discriminant
 #[unstable(
     feature = "discriminant_kind",
     issue = "none",

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -76,7 +76,6 @@ macro marker_impls {
 ///
 /// This trait is automatically implemented when the compiler determines it's
 /// appropriate.
-// FIXME(pvdrz): fix docs
 ///
 /// An example of a non-`Send` type is the reference-counting pointer
 /// [`rc::Rc`][`Rc`]. If two threads attempt to clone [`Rc`]s that point to the same
@@ -165,7 +164,6 @@ pub trait Sized {
 }
 
 /// Types that can be "unsized" to a dynamically-sized type.
-// FIXME(pvdrz): fix docs
 ///
 /// For example, the sized array type `[i8; 2]` implements `Unsize<[i8]>` and
 /// `Unsize<dyn fmt::Debug>`.
@@ -320,7 +318,6 @@ marker_impls! {
 /// impl<T: Copy> Copy for MyStruct<T> { }
 /// ```
 ///
-// FIXME(pvdrz): fix docs
 /// This isn't always desired. For example, shared references (`&T`) can be copied regardless of
 /// whether `T` is `Copy`. Likewise, a generic struct containing markers such as [`PhantomData`]
 /// could potentially be duplicated with a bit-wise copy.
@@ -393,7 +390,6 @@ marker_impls! {
 /// mutable reference. Copying [`String`] would duplicate responsibility for managing the
 /// [`String`]'s buffer, leading to a double free.
 ///
-// FIXME(pvdrz): fix docs
 /// Generalizing the latter case, any type implementing [`Drop`] can't be `Copy`, because it's
 /// managing some resource besides its own [`size_of::<T>`] bytes.
 ///
@@ -424,7 +420,6 @@ marker_impls! {
 ///
 /// [`Vec<T>`]: ../../std/vec/struct.Vec.html
 /// [`String`]: ../../std/string/struct.String.html
-// FIXME(pvdrz): fix docs
 /// [`size_of::<T>`]: size_of
 /// [impls]: #implementors
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -513,7 +508,6 @@ pub trait BikeshedGuaranteedNoDrop {}
 /// This trait is automatically implemented when the compiler determines
 /// it's appropriate.
 ///
-// FIXME(pvdrz): fix docs
 /// The precise definition is: a type `T` is [`Sync`] if and only if `&T` is
 /// [`Send`]. In other words, if there is no possibility of
 /// [undefined behavior][ub] (including data races) when passing
@@ -873,7 +867,6 @@ impl<T: ?Sized> Default for PhantomData<T> {
 impl<T: ?Sized> StructuralPartialEq for PhantomData<T> {}
 
 /// Compiler-internal trait used to indicate the type of enum discriminants.
-// FIXME(pvdrz): fix docs
 ///
 /// This trait is automatically implemented for every type and does not add any
 /// guarantees to [`mem::Discriminant`]. It is **undefined behavior** to transmute

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -911,7 +911,6 @@ pub const fn replace<T>(dest: &mut T, src: T) -> T {
 /// the function returns.
 ///
 /// [drop]: Drop
-// FIXME(pvdrz): fix docs
 ///
 /// # Examples
 ///

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -912,50 +912,50 @@ pub const fn replace<T>(dest: &mut T, src: T) -> T {
 ///
 /// [drop]: Drop
 // FIXME(pvdrz): fix docs
-// ///
-// /// # Examples
-// ///
-// /// Basic usage:
-// ///
-// /// ```
-// /// let v = vec![1, 2, 3];
-// ///
-// /// drop(v); // explicitly drop the vector
-// /// ```
-// ///
-// /// Since [`RefCell`] enforces the borrow rules at runtime, `drop` can
-// /// release a [`RefCell`] borrow:
-// ///
-// /// ```
-// /// use std::cell::RefCell;
-// ///
-// /// let x = RefCell::new(1);
-// ///
-// /// let mut mutable_borrow = x.borrow_mut();
-// /// *mutable_borrow = 1;
-// ///
-// /// drop(mutable_borrow); // relinquish the mutable borrow on this slot
-// ///
-// /// let borrow = x.borrow();
-// /// println!("{}", *borrow);
-// /// ```
-// ///
-// /// Integers and other types implementing [`Copy`] are unaffected by `drop`.
-// ///
-// /// ```
-// /// # #![allow(dropping_copy_types)]
-// /// #[derive(Copy, Clone)]
-// /// struct Foo(u8);
-// ///
-// /// let x = 1;
-// /// let y = Foo(2);
-// /// drop(x); // a copy of `x` is moved and dropped
-// /// drop(y); // a copy of `y` is moved and dropped
-// ///
-// /// println!("x: {}, y: {}", x, y.0); // still available
-// /// ```
-// ///
-// /// [`RefCell`]: crate::cell::RefCell
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// let v = vec![1, 2, 3];
+///
+/// drop(v); // explicitly drop the vector
+/// ```
+///
+/// Since [`RefCell`] enforces the borrow rules at runtime, `drop` can
+/// release a [`RefCell`] borrow:
+///
+/// ```
+/// use std::cell::RefCell;
+///
+/// let x = RefCell::new(1);
+///
+/// let mut mutable_borrow = x.borrow_mut();
+/// *mutable_borrow = 1;
+///
+/// drop(mutable_borrow); // relinquish the mutable borrow on this slot
+///
+/// let borrow = x.borrow();
+/// println!("{}", *borrow);
+/// ```
+///
+/// Integers and other types implementing [`Copy`] are unaffected by `drop`.
+///
+/// ```
+/// # #![allow(dropping_copy_types)]
+/// #[derive(Copy, Clone)]
+/// struct Foo(u8);
+///
+/// let x = 1;
+/// let y = Foo(2);
+/// drop(x); // a copy of `x` is moved and dropped
+/// drop(y); // a copy of `y` is moved and dropped
+///
+/// println!("x: {}, y: {}", x, y.0); // still available
+/// ```
+///
+/// [`RefCell`]: crate::cell::RefCell
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "mem_drop"]

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -26,27 +26,27 @@ macro_rules! int_impl {
     ) => {
         /// The smallest value that can be represented by this integer type
                 // #[doc = concat!("(&minus;2<sup>", $BITS_MINUS_ONE, "</sup>", $bound_condition, ").")]
-        // ///
-        // /// # Examples
-        // ///
-        // /// Basic usage:
-        // ///
-        // /// ```
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
         // #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN, ", stringify!($Min), ");")]
-        // /// ```
+        /// ```
         #[stable(feature = "assoc_int_consts", since = "1.43.0")]
         pub const MIN: Self = !Self::MAX;
 
         /// The largest value that can be represented by this integer type
                 // #[doc = concat!("(2<sup>", $BITS_MINUS_ONE, "</sup> &minus; 1", $bound_condition, ").")]
-        // ///
-        // /// # Examples
-        // ///
-        // /// Basic usage:
-        // ///
-        // /// ```
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
         // #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX, ", stringify!($Max), ");")]
-        // /// ```
+        /// ```
         #[stable(feature = "assoc_int_consts", since = "1.43.0")]
         pub const MAX: Self = (<$UnsignedT>::MAX >> 1) as Self;
 

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -25,27 +25,27 @@ macro_rules! int_impl {
         bound_condition = $bound_condition:literal,
     ) => {
         /// The smallest value that can be represented by this integer type
-                // #[doc = concat!("(&minus;2<sup>", $BITS_MINUS_ONE, "</sup>", $bound_condition, ").")]
+        #[doc = concat!("(&minus;2<sup>", $BITS_MINUS_ONE, "</sup>", $bound_condition, ").")]
         ///
         /// # Examples
         ///
         /// Basic usage:
         ///
         /// ```
-        // #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN, ", stringify!($Min), ");")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN, ", stringify!($Min), ");")]
         /// ```
         #[stable(feature = "assoc_int_consts", since = "1.43.0")]
         pub const MIN: Self = !Self::MAX;
 
         /// The largest value that can be represented by this integer type
-                // #[doc = concat!("(2<sup>", $BITS_MINUS_ONE, "</sup> &minus; 1", $bound_condition, ").")]
+        #[doc = concat!("(2<sup>", $BITS_MINUS_ONE, "</sup> &minus; 1", $bound_condition, ").")]
         ///
         /// # Examples
         ///
         /// Basic usage:
         ///
         /// ```
-        // #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX, ", stringify!($Max), ");")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX, ", stringify!($Max), ");")]
         /// ```
         #[stable(feature = "assoc_int_consts", since = "1.43.0")]
         pub const MAX: Self = (<$UnsignedT>::MAX >> 1) as Self;

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -25,8 +25,7 @@ macro_rules! int_impl {
         bound_condition = $bound_condition:literal,
     ) => {
         /// The smallest value that can be represented by this integer type
-        // FIXME(pvdrz): fix docs
-        // #[doc = concat!("(&minus;2<sup>", $BITS_MINUS_ONE, "</sup>", $bound_condition, ").")]
+                // #[doc = concat!("(&minus;2<sup>", $BITS_MINUS_ONE, "</sup>", $bound_condition, ").")]
         // ///
         // /// # Examples
         // ///
@@ -39,8 +38,7 @@ macro_rules! int_impl {
         pub const MIN: Self = !Self::MAX;
 
         /// The largest value that can be represented by this integer type
-        // FIXME(pvdrz): fix docs
-        // #[doc = concat!("(2<sup>", $BITS_MINUS_ONE, "</sup> &minus; 1", $bound_condition, ").")]
+                // #[doc = concat!("(2<sup>", $BITS_MINUS_ONE, "</sup> &minus; 1", $bound_condition, ").")]
         // ///
         // /// # Examples
         // ///

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -24,8 +24,7 @@ macro_rules! uint_impl {
         bound_condition = $bound_condition:literal,
     ) => {
         /// The smallest value that can be represented by this integer type.
-        // FIXME(pvdrz): fix docs
-        // ///
+                // ///
         // /// # Examples
         // ///
         // /// Basic usage:
@@ -37,8 +36,7 @@ macro_rules! uint_impl {
         pub const MIN: Self = 0;
 
         /// The largest value that can be represented by this integer type
-        // FIXME(pvdrz): fix docs
-        // #[doc = concat!("(2<sup>", $BITS, "</sup> &minus; 1", $bound_condition, ").")]
+                // #[doc = concat!("(2<sup>", $BITS, "</sup> &minus; 1", $bound_condition, ").")]
         // ///
         // /// # Examples
         // ///
@@ -62,8 +60,7 @@ macro_rules! uint_impl {
         pub const BITS: u32 = Self::MAX.count_ones();
 
         /// Returns the number of ones in the binary representation of `self`.
-        // FIXME(pvdrz): fix docs
-        // ///
+                // ///
         // /// # Examples
         // ///
         // /// Basic usage:
@@ -3557,8 +3554,7 @@ macro_rules! uint_impl {
         }
 
         /// Returns `true` if and only if `self == 2^k` for some unsigned integer `k`.
-        // FIXME(pvdrz): fix docs
-        // ///
+                // ///
         // /// # Examples
         // ///
         // /// Basic usage:

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -24,27 +24,27 @@ macro_rules! uint_impl {
         bound_condition = $bound_condition:literal,
     ) => {
         /// The smallest value that can be represented by this integer type.
-                // ///
-        // /// # Examples
-        // ///
-        // /// Basic usage:
-        // ///
-        // /// ```
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
         // #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN, 0);")]
-        // /// ```
+        /// ```
         #[stable(feature = "assoc_int_consts", since = "1.43.0")]
         pub const MIN: Self = 0;
 
         /// The largest value that can be represented by this integer type
                 // #[doc = concat!("(2<sup>", $BITS, "</sup> &minus; 1", $bound_condition, ").")]
-        // ///
-        // /// # Examples
-        // ///
-        // /// Basic usage:
-        // ///
-        // /// ```
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
         // #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX, ", stringify!($MaxV), ");")]
-        // /// ```
+        /// ```
         #[stable(feature = "assoc_int_consts", since = "1.43.0")]
         pub const MAX: Self = !0;
 
@@ -60,21 +60,21 @@ macro_rules! uint_impl {
         pub const BITS: u32 = Self::MAX.count_ones();
 
         /// Returns the number of ones in the binary representation of `self`.
-                // ///
-        // /// # Examples
-        // ///
-        // /// Basic usage:
-        // ///
-        // /// ```
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
         // #[doc = concat!("let n = 0b01001100", stringify!($SelfT), ";")]
-        // /// assert_eq!(n.count_ones(), 3);
-        // ///
+        /// assert_eq!(n.count_ones(), 3);
+        ///
         // #[doc = concat!("let max = ", stringify!($SelfT),"::MAX;")]
         // #[doc = concat!("assert_eq!(max.count_ones(), ", stringify!($BITS), ");")]
-        // ///
+        ///
         // #[doc = concat!("let zero = 0", stringify!($SelfT), ";")]
-        // /// assert_eq!(zero.count_ones(), 0);
-        // /// ```
+        /// assert_eq!(zero.count_ones(), 0);
+        /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_stable(feature = "const_math", since = "1.32.0")]
         #[doc(alias = "popcount")]
@@ -3554,15 +3554,15 @@ macro_rules! uint_impl {
         }
 
         /// Returns `true` if and only if `self == 2^k` for some unsigned integer `k`.
-                // ///
-        // /// # Examples
-        // ///
-        // /// Basic usage:
-        // ///
-        // /// ```
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
         // #[doc = concat!("assert!(16", stringify!($SelfT), ".is_power_of_two());")]
         // #[doc = concat!("assert!(!10", stringify!($SelfT), ".is_power_of_two());")]
-        // /// ```
+        /// ```
         #[must_use]
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_stable(feature = "const_is_power_of_two", since = "1.32.0")]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -30,20 +30,20 @@ macro_rules! uint_impl {
         /// Basic usage:
         ///
         /// ```
-        // #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN, 0);")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN, 0);")]
         /// ```
         #[stable(feature = "assoc_int_consts", since = "1.43.0")]
         pub const MIN: Self = 0;
 
         /// The largest value that can be represented by this integer type
-                // #[doc = concat!("(2<sup>", $BITS, "</sup> &minus; 1", $bound_condition, ").")]
+        #[doc = concat!("(2<sup>", $BITS, "</sup> &minus; 1", $bound_condition, ").")]
         ///
         /// # Examples
         ///
         /// Basic usage:
         ///
         /// ```
-        // #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX, ", stringify!($MaxV), ");")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX, ", stringify!($MaxV), ");")]
         /// ```
         #[stable(feature = "assoc_int_consts", since = "1.43.0")]
         pub const MAX: Self = !0;
@@ -66,13 +66,13 @@ macro_rules! uint_impl {
         /// Basic usage:
         ///
         /// ```
-        // #[doc = concat!("let n = 0b01001100", stringify!($SelfT), ";")]
+        #[doc = concat!("let n = 0b01001100", stringify!($SelfT), ";")]
         /// assert_eq!(n.count_ones(), 3);
         ///
-        // #[doc = concat!("let max = ", stringify!($SelfT),"::MAX;")]
-        // #[doc = concat!("assert_eq!(max.count_ones(), ", stringify!($BITS), ");")]
+        #[doc = concat!("let max = ", stringify!($SelfT),"::MAX;")]
+        #[doc = concat!("assert_eq!(max.count_ones(), ", stringify!($BITS), ");")]
         ///
-        // #[doc = concat!("let zero = 0", stringify!($SelfT), ";")]
+        #[doc = concat!("let zero = 0", stringify!($SelfT), ";")]
         /// assert_eq!(zero.count_ones(), 0);
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -3560,8 +3560,8 @@ macro_rules! uint_impl {
         /// Basic usage:
         ///
         /// ```
-        // #[doc = concat!("assert!(16", stringify!($SelfT), ".is_power_of_two());")]
-        // #[doc = concat!("assert!(!10", stringify!($SelfT), ".is_power_of_two());")]
+        #[doc = concat!("assert!(16", stringify!($SelfT), ".is_power_of_two());")]
+        #[doc = concat!("assert!(!10", stringify!($SelfT), ".is_power_of_two());")]
         /// ```
         #[must_use]
         #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -2,83 +2,83 @@ use crate::{convert, ops};
 
 /// Used to tell an operation whether it should exit early or go on as usual.
 // FIXME(pvdrz): fix docs
-// ///
-// /// This is used when exposing things (like graph traversals or visitors) where
-// /// you want the user to be able to choose whether to exit early.
-// /// Having the enum makes it clearer -- no more wondering "wait, what did `false`
-// /// mean again?" -- and allows including a value.
-// ///
-// /// Similar to [`Option`] and [`Result`], this enum can be used with the `?` operator
-// /// to return immediately if the [`Break`] variant is present or otherwise continue normally
-// /// with the value inside the [`Continue`] variant.
-// ///
-// /// # Examples
-// ///
-// /// Early-exiting from [`Iterator::try_for_each`]:
-// /// ```
-// /// use std::ops::ControlFlow;
-// ///
-// /// let r = (2..100).try_for_each(|x| {
-// ///     if 403 % x == 0 {
-// ///         return ControlFlow::Break(x)
-// ///     }
-// ///
-// ///     ControlFlow::Continue(())
-// /// });
-// /// assert_eq!(r, ControlFlow::Break(13));
-// /// ```
-// ///
-// /// A basic tree traversal:
-// /// ```
-// /// use std::ops::ControlFlow;
-// ///
-// /// pub struct TreeNode<T> {
-// ///     value: T,
-// ///     left: Option<Box<TreeNode<T>>>,
-// ///     right: Option<Box<TreeNode<T>>>,
-// /// }
-// ///
-// /// impl<T> TreeNode<T> {
-// ///     pub fn traverse_inorder<B>(&self, f: &mut impl FnMut(&T) -> ControlFlow<B>) -> ControlFlow<B> {
-// ///         if let Some(left) = &self.left {
-// ///             left.traverse_inorder(f)?;
-// ///         }
-// ///         f(&self.value)?;
-// ///         if let Some(right) = &self.right {
-// ///             right.traverse_inorder(f)?;
-// ///         }
-// ///         ControlFlow::Continue(())
-// ///     }
-// ///     fn leaf(value: T) -> Option<Box<TreeNode<T>>> {
-// ///         Some(Box::new(Self { value, left: None, right: None }))
-// ///     }
-// /// }
-// ///
-// /// let node = TreeNode {
-// ///     value: 0,
-// ///     left: TreeNode::leaf(1),
-// ///     right: Some(Box::new(TreeNode {
-// ///         value: -1,
-// ///         left: TreeNode::leaf(5),
-// ///         right: TreeNode::leaf(2),
-// ///     }))
-// /// };
-// /// let mut sum = 0;
-// ///
-// /// let res = node.traverse_inorder(&mut |val| {
-// ///     if *val < 0 {
-// ///         ControlFlow::Break(*val)
-// ///     } else {
-// ///         sum += *val;
-// ///         ControlFlow::Continue(())
-// ///     }
-// /// });
-// /// assert_eq!(res, ControlFlow::Break(-1));
-// /// assert_eq!(sum, 6);
-// /// ```
-// ///
-// /// [`Break`]: ControlFlow::Break
-// /// [`Continue`]: ControlFlow::Continue
+///
+/// This is used when exposing things (like graph traversals or visitors) where
+/// you want the user to be able to choose whether to exit early.
+/// Having the enum makes it clearer -- no more wondering "wait, what did `false`
+/// mean again?" -- and allows including a value.
+///
+/// Similar to [`Option`] and [`Result`], this enum can be used with the `?` operator
+/// to return immediately if the [`Break`] variant is present or otherwise continue normally
+/// with the value inside the [`Continue`] variant.
+///
+/// # Examples
+///
+/// Early-exiting from [`Iterator::try_for_each`]:
+/// ```
+/// use std::ops::ControlFlow;
+///
+/// let r = (2..100).try_for_each(|x| {
+///     if 403 % x == 0 {
+///         return ControlFlow::Break(x)
+///     }
+///
+///     ControlFlow::Continue(())
+/// });
+/// assert_eq!(r, ControlFlow::Break(13));
+/// ```
+///
+/// A basic tree traversal:
+/// ```
+/// use std::ops::ControlFlow;
+///
+/// pub struct TreeNode<T> {
+///     value: T,
+///     left: Option<Box<TreeNode<T>>>,
+///     right: Option<Box<TreeNode<T>>>,
+/// }
+///
+/// impl<T> TreeNode<T> {
+///     pub fn traverse_inorder<B>(&self, f: &mut impl FnMut(&T) -> ControlFlow<B>) -> ControlFlow<B> {
+///         if let Some(left) = &self.left {
+///             left.traverse_inorder(f)?;
+///         }
+///         f(&self.value)?;
+///         if let Some(right) = &self.right {
+///             right.traverse_inorder(f)?;
+///         }
+///         ControlFlow::Continue(())
+///     }
+///     fn leaf(value: T) -> Option<Box<TreeNode<T>>> {
+///         Some(Box::new(Self { value, left: None, right: None }))
+///     }
+/// }
+///
+/// let node = TreeNode {
+///     value: 0,
+///     left: TreeNode::leaf(1),
+///     right: Some(Box::new(TreeNode {
+///         value: -1,
+///         left: TreeNode::leaf(5),
+///         right: TreeNode::leaf(2),
+///     }))
+/// };
+/// let mut sum = 0;
+///
+/// let res = node.traverse_inorder(&mut |val| {
+///     if *val < 0 {
+///         ControlFlow::Break(*val)
+///     } else {
+///         sum += *val;
+///         ControlFlow::Continue(())
+///     }
+/// });
+/// assert_eq!(res, ControlFlow::Break(-1));
+/// assert_eq!(sum, 6);
+/// ```
+///
+/// [`Break`]: ControlFlow::Break
+/// [`Continue`]: ControlFlow::Continue
 #[stable(feature = "control_flow_enum_type", since = "1.55.0")]
 #[rustc_diagnostic_item = "ControlFlow"]
 #[must_use]

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -1,7 +1,6 @@
 use crate::{convert, ops};
 
 /// Used to tell an operation whether it should exit early or go on as usual.
-// FIXME(pvdrz): fix docs
 ///
 /// This is used when exposing things (like graph traversals or visitors) where
 /// you want the user to be able to choose whether to exit early.

--- a/library/core/src/ops/deref.rs
+++ b/library/core/src/ops/deref.rs
@@ -1,134 +1,134 @@
 /// Used for immutable dereferencing operations, like `*v`.
 // FIXME(pvdrz): fix docs
-// ///
-// /// In addition to being used for explicit dereferencing operations with the
-// /// (unary) `*` operator in immutable contexts, `Deref` is also used implicitly
-// /// by the compiler in many circumstances. This mechanism is called
-// /// ["`Deref` coercion"][coercion]. In mutable contexts, [`DerefMut`] is used and
-// /// mutable deref coercion similarly occurs.
-// ///
-// /// **Warning:** Deref coercion is a powerful language feature which has
-// /// far-reaching implications for every type that implements `Deref`. The
-// /// compiler will silently insert calls to `Deref::deref`. For this reason, one
-// /// should be careful about implementing `Deref` and only do so when deref
-// /// coercion is desirable. See [below][implementing] for advice on when this is
-// /// typically desirable or undesirable.
-// ///
-// /// Types that implement `Deref` or `DerefMut` are often called "smart
-// /// pointers" and the mechanism of deref coercion has been specifically designed
-// /// to facilitate the pointer-like behavior that name suggests. Often, the
-// /// purpose of a "smart pointer" type is to change the ownership semantics
-// /// of a contained value (for example, [`Rc`][rc] or [`Cow`][cow]) or the
-// /// storage semantics of a contained value (for example, [`Box`][box]).
-// ///
-// /// # Deref coercion
-// ///
-// /// If `T` implements `Deref<Target = U>`, and `v` is a value of type `T`, then:
-// ///
-// /// * In immutable contexts, `*v` (where `T` is neither a reference nor a raw
-// ///   pointer) is equivalent to `*Deref::deref(&v)`.
-// /// * Values of type `&T` are coerced to values of type `&U`
-// /// * `T` implicitly implements all the methods of the type `U` which take the
-// ///   `&self` receiver.
-// ///
-// /// For more details, visit [the chapter in *The Rust Programming Language*][book]
-// /// as well as the reference sections on [the dereference operator][ref-deref-op],
-// /// [method resolution], and [type coercions].
-// ///
-// /// # When to implement `Deref` or `DerefMut`
-// ///
-// /// The same advice applies to both deref traits. In general, deref traits
-// /// **should** be implemented if:
-// ///
-// /// 1. a value of the type transparently behaves like a value of the target
-// ///    type;
-// /// 1. the implementation of the deref function is cheap; and
-// /// 1. users of the type will not be surprised by any deref coercion behavior.
-// ///
-// /// In general, deref traits **should not** be implemented if:
-// ///
-// /// 1. the deref implementations could fail unexpectedly; or
-// /// 1. the type has methods that are likely to collide with methods on the
-// ///    target type; or
-// /// 1. committing to deref coercion as part of the public API is not desirable.
-// ///
-// /// Note that there's a large difference between implementing deref traits
-// /// generically over many target types, and doing so only for specific target
-// /// types.
-// ///
-// /// Generic implementations, such as for [`Box<T>`][box] (which is generic over
-// /// every type and dereferences to `T`) should be careful to provide few or no
-// /// methods, since the target type is unknown and therefore every method could
-// /// collide with one on the target type, causing confusion for users.
-// /// `impl<T> Box<T>` has no methods (though several associated functions),
-// /// partly for this reason.
-// ///
-// /// Specific implementations, such as for [`String`][string] (whose `Deref`
-// /// implementation has `Target = str`) can have many methods, since avoiding
-// /// collision is much easier. `String` and `str` both have many methods, and
-// /// `String` additionally behaves as if it has every method of `str` because of
-// /// deref coercion. The implementing type may also be generic while the
-// /// implementation is still specific in this sense; for example, [`Vec<T>`][vec]
-// /// dereferences to `[T]`, so methods of `T` are not applicable.
-// ///
-// /// Consider also that deref coercion means that deref traits are a much larger
-// /// part of a type's public API than any other trait as it is implicitly called
-// /// by the compiler. Therefore, it is advisable to consider whether this is
-// /// something you are comfortable supporting as a public API.
-// ///
-// /// The [`AsRef`] and [`Borrow`][core::borrow::Borrow] traits have very similar
-// /// signatures to `Deref`. It may be desirable to implement either or both of
-// /// these, whether in addition to or rather than deref traits. See their
-// /// documentation for details.
-// ///
-// /// # Fallibility
-// ///
-// /// **This trait's method should never unexpectedly fail**. Deref coercion means
-// /// the compiler will often insert calls to `Deref::deref` implicitly. Failure
-// /// during dereferencing can be extremely confusing when `Deref` is invoked
-// /// implicitly. In the majority of uses it should be infallible, though it may
-// /// be acceptable to panic if the type is misused through programmer error, for
-// /// example.
-// ///
-// /// However, infallibility is not enforced and therefore not guaranteed.
-// /// As such, `unsafe` code should not rely on infallibility in general for
-// /// soundness.
-// ///
-// /// [book]: ../../book/ch15-02-deref.html
-// /// [coercion]: #deref-coercion
-// /// [implementing]: #when-to-implement-deref-or-derefmut
-// /// [ref-deref-op]: ../../reference/expressions/operator-expr.html#the-dereference-operator
-// /// [method resolution]: ../../reference/expressions/method-call-expr.html
-// /// [type coercions]: ../../reference/type-coercions.html
-// /// [box]: ../../alloc/boxed/struct.Box.html
-// /// [string]: ../../alloc/string/struct.String.html
-// /// [vec]: ../../alloc/vec/struct.Vec.html
-// /// [rc]: ../../alloc/rc/struct.Rc.html
-// /// [cow]: ../../alloc/borrow/enum.Cow.html
-// ///
-// /// # Examples
-// ///
-// /// A struct with a single field which is accessible by dereferencing the
-// /// struct.
-// ///
-// /// ```
-// /// use std::ops::Deref;
-// ///
-// /// struct DerefExample<T> {
-// ///     value: T
-// /// }
-// ///
-// /// impl<T> Deref for DerefExample<T> {
-// ///     type Target = T;
-// ///
-// ///     fn deref(&self) -> &Self::Target {
-// ///         &self.value
-// ///     }
-// /// }
-// ///
-// /// let x = DerefExample { value: 'a' };
-// /// assert_eq!('a', *x);
-// /// ```
+///
+/// In addition to being used for explicit dereferencing operations with the
+/// (unary) `*` operator in immutable contexts, `Deref` is also used implicitly
+/// by the compiler in many circumstances. This mechanism is called
+/// ["`Deref` coercion"][coercion]. In mutable contexts, [`DerefMut`] is used and
+/// mutable deref coercion similarly occurs.
+///
+/// **Warning:** Deref coercion is a powerful language feature which has
+/// far-reaching implications for every type that implements `Deref`. The
+/// compiler will silently insert calls to `Deref::deref`. For this reason, one
+/// should be careful about implementing `Deref` and only do so when deref
+/// coercion is desirable. See [below][implementing] for advice on when this is
+/// typically desirable or undesirable.
+///
+/// Types that implement `Deref` or `DerefMut` are often called "smart
+/// pointers" and the mechanism of deref coercion has been specifically designed
+/// to facilitate the pointer-like behavior that name suggests. Often, the
+/// purpose of a "smart pointer" type is to change the ownership semantics
+/// of a contained value (for example, [`Rc`][rc] or [`Cow`][cow]) or the
+/// storage semantics of a contained value (for example, [`Box`][box]).
+///
+/// # Deref coercion
+///
+/// If `T` implements `Deref<Target = U>`, and `v` is a value of type `T`, then:
+///
+/// * In immutable contexts, `*v` (where `T` is neither a reference nor a raw
+///   pointer) is equivalent to `*Deref::deref(&v)`.
+/// * Values of type `&T` are coerced to values of type `&U`
+/// * `T` implicitly implements all the methods of the type `U` which take the
+///   `&self` receiver.
+///
+/// For more details, visit [the chapter in *The Rust Programming Language*][book]
+/// as well as the reference sections on [the dereference operator][ref-deref-op],
+/// [method resolution], and [type coercions].
+///
+/// # When to implement `Deref` or `DerefMut`
+///
+/// The same advice applies to both deref traits. In general, deref traits
+/// **should** be implemented if:
+///
+/// 1. a value of the type transparently behaves like a value of the target
+///    type;
+/// 1. the implementation of the deref function is cheap; and
+/// 1. users of the type will not be surprised by any deref coercion behavior.
+///
+/// In general, deref traits **should not** be implemented if:
+///
+/// 1. the deref implementations could fail unexpectedly; or
+/// 1. the type has methods that are likely to collide with methods on the
+///    target type; or
+/// 1. committing to deref coercion as part of the public API is not desirable.
+///
+/// Note that there's a large difference between implementing deref traits
+/// generically over many target types, and doing so only for specific target
+/// types.
+///
+/// Generic implementations, such as for [`Box<T>`][box] (which is generic over
+/// every type and dereferences to `T`) should be careful to provide few or no
+/// methods, since the target type is unknown and therefore every method could
+/// collide with one on the target type, causing confusion for users.
+/// `impl<T> Box<T>` has no methods (though several associated functions),
+/// partly for this reason.
+///
+/// Specific implementations, such as for [`String`][string] (whose `Deref`
+/// implementation has `Target = str`) can have many methods, since avoiding
+/// collision is much easier. `String` and `str` both have many methods, and
+/// `String` additionally behaves as if it has every method of `str` because of
+/// deref coercion. The implementing type may also be generic while the
+/// implementation is still specific in this sense; for example, [`Vec<T>`][vec]
+/// dereferences to `[T]`, so methods of `T` are not applicable.
+///
+/// Consider also that deref coercion means that deref traits are a much larger
+/// part of a type's public API than any other trait as it is implicitly called
+/// by the compiler. Therefore, it is advisable to consider whether this is
+/// something you are comfortable supporting as a public API.
+///
+/// The [`AsRef`] and [`Borrow`][core::borrow::Borrow] traits have very similar
+/// signatures to `Deref`. It may be desirable to implement either or both of
+/// these, whether in addition to or rather than deref traits. See their
+/// documentation for details.
+///
+/// # Fallibility
+///
+/// **This trait's method should never unexpectedly fail**. Deref coercion means
+/// the compiler will often insert calls to `Deref::deref` implicitly. Failure
+/// during dereferencing can be extremely confusing when `Deref` is invoked
+/// implicitly. In the majority of uses it should be infallible, though it may
+/// be acceptable to panic if the type is misused through programmer error, for
+/// example.
+///
+/// However, infallibility is not enforced and therefore not guaranteed.
+/// As such, `unsafe` code should not rely on infallibility in general for
+/// soundness.
+///
+/// [book]: ../../book/ch15-02-deref.html
+/// [coercion]: #deref-coercion
+/// [implementing]: #when-to-implement-deref-or-derefmut
+/// [ref-deref-op]: ../../reference/expressions/operator-expr.html#the-dereference-operator
+/// [method resolution]: ../../reference/expressions/method-call-expr.html
+/// [type coercions]: ../../reference/type-coercions.html
+/// [box]: ../../alloc/boxed/struct.Box.html
+/// [string]: ../../alloc/string/struct.String.html
+/// [vec]: ../../alloc/vec/struct.Vec.html
+/// [rc]: ../../alloc/rc/struct.Rc.html
+/// [cow]: ../../alloc/borrow/enum.Cow.html
+///
+/// # Examples
+///
+/// A struct with a single field which is accessible by dereferencing the
+/// struct.
+///
+/// ```
+/// use std::ops::Deref;
+///
+/// struct DerefExample<T> {
+///     value: T
+/// }
+///
+/// impl<T> Deref for DerefExample<T> {
+///     type Target = T;
+///
+///     fn deref(&self) -> &Self::Target {
+///         &self.value
+///     }
+/// }
+///
+/// let x = DerefExample { value: 'a' };
+/// assert_eq!('a', *x);
+/// ```
 #[lang = "deref"]
 #[doc(alias = "*")]
 #[doc(alias = "&*")]
@@ -176,94 +176,94 @@ impl<T: ?Sized> const Deref for &mut T {
 
 /// Used for mutable dereferencing operations, like in `*v = 1;`.
 // FIXME(pvdrz): fix docs
-// ///
-// /// In addition to being used for explicit dereferencing operations with the
-// /// (unary) `*` operator in mutable contexts, `DerefMut` is also used implicitly
-// /// by the compiler in many circumstances. This mechanism is called
-// /// ["mutable deref coercion"][coercion]. In immutable contexts, [`Deref`] is used.
-// ///
-// /// **Warning:** Deref coercion is a powerful language feature which has
-// /// far-reaching implications for every type that implements `DerefMut`. The
-// /// compiler will silently insert calls to `DerefMut::deref_mut`. For this
-// /// reason, one should be careful about implementing `DerefMut` and only do so
-// /// when mutable deref coercion is desirable. See [the `Deref` docs][implementing]
-// /// for advice on when this is typically desirable or undesirable.
-// ///
-// /// Types that implement `DerefMut` or `Deref` are often called "smart
-// /// pointers" and the mechanism of deref coercion has been specifically designed
-// /// to facilitate the pointer-like behavior that name suggests. Often, the
-// /// purpose of a "smart pointer" type is to change the ownership semantics
-// /// of a contained value (for example, [`Rc`][rc] or [`Cow`][cow]) or the
-// /// storage semantics of a contained value (for example, [`Box`][box]).
-// ///
+///
+/// In addition to being used for explicit dereferencing operations with the
+/// (unary) `*` operator in mutable contexts, `DerefMut` is also used implicitly
+/// by the compiler in many circumstances. This mechanism is called
+/// ["mutable deref coercion"][coercion]. In immutable contexts, [`Deref`] is used.
+///
+/// **Warning:** Deref coercion is a powerful language feature which has
+/// far-reaching implications for every type that implements `DerefMut`. The
+/// compiler will silently insert calls to `DerefMut::deref_mut`. For this
+/// reason, one should be careful about implementing `DerefMut` and only do so
+/// when mutable deref coercion is desirable. See [the `Deref` docs][implementing]
+/// for advice on when this is typically desirable or undesirable.
+///
+/// Types that implement `DerefMut` or `Deref` are often called "smart
+/// pointers" and the mechanism of deref coercion has been specifically designed
+/// to facilitate the pointer-like behavior that name suggests. Often, the
+/// purpose of a "smart pointer" type is to change the ownership semantics
+/// of a contained value (for example, [`Rc`][rc] or [`Cow`][cow]) or the
+/// storage semantics of a contained value (for example, [`Box`][box]).
+///
 /// # Mutable deref coercion
-// ///
-// /// If `T` implements `DerefMut<Target = U>`, and `v` is a value of type `T`,
-// /// then:
-// ///
-// /// * In mutable contexts, `*v` (where `T` is neither a reference nor a raw pointer)
-// ///   is equivalent to `*DerefMut::deref_mut(&mut v)`.
-// /// * Values of type `&mut T` are coerced to values of type `&mut U`
-// /// * `T` implicitly implements all the (mutable) methods of the type `U`.
-// ///
-// /// For more details, visit [the chapter in *The Rust Programming Language*][book]
-// /// as well as the reference sections on [the dereference operator][ref-deref-op],
-// /// [method resolution] and [type coercions].
-// ///
-// /// # Fallibility
-// ///
-// /// **This trait's method should never unexpectedly fail**. Deref coercion means
-// /// the compiler will often insert calls to `DerefMut::deref_mut` implicitly.
-// /// Failure during dereferencing can be extremely confusing when `DerefMut` is
-// /// invoked implicitly. In the majority of uses it should be infallible, though
-// /// it may be acceptable to panic if the type is misused through programmer
-// /// error, for example.
-// ///
-// /// However, infallibility is not enforced and therefore not guaranteed.
-// /// As such, `unsafe` code should not rely on infallibility in general for
-// /// soundness.
-// ///
-// /// [book]: ../../book/ch15-02-deref.html
-// /// [coercion]: #mutable-deref-coercion
-// /// [implementing]: Deref#when-to-implement-deref-or-derefmut
-// /// [ref-deref-op]: ../../reference/expressions/operator-expr.html#the-dereference-operator
-// /// [method resolution]: ../../reference/expressions/method-call-expr.html
-// /// [type coercions]: ../../reference/type-coercions.html
-// /// [box]: ../../alloc/boxed/struct.Box.html
-// /// [string]: ../../alloc/string/struct.String.html
-// /// [rc]: ../../alloc/rc/struct.Rc.html
-// /// [cow]: ../../alloc/borrow/enum.Cow.html
-// ///
-// /// # Examples
-// ///
-// /// A struct with a single field which is modifiable by dereferencing the
-// /// struct.
-// ///
-// /// ```
-// /// use std::ops::{Deref, DerefMut};
-// ///
-// /// struct DerefMutExample<T> {
-// ///     value: T
-// /// }
-// ///
-// /// impl<T> Deref for DerefMutExample<T> {
-// ///     type Target = T;
-// ///
-// ///     fn deref(&self) -> &Self::Target {
-// ///         &self.value
-// ///     }
-// /// }
-// ///
-// /// impl<T> DerefMut for DerefMutExample<T> {
-// ///     fn deref_mut(&mut self) -> &mut Self::Target {
-// ///         &mut self.value
-// ///     }
-// /// }
-// ///
-// /// let mut x = DerefMutExample { value: 'a' };
-// /// *x = 'b';
-// /// assert_eq!('b', x.value);
-// /// ```
+///
+/// If `T` implements `DerefMut<Target = U>`, and `v` is a value of type `T`,
+/// then:
+///
+/// * In mutable contexts, `*v` (where `T` is neither a reference nor a raw pointer)
+///   is equivalent to `*DerefMut::deref_mut(&mut v)`.
+/// * Values of type `&mut T` are coerced to values of type `&mut U`
+/// * `T` implicitly implements all the (mutable) methods of the type `U`.
+///
+/// For more details, visit [the chapter in *The Rust Programming Language*][book]
+/// as well as the reference sections on [the dereference operator][ref-deref-op],
+/// [method resolution] and [type coercions].
+///
+/// # Fallibility
+///
+/// **This trait's method should never unexpectedly fail**. Deref coercion means
+/// the compiler will often insert calls to `DerefMut::deref_mut` implicitly.
+/// Failure during dereferencing can be extremely confusing when `DerefMut` is
+/// invoked implicitly. In the majority of uses it should be infallible, though
+/// it may be acceptable to panic if the type is misused through programmer
+/// error, for example.
+///
+/// However, infallibility is not enforced and therefore not guaranteed.
+/// As such, `unsafe` code should not rely on infallibility in general for
+/// soundness.
+///
+/// [book]: ../../book/ch15-02-deref.html
+/// [coercion]: #mutable-deref-coercion
+/// [implementing]: Deref#when-to-implement-deref-or-derefmut
+/// [ref-deref-op]: ../../reference/expressions/operator-expr.html#the-dereference-operator
+/// [method resolution]: ../../reference/expressions/method-call-expr.html
+/// [type coercions]: ../../reference/type-coercions.html
+/// [box]: ../../alloc/boxed/struct.Box.html
+/// [string]: ../../alloc/string/struct.String.html
+/// [rc]: ../../alloc/rc/struct.Rc.html
+/// [cow]: ../../alloc/borrow/enum.Cow.html
+///
+/// # Examples
+///
+/// A struct with a single field which is modifiable by dereferencing the
+/// struct.
+///
+/// ```
+/// use std::ops::{Deref, DerefMut};
+///
+/// struct DerefMutExample<T> {
+///     value: T
+/// }
+///
+/// impl<T> Deref for DerefMutExample<T> {
+///     type Target = T;
+///
+///     fn deref(&self) -> &Self::Target {
+///         &self.value
+///     }
+/// }
+///
+/// impl<T> DerefMut for DerefMutExample<T> {
+///     fn deref_mut(&mut self) -> &mut Self::Target {
+///         &mut self.value
+///     }
+/// }
+///
+/// let mut x = DerefMutExample { value: 'a' };
+/// *x = 'b';
+/// assert_eq!('b', x.value);
+/// ```
 #[lang = "deref_mut"]
 #[doc(alias = "*")]
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/ops/deref.rs
+++ b/library/core/src/ops/deref.rs
@@ -1,5 +1,4 @@
 /// Used for immutable dereferencing operations, like `*v`.
-// FIXME(pvdrz): fix docs
 ///
 /// In addition to being used for explicit dereferencing operations with the
 /// (unary) `*` operator in immutable contexts, `Deref` is also used implicitly
@@ -175,7 +174,6 @@ impl<T: ?Sized> const Deref for &mut T {
 }
 
 /// Used for mutable dereferencing operations, like in `*v = 1;`.
-// FIXME(pvdrz): fix docs
 ///
 /// In addition to being used for explicit dereferencing operations with the
 /// (unary) `*` operator in mutable contexts, `DerefMut` is also used implicitly

--- a/library/core/src/ops/drop.rs
+++ b/library/core/src/ops/drop.rs
@@ -207,36 +207,36 @@
 #[rustc_const_unstable(feature = "const_destruct", issue = "133214")]
 pub trait Drop {
     /// Executes the destructor for this type.
-    // ///
-    // /// This method is called implicitly when the value goes out of scope,
-    // /// and cannot be called explicitly (this is compiler error [E0040]).
-    // /// However, the [`mem::drop`] function in the prelude can be
-    // /// used to call the argument's `Drop` implementation.
-    // ///
-    // /// When this method has been called, `self` has not yet been deallocated.
-    // /// That only happens after the method is over.
-    // /// If this wasn't the case, `self` would be a dangling reference.
-    // ///
-    // /// # Panics
-    // ///
-    // /// Implementations should generally avoid [`panic!`]ing, because `drop()` may itself be called
-    // /// during unwinding due to a panic, and if the `drop()` panics in that situation (a “double
-    // /// panic”), this will likely abort the program. It is possible to check [`panicking()`] first,
-    // /// which may be desirable for a `Drop` implementation that is reporting a bug of the kind
-    // /// “you didn't finish using this before it was dropped”; but most types should simply clean up
-    // /// their owned allocations or other resources and return normally from `drop()`, regardless of
-    // /// what state they are in.
-    // ///
-    // /// Note that even if this panics, the value is considered to be dropped;
-    // /// you must not cause `drop` to be called again. This is normally automatically
-    // /// handled by the compiler, but when using unsafe code, can sometimes occur
-    // /// unintentionally, particularly when using [`ptr::drop_in_place`].
-    // ///
-    // /// [E0040]: ../../error_codes/E0040.html
-    // /// [`panic!`]: crate::panic!
-    // /// [`panicking()`]: ../../std/thread/fn.panicking.html
-    // /// [`mem::drop`]: drop
-    // /// [`ptr::drop_in_place`]: crate::ptr::drop_in_place
+    ///
+    /// This method is called implicitly when the value goes out of scope,
+    /// and cannot be called explicitly (this is compiler error [E0040]).
+    /// However, the [`mem::drop`] function in the prelude can be
+    /// used to call the argument's `Drop` implementation.
+    ///
+    /// When this method has been called, `self` has not yet been deallocated.
+    /// That only happens after the method is over.
+    /// If this wasn't the case, `self` would be a dangling reference.
+    ///
+    /// # Panics
+    ///
+    /// Implementations should generally avoid [`panic!`]ing, because `drop()` may itself be called
+    /// during unwinding due to a panic, and if the `drop()` panics in that situation (a “double
+    /// panic”), this will likely abort the program. It is possible to check [`panicking()`] first,
+    /// which may be desirable for a `Drop` implementation that is reporting a bug of the kind
+    /// “you didn't finish using this before it was dropped”; but most types should simply clean up
+    /// their owned allocations or other resources and return normally from `drop()`, regardless of
+    /// what state they are in.
+    ///
+    /// Note that even if this panics, the value is considered to be dropped;
+    /// you must not cause `drop` to be called again. This is normally automatically
+    /// handled by the compiler, but when using unsafe code, can sometimes occur
+    /// unintentionally, particularly when using [`ptr::drop_in_place`].
+    ///
+    /// [E0040]: ../../error_codes/E0040.html
+    /// [`panic!`]: crate::panic!
+    /// [`panicking()`]: ../../std/thread/fn.panicking.html
+    /// [`mem::drop`]: drop
+    /// [`ptr::drop_in_place`]: crate::ptr::drop_in_place
     #[stable(feature = "rust1", since = "1.0.0")]
     fn drop(&mut self);
 }

--- a/library/core/src/ops/drop.rs
+++ b/library/core/src/ops/drop.rs
@@ -1,207 +1,207 @@
 /// Custom code within the destructor.
 // FIXME(pvdrz): fix docs
-// ///
-// /// When a value is no longer needed, Rust will run a "destructor" on that value.
-// /// The most common way that a value is no longer needed is when it goes out of
-// /// scope. Destructors may still run in other circumstances, but we're going to
-// /// focus on scope for the examples here. To learn about some of those other cases,
-// /// please see [the reference] section on destructors.
-// ///
-// /// [the reference]: https://doc.rust-lang.org/reference/destructors.html
-// ///
-// /// This destructor consists of two components:
-// /// - A call to `Drop::drop` for that value, if this special `Drop` trait is implemented for its type.
-// /// - The automatically generated "drop glue" which recursively calls the destructors
-// ///     of all the fields of this value.
-// ///
-// /// As Rust automatically calls the destructors of all contained fields,
-// /// you don't have to implement `Drop` in most cases. But there are some cases where
-// /// it is useful, for example for types which directly manage a resource.
-// /// That resource may be memory, it may be a file descriptor, it may be a network socket.
-// /// Once a value of that type is no longer going to be used, it should "clean up" its
-// /// resource by freeing the memory or closing the file or socket. This is
-// /// the job of a destructor, and therefore the job of `Drop::drop`.
-// ///
-// /// ## Examples
-// ///
-// /// To see destructors in action, let's take a look at the following program:
-// ///
-// /// ```rust
-// /// struct HasDrop;
-// ///
-// /// impl Drop for HasDrop {
-// ///     fn drop(&mut self) {
-// ///         println!("Dropping HasDrop!");
-// ///     }
-// /// }
-// ///
-// /// struct HasTwoDrops {
-// ///     one: HasDrop,
-// ///     two: HasDrop,
-// /// }
-// ///
-// /// impl Drop for HasTwoDrops {
-// ///     fn drop(&mut self) {
-// ///         println!("Dropping HasTwoDrops!");
-// ///     }
-// /// }
-// ///
-// /// fn main() {
-// ///     let _x = HasTwoDrops { one: HasDrop, two: HasDrop };
-// ///     println!("Running!");
-// /// }
-// /// ```
-// ///
-// /// Rust will first call `Drop::drop` for `_x` and then for both `_x.one` and `_x.two`,
-// /// meaning that running this will print
-// ///
-// /// ```text
-// /// Running!
-// /// Dropping HasTwoDrops!
-// /// Dropping HasDrop!
-// /// Dropping HasDrop!
-// /// ```
-// ///
-// /// Even if we remove the implementation of `Drop` for `HasTwoDrop`, the destructors of its fields are still called.
-// /// This would result in
-// ///
-// /// ```test
-// /// Running!
-// /// Dropping HasDrop!
-// /// Dropping HasDrop!
-// /// ```
-// ///
-// /// ## You cannot call `Drop::drop` yourself
-// ///
-// /// Because `Drop::drop` is used to clean up a value, it may be dangerous to use this value after
-// /// the method has been called. As `Drop::drop` does not take ownership of its input,
-// /// Rust prevents misuse by not allowing you to call `Drop::drop` directly.
-// ///
-// /// In other words, if you tried to explicitly call `Drop::drop` in the above example, you'd get a compiler error.
-// ///
-// /// If you'd like to explicitly call the destructor of a value, [`mem::drop`] can be used instead.
-// ///
-// /// [`mem::drop`]: drop
-// ///
-// /// ## Drop order
-// ///
-// /// Which of our two `HasDrop` drops first, though? For structs, it's the same
-// /// order that they're declared: first `one`, then `two`. If you'd like to try
-// /// this yourself, you can modify `HasDrop` above to contain some data, like an
-// /// integer, and then use it in the `println!` inside of `Drop`. This behavior is
-// /// guaranteed by the language.
-// ///
-// /// Unlike for structs, local variables are dropped in reverse order:
-// ///
-// /// ```rust
-// /// struct Foo;
-// ///
-// /// impl Drop for Foo {
-// ///     fn drop(&mut self) {
-// ///         println!("Dropping Foo!")
-// ///     }
-// /// }
-// ///
-// /// struct Bar;
-// ///
-// /// impl Drop for Bar {
-// ///     fn drop(&mut self) {
-// ///         println!("Dropping Bar!")
-// ///     }
-// /// }
-// ///
-// /// fn main() {
-// ///     let _foo = Foo;
-// ///     let _bar = Bar;
-// /// }
-// /// ```
-// ///
-// /// This will print
-// ///
-// /// ```text
-// /// Dropping Bar!
-// /// Dropping Foo!
-// /// ```
-// ///
-// /// Please see [the reference] for the full rules.
-// ///
-// /// [the reference]: https://doc.rust-lang.org/reference/destructors.html
-// ///
-// /// ## `Copy` and `Drop` are exclusive
-// ///
-// /// You cannot implement both [`Copy`] and `Drop` on the same type. Types that
-// /// are `Copy` get implicitly duplicated by the compiler, making it very
-// /// hard to predict when, and how often destructors will be executed. As such,
-// /// these types cannot have destructors.
-// ///
+///
+/// When a value is no longer needed, Rust will run a "destructor" on that value.
+/// The most common way that a value is no longer needed is when it goes out of
+/// scope. Destructors may still run in other circumstances, but we're going to
+/// focus on scope for the examples here. To learn about some of those other cases,
+/// please see [the reference] section on destructors.
+///
+/// [the reference]: https://doc.rust-lang.org/reference/destructors.html
+///
+/// This destructor consists of two components:
+/// - A call to `Drop::drop` for that value, if this special `Drop` trait is implemented for its type.
+/// - The automatically generated "drop glue" which recursively calls the destructors
+///     of all the fields of this value.
+///
+/// As Rust automatically calls the destructors of all contained fields,
+/// you don't have to implement `Drop` in most cases. But there are some cases where
+/// it is useful, for example for types which directly manage a resource.
+/// That resource may be memory, it may be a file descriptor, it may be a network socket.
+/// Once a value of that type is no longer going to be used, it should "clean up" its
+/// resource by freeing the memory or closing the file or socket. This is
+/// the job of a destructor, and therefore the job of `Drop::drop`.
+///
+/// ## Examples
+///
+/// To see destructors in action, let's take a look at the following program:
+///
+/// ```rust
+/// struct HasDrop;
+///
+/// impl Drop for HasDrop {
+///     fn drop(&mut self) {
+///         println!("Dropping HasDrop!");
+///     }
+/// }
+///
+/// struct HasTwoDrops {
+///     one: HasDrop,
+///     two: HasDrop,
+/// }
+///
+/// impl Drop for HasTwoDrops {
+///     fn drop(&mut self) {
+///         println!("Dropping HasTwoDrops!");
+///     }
+/// }
+///
+/// fn main() {
+///     let _x = HasTwoDrops { one: HasDrop, two: HasDrop };
+///     println!("Running!");
+/// }
+/// ```
+///
+/// Rust will first call `Drop::drop` for `_x` and then for both `_x.one` and `_x.two`,
+/// meaning that running this will print
+///
+/// ```text
+/// Running!
+/// Dropping HasTwoDrops!
+/// Dropping HasDrop!
+/// Dropping HasDrop!
+/// ```
+///
+/// Even if we remove the implementation of `Drop` for `HasTwoDrop`, the destructors of its fields are still called.
+/// This would result in
+///
+/// ```test
+/// Running!
+/// Dropping HasDrop!
+/// Dropping HasDrop!
+/// ```
+///
+/// ## You cannot call `Drop::drop` yourself
+///
+/// Because `Drop::drop` is used to clean up a value, it may be dangerous to use this value after
+/// the method has been called. As `Drop::drop` does not take ownership of its input,
+/// Rust prevents misuse by not allowing you to call `Drop::drop` directly.
+///
+/// In other words, if you tried to explicitly call `Drop::drop` in the above example, you'd get a compiler error.
+///
+/// If you'd like to explicitly call the destructor of a value, [`mem::drop`] can be used instead.
+///
+/// [`mem::drop`]: drop
+///
+/// ## Drop order
+///
+/// Which of our two `HasDrop` drops first, though? For structs, it's the same
+/// order that they're declared: first `one`, then `two`. If you'd like to try
+/// this yourself, you can modify `HasDrop` above to contain some data, like an
+/// integer, and then use it in the `println!` inside of `Drop`. This behavior is
+/// guaranteed by the language.
+///
+/// Unlike for structs, local variables are dropped in reverse order:
+///
+/// ```rust
+/// struct Foo;
+///
+/// impl Drop for Foo {
+///     fn drop(&mut self) {
+///         println!("Dropping Foo!")
+///     }
+/// }
+///
+/// struct Bar;
+///
+/// impl Drop for Bar {
+///     fn drop(&mut self) {
+///         println!("Dropping Bar!")
+///     }
+/// }
+///
+/// fn main() {
+///     let _foo = Foo;
+///     let _bar = Bar;
+/// }
+/// ```
+///
+/// This will print
+///
+/// ```text
+/// Dropping Bar!
+/// Dropping Foo!
+/// ```
+///
+/// Please see [the reference] for the full rules.
+///
+/// [the reference]: https://doc.rust-lang.org/reference/destructors.html
+///
+/// ## `Copy` and `Drop` are exclusive
+///
+/// You cannot implement both [`Copy`] and `Drop` on the same type. Types that
+/// are `Copy` get implicitly duplicated by the compiler, making it very
+/// hard to predict when, and how often destructors will be executed. As such,
+/// these types cannot have destructors.
+///
 /// ## Drop check
-// ///
-// /// Dropping interacts with the borrow checker in subtle ways: when a type `T` is being implicitly
-// /// dropped as some variable of this type goes out of scope, the borrow checker needs to ensure that
-// /// calling `T`'s destructor at this moment is safe. In particular, it also needs to be safe to
-// /// recursively drop all the fields of `T`. For example, it is crucial that code like the following
-// /// is being rejected:
-// ///
-// /// ```compile_fail,E0597
-// /// use std::cell::Cell;
-// ///
-// /// struct S<'a>(Cell<Option<&'a S<'a>>>, Box<i32>);
-// /// impl Drop for S<'_> {
-// ///     fn drop(&mut self) {
-// ///         if let Some(r) = self.0.get() {
-// ///             // Print the contents of the `Box` in `r`.
-// ///             println!("{}", r.1);
-// ///         }
-// ///     }
-// /// }
-// ///
-// /// fn main() {
-// ///     // Set up two `S` that point to each other.
-// ///     let s1 = S(Cell::new(None), Box::new(42));
-// ///     let s2 = S(Cell::new(Some(&s1)), Box::new(42));
-// ///     s1.0.set(Some(&s2));
-// ///     // Now they both get dropped. But whichever is the 2nd one
-// ///     // to be dropped will access the `Box` in the first one,
-// ///     // which is a use-after-free!
-// /// }
-// /// ```
-// ///
-// /// The Nomicon discusses the need for [drop check in more detail][drop check].
-// ///
-// /// To reject such code, the "drop check" analysis determines which types and lifetimes need to
-// /// still be live when `T` gets dropped. The exact details of this analysis are not yet
-// /// stably guaranteed and **subject to change**. Currently, the analysis works as follows:
-// /// - If `T` has no drop glue, then trivially nothing is required to be live. This is the case if
-// ///   neither `T` nor any of its (recursive) fields have a destructor (`impl Drop`). [`PhantomData`],
-// ///   arrays of length 0 and [`ManuallyDrop`] are considered to never have a destructor, no matter
-// ///   their field type.
-// /// - If `T` has drop glue, then, for all types `U` that are *owned* by any field of `T`,
-// ///   recursively add the types and lifetimes that need to be live when `U` gets dropped. The set of
-// ///   owned types is determined by recursively traversing `T`:
-// ///   - Recursively descend through `PhantomData`, `Box`, tuples, and arrays (excluding arrays of
-// ///     length 0).
-// ///   - Stop at reference and raw pointer types as well as function pointers and function items;
-// ///     they do not own anything.
-// ///   - Stop at non-composite types (type parameters that remain generic in the current context and
-// ///     base types such as integers and `bool`); these types are owned.
-// ///   - When hitting an ADT with `impl Drop`, stop there; this type is owned.
-// ///   - When hitting an ADT without `impl Drop`, recursively descend to its fields. (For an `enum`,
-// ///     consider all fields of all variants.)
-// /// - Furthermore, if `T` implements `Drop`, then all generic (lifetime and type) parameters of `T`
-// ///   must be live.
-// ///
-// /// In the above example, the last clause implies that `'a` must be live when `S<'a>` is dropped,
-// /// and hence the example is rejected. If we remove the `impl Drop`, the liveness requirement
-// /// disappears and the example is accepted.
-// ///
-// /// There exists an unstable way for a type to opt-out of the last clause; this is called "drop
-// /// check eyepatch" or `may_dangle`. For more details on this nightly-only feature, see the
-// /// [discussion in the Nomicon][nomicon].
-// ///
-// /// [`ManuallyDrop`]: crate::mem::ManuallyDrop
-// /// [`PhantomData`]: crate::marker::PhantomData
-// /// [drop check]: ../../nomicon/dropck.html
-// /// [nomicon]: ../../nomicon/phantom-data.html#an-exception-the-special-case-of-the-standard-library-and-its-unstable-may_dangle
+///
+/// Dropping interacts with the borrow checker in subtle ways: when a type `T` is being implicitly
+/// dropped as some variable of this type goes out of scope, the borrow checker needs to ensure that
+/// calling `T`'s destructor at this moment is safe. In particular, it also needs to be safe to
+/// recursively drop all the fields of `T`. For example, it is crucial that code like the following
+/// is being rejected:
+///
+/// ```compile_fail,E0597
+/// use std::cell::Cell;
+///
+/// struct S<'a>(Cell<Option<&'a S<'a>>>, Box<i32>);
+/// impl Drop for S<'_> {
+///     fn drop(&mut self) {
+///         if let Some(r) = self.0.get() {
+///             // Print the contents of the `Box` in `r`.
+///             println!("{}", r.1);
+///         }
+///     }
+/// }
+///
+/// fn main() {
+///     // Set up two `S` that point to each other.
+///     let s1 = S(Cell::new(None), Box::new(42));
+///     let s2 = S(Cell::new(Some(&s1)), Box::new(42));
+///     s1.0.set(Some(&s2));
+///     // Now they both get dropped. But whichever is the 2nd one
+///     // to be dropped will access the `Box` in the first one,
+///     // which is a use-after-free!
+/// }
+/// ```
+///
+/// The Nomicon discusses the need for [drop check in more detail][drop check].
+///
+/// To reject such code, the "drop check" analysis determines which types and lifetimes need to
+/// still be live when `T` gets dropped. The exact details of this analysis are not yet
+/// stably guaranteed and **subject to change**. Currently, the analysis works as follows:
+/// - If `T` has no drop glue, then trivially nothing is required to be live. This is the case if
+///   neither `T` nor any of its (recursive) fields have a destructor (`impl Drop`). [`PhantomData`],
+///   arrays of length 0 and [`ManuallyDrop`] are considered to never have a destructor, no matter
+///   their field type.
+/// - If `T` has drop glue, then, for all types `U` that are *owned* by any field of `T`,
+///   recursively add the types and lifetimes that need to be live when `U` gets dropped. The set of
+///   owned types is determined by recursively traversing `T`:
+///   - Recursively descend through `PhantomData`, `Box`, tuples, and arrays (excluding arrays of
+///     length 0).
+///   - Stop at reference and raw pointer types as well as function pointers and function items;
+///     they do not own anything.
+///   - Stop at non-composite types (type parameters that remain generic in the current context and
+///     base types such as integers and `bool`); these types are owned.
+///   - When hitting an ADT with `impl Drop`, stop there; this type is owned.
+///   - When hitting an ADT without `impl Drop`, recursively descend to its fields. (For an `enum`,
+///     consider all fields of all variants.)
+/// - Furthermore, if `T` implements `Drop`, then all generic (lifetime and type) parameters of `T`
+///   must be live.
+///
+/// In the above example, the last clause implies that `'a` must be live when `S<'a>` is dropped,
+/// and hence the example is rejected. If we remove the `impl Drop`, the liveness requirement
+/// disappears and the example is accepted.
+///
+/// There exists an unstable way for a type to opt-out of the last clause; this is called "drop
+/// check eyepatch" or `may_dangle`. For more details on this nightly-only feature, see the
+/// [discussion in the Nomicon][nomicon].
+///
+/// [`ManuallyDrop`]: crate::mem::ManuallyDrop
+/// [`PhantomData`]: crate::marker::PhantomData
+/// [drop check]: ../../nomicon/dropck.html
+/// [nomicon]: ../../nomicon/phantom-data.html#an-exception-the-special-case-of-the-standard-library-and-its-unstable-may_dangle
 #[lang = "drop"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[const_trait]

--- a/library/core/src/ops/drop.rs
+++ b/library/core/src/ops/drop.rs
@@ -1,5 +1,4 @@
 /// Custom code within the destructor.
-// FIXME(pvdrz): fix docs
 ///
 /// When a value is no longer needed, Rust will run a "destructor" on that value.
 /// The most common way that a value is no longer needed is when it goes out of
@@ -208,7 +207,6 @@
 #[rustc_const_unstable(feature = "const_destruct", issue = "133214")]
 pub trait Drop {
     /// Executes the destructor for this type.
-    // FIXME(pvdrz): fix docs
     // ///
     // /// This method is called implicitly when the value goes out of scope,
     // /// and cannot be called explicitly (this is compiler error [E0040]).

--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -1,140 +1,140 @@
 //! Overloadable operators.
-// //!
-// //! Implementing these traits allows you to overload certain operators.
-// //!
-// //! Some of these traits are imported by the prelude, so they are available in
-// //! every Rust program. Only operators backed by traits can be overloaded. For
-// //! example, the addition operator (`+`) can be overloaded through the [`Add`]
-// //! trait, but since the assignment operator (`=`) has no backing trait, there
-// //! is no way of overloading its semantics. Additionally, this module does not
-// //! provide any mechanism to create new operators. If traitless overloading or
-// //! custom operators are required, you should look toward macros to extend
-// //! Rust's syntax.
-// //!
-// //! Implementations of operator traits should be unsurprising in their
-// //! respective contexts, keeping in mind their usual meanings and
-// //! [operator precedence]. For example, when implementing [`Mul`], the operation
-// //! should have some resemblance to multiplication (and share expected
-// //! properties like associativity).
-// //!
-// //! Note that the `&&` and `||` operators are currently not supported for
-// //! overloading. Due to their short circuiting nature, they require a different
-// //! design from traits for other operators like [`BitAnd`]. Designs for them are
-// //! under discussion.
-// //!
-// //! Many of the operators take their operands by value. In non-generic
-// //! contexts involving built-in types, this is usually not a problem.
-// //! However, using these operators in generic code, requires some
-// //! attention if values have to be reused as opposed to letting the operators
-// //! consume them. One option is to occasionally use [`clone`].
-// //! Another option is to rely on the types involved providing additional
-// //! operator implementations for references. For example, for a user-defined
-// //! type `T` which is supposed to support addition, it is probably a good
-// //! idea to have both `T` and `&T` implement the traits [`Add<T>`][`Add`] and
-// //! [`Add<&T>`][`Add`] so that generic code can be written without unnecessary
-// //! cloning.
-// //!
-// //! # Examples
-// //!
-// //! This example creates a `Point` struct that implements [`Add`] and [`Sub`],
-// //! and then demonstrates adding and subtracting two `Point`s.
-// //!
-// //! ```rust
-// //! use std::ops::{Add, Sub};
-// //!
-// //! #[derive(Debug, Copy, Clone, PartialEq)]
-// //! struct Point {
-// //!     x: i32,
-// //!     y: i32,
-// //! }
-// //!
-// //! impl Add for Point {
-// //!     type Output = Self;
-// //!
-// //!     fn add(self, other: Self) -> Self {
-// //!         Self {x: self.x + other.x, y: self.y + other.y}
-// //!     }
-// //! }
-// //!
-// //! impl Sub for Point {
-// //!     type Output = Self;
-// //!
-// //!     fn sub(self, other: Self) -> Self {
-// //!         Self {x: self.x - other.x, y: self.y - other.y}
-// //!     }
-// //! }
-// //!
-// //! assert_eq!(Point {x: 3, y: 3}, Point {x: 1, y: 0} + Point {x: 2, y: 3});
-// //! assert_eq!(Point {x: -1, y: -3}, Point {x: 1, y: 0} - Point {x: 2, y: 3});
-// //! ```
-// //!
-// //! See the documentation for each trait for an example implementation.
-// //!
-// //! The [`Fn`], [`FnMut`], and [`FnOnce`] traits are implemented by types that can be
-// //! invoked like functions. Note that [`Fn`] takes `&self`, [`FnMut`] takes `&mut
-// //! self` and [`FnOnce`] takes `self`. These correspond to the three kinds of
-// //! methods that can be invoked on an instance: call-by-reference,
-// //! call-by-mutable-reference, and call-by-value. The most common use of these
-// //! traits is to act as bounds to higher-level functions that take functions or
-// //! closures as arguments.
-// //!
-// //! Taking a [`Fn`] as a parameter:
-// //!
-// //! ```rust
-// //! fn call_with_one<F>(func: F) -> usize
-// //!     where F: Fn(usize) -> usize
-// //! {
-// //!     func(1)
-// //! }
-// //!
-// //! let double = |x| x * 2;
-// //! assert_eq!(call_with_one(double), 2);
-// //! ```
-// //!
-// //! Taking a [`FnMut`] as a parameter:
-// //!
-// //! ```rust
-// //! fn do_twice<F>(mut func: F)
-// //!     where F: FnMut()
-// //! {
-// //!     func();
-// //!     func();
-// //! }
-// //!
-// //! let mut x: usize = 1;
-// //! {
-// //!     let add_two_to_x = || x += 2;
-// //!     do_twice(add_two_to_x);
-// //! }
-// //!
-// //! assert_eq!(x, 5);
-// //! ```
-// //!
-// //! Taking a [`FnOnce`] as a parameter:
-// //!
-// //! ```rust
-// //! fn consume_with_relish<F>(func: F)
-// //!     where F: FnOnce() -> String
-// //! {
-// //!     // `func` consumes its captured variables, so it cannot be run more
-// //!     // than once
-// //!     println!("Consumed: {}", func());
-// //!
-// //!     println!("Delicious!");
-// //!
-// //!     // Attempting to invoke `func()` again will throw a `use of moved
-// //!     // value` error for `func`
-// //! }
-// //!
-// //! let x = String::from("x");
-// //! let consume_and_return_x = move || x;
-// //! consume_with_relish(consume_and_return_x);
-// //!
-// //! // `consume_and_return_x` can no longer be invoked at this point
-// //! ```
-// //!
-// //! [`clone`]: Clone::clone
-// //! [operator precedence]: ../../reference/expressions.html#expression-precedence
+//!
+//! Implementing these traits allows you to overload certain operators.
+//!
+//! Some of these traits are imported by the prelude, so they are available in
+//! every Rust program. Only operators backed by traits can be overloaded. For
+//! example, the addition operator (`+`) can be overloaded through the [`Add`]
+//! trait, but since the assignment operator (`=`) has no backing trait, there
+//! is no way of overloading its semantics. Additionally, this module does not
+//! provide any mechanism to create new operators. If traitless overloading or
+//! custom operators are required, you should look toward macros to extend
+//! Rust's syntax.
+//!
+//! Implementations of operator traits should be unsurprising in their
+//! respective contexts, keeping in mind their usual meanings and
+//! [operator precedence]. For example, when implementing [`Mul`], the operation
+//! should have some resemblance to multiplication (and share expected
+//! properties like associativity).
+//!
+//! Note that the `&&` and `||` operators are currently not supported for
+//! overloading. Due to their short circuiting nature, they require a different
+//! design from traits for other operators like [`BitAnd`]. Designs for them are
+//! under discussion.
+//!
+//! Many of the operators take their operands by value. In non-generic
+//! contexts involving built-in types, this is usually not a problem.
+//! However, using these operators in generic code, requires some
+//! attention if values have to be reused as opposed to letting the operators
+//! consume them. One option is to occasionally use [`clone`].
+//! Another option is to rely on the types involved providing additional
+//! operator implementations for references. For example, for a user-defined
+//! type `T` which is supposed to support addition, it is probably a good
+//! idea to have both `T` and `&T` implement the traits [`Add<T>`][`Add`] and
+//! [`Add<&T>`][`Add`] so that generic code can be written without unnecessary
+//! cloning.
+//!
+//! # Examples
+//!
+//! This example creates a `Point` struct that implements [`Add`] and [`Sub`],
+//! and then demonstrates adding and subtracting two `Point`s.
+//!
+//! ```rust
+//! use std::ops::{Add, Sub};
+//!
+//! #[derive(Debug, Copy, Clone, PartialEq)]
+//! struct Point {
+//!     x: i32,
+//!     y: i32,
+//! }
+//!
+//! impl Add for Point {
+//!     type Output = Self;
+//!
+//!     fn add(self, other: Self) -> Self {
+//!         Self {x: self.x + other.x, y: self.y + other.y}
+//!     }
+//! }
+//!
+//! impl Sub for Point {
+//!     type Output = Self;
+//!
+//!     fn sub(self, other: Self) -> Self {
+//!         Self {x: self.x - other.x, y: self.y - other.y}
+//!     }
+//! }
+//!
+//! assert_eq!(Point {x: 3, y: 3}, Point {x: 1, y: 0} + Point {x: 2, y: 3});
+//! assert_eq!(Point {x: -1, y: -3}, Point {x: 1, y: 0} - Point {x: 2, y: 3});
+//! ```
+//!
+//! See the documentation for each trait for an example implementation.
+//!
+//! The [`Fn`], [`FnMut`], and [`FnOnce`] traits are implemented by types that can be
+//! invoked like functions. Note that [`Fn`] takes `&self`, [`FnMut`] takes `&mut
+//! self` and [`FnOnce`] takes `self`. These correspond to the three kinds of
+//! methods that can be invoked on an instance: call-by-reference,
+//! call-by-mutable-reference, and call-by-value. The most common use of these
+//! traits is to act as bounds to higher-level functions that take functions or
+//! closures as arguments.
+//!
+//! Taking a [`Fn`] as a parameter:
+//!
+//! ```rust
+//! fn call_with_one<F>(func: F) -> usize
+//!     where F: Fn(usize) -> usize
+//! {
+//!     func(1)
+//! }
+//!
+//! let double = |x| x * 2;
+//! assert_eq!(call_with_one(double), 2);
+//! ```
+//!
+//! Taking a [`FnMut`] as a parameter:
+//!
+//! ```rust
+//! fn do_twice<F>(mut func: F)
+//!     where F: FnMut()
+//! {
+//!     func();
+//!     func();
+//! }
+//!
+//! let mut x: usize = 1;
+//! {
+//!     let add_two_to_x = || x += 2;
+//!     do_twice(add_two_to_x);
+//! }
+//!
+//! assert_eq!(x, 5);
+//! ```
+//!
+//! Taking a [`FnOnce`] as a parameter:
+//!
+//! ```rust
+//! fn consume_with_relish<F>(func: F)
+//!     where F: FnOnce() -> String
+//! {
+//!     // `func` consumes its captured variables, so it cannot be run more
+//!     // than once
+//!     println!("Consumed: {}", func());
+//!
+//!     println!("Delicious!");
+//!
+//!     // Attempting to invoke `func()` again will throw a `use of moved
+//!     // value` error for `func`
+//! }
+//!
+//! let x = String::from("x");
+//! let consume_and_return_x = move || x;
+//! consume_with_relish(consume_and_return_x);
+//!
+//! // `consume_and_return_x` can no longer be invoked at this point
+//! ```
+//!
+//! [`clone`]: Clone::clone
+//! [operator precedence]: ../../reference/expressions.html#expression-precedence
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -1,5 +1,4 @@
 //! Overloadable operators.
-// FIXME(pvdrz): fix docs
 // //!
 // //! Implementing these traits allows you to overload certain operators.
 // //!

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -389,23 +389,23 @@ impl<Idx> RangeInclusive<Idx> {
     }
 
     /// Returns the lower bound of the range (inclusive).
-    // ///
-    // /// When using an inclusive range for iteration, the values of `start()` and
-    // /// [`end()`] are unspecified after the iteration ended. To determine
-    // /// whether the inclusive range is empty, use the [`is_empty()`] method
-    // /// instead of comparing `start() > end()`.
-    // ///
-    // /// Note: the value returned by this method is unspecified after the range
-    // /// has been iterated to exhaustion.
-    // ///
-    // /// [`end()`]: RangeInclusive::end
-    // /// [`is_empty()`]: RangeInclusive::is_empty
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```
-    // /// assert_eq!((3..=5).start(), &3);
-    // /// ```
+    ///
+    /// When using an inclusive range for iteration, the values of `start()` and
+    /// [`end()`] are unspecified after the iteration ended. To determine
+    /// whether the inclusive range is empty, use the [`is_empty()`] method
+    /// instead of comparing `start() > end()`.
+    ///
+    /// Note: the value returned by this method is unspecified after the range
+    /// has been iterated to exhaustion.
+    ///
+    /// [`end()`]: RangeInclusive::end
+    /// [`is_empty()`]: RangeInclusive::is_empty
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert_eq!((3..=5).start(), &3);
+    /// ```
     #[stable(feature = "inclusive_range_methods", since = "1.27.0")]
     #[rustc_const_stable(feature = "const_inclusive_range_methods", since = "1.32.0")]
     #[inline]
@@ -414,23 +414,23 @@ impl<Idx> RangeInclusive<Idx> {
     }
 
     /// Returns the upper bound of the range (inclusive).
-    // ///
-    // /// When using an inclusive range for iteration, the values of [`start()`]
-    // /// and `end()` are unspecified after the iteration ended. To determine
-    // /// whether the inclusive range is empty, use the [`is_empty()`] method
-    // /// instead of comparing `start() > end()`.
-    // ///
-    // /// Note: the value returned by this method is unspecified after the range
-    // /// has been iterated to exhaustion.
-    // ///
-    // /// [`start()`]: RangeInclusive::start
-    // /// [`is_empty()`]: RangeInclusive::is_empty
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```
-    // /// assert_eq!((3..=5).end(), &5);
-    // /// ```
+    ///
+    /// When using an inclusive range for iteration, the values of [`start()`]
+    /// and `end()` are unspecified after the iteration ended. To determine
+    /// whether the inclusive range is empty, use the [`is_empty()`] method
+    /// instead of comparing `start() > end()`.
+    ///
+    /// Note: the value returned by this method is unspecified after the range
+    /// has been iterated to exhaustion.
+    ///
+    /// [`start()`]: RangeInclusive::start
+    /// [`is_empty()`]: RangeInclusive::is_empty
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert_eq!((3..=5).end(), &5);
+    /// ```
     #[stable(feature = "inclusive_range_methods", since = "1.27.0")]
     #[rustc_const_stable(feature = "const_inclusive_range_methods", since = "1.32.0")]
     #[inline]

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -5,40 +5,40 @@ use crate::hash::Hash;
 
 /// An unbounded range (`..`).
 // FIXME(pvdrz): fix docs
-// ///
-// /// `RangeFull` is primarily used as a [slicing index], its shorthand is `..`.
-// /// It cannot serve as an [`Iterator`] because it doesn't have a starting point.
-// ///
-// /// # Examples
-// ///
-// /// The `..` syntax is a `RangeFull`:
-// ///
-// /// ```
-// /// assert_eq!(.., std::ops::RangeFull);
-// /// ```
-// ///
-// /// It does not have an [`IntoIterator`] implementation, so you can't use it in
-// /// a `for` loop directly. This won't compile:
-// ///
-// /// ```compile_fail,E0277
-// /// for i in .. {
-// ///     // // ...
-// /// }
-// /// ```
-// ///
-// /// Used as a [slicing index], `RangeFull` produces the full array as a slice.
-// ///
-// /// ```
-// /// let arr = [0, 1, 2, 3, 4];
-// /// assert_eq!(arr[ ..  ], [0, 1, 2, 3, 4]); // // This is the `RangeFull`
-// /// assert_eq!(arr[ .. 3], [0, 1, 2      ]);
-// /// assert_eq!(arr[ ..=3], [0, 1, 2, 3   ]);
-// /// assert_eq!(arr[1..  ], [   1, 2, 3, 4]);
-// /// assert_eq!(arr[1.. 3], [   1, 2      ]);
-// /// assert_eq!(arr[1..=3], [   1, 2, 3   ]);
-// /// ```
-// ///
-// /// [slicing index]: crate::slice::SliceIndex
+///
+/// `RangeFull` is primarily used as a [slicing index], its shorthand is `..`.
+/// It cannot serve as an [`Iterator`] because it doesn't have a starting point.
+///
+/// # Examples
+///
+/// The `..` syntax is a `RangeFull`:
+///
+/// ```
+/// assert_eq!(.., std::ops::RangeFull);
+/// ```
+///
+/// It does not have an [`IntoIterator`] implementation, so you can't use it in
+/// a `for` loop directly. This won't compile:
+///
+/// ```compile_fail,E0277
+/// for i in .. {
+///     // // ...
+/// }
+/// ```
+///
+/// Used as a [slicing index], `RangeFull` produces the full array as a slice.
+///
+/// ```
+/// let arr = [0, 1, 2, 3, 4];
+/// assert_eq!(arr[ ..  ], [0, 1, 2, 3, 4]); // // This is the `RangeFull`
+/// assert_eq!(arr[ .. 3], [0, 1, 2      ]);
+/// assert_eq!(arr[ ..=3], [0, 1, 2, 3   ]);
+/// assert_eq!(arr[1..  ], [   1, 2, 3, 4]);
+/// assert_eq!(arr[1.. 3], [   1, 2      ]);
+/// assert_eq!(arr[1..=3], [   1, 2, 3   ]);
+/// ```
+///
+/// [slicing index]: crate::slice::SliceIndex
 #[lang = "RangeFull"]
 #[doc(alias = "..")]
 #[cfg_attr(not(feature = "ferrocene_certified"), derive(Copy, Clone, Default, PartialEq, Eq, Hash))]
@@ -157,38 +157,38 @@ impl<Idx: PartialOrd<Idx>> Range<Idx> {
 
 /// A range only bounded inclusively below (`start..`).
 // FIXME(pvdrz): fix docs
-// ///
-// /// The `RangeFrom` `start..` contains all values with `x >= start`.
-// ///
-// /// *Note*: Overflow in the [`Iterator`] implementation (when the contained
-// /// data type reaches its numerical limit) is allowed to panic, wrap, or
-// /// saturate. This behavior is defined by the implementation of the [`Step`]
-// /// trait. For primitive integers, this follows the normal rules, and respects
-// /// the overflow checks profile (panic in debug, wrap in release). Note also
-// /// that overflow happens earlier than you might assume: the overflow happens
-// /// in the call to `next` that yields the maximum value, as the range must be
-// /// set to a state to yield the next value.
-// ///
-// /// [`Step`]: crate::iter::Step
-// ///
-// /// # Examples
-// ///
-// /// The `start..` syntax is a `RangeFrom`:
-// ///
-// /// ```
-// /// assert_eq!((2..), std::ops::RangeFrom { start: 2 });
-// /// assert_eq!(2 + 3 + 4, (2..).take(3).sum());
-// /// ```
-// ///
-// /// ```
-// /// let arr = [0, 1, 2, 3, 4];
-// /// assert_eq!(arr[ ..  ], [0, 1, 2, 3, 4]);
-// /// assert_eq!(arr[ .. 3], [0, 1, 2      ]);
-// /// assert_eq!(arr[ ..=3], [0, 1, 2, 3   ]);
-// /// assert_eq!(arr[1..  ], [   1, 2, 3, 4]); // // This is a `RangeFrom`
-// /// assert_eq!(arr[1.. 3], [   1, 2      ]);
-// /// assert_eq!(arr[1..=3], [   1, 2, 3   ]);
-// /// ```
+///
+/// The `RangeFrom` `start..` contains all values with `x >= start`.
+///
+/// *Note*: Overflow in the [`Iterator`] implementation (when the contained
+/// data type reaches its numerical limit) is allowed to panic, wrap, or
+/// saturate. This behavior is defined by the implementation of the [`Step`]
+/// trait. For primitive integers, this follows the normal rules, and respects
+/// the overflow checks profile (panic in debug, wrap in release). Note also
+/// that overflow happens earlier than you might assume: the overflow happens
+/// in the call to `next` that yields the maximum value, as the range must be
+/// set to a state to yield the next value.
+///
+/// [`Step`]: crate::iter::Step
+///
+/// # Examples
+///
+/// The `start..` syntax is a `RangeFrom`:
+///
+/// ```
+/// assert_eq!((2..), std::ops::RangeFrom { start: 2 });
+/// assert_eq!(2 + 3 + 4, (2..).take(3).sum());
+/// ```
+///
+/// ```
+/// let arr = [0, 1, 2, 3, 4];
+/// assert_eq!(arr[ ..  ], [0, 1, 2, 3, 4]);
+/// assert_eq!(arr[ .. 3], [0, 1, 2      ]);
+/// assert_eq!(arr[ ..=3], [0, 1, 2, 3   ]);
+/// assert_eq!(arr[1..  ], [   1, 2, 3, 4]); // // This is a `RangeFrom`
+/// assert_eq!(arr[1.. 3], [   1, 2      ]);
+/// assert_eq!(arr[1..=3], [   1, 2, 3   ]);
+/// ```
 #[lang = "RangeFrom"]
 #[doc(alias = "..")]
 #[cfg_attr(not(feature = "ferrocene_certified"), derive(Clone, PartialEq, Eq, Hash))] // not Copy -- see #27186
@@ -237,43 +237,43 @@ impl<Idx: PartialOrd<Idx>> RangeFrom<Idx> {
 
 /// A range only bounded exclusively above (`..end`).
 // FIXME(pvdrz): fix docs
-// ///
-// /// The `RangeTo` `..end` contains all values with `x < end`.
-// /// It cannot serve as an [`Iterator`] because it doesn't have a starting point.
-// ///
-// /// # Examples
-// ///
-// /// The `..end` syntax is a `RangeTo`:
-// ///
-// /// ```
-// /// assert_eq!((..5), std::ops::RangeTo { end: 5 });
-// /// ```
-// ///
-// /// It does not have an [`IntoIterator`] implementation, so you can't use it in
-// /// a `for` loop directly. This won't compile:
-// ///
-// /// ```compile_fail,E0277
-// /// // // error[E0277]: the trait bound `std::ops::RangeTo<{integer}>:
-// /// // // std::iter::Iterator` is not satisfied
-// /// for i in ..5 {
-// ///     // // ...
-// /// }
-// /// ```
-// ///
-// /// When used as a [slicing index], `RangeTo` produces a slice of all array
-// /// elements before the index indicated by `end`.
-// ///
-// /// ```
-// /// let arr = [0, 1, 2, 3, 4];
-// /// assert_eq!(arr[ ..  ], [0, 1, 2, 3, 4]);
-// /// assert_eq!(arr[ .. 3], [0, 1, 2      ]); // // This is a `RangeTo`
-// /// assert_eq!(arr[ ..=3], [0, 1, 2, 3   ]);
-// /// assert_eq!(arr[1..  ], [   1, 2, 3, 4]);
-// /// assert_eq!(arr[1.. 3], [   1, 2      ]);
-// /// assert_eq!(arr[1..=3], [   1, 2, 3   ]);
-// /// ```
-// ///
-// /// [slicing index]: crate::slice::SliceIndex
+///
+/// The `RangeTo` `..end` contains all values with `x < end`.
+/// It cannot serve as an [`Iterator`] because it doesn't have a starting point.
+///
+/// # Examples
+///
+/// The `..end` syntax is a `RangeTo`:
+///
+/// ```
+/// assert_eq!((..5), std::ops::RangeTo { end: 5 });
+/// ```
+///
+/// It does not have an [`IntoIterator`] implementation, so you can't use it in
+/// a `for` loop directly. This won't compile:
+///
+/// ```compile_fail,E0277
+/// // // error[E0277]: the trait bound `std::ops::RangeTo<{integer}>:
+/// // // std::iter::Iterator` is not satisfied
+/// for i in ..5 {
+///     // // ...
+/// }
+/// ```
+///
+/// When used as a [slicing index], `RangeTo` produces a slice of all array
+/// elements before the index indicated by `end`.
+///
+/// ```
+/// let arr = [0, 1, 2, 3, 4];
+/// assert_eq!(arr[ ..  ], [0, 1, 2, 3, 4]);
+/// assert_eq!(arr[ .. 3], [0, 1, 2      ]); // // This is a `RangeTo`
+/// assert_eq!(arr[ ..=3], [0, 1, 2, 3   ]);
+/// assert_eq!(arr[1..  ], [   1, 2, 3, 4]);
+/// assert_eq!(arr[1.. 3], [   1, 2      ]);
+/// assert_eq!(arr[1..=3], [   1, 2, 3   ]);
+/// ```
+///
+/// [slicing index]: crate::slice::SliceIndex
 #[lang = "RangeTo"]
 #[doc(alias = "..")]
 #[cfg_attr(not(feature = "ferrocene_certified"), derive(Copy, Clone, PartialEq, Eq, Hash))]
@@ -322,35 +322,35 @@ impl<Idx: PartialOrd<Idx>> RangeTo<Idx> {
 
 /// A range bounded inclusively below and above (`start..=end`).
 // FIXME(pvdrz): fix docs
-// ///
-// /// The `RangeInclusive` `start..=end` contains all values with `x >= start`
-// /// and `x <= end`. It is empty unless `start <= end`.
-// ///
-// /// This iterator is [fused], but the specific values of `start` and `end` after
-// /// iteration has finished are **unspecified** other than that [`.is_empty()`]
-// /// will return `true` once no more values will be produced.
-// ///
-// /// [fused]: crate::iter::FusedIterator
-// /// [`.is_empty()`]: RangeInclusive::is_empty
-// ///
-// /// # Examples
-// ///
-// /// The `start..=end` syntax is a `RangeInclusive`:
-// ///
-// /// ```
-// /// assert_eq!((3..=5), std::ops::RangeInclusive::new(3, 5));
-// /// assert_eq!(3 + 4 + 5, (3..=5).sum());
-// /// ```
-// ///
-// /// ```
-// /// let arr = [0, 1, 2, 3, 4];
-// /// assert_eq!(arr[ ..  ], [0, 1, 2, 3, 4]);
-// /// assert_eq!(arr[ .. 3], [0, 1, 2      ]);
-// /// assert_eq!(arr[ ..=3], [0, 1, 2, 3   ]);
-// /// assert_eq!(arr[1..  ], [   1, 2, 3, 4]);
-// /// assert_eq!(arr[1.. 3], [   1, 2      ]);
-// /// assert_eq!(arr[1..=3], [   1, 2, 3   ]); // // This is a `RangeInclusive`
-// /// ```
+///
+/// The `RangeInclusive` `start..=end` contains all values with `x >= start`
+/// and `x <= end`. It is empty unless `start <= end`.
+///
+/// This iterator is [fused], but the specific values of `start` and `end` after
+/// iteration has finished are **unspecified** other than that [`.is_empty()`]
+/// will return `true` once no more values will be produced.
+///
+/// [fused]: crate::iter::FusedIterator
+/// [`.is_empty()`]: RangeInclusive::is_empty
+///
+/// # Examples
+///
+/// The `start..=end` syntax is a `RangeInclusive`:
+///
+/// ```
+/// assert_eq!((3..=5), std::ops::RangeInclusive::new(3, 5));
+/// assert_eq!(3 + 4 + 5, (3..=5).sum());
+/// ```
+///
+/// ```
+/// let arr = [0, 1, 2, 3, 4];
+/// assert_eq!(arr[ ..  ], [0, 1, 2, 3, 4]);
+/// assert_eq!(arr[ .. 3], [0, 1, 2      ]);
+/// assert_eq!(arr[ ..=3], [0, 1, 2, 3   ]);
+/// assert_eq!(arr[1..  ], [   1, 2, 3, 4]);
+/// assert_eq!(arr[1.. 3], [   1, 2      ]);
+/// assert_eq!(arr[1..=3], [   1, 2, 3   ]); // // This is a `RangeInclusive`
+/// ```
 #[lang = "RangeInclusive"]
 #[doc(alias = "..=")]
 #[cfg_attr(not(feature = "ferrocene_certified"), derive(Clone, PartialEq, Eq, Hash))] // not Copy -- see #27186
@@ -568,43 +568,43 @@ impl<Idx: PartialOrd<Idx>> RangeInclusive<Idx> {
 
 /// A range only bounded inclusively above (`..=end`).
 // FIXME(pvdrz): fix docs
-// ///
-// /// The `RangeToInclusive` `..=end` contains all values with `x <= end`.
-// /// It cannot serve as an [`Iterator`] because it doesn't have a starting point.
-// ///
-// /// # Examples
-// ///
-// /// The `..=end` syntax is a `RangeToInclusive`:
-// ///
-// /// ```
-// /// assert_eq!((..=5), std::ops::RangeToInclusive{ end: 5 });
-// /// ```
-// ///
-// /// It does not have an [`IntoIterator`] implementation, so you can't use it in a
-// /// `for` loop directly. This won't compile:
-// ///
-// /// ```compile_fail,E0277
-// /// // // error[E0277]: the trait bound `std::ops::RangeToInclusive<{integer}>:
-// /// // // std::iter::Iterator` is not satisfied
-// /// for i in ..=5 {
-// ///     // // ...
-// /// }
-// /// ```
-// ///
-// /// When used as a [slicing index], `RangeToInclusive` produces a slice of all
-// /// array elements up to and including the index indicated by `end`.
-// ///
-// /// ```
-// /// let arr = [0, 1, 2, 3, 4];
-// /// assert_eq!(arr[ ..  ], [0, 1, 2, 3, 4]);
-// /// assert_eq!(arr[ .. 3], [0, 1, 2      ]);
-// /// assert_eq!(arr[ ..=3], [0, 1, 2, 3   ]); // // This is a `RangeToInclusive`
-// /// assert_eq!(arr[1..  ], [   1, 2, 3, 4]);
-// /// assert_eq!(arr[1.. 3], [   1, 2      ]);
-// /// assert_eq!(arr[1..=3], [   1, 2, 3   ]);
-// /// ```
-// ///
-// /// [slicing index]: crate::slice::SliceIndex
+///
+/// The `RangeToInclusive` `..=end` contains all values with `x <= end`.
+/// It cannot serve as an [`Iterator`] because it doesn't have a starting point.
+///
+/// # Examples
+///
+/// The `..=end` syntax is a `RangeToInclusive`:
+///
+/// ```
+/// assert_eq!((..=5), std::ops::RangeToInclusive{ end: 5 });
+/// ```
+///
+/// It does not have an [`IntoIterator`] implementation, so you can't use it in a
+/// `for` loop directly. This won't compile:
+///
+/// ```compile_fail,E0277
+/// // // error[E0277]: the trait bound `std::ops::RangeToInclusive<{integer}>:
+/// // // std::iter::Iterator` is not satisfied
+/// for i in ..=5 {
+///     // // ...
+/// }
+/// ```
+///
+/// When used as a [slicing index], `RangeToInclusive` produces a slice of all
+/// array elements up to and including the index indicated by `end`.
+///
+/// ```
+/// let arr = [0, 1, 2, 3, 4];
+/// assert_eq!(arr[ ..  ], [0, 1, 2, 3, 4]);
+/// assert_eq!(arr[ .. 3], [0, 1, 2      ]);
+/// assert_eq!(arr[ ..=3], [0, 1, 2, 3   ]); // // This is a `RangeToInclusive`
+/// assert_eq!(arr[1..  ], [   1, 2, 3, 4]);
+/// assert_eq!(arr[1.. 3], [   1, 2      ]);
+/// assert_eq!(arr[1..=3], [   1, 2, 3   ]);
+/// ```
+///
+/// [slicing index]: crate::slice::SliceIndex
 #[lang = "RangeToInclusive"]
 #[doc(alias = "..=")]
 #[cfg_attr(not(feature = "ferrocene_certified"), derive(Copy, Clone, PartialEq, Eq, Hash))]

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -4,7 +4,6 @@ use crate::fmt;
 use crate::hash::Hash;
 
 /// An unbounded range (`..`).
-// FIXME(pvdrz): fix docs
 ///
 /// `RangeFull` is primarily used as a [slicing index], its shorthand is `..`.
 /// It cannot serve as an [`Iterator`] because it doesn't have a starting point.
@@ -156,7 +155,6 @@ impl<Idx: PartialOrd<Idx>> Range<Idx> {
 }
 
 /// A range only bounded inclusively below (`start..`).
-// FIXME(pvdrz): fix docs
 ///
 /// The `RangeFrom` `start..` contains all values with `x >= start`.
 ///
@@ -236,7 +234,6 @@ impl<Idx: PartialOrd<Idx>> RangeFrom<Idx> {
 }
 
 /// A range only bounded exclusively above (`..end`).
-// FIXME(pvdrz): fix docs
 ///
 /// The `RangeTo` `..end` contains all values with `x < end`.
 /// It cannot serve as an [`Iterator`] because it doesn't have a starting point.
@@ -321,7 +318,6 @@ impl<Idx: PartialOrd<Idx>> RangeTo<Idx> {
 }
 
 /// A range bounded inclusively below and above (`start..=end`).
-// FIXME(pvdrz): fix docs
 ///
 /// The `RangeInclusive` `start..=end` contains all values with `x >= start`
 /// and `x <= end`. It is empty unless `start <= end`.
@@ -393,7 +389,6 @@ impl<Idx> RangeInclusive<Idx> {
     }
 
     /// Returns the lower bound of the range (inclusive).
-    // FIXME(pvdrz): fix docs
     // ///
     // /// When using an inclusive range for iteration, the values of `start()` and
     // /// [`end()`] are unspecified after the iteration ended. To determine
@@ -419,7 +414,6 @@ impl<Idx> RangeInclusive<Idx> {
     }
 
     /// Returns the upper bound of the range (inclusive).
-    // FIXME(pvdrz): fix docs
     // ///
     // /// When using an inclusive range for iteration, the values of [`start()`]
     // /// and `end()` are unspecified after the iteration ended. To determine
@@ -567,7 +561,6 @@ impl<Idx: PartialOrd<Idx>> RangeInclusive<Idx> {
 }
 
 /// A range only bounded inclusively above (`..=end`).
-// FIXME(pvdrz): fix docs
 ///
 /// The `RangeToInclusive` `..=end` contains all values with `x <= end`.
 /// It cannot serve as an [`Iterator`] because it doesn't have a starting point.

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -1,7 +1,6 @@
 use crate::ops::ControlFlow;
 
 /// The `?` operator and `try {}` blocks.
-// FIXME(pvdrz): fix docs
 ///
 /// `try_*` methods typically involve a type implementing this trait.  For
 /// example, the closures passed to [`Iterator::try_fold`] and

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -2,117 +2,117 @@ use crate::ops::ControlFlow;
 
 /// The `?` operator and `try {}` blocks.
 // FIXME(pvdrz): fix docs
-// ///
-// /// `try_*` methods typically involve a type implementing this trait.  For
-// /// example, the closures passed to [`Iterator::try_fold`] and
-// /// [`Iterator::try_for_each`] must return such a type.
-// ///
-// /// `Try` types are typically those containing two or more categories of values,
-// /// some subset of which are so commonly handled via early returns that it's
-// /// worth providing a terse (but still visible) syntax to make that easy.
-// ///
-// /// This is most often seen for error handling with [`Result`] and [`Option`].
-// /// The quintessential implementation of this trait is on [`ControlFlow`].
-// ///
-// /// # Using `Try` in Generic Code
-// ///
-// /// `Iterator::try_fold` was stabilized to call back in Rust 1.27, but
-// /// this trait is much newer.  To illustrate the various associated types and
-// /// methods, let's implement our own version.
-// ///
-// /// As a reminder, an infallible version of a fold looks something like this:
-// /// ```
-// /// fn simple_fold<A, T>(
-// ///     iter: impl Iterator<Item = T>,
-// ///     mut accum: A,
-// ///     mut f: impl FnMut(A, T) -> A,
-// /// ) -> A {
-// ///     for x in iter {
-// ///         accum = f(accum, x);
-// ///     }
-// ///     accum
-// /// }
-// /// ```
-// ///
-// /// So instead of `f` returning just an `A`, we'll need it to return some other
-// /// type that produces an `A` in the "don't short circuit" path.  Conveniently,
-// /// that's also the type we need to return from the function.
-// ///
-// /// Let's add a new generic parameter `R` for that type, and bound it to the
-// /// output type that we want:
-// /// ```
-// /// # #![feature(try_trait_v2)]
-// /// # use std::ops::Try;
-// /// fn simple_try_fold_1<A, T, R: Try<Output = A>>(
-// ///     iter: impl Iterator<Item = T>,
-// ///     mut accum: A,
-// ///     mut f: impl FnMut(A, T) -> R,
-// /// ) -> R {
-// ///     todo!()
-// /// }
-// /// ```
-// ///
-// /// If we get through the entire iterator, we need to wrap up the accumulator
-// /// into the return type using [`Try::from_output`]:
-// /// ```
-// /// # #![feature(try_trait_v2)]
-// /// # use std::ops::{ControlFlow, Try};
-// /// fn simple_try_fold_2<A, T, R: Try<Output = A>>(
-// ///     iter: impl Iterator<Item = T>,
-// ///     mut accum: A,
-// ///     mut f: impl FnMut(A, T) -> R,
-// /// ) -> R {
-// ///     for x in iter {
-// ///         let cf = f(accum, x).branch();
-// ///         match cf {
-// ///             ControlFlow::Continue(a) => accum = a,
-// ///             ControlFlow::Break(_) => todo!(),
-// ///         }
-// ///     }
-// ///     R::from_output(accum)
-// /// }
-// /// ```
-// ///
-// /// We'll also need [`FromResidual::from_residual`] to turn the residual back
-// /// into the original type.  But because it's a supertrait of `Try`, we don't
-// /// need to mention it in the bounds.  All types which implement `Try` can be
-// /// recreated from their corresponding residual, so we'll just call it:
-// /// ```
-// /// # #![feature(try_trait_v2)]
-// /// # use std::ops::{ControlFlow, Try};
-// /// pub fn simple_try_fold_3<A, T, R: Try<Output = A>>(
-// ///     iter: impl Iterator<Item = T>,
-// ///     mut accum: A,
-// ///     mut f: impl FnMut(A, T) -> R,
-// /// ) -> R {
-// ///     for x in iter {
-// ///         let cf = f(accum, x).branch();
-// ///         match cf {
-// ///             ControlFlow::Continue(a) => accum = a,
-// ///             ControlFlow::Break(r) => return R::from_residual(r),
-// ///         }
-// ///     }
-// ///     R::from_output(accum)
-// /// }
-// /// ```
-// ///
-// /// But this "call `branch`, then `match` on it, and `return` if it was a
-// /// `Break`" is exactly what happens inside the `?` operator.  So rather than
-// /// do all this manually, we can just use `?` instead:
-// /// ```
-// /// # #![feature(try_trait_v2)]
-// /// # use std::ops::Try;
-// /// fn simple_try_fold<A, T, R: Try<Output = A>>(
-// ///     iter: impl Iterator<Item = T>,
-// ///     mut accum: A,
-// ///     mut f: impl FnMut(A, T) -> R,
-// /// ) -> R {
-// ///     for x in iter {
-// ///         accum = f(accum, x)?;
-// ///     }
-// ///     R::from_output(accum)
-// /// }
-// /// ```
+///
+/// `try_*` methods typically involve a type implementing this trait.  For
+/// example, the closures passed to [`Iterator::try_fold`] and
+/// [`Iterator::try_for_each`] must return such a type.
+///
+/// `Try` types are typically those containing two or more categories of values,
+/// some subset of which are so commonly handled via early returns that it's
+/// worth providing a terse (but still visible) syntax to make that easy.
+///
+/// This is most often seen for error handling with [`Result`] and [`Option`].
+/// The quintessential implementation of this trait is on [`ControlFlow`].
+///
+/// # Using `Try` in Generic Code
+///
+/// `Iterator::try_fold` was stabilized to call back in Rust 1.27, but
+/// this trait is much newer.  To illustrate the various associated types and
+/// methods, let's implement our own version.
+///
+/// As a reminder, an infallible version of a fold looks something like this:
+/// ```
+/// fn simple_fold<A, T>(
+///     iter: impl Iterator<Item = T>,
+///     mut accum: A,
+///     mut f: impl FnMut(A, T) -> A,
+/// ) -> A {
+///     for x in iter {
+///         accum = f(accum, x);
+///     }
+///     accum
+/// }
+/// ```
+///
+/// So instead of `f` returning just an `A`, we'll need it to return some other
+/// type that produces an `A` in the "don't short circuit" path.  Conveniently,
+/// that's also the type we need to return from the function.
+///
+/// Let's add a new generic parameter `R` for that type, and bound it to the
+/// output type that we want:
+/// ```
+/// # #![feature(try_trait_v2)]
+/// # use std::ops::Try;
+/// fn simple_try_fold_1<A, T, R: Try<Output = A>>(
+///     iter: impl Iterator<Item = T>,
+///     mut accum: A,
+///     mut f: impl FnMut(A, T) -> R,
+/// ) -> R {
+///     todo!()
+/// }
+/// ```
+///
+/// If we get through the entire iterator, we need to wrap up the accumulator
+/// into the return type using [`Try::from_output`]:
+/// ```
+/// # #![feature(try_trait_v2)]
+/// # use std::ops::{ControlFlow, Try};
+/// fn simple_try_fold_2<A, T, R: Try<Output = A>>(
+///     iter: impl Iterator<Item = T>,
+///     mut accum: A,
+///     mut f: impl FnMut(A, T) -> R,
+/// ) -> R {
+///     for x in iter {
+///         let cf = f(accum, x).branch();
+///         match cf {
+///             ControlFlow::Continue(a) => accum = a,
+///             ControlFlow::Break(_) => todo!(),
+///         }
+///     }
+///     R::from_output(accum)
+/// }
+/// ```
+///
+/// We'll also need [`FromResidual::from_residual`] to turn the residual back
+/// into the original type.  But because it's a supertrait of `Try`, we don't
+/// need to mention it in the bounds.  All types which implement `Try` can be
+/// recreated from their corresponding residual, so we'll just call it:
+/// ```
+/// # #![feature(try_trait_v2)]
+/// # use std::ops::{ControlFlow, Try};
+/// pub fn simple_try_fold_3<A, T, R: Try<Output = A>>(
+///     iter: impl Iterator<Item = T>,
+///     mut accum: A,
+///     mut f: impl FnMut(A, T) -> R,
+/// ) -> R {
+///     for x in iter {
+///         let cf = f(accum, x).branch();
+///         match cf {
+///             ControlFlow::Continue(a) => accum = a,
+///             ControlFlow::Break(r) => return R::from_residual(r),
+///         }
+///     }
+///     R::from_output(accum)
+/// }
+/// ```
+///
+/// But this "call `branch`, then `match` on it, and `return` if it was a
+/// `Break`" is exactly what happens inside the `?` operator.  So rather than
+/// do all this manually, we can just use `?` instead:
+/// ```
+/// # #![feature(try_trait_v2)]
+/// # use std::ops::Try;
+/// fn simple_try_fold<A, T, R: Try<Output = A>>(
+///     iter: impl Iterator<Item = T>,
+///     mut accum: A,
+///     mut f: impl FnMut(A, T) -> R,
+/// ) -> R {
+///     for x in iter {
+///         accum = f(accum, x)?;
+///     }
+///     R::from_output(accum)
+/// }
+/// ```
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 #[rustc_on_unimplemented(
     on(

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -273,20 +273,20 @@
 //! [`map_or`]: Option::map_or
 //! [`map_or_else`]: Option::map_or_else
 //!
-// //! These methods combine the [`Some`] variants of two [`Option`] values:
-// //!
-// //! * [`zip`] returns [`Some((s, o))`] if `self` is [`Some(s)`] and the
-// //!   provided [`Option`] value is [`Some(o)`]; otherwise, returns [`None`]
-// //! * [`zip_with`] calls the provided function `f` and returns
-// //!   [`Some(f(s, o))`] if `self` is [`Some(s)`] and the provided
-// //!   [`Option`] value is [`Some(o)`]; otherwise, returns [`None`]
-// //!
-// //! [`Some(f(s, o))`]: Some
-// //! [`Some(o)`]: Some
-// //! [`Some(s)`]: Some
-// //! [`Some((s, o))`]: Some
-// //! [`zip`]: Option::zip
-// //! [`zip_with`]: Option::zip_with
+//! These methods combine the [`Some`] variants of two [`Option`] values:
+//!
+//! * [`zip`] returns [`Some((s, o))`] if `self` is [`Some(s)`] and the
+//!   provided [`Option`] value is [`Some(o)`]; otherwise, returns [`None`]
+//! * [`zip_with`] calls the provided function `f` and returns
+//!   [`Some(f(s, o))`] if `self` is [`Some(s)`] and the provided
+//!   [`Option`] value is [`Some(o)`]; otherwise, returns [`None`]
+//!
+//! [`Some(f(s, o))`]: Some
+//! [`Some(o)`]: Some
+//! [`Some(s)`]: Some
+//! [`Some((s, o))`]: Some
+//! [`zip`]: Option::zip
+//! [`zip_with`]: Option::zip_with
 //!
 //! ## Boolean operators
 //!

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1083,8 +1083,8 @@ impl<T> Option<T> {
     /// ```
     ///
     /// [default value]: Default::default
-    // /// [`parse`]: str::parse
-    // /// [`FromStr`]: crate::str::FromStr
+    /// [`parse`]: str::parse
+    /// [`FromStr`]: crate::str::FromStr
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn unwrap_or_default(self) -> T
@@ -1534,9 +1534,9 @@ impl<T> Option<T> {
     ///   value), and
     /// - [`None`] if `predicate` returns `false`.
     ///
-    // /// This function works similar to [`Iterator::filter()`]. You can imagine
-    // /// the `Option<T>` being an iterator over one or zero elements. `filter()`
-    // /// lets you decide which elements to keep.
+    /// This function works similar to [`Iterator::filter()`]. You can imagine
+    /// the `Option<T>` being an iterator over one or zero elements. `filter()`
+    /// lets you decide which elements to keep.
     ///
     /// # Examples
     ///

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1921,7 +1921,7 @@ impl<T> Option<T> {
     /// assert_eq!(x.zip_with(None, Point::new), None);
     /// ```
     #[unstable(feature = "option_zip", issue = "70086")]
-    #[cfg(feature = "unstable")]
+    #[cfg(not(feature = "ferrocene_uncertified"))]
     pub fn zip_with<U, F, R>(self, other: Option<U>, f: F) -> Option<R>
     where
         F: FnOnce(T, U) -> R,

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1083,7 +1083,6 @@ impl<T> Option<T> {
     /// ```
     ///
     /// [default value]: Default::default
-    // FIXME(pvdrz): fix docs
     // /// [`parse`]: str::parse
     // /// [`FromStr`]: crate::str::FromStr
     #[inline]
@@ -1535,7 +1534,6 @@ impl<T> Option<T> {
     ///   value), and
     /// - [`None`] if `predicate` returns `false`.
     ///
-    // FIXME(pvdrz): fix docs
     // /// This function works similar to [`Iterator::filter()`]. You can imagine
     // /// the `Option<T>` being an iterator over one or zero elements. `filter()`
     // /// lets you decide which elements to keep.

--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -103,38 +103,38 @@ impl<'a> Location<'a> {
     }
 
     /// Returns the name of the source file from which the panic originated.
-    // ///
-    // /// # `&str`, not `&Path`
-    // ///
-    // /// The returned name refers to a source path on the compiling system, but it isn't valid to
-    // /// represent this directly as a `&Path`. The compiled code may run on a different system with
-    // /// a different `Path` implementation than the system providing the contents and this library
-    // /// does not currently have a different "host path" type.
-    // ///
-    // /// The most surprising behavior occurs when "the same" file is reachable via multiple paths in
-    // /// the module system (usually using the `#[path = "..."]` attribute or similar), which can
-    // /// cause what appears to be identical code to return differing values from this function.
-    // ///
-    // /// # Cross-compilation
-    // ///
-    // /// This value is not suitable for passing to `Path::new` or similar constructors when the host
-    // /// platform and target platform differ.
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```should_panic
-    // /// use std::panic;
-    // ///
-    // /// panic::set_hook(Box::new(|panic_info| {
-    // ///     if let Some(location) = panic_info.location() {
-    // ///         println!("panic occurred in file '{}'", location.file());
-    // ///     } else {
-    // ///         println!("panic occurred but can't get location information...");
-    // ///     }
-    // /// }));
-    // ///
-    // /// panic!("Normal panic");
-    // /// ```
+    ///
+    /// # `&str`, not `&Path`
+    ///
+    /// The returned name refers to a source path on the compiling system, but it isn't valid to
+    /// represent this directly as a `&Path`. The compiled code may run on a different system with
+    /// a different `Path` implementation than the system providing the contents and this library
+    /// does not currently have a different "host path" type.
+    ///
+    /// The most surprising behavior occurs when "the same" file is reachable via multiple paths in
+    /// the module system (usually using the `#[path = "..."]` attribute or similar), which can
+    /// cause what appears to be identical code to return differing values from this function.
+    ///
+    /// # Cross-compilation
+    ///
+    /// This value is not suitable for passing to `Path::new` or similar constructors when the host
+    /// platform and target platform differ.
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::panic;
+    ///
+    /// panic::set_hook(Box::new(|panic_info| {
+    ///     if let Some(location) = panic_info.location() {
+    ///         println!("panic occurred in file '{}'", location.file());
+    ///     } else {
+    ///         println!("panic occurred but can't get location information...");
+    ///     }
+    /// }));
+    ///
+    /// panic!("Normal panic");
+    /// ```
     #[must_use]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
     #[rustc_const_stable(feature = "const_location_fields", since = "1.79.0")]
@@ -161,22 +161,22 @@ impl<'a> Location<'a> {
     }
 
     /// Returns the line number from which the panic originated.
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```should_panic
-    // /// use std::panic;
-    // ///
-    // /// panic::set_hook(Box::new(|panic_info| {
-    // ///     if let Some(location) = panic_info.location() {
-    // ///         println!("panic occurred at line {}", location.line());
-    // ///     } else {
-    // ///         println!("panic occurred but can't get location information...");
-    // ///     }
-    // /// }));
-    // ///
-    // /// panic!("Normal panic");
-    // /// ```
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::panic;
+    ///
+    /// panic::set_hook(Box::new(|panic_info| {
+    ///     if let Some(location) = panic_info.location() {
+    ///         println!("panic occurred at line {}", location.line());
+    ///     } else {
+    ///         println!("panic occurred but can't get location information...");
+    ///     }
+    /// }));
+    ///
+    /// panic!("Normal panic");
+    /// ```
     #[must_use]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
     #[rustc_const_stable(feature = "const_location_fields", since = "1.79.0")]
@@ -186,22 +186,22 @@ impl<'a> Location<'a> {
     }
 
     /// Returns the column from which the panic originated.
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```should_panic
-    // /// use std::panic;
-    // ///
-    // /// panic::set_hook(Box::new(|panic_info| {
-    // ///     if let Some(location) = panic_info.location() {
-    // ///         println!("panic occurred at column {}", location.column());
-    // ///     } else {
-    // ///         println!("panic occurred but can't get location information...");
-    // ///     }
-    // /// }));
-    // ///
-    // /// panic!("Normal panic");
-    // /// ```
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::panic;
+    ///
+    /// panic::set_hook(Box::new(|panic_info| {
+    ///     if let Some(location) = panic_info.location() {
+    ///         println!("panic occurred at column {}", location.column());
+    ///     } else {
+    ///         println!("panic occurred but can't get location information...");
+    ///     }
+    /// }));
+    ///
+    /// panic!("Normal panic");
+    /// ```
     #[must_use]
     #[stable(feature = "panic_col", since = "1.25.0")]
     #[rustc_const_stable(feature = "const_location_fields", since = "1.79.0")]

--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -4,7 +4,6 @@ use crate::ffi::CStr;
 use crate::fmt;
 
 /// A struct containing information about the location of a panic.
-// FIXME(pvdrz): fix docs
 ///
 /// This structure is created by [`PanicHookInfo::location()`] and [`PanicInfo::location()`].
 ///
@@ -104,7 +103,6 @@ impl<'a> Location<'a> {
     }
 
     /// Returns the name of the source file from which the panic originated.
-    // FIXME(pvdrz): fix docs
     // ///
     // /// # `&str`, not `&Path`
     // ///
@@ -163,7 +161,6 @@ impl<'a> Location<'a> {
     }
 
     /// Returns the line number from which the panic originated.
-    // FIXME(pvdrz): fix docs
     // ///
     // /// # Examples
     // ///
@@ -189,7 +186,6 @@ impl<'a> Location<'a> {
     }
 
     /// Returns the column from which the panic originated.
-    // FIXME(pvdrz): fix docs
     // ///
     // /// # Examples
     // ///

--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -5,33 +5,33 @@ use crate::fmt;
 
 /// A struct containing information about the location of a panic.
 // FIXME(pvdrz): fix docs
-// ///
-// /// This structure is created by [`PanicHookInfo::location()`] and [`PanicInfo::location()`].
-// ///
-// /// [`PanicInfo::location()`]: crate::panic::PanicInfo::location
-// /// [`PanicHookInfo::location()`]: ../../std/panic/struct.PanicHookInfo.html#method.location
-// ///
-// /// # Examples
-// ///
-// /// ```should_panic
-// /// use std::panic;
-// ///
-// /// panic::set_hook(Box::new(|panic_info| {
-// ///     if let Some(location) = panic_info.location() {
-// ///         println!("panic occurred in file '{}' at line {}", location.file(), location.line());
-// ///     } else {
-// ///         println!("panic occurred but can't get location information...");
-// ///     }
-// /// }));
-// ///
-// /// panic!("Normal panic");
-// /// ```
-// ///
-// /// # Comparisons
-// ///
-// /// Comparisons for equality and ordering are made in file, line, then column priority.
-// /// Files are compared as strings, not `Path`, which could be unexpected.
-// /// See [`Location::file`]'s documentation for more discussion.
+///
+/// This structure is created by [`PanicHookInfo::location()`] and [`PanicInfo::location()`].
+///
+/// [`PanicInfo::location()`]: crate::panic::PanicInfo::location
+/// [`PanicHookInfo::location()`]: ../../std/panic/struct.PanicHookInfo.html#method.location
+///
+/// # Examples
+///
+/// ```should_panic
+/// use std::panic;
+///
+/// panic::set_hook(Box::new(|panic_info| {
+///     if let Some(location) = panic_info.location() {
+///         println!("panic occurred in file '{}' at line {}", location.file(), location.line());
+///     } else {
+///         println!("panic occurred but can't get location information...");
+///     }
+/// }));
+///
+/// panic!("Normal panic");
+/// ```
+///
+/// # Comparisons
+///
+/// Comparisons for equality and ordering are made in file, line, then column priority.
+/// Files are compared as strings, not `Path`, which could be unexpected.
+/// See [`Location::file`]'s documentation for more discussion.
 #[lang = "panic_location"]
 #[cfg_attr(
     not(feature = "ferrocene_certified"),

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -3,61 +3,61 @@
 #[doc(alias = "false")]
 /// The boolean type.
 // FIXME(pvdrz): fix docs
-// ///
-// /// The `bool` represents a value, which could only be either [`true`] or [`false`]. If you cast
-// /// a `bool` into an integer, [`true`] will be 1 and [`false`] will be 0.
-// ///
-// /// # Basic usage
-// ///
-// /// `bool` implements various traits, such as [`BitAnd`], [`BitOr`], [`Not`], etc.,
-// /// which allow us to perform boolean operations using `&`, `|` and `!`.
-// ///
-// /// [`if`] requires a `bool` value as its conditional. [`assert!`], which is an
-// /// important macro in testing, checks whether an expression is [`true`] and panics
-// /// if it isn't.
-// ///
-// /// ```
-// /// let bool_val = true & false | false;
-// /// assert!(!bool_val);
-// /// ```
-// ///
-// /// [`true`]: ../std/keyword.true.html
-// /// [`false`]: ../std/keyword.false.html
-// /// [`BitAnd`]: ops::BitAnd
-// /// [`BitOr`]: ops::BitOr
-// /// [`Not`]: ops::Not
-// /// [`if`]: ../std/keyword.if.html
-// ///
-// /// # Examples
-// ///
-// /// A trivial example of the usage of `bool`:
-// ///
-// /// ```
-// /// let praise_the_borrow_checker = true;
-// ///
-// /// // // using the `if` conditional
-// /// if praise_the_borrow_checker {
-// ///     println!("oh, yeah!");
-// /// } else {
-// ///     println!("what?!!");
-// /// }
-// ///
-// /// // // ... or, a match pattern
-// /// match praise_the_borrow_checker {
-// ///     true => println!("keep praising!"),
-// ///     false => println!("you should praise!"),
-// /// }
-// /// ```
-// ///
-// /// Also, since `bool` implements the [`Copy`] trait, we don't
-// /// have to worry about the move semantics (just like the integer and float primitives).
-// ///
-// /// Now an example of `bool` cast to integer type:
-// ///
-// /// ```
-// /// assert_eq!(true as i32, 1);
-// /// assert_eq!(false as i32, 0);
-// /// ```
+///
+/// The `bool` represents a value, which could only be either [`true`] or [`false`]. If you cast
+/// a `bool` into an integer, [`true`] will be 1 and [`false`] will be 0.
+///
+/// # Basic usage
+///
+/// `bool` implements various traits, such as [`BitAnd`], [`BitOr`], [`Not`], etc.,
+/// which allow us to perform boolean operations using `&`, `|` and `!`.
+///
+/// [`if`] requires a `bool` value as its conditional. [`assert!`], which is an
+/// important macro in testing, checks whether an expression is [`true`] and panics
+/// if it isn't.
+///
+/// ```
+/// let bool_val = true & false | false;
+/// assert!(!bool_val);
+/// ```
+///
+/// [`true`]: ../std/keyword.true.html
+/// [`false`]: ../std/keyword.false.html
+/// [`BitAnd`]: ops::BitAnd
+/// [`BitOr`]: ops::BitOr
+/// [`Not`]: ops::Not
+/// [`if`]: ../std/keyword.if.html
+///
+/// # Examples
+///
+/// A trivial example of the usage of `bool`:
+///
+/// ```
+/// let praise_the_borrow_checker = true;
+///
+/// // // using the `if` conditional
+/// if praise_the_borrow_checker {
+///     println!("oh, yeah!");
+/// } else {
+///     println!("what?!!");
+/// }
+///
+/// // // ... or, a match pattern
+/// match praise_the_borrow_checker {
+///     true => println!("keep praising!"),
+///     false => println!("you should praise!"),
+/// }
+/// ```
+///
+/// Also, since `bool` implements the [`Copy`] trait, we don't
+/// have to worry about the move semantics (just like the integer and float primitives).
+///
+/// Now an example of `bool` cast to integer type:
+///
+/// ```
+/// assert_eq!(true as i32, 1);
+/// assert_eq!(false as i32, 0);
+/// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_bool {}
 
@@ -628,209 +628,209 @@ mod prim_pointer {}
 /// A fixed-size array, denoted `[T; N]`, for the element type, `T`, and the
 /// non-negative compile-time constant size, `N`.
 // FIXME(pvdrz): fix docs
-// ///
-// /// There are two syntactic forms for creating an array:
-// ///
-// /// * A list with each element, i.e., `[x, y, z]`.
-// /// * A repeat expression `[expr; N]` where `N` is how many times to repeat `expr` in the array. `expr` must either be:
-// ///
-// ///   * A value of a type implementing the [`Copy`] trait
-// ///   * A `const` value
-// ///
-// /// Note that `[expr; 0]` is allowed, and produces an empty array.
-// /// This will still evaluate `expr`, however, and immediately drop the resulting value, so
-// /// be mindful of side effects.
-// ///
-// /// Arrays of *any* size implement the following traits if the element type allows it:
-// ///
-// /// - [`Copy`]
-// /// - [`Clone`]
-// /// - [`Debug`]
-// /// - [`IntoIterator`] (implemented for `[T; N]`, `&[T; N]` and `&mut [T; N]`)
-// /// - [`PartialEq`], [`PartialOrd`], [`Eq`], [`Ord`]
-// /// - [`Hash`]
-// /// - [`AsRef`], [`AsMut`]
-// /// - [`Borrow`], [`BorrowMut`]
-// ///
-// /// Arrays of sizes from 0 to 32 (inclusive) implement the [`Default`] trait
-// /// if the element type allows it. As a stopgap, trait implementations are
-// /// statically generated up to size 32.
-// ///
-// /// Arrays of sizes from 1 to 12 (inclusive) implement [`From<Tuple>`], where `Tuple`
-// /// is a homogeneous [prim@tuple] of appropriate length.
-// ///
-// /// Arrays coerce to [slices (`[T]`)][slice], so a slice method may be called on
-// /// an array. Indeed, this provides most of the API for working with arrays.
-// ///
-// /// Slices have a dynamic size and do not coerce to arrays. Instead, use
-// /// `slice.try_into().unwrap()` or `<ArrayType>::try_from(slice).unwrap()`.
-// ///
-// /// Array's `try_from(slice)` implementations (and the corresponding `slice.try_into()`
-// /// array implementations) succeed if the input slice length is the same as the result
-// /// array length. They optimize especially well when the optimizer can easily determine
-// /// the slice length, e.g. `<[u8; 4]>::try_from(&slice[4..8]).unwrap()`. Array implements
-// /// [TryFrom](crate::convert::TryFrom) returning:
-// ///
-// /// - `[T; N]` copies from the slice's elements
-// /// - `&[T; N]` references the original slice's elements
-// /// - `&mut [T; N]` references the original slice's elements
-// ///
-// /// You can move elements out of an array with a [slice pattern]. If you want
-// /// one element, see [`mem::replace`].
-// ///
-// /// # Examples
-// ///
-// /// ```
-// /// let mut array: [i32; 3] = [0; 3];
-// ///
-// /// array[1] = 1;
-// /// array[2] = 2;
-// ///
-// /// assert_eq!([1, 2], &array[1..]);
-// ///
-// /// // // This loop prints: 0 1 2
-// /// for x in array {
-// ///     print!("{x} ");
-// /// }
-// /// ```
-// ///
-// /// You can also iterate over reference to the array's elements:
-// ///
-// /// ```
-// /// let array: [i32; 3] = [0; 3];
-// ///
-// /// for x in &array { }
-// /// ```
-// ///
-// /// You can use `<ArrayType>::try_from(slice)` or `slice.try_into()` to get an array from
-// /// a slice:
-// ///
-// /// ```
-// /// let bytes: [u8; 3] = [1, 0, 2];
-// /// assert_eq!(1, u16::from_le_bytes(<[u8; 2]>::try_from(&bytes[0..2]).unwrap()));
-// /// assert_eq!(512, u16::from_le_bytes(bytes[1..3].try_into().unwrap()));
-// /// ```
-// ///
-// /// You can use a [slice pattern] to move elements out of an array:
-// ///
-// /// ```
-// /// fn move_away(_: String) { /* Do interesting things. */ }
-// ///
-// /// let [john, roa] = ["John".to_string(), "Roa".to_string()];
-// /// move_away(john);
-// /// move_away(roa);
-// /// ```
-// ///
-// /// Arrays can be created from homogeneous tuples of appropriate length:
-// ///
-// /// ```
-// /// let tuple: (u32, u32, u32) = (1, 2, 3);
-// /// let array: [u32; 3] = tuple.into();
-// /// ```
-// ///
-// /// # Editions
-// ///
-// /// Prior to Rust 1.53, arrays did not implement [`IntoIterator`] by value, so the method call
-// /// `array.into_iter()` auto-referenced into a [slice iterator](slice::iter). Right now, the old
-// /// behavior is preserved in the 2015 and 2018 editions of Rust for compatibility, ignoring
-// /// [`IntoIterator`] by value. In the future, the behavior on the 2015 and 2018 edition
-// /// might be made consistent to the behavior of later editions.
-// ///
-// /// ```rust,edition2018
-// /// // // Rust 2015 and 2018:
-// ///
-// /// # #![allow(array_into_iter)] // // override our `deny(warnings)`
-// /// let array: [i32; 3] = [0; 3];
-// ///
-// /// // // This creates a slice iterator, producing references to each value.
-// /// for item in array.into_iter().enumerate() {
-// ///     let (i, x): (usize, &i32) = item;
-// ///     println!("array[{i}] = {x}");
-// /// }
-// ///
-// /// // // The `array_into_iter` lint suggests this change for future compatibility:
-// /// for item in array.iter().enumerate() {
-// ///     let (i, x): (usize, &i32) = item;
-// ///     println!("array[{i}] = {x}");
-// /// }
-// ///
-// /// // // You can explicitly iterate an array by value using `IntoIterator::into_iter`
-// /// for item in IntoIterator::into_iter(array).enumerate() {
-// ///     let (i, x): (usize, i32) = item;
-// ///     println!("array[{i}] = {x}");
-// /// }
-// /// ```
-// ///
-// /// Starting in the 2021 edition, `array.into_iter()` uses `IntoIterator` normally to iterate
-// /// by value, and `iter()` should be used to iterate by reference like previous editions.
-// ///
-// /// ```rust,edition2021
-// /// // // Rust 2021:
-// ///
-// /// let array: [i32; 3] = [0; 3];
-// ///
-// /// // // This iterates by reference:
-// /// for item in array.iter().enumerate() {
-// ///     let (i, x): (usize, &i32) = item;
-// ///     println!("array[{i}] = {x}");
-// /// }
-// ///
-// /// // // This iterates by value:
-// /// for item in array.into_iter().enumerate() {
-// ///     let (i, x): (usize, i32) = item;
-// ///     println!("array[{i}] = {x}");
-// /// }
-// /// ```
-// ///
-// /// Future language versions might start treating the `array.into_iter()`
-// /// syntax on editions 2015 and 2018 the same as on edition 2021. So code using
-// /// those older editions should still be written with this change in mind, to
-// /// prevent breakage in the future. The safest way to accomplish this is to
-// /// avoid the `into_iter` syntax on those editions. If an edition update is not
-// /// viable/desired, there are multiple alternatives:
-// /// * use `iter`, equivalent to the old behavior, creating references
-// /// * use [`IntoIterator::into_iter`], equivalent to the post-2021 behavior (Rust 1.53+)
-// /// * replace `for ... in array.into_iter() {` with `for ... in array {`,
-// ///   equivalent to the post-2021 behavior (Rust 1.53+)
-// ///
-// /// ```rust,edition2018
-// /// // // Rust 2015 and 2018:
-// ///
-// /// let array: [i32; 3] = [0; 3];
-// ///
-// /// // // This iterates by reference:
-// /// for item in array.iter() {
-// ///     let x: &i32 = item;
-// ///     println!("{x}");
-// /// }
-// ///
-// /// // // This iterates by value:
-// /// for item in IntoIterator::into_iter(array) {
-// ///     let x: i32 = item;
-// ///     println!("{x}");
-// /// }
-// ///
-// /// // // This iterates by value:
-// /// for item in array {
-// ///     let x: i32 = item;
-// ///     println!("{x}");
-// /// }
-// ///
-// /// // // IntoIter can also start a chain.
-// /// // // This iterates by value:
-// /// for item in IntoIterator::into_iter(array).enumerate() {
-// ///     let (i, x): (usize, i32) = item;
-// ///     println!("array[{i}] = {x}");
-// /// }
-// /// ```
-// ///
-// /// [slice]: prim@slice
-// /// [`Debug`]: fmt::Debug
-// /// [`Hash`]: hash::Hash
-// /// [`Borrow`]: borrow::Borrow
-// /// [`BorrowMut`]: borrow::BorrowMut
-// /// [slice pattern]: ../reference/patterns.html#slice-patterns
-// /// [`From<Tuple>`]: convert::From
+///
+/// There are two syntactic forms for creating an array:
+///
+/// * A list with each element, i.e., `[x, y, z]`.
+/// * A repeat expression `[expr; N]` where `N` is how many times to repeat `expr` in the array. `expr` must either be:
+///
+///   * A value of a type implementing the [`Copy`] trait
+///   * A `const` value
+///
+/// Note that `[expr; 0]` is allowed, and produces an empty array.
+/// This will still evaluate `expr`, however, and immediately drop the resulting value, so
+/// be mindful of side effects.
+///
+/// Arrays of *any* size implement the following traits if the element type allows it:
+///
+/// - [`Copy`]
+/// - [`Clone`]
+/// - [`Debug`]
+/// - [`IntoIterator`] (implemented for `[T; N]`, `&[T; N]` and `&mut [T; N]`)
+/// - [`PartialEq`], [`PartialOrd`], [`Eq`], [`Ord`]
+/// - [`Hash`]
+/// - [`AsRef`], [`AsMut`]
+/// - [`Borrow`], [`BorrowMut`]
+///
+/// Arrays of sizes from 0 to 32 (inclusive) implement the [`Default`] trait
+/// if the element type allows it. As a stopgap, trait implementations are
+/// statically generated up to size 32.
+///
+/// Arrays of sizes from 1 to 12 (inclusive) implement [`From<Tuple>`], where `Tuple`
+/// is a homogeneous [prim@tuple] of appropriate length.
+///
+/// Arrays coerce to [slices (`[T]`)][slice], so a slice method may be called on
+/// an array. Indeed, this provides most of the API for working with arrays.
+///
+/// Slices have a dynamic size and do not coerce to arrays. Instead, use
+/// `slice.try_into().unwrap()` or `<ArrayType>::try_from(slice).unwrap()`.
+///
+/// Array's `try_from(slice)` implementations (and the corresponding `slice.try_into()`
+/// array implementations) succeed if the input slice length is the same as the result
+/// array length. They optimize especially well when the optimizer can easily determine
+/// the slice length, e.g. `<[u8; 4]>::try_from(&slice[4..8]).unwrap()`. Array implements
+/// [TryFrom](crate::convert::TryFrom) returning:
+///
+/// - `[T; N]` copies from the slice's elements
+/// - `&[T; N]` references the original slice's elements
+/// - `&mut [T; N]` references the original slice's elements
+///
+/// You can move elements out of an array with a [slice pattern]. If you want
+/// one element, see [`mem::replace`].
+///
+/// # Examples
+///
+/// ```
+/// let mut array: [i32; 3] = [0; 3];
+///
+/// array[1] = 1;
+/// array[2] = 2;
+///
+/// assert_eq!([1, 2], &array[1..]);
+///
+/// // // This loop prints: 0 1 2
+/// for x in array {
+///     print!("{x} ");
+/// }
+/// ```
+///
+/// You can also iterate over reference to the array's elements:
+///
+/// ```
+/// let array: [i32; 3] = [0; 3];
+///
+/// for x in &array { }
+/// ```
+///
+/// You can use `<ArrayType>::try_from(slice)` or `slice.try_into()` to get an array from
+/// a slice:
+///
+/// ```
+/// let bytes: [u8; 3] = [1, 0, 2];
+/// assert_eq!(1, u16::from_le_bytes(<[u8; 2]>::try_from(&bytes[0..2]).unwrap()));
+/// assert_eq!(512, u16::from_le_bytes(bytes[1..3].try_into().unwrap()));
+/// ```
+///
+/// You can use a [slice pattern] to move elements out of an array:
+///
+/// ```
+/// fn move_away(_: String) { /* Do interesting things. */ }
+///
+/// let [john, roa] = ["John".to_string(), "Roa".to_string()];
+/// move_away(john);
+/// move_away(roa);
+/// ```
+///
+/// Arrays can be created from homogeneous tuples of appropriate length:
+///
+/// ```
+/// let tuple: (u32, u32, u32) = (1, 2, 3);
+/// let array: [u32; 3] = tuple.into();
+/// ```
+///
+/// # Editions
+///
+/// Prior to Rust 1.53, arrays did not implement [`IntoIterator`] by value, so the method call
+/// `array.into_iter()` auto-referenced into a [slice iterator](slice::iter). Right now, the old
+/// behavior is preserved in the 2015 and 2018 editions of Rust for compatibility, ignoring
+/// [`IntoIterator`] by value. In the future, the behavior on the 2015 and 2018 edition
+/// might be made consistent to the behavior of later editions.
+///
+/// ```rust,edition2018
+/// // // Rust 2015 and 2018:
+///
+/// # #![allow(array_into_iter)] // // override our `deny(warnings)`
+/// let array: [i32; 3] = [0; 3];
+///
+/// // // This creates a slice iterator, producing references to each value.
+/// for item in array.into_iter().enumerate() {
+///     let (i, x): (usize, &i32) = item;
+///     println!("array[{i}] = {x}");
+/// }
+///
+/// // // The `array_into_iter` lint suggests this change for future compatibility:
+/// for item in array.iter().enumerate() {
+///     let (i, x): (usize, &i32) = item;
+///     println!("array[{i}] = {x}");
+/// }
+///
+/// // // You can explicitly iterate an array by value using `IntoIterator::into_iter`
+/// for item in IntoIterator::into_iter(array).enumerate() {
+///     let (i, x): (usize, i32) = item;
+///     println!("array[{i}] = {x}");
+/// }
+/// ```
+///
+/// Starting in the 2021 edition, `array.into_iter()` uses `IntoIterator` normally to iterate
+/// by value, and `iter()` should be used to iterate by reference like previous editions.
+///
+/// ```rust,edition2021
+/// // // Rust 2021:
+///
+/// let array: [i32; 3] = [0; 3];
+///
+/// // // This iterates by reference:
+/// for item in array.iter().enumerate() {
+///     let (i, x): (usize, &i32) = item;
+///     println!("array[{i}] = {x}");
+/// }
+///
+/// // // This iterates by value:
+/// for item in array.into_iter().enumerate() {
+///     let (i, x): (usize, i32) = item;
+///     println!("array[{i}] = {x}");
+/// }
+/// ```
+///
+/// Future language versions might start treating the `array.into_iter()`
+/// syntax on editions 2015 and 2018 the same as on edition 2021. So code using
+/// those older editions should still be written with this change in mind, to
+/// prevent breakage in the future. The safest way to accomplish this is to
+/// avoid the `into_iter` syntax on those editions. If an edition update is not
+/// viable/desired, there are multiple alternatives:
+/// * use `iter`, equivalent to the old behavior, creating references
+/// * use [`IntoIterator::into_iter`], equivalent to the post-2021 behavior (Rust 1.53+)
+/// * replace `for ... in array.into_iter() {` with `for ... in array {`,
+///   equivalent to the post-2021 behavior (Rust 1.53+)
+///
+/// ```rust,edition2018
+/// // // Rust 2015 and 2018:
+///
+/// let array: [i32; 3] = [0; 3];
+///
+/// // // This iterates by reference:
+/// for item in array.iter() {
+///     let x: &i32 = item;
+///     println!("{x}");
+/// }
+///
+/// // // This iterates by value:
+/// for item in IntoIterator::into_iter(array) {
+///     let x: i32 = item;
+///     println!("{x}");
+/// }
+///
+/// // // This iterates by value:
+/// for item in array {
+///     let x: i32 = item;
+///     println!("{x}");
+/// }
+///
+/// // // IntoIter can also start a chain.
+/// // // This iterates by value:
+/// for item in IntoIterator::into_iter(array).enumerate() {
+///     let (i, x): (usize, i32) = item;
+///     println!("array[{i}] = {x}");
+/// }
+/// ```
+///
+/// [slice]: prim@slice
+/// [`Debug`]: fmt::Debug
+/// [`Hash`]: hash::Hash
+/// [`Borrow`]: borrow::Borrow
+/// [`BorrowMut`]: borrow::BorrowMut
+/// [slice pattern]: ../reference/patterns.html#slice-patterns
+/// [`From<Tuple>`]: convert::From
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_array {}
 
@@ -1246,8 +1246,8 @@ mod prim_f16 {}
 /// For more information on floating-point numbers, see [Wikipedia][wikipedia].
 ///
 // FIXME(pvdrz): fix docs
-// /// *[See also the `std::f32::consts` module](crate::f32::consts).*
-// ///
+/// *[See also the `std::f32::consts` module](crate::f32::consts).*
+///
 /// [wikipedia]: https://en.wikipedia.org/wiki/Single-precision_floating-point_format
 ///
 /// # NaN bit patterns
@@ -1385,8 +1385,8 @@ mod prim_f32 {}
 /// values][wikipedia] for more information.
 ///
 // FIXME(pvdrz): fix docs
-// /// *[See also the `std::f64::consts` module](crate::f64::consts).*
-// ///
+/// *[See also the `std::f64::consts` module](crate::f64::consts).*
+///
 /// [wikipedia]: https://en.wikipedia.org/wiki/Double-precision_floating-point_format
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_f64 {}

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -2,7 +2,6 @@
 #[doc(alias = "true")]
 #[doc(alias = "false")]
 /// The boolean type.
-// FIXME(pvdrz): fix docs
 ///
 /// The `bool` represents a value, which could only be either [`true`] or [`false`]. If you cast
 /// a `bool` into an integer, [`true`] will be 1 and [`false`] will be 0.
@@ -627,7 +626,6 @@ mod prim_pointer {}
 #[doc(alias = "[T; N]")]
 /// A fixed-size array, denoted `[T; N]`, for the element type, `T`, and the
 /// non-negative compile-time constant size, `N`.
-// FIXME(pvdrz): fix docs
 ///
 /// There are two syntactic forms for creating an array:
 ///
@@ -1245,7 +1243,6 @@ mod prim_f16 {}
 ///
 /// For more information on floating-point numbers, see [Wikipedia][wikipedia].
 ///
-// FIXME(pvdrz): fix docs
 /// *[See also the `std::f32::consts` module](crate::f32::consts).*
 ///
 /// [wikipedia]: https://en.wikipedia.org/wiki/Single-precision_floating-point_format
@@ -1384,7 +1381,6 @@ mod prim_f32 {}
 /// bits. Please see [the documentation for `f32`](prim@f32) or [Wikipedia on double-precision
 /// values][wikipedia] for more information.
 ///
-// FIXME(pvdrz): fix docs
 /// *[See also the `std::f64::consts` module](crate::f64::consts).*
 ///
 /// [wikipedia]: https://en.wikipedia.org/wiki/Double-precision_floating-point_format

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1689,7 +1689,7 @@ impl<T, const N: usize> *const [T; N] {
 }
 
 // FIXME(pvdrz): fix docs
-// /// Pointer equality is by address, as produced by the [`<*const T>::addr`](pointer::addr) method.
+/// Pointer equality is by address, as produced by the [`<*const T>::addr`](pointer::addr) method.
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> PartialEq for *const T {
     #[inline]

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -11,31 +11,31 @@ use crate::slice::{self, SliceIndex};
 
 impl<T: ?Sized> *const T {
     /// Returns `true` if the pointer is null.
-    // ///
-    // /// Note that unsized types have many possible null pointers, as only the
-    // /// raw data pointer is considered, not their length, vtable, etc.
-    // /// Therefore, two pointers that are null may still not compare equal to
-    // /// each other.
-    // ///
-    // /// # Panics during const evaluation
-    // ///
-    // /// If this method is used during const evaluation, and `self` is a pointer
-    // /// that is offset beyond the bounds of the memory it initially pointed to,
-    // /// then there might not be enough information to determine whether the
-    // /// pointer is null. This is because the absolute address in memory is not
-    // /// known at compile time. If the nullness of the pointer cannot be
-    // /// determined, this method will panic.
-    // ///
-    // /// In-bounds pointers are never null, so the method will never panic for
-    // /// such pointers.
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```
-    // /// let s: &str = "Follow the rabbit";
-    // /// let ptr: *const u8 = s.as_ptr();
-    // /// assert!(!ptr.is_null());
-    // /// ```
+    ///
+    /// Note that unsized types have many possible null pointers, as only the
+    /// raw data pointer is considered, not their length, vtable, etc.
+    /// Therefore, two pointers that are null may still not compare equal to
+    /// each other.
+    ///
+    /// # Panics during const evaluation
+    ///
+    /// If this method is used during const evaluation, and `self` is a pointer
+    /// that is offset beyond the bounds of the memory it initially pointed to,
+    /// then there might not be enough information to determine whether the
+    /// pointer is null. This is because the absolute address in memory is not
+    /// known at compile time. If the nullness of the pointer cannot be
+    /// determined, this method will panic.
+    ///
+    /// In-bounds pointers are never null, so the method will never panic for
+    /// such pointers.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let s: &str = "Follow the rabbit";
+    /// let ptr: *const u8 = s.as_ptr();
+    /// assert!(!ptr.is_null());
+    /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_ptr_is_null", since = "1.84.0")]
     #[rustc_diagnostic_item = "ptr_const_is_null"]
@@ -171,27 +171,27 @@ impl<T: ?Sized> *const T {
     }
 
     /// Gets the "address" portion of the pointer.
-    // ///
-    // /// This is similar to `self as usize`, except that the [provenance][crate::ptr#provenance] of
-    // /// the pointer is discarded and not [exposed][crate::ptr#exposed-provenance]. This means that
-    // /// casting the returned address back to a pointer yields a [pointer without
-    // /// provenance][without_provenance], which is undefined behavior to dereference. To properly
-    // /// restore the lost information and obtain a dereferenceable pointer, use
-    // /// [`with_addr`][pointer::with_addr] or [`map_addr`][pointer::map_addr].
-    // ///
-    // /// If using those APIs is not possible because there is no way to preserve a pointer with the
-    // /// required provenance, then Strict Provenance might not be for you. Use pointer-integer casts
-    // /// or [`expose_provenance`][pointer::expose_provenance] and [`with_exposed_provenance`][with_exposed_provenance]
-    // /// instead. However, note that this makes your code less portable and less amenable to tools
-    // /// that check for compliance with the Rust memory model.
-    // ///
-    // /// On most platforms this will produce a value with the same bytes as the original
-    // /// pointer, because all the bytes are dedicated to describing the address.
-    // /// Platforms which need to store additional information in the pointer may
-    // /// perform a change of representation to produce a value containing only the address
-    // /// portion of the pointer. What that means is up to the platform to define.
-    // ///
-    // /// This is a [Strict Provenance][crate::ptr#strict-provenance] API.
+    ///
+    /// This is similar to `self as usize`, except that the [provenance][crate::ptr#provenance] of
+    /// the pointer is discarded and not [exposed][crate::ptr#exposed-provenance]. This means that
+    /// casting the returned address back to a pointer yields a [pointer without
+    /// provenance][without_provenance], which is undefined behavior to dereference. To properly
+    /// restore the lost information and obtain a dereferenceable pointer, use
+    /// [`with_addr`][pointer::with_addr] or [`map_addr`][pointer::map_addr].
+    ///
+    /// If using those APIs is not possible because there is no way to preserve a pointer with the
+    /// required provenance, then Strict Provenance might not be for you. Use pointer-integer casts
+    /// or [`expose_provenance`][pointer::expose_provenance] and [`with_exposed_provenance`][with_exposed_provenance]
+    /// instead. However, note that this makes your code less portable and less amenable to tools
+    /// that check for compliance with the Rust memory model.
+    ///
+    /// On most platforms this will produce a value with the same bytes as the original
+    /// pointer, because all the bytes are dedicated to describing the address.
+    /// Platforms which need to store additional information in the pointer may
+    /// perform a change of representation to produce a value containing only the address
+    /// portion of the pointer. What that means is up to the platform to define.
+    ///
+    /// This is a [Strict Provenance][crate::ptr#strict-provenance] API.
     #[must_use]
     #[inline(always)]
     #[stable(feature = "strict_provenance", since = "1.84.0")]
@@ -1448,32 +1448,32 @@ impl<T: ?Sized> *const T {
     ///
     /// For non-`Sized` pointees this operation considers only the data pointer,
     /// ignoring the metadata.
-    // ///
-    // /// # Panics
-    // ///
-    // /// The function panics if `align` is not a power-of-two (this includes 0).
-    // ///
-    // /// # Examples
-    // ///
-    // /// ```
-    // /// #![feature(pointer_is_aligned_to)]
-    // ///
-    // /// // On some platforms, the alignment of i32 is less than 4.
-    // /// #[repr(align(4))]
-    // /// struct AlignedI32(i32);
-    // ///
-    // /// let data = AlignedI32(42);
-    // /// let ptr = &data as *const AlignedI32;
-    // ///
-    // /// assert!(ptr.is_aligned_to(1));
-    // /// assert!(ptr.is_aligned_to(2));
-    // /// assert!(ptr.is_aligned_to(4));
-    // ///
-    // /// assert!(ptr.wrapping_byte_add(2).is_aligned_to(2));
-    // /// assert!(!ptr.wrapping_byte_add(2).is_aligned_to(4));
-    // ///
-    // /// assert_ne!(ptr.is_aligned_to(8), ptr.wrapping_add(1).is_aligned_to(8));
-    // /// ```
+    ///
+    /// # Panics
+    ///
+    /// The function panics if `align` is not a power-of-two (this includes 0).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(pointer_is_aligned_to)]
+    ///
+    /// // On some platforms, the alignment of i32 is less than 4.
+    /// #[repr(align(4))]
+    /// struct AlignedI32(i32);
+    ///
+    /// let data = AlignedI32(42);
+    /// let ptr = &data as *const AlignedI32;
+    ///
+    /// assert!(ptr.is_aligned_to(1));
+    /// assert!(ptr.is_aligned_to(2));
+    /// assert!(ptr.is_aligned_to(4));
+    ///
+    /// assert!(ptr.wrapping_byte_add(2).is_aligned_to(2));
+    /// assert!(!ptr.wrapping_byte_add(2).is_aligned_to(4));
+    ///
+    /// assert_ne!(ptr.is_aligned_to(8), ptr.wrapping_add(1).is_aligned_to(8));
+    /// ```
     #[must_use]
     #[inline]
     #[unstable(feature = "pointer_is_aligned_to", issue = "96284")]

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -11,7 +11,6 @@ use crate::slice::{self, SliceIndex};
 
 impl<T: ?Sized> *const T {
     /// Returns `true` if the pointer is null.
-    // FIXME(pvdrz): fix docs
     // ///
     // /// Note that unsized types have many possible null pointers, as only the
     // /// raw data pointer is considered, not their length, vtable, etc.
@@ -172,7 +171,6 @@ impl<T: ?Sized> *const T {
     }
 
     /// Gets the "address" portion of the pointer.
-    // FIXME(pvdrz): fix docs
     // ///
     // /// This is similar to `self as usize`, except that the [provenance][crate::ptr#provenance] of
     // /// the pointer is discarded and not [exposed][crate::ptr#exposed-provenance]. This means that
@@ -1450,7 +1448,6 @@ impl<T: ?Sized> *const T {
     ///
     /// For non-`Sized` pointees this operation considers only the data pointer,
     /// ignoring the metadata.
-    // FIXME(pvdrz): fix docs
     // ///
     // /// # Panics
     // ///
@@ -1688,7 +1685,6 @@ impl<T, const N: usize> *const [T; N] {
     }
 }
 
-// FIXME(pvdrz): fix docs
 /// Pointer equality is by address, as produced by the [`<*const T>::addr`](pointer::addr) method.
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> PartialEq for *const T {

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -15,51 +15,51 @@ use crate::ptr::NonNull;
 
 /// Provides the pointer metadata type of any pointed-to type.
 // FIXME(pvdrz): fix docs
-// ///
-// /// # Pointer metadata
-// ///
-// /// Raw pointer types and reference types in Rust can be thought of as made of two parts:
-// /// a data pointer that contains the memory address of the value, and some metadata.
-// ///
-// /// For statically-sized types (that implement the `Sized` traits)
-// /// as well as for `extern` types,
-// /// pointers are said to be “thin”: metadata is zero-sized and its type is `()`.
-// ///
-// /// Pointers to [dynamically-sized types][dst] are said to be “wide” or “fat”,
-// /// they have non-zero-sized metadata:
-// ///
-// /// * For structs whose last field is a DST, metadata is the metadata for the last field
-// /// * For the `str` type, metadata is the length in bytes as `usize`
-// /// * For slice types like `[T]`, metadata is the length in items as `usize`
-// /// * For trait objects like `dyn SomeTrait`, metadata is [`DynMetadata<Self>`][DynMetadata]
-// ///   (e.g. `DynMetadata<dyn SomeTrait>`)
-// ///
-// /// In the future, the Rust language may gain new kinds of types
-// /// that have different pointer metadata.
-// ///
-// /// [dst]: https://doc.rust-lang.org/nomicon/exotic-sizes.html#dynamically-sized-types-dsts
-// ///
-// ///
-// /// # The `Pointee` trait
-// ///
-// /// The point of this trait is its `Metadata` associated type,
-// /// which is `()` or `usize` or `DynMetadata<_>` as described above.
-// /// It is automatically implemented for every type.
-// /// It can be assumed to be implemented in a generic context, even without a corresponding bound.
-// ///
-// ///
-// /// # Usage
-// ///
-// /// Raw pointers can be decomposed into the data pointer and metadata components
-// /// with their [`to_raw_parts`] method.
-// ///
-// /// Alternatively, metadata alone can be extracted with the [`metadata`] function.
-// /// A reference can be passed to [`metadata`] and implicitly coerced.
-// ///
-// /// A (possibly-wide) pointer can be put back together from its data pointer and metadata
-// /// with [`from_raw_parts`] or [`from_raw_parts_mut`].
-// ///
-// /// [`to_raw_parts`]: *const::to_raw_parts
+///
+/// # Pointer metadata
+///
+/// Raw pointer types and reference types in Rust can be thought of as made of two parts:
+/// a data pointer that contains the memory address of the value, and some metadata.
+///
+/// For statically-sized types (that implement the `Sized` traits)
+/// as well as for `extern` types,
+/// pointers are said to be “thin”: metadata is zero-sized and its type is `()`.
+///
+/// Pointers to [dynamically-sized types][dst] are said to be “wide” or “fat”,
+/// they have non-zero-sized metadata:
+///
+/// * For structs whose last field is a DST, metadata is the metadata for the last field
+/// * For the `str` type, metadata is the length in bytes as `usize`
+/// * For slice types like `[T]`, metadata is the length in items as `usize`
+/// * For trait objects like `dyn SomeTrait`, metadata is [`DynMetadata<Self>`][DynMetadata]
+///   (e.g. `DynMetadata<dyn SomeTrait>`)
+///
+/// In the future, the Rust language may gain new kinds of types
+/// that have different pointer metadata.
+///
+/// [dst]: https://doc.rust-lang.org/nomicon/exotic-sizes.html#dynamically-sized-types-dsts
+///
+///
+/// # The `Pointee` trait
+///
+/// The point of this trait is its `Metadata` associated type,
+/// which is `()` or `usize` or `DynMetadata<_>` as described above.
+/// It is automatically implemented for every type.
+/// It can be assumed to be implemented in a generic context, even without a corresponding bound.
+///
+///
+/// # Usage
+///
+/// Raw pointers can be decomposed into the data pointer and metadata components
+/// with their [`to_raw_parts`] method.
+///
+/// Alternatively, metadata alone can be extracted with the [`metadata`] function.
+/// A reference can be passed to [`metadata`] and implicitly coerced.
+///
+/// A (possibly-wide) pointer can be put back together from its data pointer and metadata
+/// with [`from_raw_parts`] or [`from_raw_parts_mut`].
+///
+/// [`to_raw_parts`]: *const::to_raw_parts
 #[lang = "pointee_trait"]
 #[rustc_deny_explicit_impl]
 #[rustc_do_not_implement_via_object]
@@ -116,12 +116,12 @@ pub const fn metadata<T: ?Sized>(ptr: *const T) -> <T as Pointee>::Metadata {
 
 /// Forms a (possibly-wide) raw pointer from a data pointer and metadata.
 // FIXME(pvdrz): fix docs
-// ///
-// /// This function is safe but the returned pointer is not necessarily safe to dereference.
-// /// For slices, see the documentation of [`slice::from_raw_parts`] for safety requirements.
-// /// For trait objects, the metadata must come from a pointer to the same underlying erased type.
-// ///
-// /// [`slice::from_raw_parts`]: crate::slice::from_raw_parts
+///
+/// This function is safe but the returned pointer is not necessarily safe to dereference.
+/// For slices, see the documentation of [`slice::from_raw_parts`] for safety requirements.
+/// For trait objects, the metadata must come from a pointer to the same underlying erased type.
+///
+/// [`slice::from_raw_parts`]: crate::slice::from_raw_parts
 #[unstable(feature = "ptr_metadata", issue = "81513")]
 #[inline]
 pub const fn from_raw_parts<T: ?Sized>(

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -14,7 +14,6 @@ use crate::marker::Freeze;
 use crate::ptr::NonNull;
 
 /// Provides the pointer metadata type of any pointed-to type.
-// FIXME(pvdrz): fix docs
 ///
 /// # Pointer metadata
 ///
@@ -115,7 +114,6 @@ pub const fn metadata<T: ?Sized>(ptr: *const T) -> <T as Pointee>::Metadata {
 }
 
 /// Forms a (possibly-wide) raw pointer from a data pointer and metadata.
-// FIXME(pvdrz): fix docs
 ///
 /// This function is safe but the returned pointer is not necessarily safe to dereference.
 /// For slices, see the documentation of [`slice::from_raw_parts`] for safety requirements.

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1632,7 +1632,7 @@ pub const unsafe fn replace<T>(dst: *mut T, src: T) -> T {
 ///
 /// Note that even if `T` has size `0`, the pointer must be properly aligned.
 ///
-// // /// # Examples
+/// # Examples
 ///
 /// Basic usage:
 ///

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1,5 +1,4 @@
 //! Manually manage memory through raw pointers.
-// FIXME(pvdrz): fix docs
 // //!
 // //! *[See also the pointer primitive types](pointer).*
 // //!
@@ -878,7 +877,6 @@ pub const fn null_mut<T: ?Sized + Thin>() -> *mut T {
 }
 
 /// Creates a pointer with the given address and no [provenance][crate::ptr#provenance].
-// FIXME(pvdrz): fix docs
 ///
 /// This is equivalent to `ptr::null().with_addr(addr)`.
 ///
@@ -918,7 +916,6 @@ pub const fn dangling<T>() -> *const T {
 }
 
 /// Creates a pointer with the given address and no [provenance][crate::ptr#provenance].
-// FIXME(pvdrz): fix docs
 ///
 /// This is equivalent to `ptr::null_mut().with_addr(addr)`.
 ///
@@ -1621,7 +1618,6 @@ pub const unsafe fn replace<T>(dst: *mut T, src: T) -> T {
 
 /// Reads the value from `src` without moving it. This leaves the
 /// memory in `src` unchanged.
-// FIXME(pvdrz): fix docs
 ///
 /// # Safety
 ///
@@ -1876,7 +1872,6 @@ pub const unsafe fn read_unaligned<T>(src: *const T) -> T {
 /// This is appropriate for initializing uninitialized memory, or overwriting
 /// memory that has previously been [`read`] from.
 ///
-// FIXME(pvdrz): fix docs
 /// # Safety
 ///
 /// Behavior is undefined if any of the following conditions are violated:

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1,396 +1,396 @@
 //! Manually manage memory through raw pointers.
-// //!
-// //! *[See also the pointer primitive types](pointer).*
-// //!
+//!
+//! *[See also the pointer primitive types](pointer).*
+//!
 //! # Safety
-// //!
-// //! Many functions in this module take raw pointers as arguments and read from or write to them. For
-// //! this to be safe, these pointers must be *valid* for the given access. Whether a pointer is valid
-// //! depends on the operation it is used for (read or write), and the extent of the memory that is
-// //! accessed (i.e., how many bytes are read/written) -- it makes no sense to ask "is this pointer
-// //! valid"; one has to ask "is this pointer valid for a given access". Most functions use `*mut T`
-// //! and `*const T` to access only a single value, in which case the documentation omits the size and
-// //! implicitly assumes it to be `size_of::<T>()` bytes.
-// //!
-// //! The precise rules for validity are not determined yet. The guarantees that are
-// //! provided at this point are very minimal:
-// //!
-// //! * For memory accesses of [size zero][zst], *every* pointer is valid, including the [null]
-// //!   pointer. The following points are only concerned with non-zero-sized accesses.
-// //! * A [null] pointer is *never* valid.
-// //! * For a pointer to be valid, it is necessary, but not always sufficient, that the pointer be
-// //!   *dereferenceable*. The [provenance] of the pointer is used to determine which [allocation]
-// //!   it is derived from; a pointer is dereferenceable if the memory range of the given size
-// //!   starting at the pointer is entirely contained within the bounds of that allocation. Note
-// //!   that in Rust, every (stack-allocated) variable is considered a separate allocation.
-// //! * All accesses performed by functions in this module are *non-atomic* in the sense
-// //!   of [atomic operations] used to synchronize between threads. This means it is
-// //!   undefined behavior to perform two concurrent accesses to the same location from different
-// //!   threads unless both accesses only read from memory. Notice that this explicitly
-// //!   includes [`read_volatile`] and [`write_volatile`]: Volatile accesses cannot
-// //!   be used for inter-thread synchronization.
-// //! * The result of casting a reference to a pointer is valid for as long as the
-// //!   underlying allocation is live and no reference (just raw pointers) is used to
-// //!   access the same memory. That is, reference and pointer accesses cannot be
-// //!   interleaved.
-// //!
-// //! These axioms, along with careful use of [`offset`] for pointer arithmetic,
-// //! are enough to correctly implement many useful things in unsafe code. Stronger guarantees
-// //! will be provided eventually, as the [aliasing] rules are being determined. For more
-// //! information, see the [book] as well as the section in the reference devoted
-// //! to [undefined behavior][ub].
-// //!
-// //! We say that a pointer is "dangling" if it is not valid for any non-zero-sized accesses. This
-// //! means out-of-bounds pointers, pointers to freed memory, null pointers, and pointers created with
-// //! [`NonNull::dangling`] are all dangling.
-// //!
-// //! ## Alignment
-// //!
-// //! Valid raw pointers as defined above are not necessarily properly aligned (where
-// //! "proper" alignment is defined by the pointee type, i.e., `*const T` must be
-// //! aligned to `align_of::<T>()`). However, most functions require their
-// //! arguments to be properly aligned, and will explicitly state
-// //! this requirement in their documentation. Notable exceptions to this are
-// //! [`read_unaligned`] and [`write_unaligned`].
-// //!
-// //! When a function requires proper alignment, it does so even if the access
-// //! has size 0, i.e., even if memory is not actually touched. Consider using
-// //! [`NonNull::dangling`] in such cases.
-// //!
+//!
+//! Many functions in this module take raw pointers as arguments and read from or write to them. For
+//! this to be safe, these pointers must be *valid* for the given access. Whether a pointer is valid
+//! depends on the operation it is used for (read or write), and the extent of the memory that is
+//! accessed (i.e., how many bytes are read/written) -- it makes no sense to ask "is this pointer
+//! valid"; one has to ask "is this pointer valid for a given access". Most functions use `*mut T`
+//! and `*const T` to access only a single value, in which case the documentation omits the size and
+//! implicitly assumes it to be `size_of::<T>()` bytes.
+//!
+//! The precise rules for validity are not determined yet. The guarantees that are
+//! provided at this point are very minimal:
+//!
+//! * For memory accesses of [size zero][zst], *every* pointer is valid, including the [null]
+//!   pointer. The following points are only concerned with non-zero-sized accesses.
+//! * A [null] pointer is *never* valid.
+//! * For a pointer to be valid, it is necessary, but not always sufficient, that the pointer be
+//!   *dereferenceable*. The [provenance] of the pointer is used to determine which [allocation]
+//!   it is derived from; a pointer is dereferenceable if the memory range of the given size
+//!   starting at the pointer is entirely contained within the bounds of that allocation. Note
+//!   that in Rust, every (stack-allocated) variable is considered a separate allocation.
+//! * All accesses performed by functions in this module are *non-atomic* in the sense
+//!   of [atomic operations] used to synchronize between threads. This means it is
+//!   undefined behavior to perform two concurrent accesses to the same location from different
+//!   threads unless both accesses only read from memory. Notice that this explicitly
+//!   includes [`read_volatile`] and [`write_volatile`]: Volatile accesses cannot
+//!   be used for inter-thread synchronization.
+//! * The result of casting a reference to a pointer is valid for as long as the
+//!   underlying allocation is live and no reference (just raw pointers) is used to
+//!   access the same memory. That is, reference and pointer accesses cannot be
+//!   interleaved.
+//!
+//! These axioms, along with careful use of [`offset`] for pointer arithmetic,
+//! are enough to correctly implement many useful things in unsafe code. Stronger guarantees
+//! will be provided eventually, as the [aliasing] rules are being determined. For more
+//! information, see the [book] as well as the section in the reference devoted
+//! to [undefined behavior][ub].
+//!
+//! We say that a pointer is "dangling" if it is not valid for any non-zero-sized accesses. This
+//! means out-of-bounds pointers, pointers to freed memory, null pointers, and pointers created with
+//! [`NonNull::dangling`] are all dangling.
+//!
+//! ## Alignment
+//!
+//! Valid raw pointers as defined above are not necessarily properly aligned (where
+//! "proper" alignment is defined by the pointee type, i.e., `*const T` must be
+//! aligned to `align_of::<T>()`). However, most functions require their
+//! arguments to be properly aligned, and will explicitly state
+//! this requirement in their documentation. Notable exceptions to this are
+//! [`read_unaligned`] and [`write_unaligned`].
+//!
+//! When a function requires proper alignment, it does so even if the access
+//! has size 0, i.e., even if memory is not actually touched. Consider using
+//! [`NonNull::dangling`] in such cases.
+//!
 //! ## Pointer to reference conversion
-// //!
-// //! When converting a pointer to a reference (e.g. via `&*ptr` or `&mut *ptr`),
-// //! there are several rules that must be followed:
-// //!
-// //! * The pointer must be properly aligned.
-// //!
-// //! * It must be non-null.
-// //!
-// //! * It must be "dereferenceable" in the sense defined above.
-// //!
-// //! * The pointer must point to a [valid value] of type `T`.
-// //!
-// //! * You must enforce Rust's aliasing rules. The exact aliasing rules are not decided yet, so we
-// //!   only give a rough overview here. The rules also depend on whether a mutable or a shared
-// //!   reference is being created.
-// //!   * When creating a mutable reference, then while this reference exists, the memory it points to
-// //!     must not get accessed (read or written) through any other pointer or reference not derived
-// //!     from this reference.
-// //!   * When creating a shared reference, then while this reference exists, the memory it points to
-// //!     must not get mutated (except inside `UnsafeCell`).
-// //!
-// //! If a pointer follows all of these rules, it is said to be
-// //! *convertible to a (mutable or shared) reference*.
-// // ^ we use this term instead of saying that the produced reference must
-// // be valid, as the validity of a reference is easily confused for the
-// // validity of the thing it refers to, and while the two concepts are
-// // closely related, they are not identical.
-// //!
-// //! These rules apply even if the result is unused!
-// //! (The part about being initialized is not yet fully decided, but until
-// //! it is, the only safe approach is to ensure that they are indeed initialized.)
-// //!
-// //! An example of the implications of the above rules is that an expression such
-// //! as `unsafe { &*(0 as *const u8) }` is Immediate Undefined Behavior.
-// //!
-// //! [valid value]: ../../reference/behavior-considered-undefined.html#invalid-values
-// //!
+//!
+//! When converting a pointer to a reference (e.g. via `&*ptr` or `&mut *ptr`),
+//! there are several rules that must be followed:
+//!
+//! * The pointer must be properly aligned.
+//!
+//! * It must be non-null.
+//!
+//! * It must be "dereferenceable" in the sense defined above.
+//!
+//! * The pointer must point to a [valid value] of type `T`.
+//!
+//! * You must enforce Rust's aliasing rules. The exact aliasing rules are not decided yet, so we
+//!   only give a rough overview here. The rules also depend on whether a mutable or a shared
+//!   reference is being created.
+//!   * When creating a mutable reference, then while this reference exists, the memory it points to
+//!     must not get accessed (read or written) through any other pointer or reference not derived
+//!     from this reference.
+//!   * When creating a shared reference, then while this reference exists, the memory it points to
+//!     must not get mutated (except inside `UnsafeCell`).
+//!
+//! If a pointer follows all of these rules, it is said to be
+//! *convertible to a (mutable or shared) reference*.
+// ^ we use this term instead of saying that the produced reference must
+// be valid, as the validity of a reference is easily confused for the
+// validity of the thing it refers to, and while the two concepts are
+// closely related, they are not identical.
+//!
+//! These rules apply even if the result is unused!
+//! (The part about being initialized is not yet fully decided, but until
+//! it is, the only safe approach is to ensure that they are indeed initialized.)
+//!
+//! An example of the implications of the above rules is that an expression such
+//! as `unsafe { &*(0 as *const u8) }` is Immediate Undefined Behavior.
+//!
+//! [valid value]: ../../reference/behavior-considered-undefined.html#invalid-values
+//!
 //! ## Allocation
-// //!
-// //! <a id="allocated-object"></a> <!-- keep old URLs working -->
-// //!
-// //! An *allocation* is a subset of program memory which is addressable
-// //! from Rust, and within which pointer arithmetic is possible. Examples of
-// //! allocations include heap allocations, stack-allocated variables,
-// //! statics, and consts. The safety preconditions of some Rust operations -
-// //! such as `offset` and field projections (`expr.field`) - are defined in
-// //! terms of the allocations on which they operate.
-// //!
-// //! An allocation has a base address, a size, and a set of memory
-// //! addresses. It is possible for an allocation to have zero size, but
-// //! such an allocation will still have a base address. The base address
-// //! of an allocation is not necessarily unique. While it is currently the
-// //! case that an allocation always has a set of memory addresses which is
-// //! fully contiguous (i.e., has no "holes"), there is no guarantee that this
-// //! will not change in the future.
-// //!
-// //! For any allocation with `base` address, `size`, and a set of
-// //! `addresses`, the following are guaranteed:
-// //! - For all addresses `a` in `addresses`, `a` is in the range `base .. (base +
-// //!   size)` (note that this requires `a < base + size`, not `a <= base + size`)
-// //! - `base` is not equal to [`null()`] (i.e., the address with the numerical
-// //!   value 0)
-// //! - `base + size <= usize::MAX`
-// //! - `size <= isize::MAX`
-// //!
-// //! As a consequence of these guarantees, given any address `a` within the set
-// //! of addresses of an allocation:
-// //! - It is guaranteed that `a - base` does not overflow `isize`
-// //! - It is guaranteed that `a - base` is non-negative
-// //! - It is guaranteed that, given `o = a - base` (i.e., the offset of `a` within
-// //!   the allocation), `base + o` will not wrap around the address space (in
-// //!   other words, will not overflow `usize`)
-// //!
-// //! [`null()`]: null
-// //!
+//!
+//! <a id="allocated-object"></a> <!-- keep old URLs working -->
+//!
+//! An *allocation* is a subset of program memory which is addressable
+//! from Rust, and within which pointer arithmetic is possible. Examples of
+//! allocations include heap allocations, stack-allocated variables,
+//! statics, and consts. The safety preconditions of some Rust operations -
+//! such as `offset` and field projections (`expr.field`) - are defined in
+//! terms of the allocations on which they operate.
+//!
+//! An allocation has a base address, a size, and a set of memory
+//! addresses. It is possible for an allocation to have zero size, but
+//! such an allocation will still have a base address. The base address
+//! of an allocation is not necessarily unique. While it is currently the
+//! case that an allocation always has a set of memory addresses which is
+//! fully contiguous (i.e., has no "holes"), there is no guarantee that this
+//! will not change in the future.
+//!
+//! For any allocation with `base` address, `size`, and a set of
+//! `addresses`, the following are guaranteed:
+//! - For all addresses `a` in `addresses`, `a` is in the range `base .. (base +
+//!   size)` (note that this requires `a < base + size`, not `a <= base + size`)
+//! - `base` is not equal to [`null()`] (i.e., the address with the numerical
+//!   value 0)
+//! - `base + size <= usize::MAX`
+//! - `size <= isize::MAX`
+//!
+//! As a consequence of these guarantees, given any address `a` within the set
+//! of addresses of an allocation:
+//! - It is guaranteed that `a - base` does not overflow `isize`
+//! - It is guaranteed that `a - base` is non-negative
+//! - It is guaranteed that, given `o = a - base` (i.e., the offset of `a` within
+//!   the allocation), `base + o` will not wrap around the address space (in
+//!   other words, will not overflow `usize`)
+//!
+//! [`null()`]: null
+//!
 //! # Provenance
-// //!
-// //! Pointers are not *simply* an "integer" or "address". For instance, it's uncontroversial
-// //! to say that a Use After Free is clearly Undefined Behavior, even if you "get lucky"
-// //! and the freed memory gets reallocated before your read/write (in fact this is the
-// //! worst-case scenario, UAFs would be much less concerning if this didn't happen!).
-// //! As another example, consider that [`wrapping_offset`] is documented to "remember"
-// //! the allocation that the original pointer points to, even if it is offset far
-// //! outside the memory range occupied by that allocation.
-// //! To rationalize claims like this, pointers need to somehow be *more* than just their addresses:
-// //! they must have **provenance**.
-// //!
-// //! A pointer value in Rust semantically contains the following information:
-// //!
-// //! * The **address** it points to, which can be represented by a `usize`.
-// //! * The **provenance** it has, defining the memory it has permission to access. Provenance can be
-// //!   absent, in which case the pointer does not have permission to access any memory.
-// //!
-// //! The exact structure of provenance is not yet specified, but the permission defined by a
-// //! pointer's provenance have a *spatial* component, a *temporal* component, and a *mutability*
-// //! component:
-// //!
-// //! * Spatial: The set of memory addresses that the pointer is allowed to access.
-// //! * Temporal: The timespan during which the pointer is allowed to access those memory addresses.
-// //! * Mutability: Whether the pointer may only access the memory for reads, or also access it for
-// //!   writes. Note that this can interact with the other components, e.g. a pointer might permit
-// //!   mutation only for a subset of addresses, or only for a subset of its maximal timespan.
-// //!
-// //! When an [allocation] is created, it has a unique Original Pointer. For alloc
-// //! APIs this is literally the pointer the call returns, and for local variables and statics,
-// //! this is the name of the variable/static. (This is mildly overloading the term "pointer"
-// //! for the sake of brevity/exposition.)
-// //!
-// //! The Original Pointer for an allocation has provenance that constrains the *spatial*
-// //! permissions of this pointer to the memory range of the allocation, and the *temporal*
-// //! permissions to the lifetime of the allocation. Provenance is implicitly inherited by all
-// //! pointers transitively derived from the Original Pointer through operations like [`offset`],
-// //! borrowing, and pointer casts. Some operations may *shrink* the permissions of the derived
-// //! provenance, limiting how much memory it can access or how long it's valid for (i.e. borrowing a
-// //! subfield and subslicing can shrink the spatial component of provenance, and all borrowing can
-// //! shrink the temporal component of provenance). However, no operation can ever *grow* the
-// //! permissions of the derived provenance: even if you "know" there is a larger allocation, you
-// //! can't derive a pointer with a larger provenance. Similarly, you cannot "recombine" two
-// //! contiguous provenances back into one (i.e. with a `fn merge(&[T], &[T]) -> &[T]`).
-// //!
-// //! A reference to a place always has provenance over at least the memory that place occupies.
-// //! A reference to a slice always has provenance over at least the range that slice describes.
-// //! Whether and when exactly the provenance of a reference gets "shrunk" to *exactly* fit
-// //! the memory it points to is not yet determined.
-// //!
-// //! A *shared* reference only ever has provenance that permits reading from memory,
-// //! and never permits writes, except inside [`UnsafeCell`].
-// //!
-// //! Provenance can affect whether a program has undefined behavior:
-// //!
-// //! * It is undefined behavior to access memory through a pointer that does not have provenance over
-// //!   that memory. Note that a pointer "at the end" of its provenance is not actually outside its
-// //!   provenance, it just has 0 bytes it can load/store. Zero-sized accesses do not require any
-// //!   provenance since they access an empty range of memory.
-// //!
-// //! * It is undefined behavior to [`offset`] a pointer across a memory range that is not contained
-// //!   in the allocation it is derived from, or to [`offset_from`] two pointers not derived
-// //!   from the same allocation. Provenance is used to say what exactly "derived from" even
-// //!   means: the lineage of a pointer is traced back to the Original Pointer it descends from, and
-// //!   that identifies the relevant allocation. In particular, it's always UB to offset a
-// //!   pointer derived from something that is now deallocated, except if the offset is 0.
-// //!
-// //! But it *is* still sound to:
-// //!
-// //! * Create a pointer without provenance from just an address (see [`without_provenance`]). Such a
-// //!   pointer cannot be used for memory accesses (except for zero-sized accesses). This can still be
-// //!   useful for sentinel values like `null` *or* to represent a tagged pointer that will never be
-// //!   dereferenceable. In general, it is always sound for an integer to pretend to be a pointer "for
-// //!   fun" as long as you don't use operations on it which require it to be valid (non-zero-sized
-// //!   offset, read, write, etc).
-// //!
-// //! * Forge an allocation of size zero at any sufficiently aligned non-null address.
-// //!   i.e. the usual "ZSTs are fake, do what you want" rules apply.
-// //!
-// //! * [`wrapping_offset`] a pointer outside its provenance. This includes pointers
-// //!   which have "no" provenance. In particular, this makes it sound to do pointer tagging tricks.
-// //!
-// //! * Compare arbitrary pointers by address. Pointer comparison ignores provenance and addresses
-// //!   *are* just integers, so there is always a coherent answer, even if the pointers are dangling
-// //!   or from different provenances. Note that if you get "lucky" and notice that a pointer at the
-// //!   end of one allocation is the "same" address as the start of another allocation,
-// //!   anything you do with that fact is *probably* going to be gibberish. The scope of that
-// //!   gibberish is kept under control by the fact that the two pointers *still* aren't allowed to
-// //!   access the other's allocation (bytes), because they still have different provenance.
-// //!
-// //! Note that the full definition of provenance in Rust is not decided yet, as this interacts
-// //! with the as-yet undecided [aliasing] rules.
-// //!
-// //! ## Pointers Vs Integers
-// //!
-// //! From this discussion, it becomes very clear that a `usize` *cannot* accurately represent a pointer,
-// //! and converting from a pointer to a `usize` is generally an operation which *only* extracts the
-// //! address. Converting this address back into pointer requires somehow answering the question:
-// //! which provenance should the resulting pointer have?
-// //!
-// //! Rust provides two ways of dealing with this situation: *Strict Provenance* and *Exposed Provenance*.
-// //!
-// //! Note that a pointer *can* represent a `usize` (via [`without_provenance`]), so the right type to
-// //! use in situations where a value is "sometimes a pointer and sometimes a bare `usize`" is a
-// //! pointer type.
-// //!
+//!
+//! Pointers are not *simply* an "integer" or "address". For instance, it's uncontroversial
+//! to say that a Use After Free is clearly Undefined Behavior, even if you "get lucky"
+//! and the freed memory gets reallocated before your read/write (in fact this is the
+//! worst-case scenario, UAFs would be much less concerning if this didn't happen!).
+//! As another example, consider that [`wrapping_offset`] is documented to "remember"
+//! the allocation that the original pointer points to, even if it is offset far
+//! outside the memory range occupied by that allocation.
+//! To rationalize claims like this, pointers need to somehow be *more* than just their addresses:
+//! they must have **provenance**.
+//!
+//! A pointer value in Rust semantically contains the following information:
+//!
+//! * The **address** it points to, which can be represented by a `usize`.
+//! * The **provenance** it has, defining the memory it has permission to access. Provenance can be
+//!   absent, in which case the pointer does not have permission to access any memory.
+//!
+//! The exact structure of provenance is not yet specified, but the permission defined by a
+//! pointer's provenance have a *spatial* component, a *temporal* component, and a *mutability*
+//! component:
+//!
+//! * Spatial: The set of memory addresses that the pointer is allowed to access.
+//! * Temporal: The timespan during which the pointer is allowed to access those memory addresses.
+//! * Mutability: Whether the pointer may only access the memory for reads, or also access it for
+//!   writes. Note that this can interact with the other components, e.g. a pointer might permit
+//!   mutation only for a subset of addresses, or only for a subset of its maximal timespan.
+//!
+//! When an [allocation] is created, it has a unique Original Pointer. For alloc
+//! APIs this is literally the pointer the call returns, and for local variables and statics,
+//! this is the name of the variable/static. (This is mildly overloading the term "pointer"
+//! for the sake of brevity/exposition.)
+//!
+//! The Original Pointer for an allocation has provenance that constrains the *spatial*
+//! permissions of this pointer to the memory range of the allocation, and the *temporal*
+//! permissions to the lifetime of the allocation. Provenance is implicitly inherited by all
+//! pointers transitively derived from the Original Pointer through operations like [`offset`],
+//! borrowing, and pointer casts. Some operations may *shrink* the permissions of the derived
+//! provenance, limiting how much memory it can access or how long it's valid for (i.e. borrowing a
+//! subfield and subslicing can shrink the spatial component of provenance, and all borrowing can
+//! shrink the temporal component of provenance). However, no operation can ever *grow* the
+//! permissions of the derived provenance: even if you "know" there is a larger allocation, you
+//! can't derive a pointer with a larger provenance. Similarly, you cannot "recombine" two
+//! contiguous provenances back into one (i.e. with a `fn merge(&[T], &[T]) -> &[T]`).
+//!
+//! A reference to a place always has provenance over at least the memory that place occupies.
+//! A reference to a slice always has provenance over at least the range that slice describes.
+//! Whether and when exactly the provenance of a reference gets "shrunk" to *exactly* fit
+//! the memory it points to is not yet determined.
+//!
+//! A *shared* reference only ever has provenance that permits reading from memory,
+//! and never permits writes, except inside [`UnsafeCell`].
+//!
+//! Provenance can affect whether a program has undefined behavior:
+//!
+//! * It is undefined behavior to access memory through a pointer that does not have provenance over
+//!   that memory. Note that a pointer "at the end" of its provenance is not actually outside its
+//!   provenance, it just has 0 bytes it can load/store. Zero-sized accesses do not require any
+//!   provenance since they access an empty range of memory.
+//!
+//! * It is undefined behavior to [`offset`] a pointer across a memory range that is not contained
+//!   in the allocation it is derived from, or to [`offset_from`] two pointers not derived
+//!   from the same allocation. Provenance is used to say what exactly "derived from" even
+//!   means: the lineage of a pointer is traced back to the Original Pointer it descends from, and
+//!   that identifies the relevant allocation. In particular, it's always UB to offset a
+//!   pointer derived from something that is now deallocated, except if the offset is 0.
+//!
+//! But it *is* still sound to:
+//!
+//! * Create a pointer without provenance from just an address (see [`without_provenance`]). Such a
+//!   pointer cannot be used for memory accesses (except for zero-sized accesses). This can still be
+//!   useful for sentinel values like `null` *or* to represent a tagged pointer that will never be
+//!   dereferenceable. In general, it is always sound for an integer to pretend to be a pointer "for
+//!   fun" as long as you don't use operations on it which require it to be valid (non-zero-sized
+//!   offset, read, write, etc).
+//!
+//! * Forge an allocation of size zero at any sufficiently aligned non-null address.
+//!   i.e. the usual "ZSTs are fake, do what you want" rules apply.
+//!
+//! * [`wrapping_offset`] a pointer outside its provenance. This includes pointers
+//!   which have "no" provenance. In particular, this makes it sound to do pointer tagging tricks.
+//!
+//! * Compare arbitrary pointers by address. Pointer comparison ignores provenance and addresses
+//!   *are* just integers, so there is always a coherent answer, even if the pointers are dangling
+//!   or from different provenances. Note that if you get "lucky" and notice that a pointer at the
+//!   end of one allocation is the "same" address as the start of another allocation,
+//!   anything you do with that fact is *probably* going to be gibberish. The scope of that
+//!   gibberish is kept under control by the fact that the two pointers *still* aren't allowed to
+//!   access the other's allocation (bytes), because they still have different provenance.
+//!
+//! Note that the full definition of provenance in Rust is not decided yet, as this interacts
+//! with the as-yet undecided [aliasing] rules.
+//!
+//! ## Pointers Vs Integers
+//!
+//! From this discussion, it becomes very clear that a `usize` *cannot* accurately represent a pointer,
+//! and converting from a pointer to a `usize` is generally an operation which *only* extracts the
+//! address. Converting this address back into pointer requires somehow answering the question:
+//! which provenance should the resulting pointer have?
+//!
+//! Rust provides two ways of dealing with this situation: *Strict Provenance* and *Exposed Provenance*.
+//!
+//! Note that a pointer *can* represent a `usize` (via [`without_provenance`]), so the right type to
+//! use in situations where a value is "sometimes a pointer and sometimes a bare `usize`" is a
+//! pointer type.
+//!
 //! ## Strict Provenance
-// //!
-// //! "Strict Provenance" refers to a set of APIs designed to make working with provenance more
-// //! explicit. They are intended as substitutes for casting a pointer to an integer and back.
-// //!
-// //! Entirely avoiding integer-to-pointer casts successfully side-steps the inherent ambiguity of
-// //! that operation. This benefits compiler optimizations, and it is pretty much a requirement for
-// //! using tools like [Miri] and architectures like [CHERI] that aim to detect and diagnose pointer
-// //! misuse.
-// //!
-// //! The key insight to making programming without integer-to-pointer casts *at all* viable is the
-// //! [`with_addr`] method:
-// //!
-// //! ```text
-// //!     /// Creates a new pointer with the given address.
-// //!     ///
-// //!     /// This performs the same operation as an `addr as ptr` cast, but copies
-// //!     /// the *provenance* of `self` to the new pointer.
-// //!     /// This allows us to dynamically preserve and propagate this important
-// //!     /// information in a way that is otherwise impossible with a unary cast.
-// //!     ///
-// //!     /// This is equivalent to using `wrapping_offset` to offset `self` to the
-// //!     /// given address, and therefore has all the same capabilities and restrictions.
-// //!     pub fn with_addr(self, addr: usize) -> Self;
-// //! ```
-// //!
-// //! So you're still able to drop down to the address representation and do whatever
-// //! clever bit tricks you want *as long as* you're able to keep around a pointer
-// //! into the allocation you care about that can "reconstitute" the provenance.
-// //! Usually this is very easy, because you only are taking a pointer, messing with the address,
-// //! and then immediately converting back to a pointer. To make this use case more ergonomic,
-// //! we provide the [`map_addr`] method.
-// //!
-// //! To help make it clear that code is "following" Strict Provenance semantics, we also provide an
-// //! [`addr`] method which promises that the returned address is not part of a
-// //! pointer-integer-pointer roundtrip. In the future we may provide a lint for pointer<->integer
-// //! casts to help you audit if your code conforms to strict provenance.
-// //!
-// //! ### Using Strict Provenance
-// //!
-// //! Most code needs no changes to conform to strict provenance, as the only really concerning
-// //! operation is casts from `usize` to a pointer. For code which *does* cast a `usize` to a pointer,
-// //! the scope of the change depends on exactly what you're doing.
-// //!
-// //! In general, you just need to make sure that if you want to convert a `usize` address to a
-// //! pointer and then use that pointer to read/write memory, you need to keep around a pointer
-// //! that has sufficient provenance to perform that read/write itself. In this way all of your
-// //! casts from an address to a pointer are essentially just applying offsets/indexing.
-// //!
-// //! This is generally trivial to do for simple cases like tagged pointers *as long as you
-// //! represent the tagged pointer as an actual pointer and not a `usize`*. For instance:
-// //!
-// //! ```
-// //! unsafe {
-// //!     // A flag we want to pack into our pointer
-// //!     static HAS_DATA: usize = 0x1;
-// //!     static FLAG_MASK: usize = !HAS_DATA;
-// //!
-// //!     // Our value, which must have enough alignment to have spare least-significant-bits.
-// //!     let my_precious_data: u32 = 17;
-// //!     assert!(align_of::<u32>() > 1);
-// //!
-// //!     // Create a tagged pointer
-// //!     let ptr = &my_precious_data as *const u32;
-// //!     let tagged = ptr.map_addr(|addr| addr | HAS_DATA);
-// //!
-// //!     // Check the flag:
-// //!     if tagged.addr() & HAS_DATA != 0 {
-// //!         // Untag and read the pointer
-// //!         let data = *tagged.map_addr(|addr| addr & FLAG_MASK);
-// //!         assert_eq!(data, 17);
-// //!     } else {
-// //!         unreachable!()
-// //!     }
-// //! }
-// //! ```
-// //!
-// //! (Yes, if you've been using [`AtomicUsize`] for pointers in concurrent datastructures, you should
-// //! be using [`AtomicPtr`] instead. If that messes up the way you atomically manipulate pointers,
-// //! we would like to know why, and what needs to be done to fix it.)
-// //!
-// //! Situations where a valid pointer *must* be created from just an address, such as baremetal code
-// //! accessing a memory-mapped interface at a fixed address, cannot currently be handled with strict
-// //! provenance APIs and should use [exposed provenance](#exposed-provenance).
-// //!
+//!
+//! "Strict Provenance" refers to a set of APIs designed to make working with provenance more
+//! explicit. They are intended as substitutes for casting a pointer to an integer and back.
+//!
+//! Entirely avoiding integer-to-pointer casts successfully side-steps the inherent ambiguity of
+//! that operation. This benefits compiler optimizations, and it is pretty much a requirement for
+//! using tools like [Miri] and architectures like [CHERI] that aim to detect and diagnose pointer
+//! misuse.
+//!
+//! The key insight to making programming without integer-to-pointer casts *at all* viable is the
+//! [`with_addr`] method:
+//!
+//! ```text
+//!     /// Creates a new pointer with the given address.
+//!     ///
+//!     /// This performs the same operation as an `addr as ptr` cast, but copies
+//!     /// the *provenance* of `self` to the new pointer.
+//!     /// This allows us to dynamically preserve and propagate this important
+//!     /// information in a way that is otherwise impossible with a unary cast.
+//!     ///
+//!     /// This is equivalent to using `wrapping_offset` to offset `self` to the
+//!     /// given address, and therefore has all the same capabilities and restrictions.
+//!     pub fn with_addr(self, addr: usize) -> Self;
+//! ```
+//!
+//! So you're still able to drop down to the address representation and do whatever
+//! clever bit tricks you want *as long as* you're able to keep around a pointer
+//! into the allocation you care about that can "reconstitute" the provenance.
+//! Usually this is very easy, because you only are taking a pointer, messing with the address,
+//! and then immediately converting back to a pointer. To make this use case more ergonomic,
+//! we provide the [`map_addr`] method.
+//!
+//! To help make it clear that code is "following" Strict Provenance semantics, we also provide an
+//! [`addr`] method which promises that the returned address is not part of a
+//! pointer-integer-pointer roundtrip. In the future we may provide a lint for pointer<->integer
+//! casts to help you audit if your code conforms to strict provenance.
+//!
+//! ### Using Strict Provenance
+//!
+//! Most code needs no changes to conform to strict provenance, as the only really concerning
+//! operation is casts from `usize` to a pointer. For code which *does* cast a `usize` to a pointer,
+//! the scope of the change depends on exactly what you're doing.
+//!
+//! In general, you just need to make sure that if you want to convert a `usize` address to a
+//! pointer and then use that pointer to read/write memory, you need to keep around a pointer
+//! that has sufficient provenance to perform that read/write itself. In this way all of your
+//! casts from an address to a pointer are essentially just applying offsets/indexing.
+//!
+//! This is generally trivial to do for simple cases like tagged pointers *as long as you
+//! represent the tagged pointer as an actual pointer and not a `usize`*. For instance:
+//!
+//! ```
+//! unsafe {
+//!     // A flag we want to pack into our pointer
+//!     static HAS_DATA: usize = 0x1;
+//!     static FLAG_MASK: usize = !HAS_DATA;
+//!
+//!     // Our value, which must have enough alignment to have spare least-significant-bits.
+//!     let my_precious_data: u32 = 17;
+//!     assert!(align_of::<u32>() > 1);
+//!
+//!     // Create a tagged pointer
+//!     let ptr = &my_precious_data as *const u32;
+//!     let tagged = ptr.map_addr(|addr| addr | HAS_DATA);
+//!
+//!     // Check the flag:
+//!     if tagged.addr() & HAS_DATA != 0 {
+//!         // Untag and read the pointer
+//!         let data = *tagged.map_addr(|addr| addr & FLAG_MASK);
+//!         assert_eq!(data, 17);
+//!     } else {
+//!         unreachable!()
+//!     }
+//! }
+//! ```
+//!
+//! (Yes, if you've been using [`AtomicUsize`] for pointers in concurrent datastructures, you should
+//! be using [`AtomicPtr`] instead. If that messes up the way you atomically manipulate pointers,
+//! we would like to know why, and what needs to be done to fix it.)
+//!
+//! Situations where a valid pointer *must* be created from just an address, such as baremetal code
+//! accessing a memory-mapped interface at a fixed address, cannot currently be handled with strict
+//! provenance APIs and should use [exposed provenance](#exposed-provenance).
+//!
 //! ## Exposed Provenance
-// //!
-// //! As discussed above, integer-to-pointer casts are not possible with Strict Provenance APIs.
-// //! This is by design: the goal of Strict Provenance is to provide a clear specification that we are
-// //! confident can be formalized unambiguously and can be subject to precise formal reasoning.
-// //! Integer-to-pointer casts do not (currently) have such a clear specification.
-// //!
-// //! However, there exist situations where integer-to-pointer casts cannot be avoided, or
-// //! where avoiding them would require major refactoring. Legacy platform APIs also regularly assume
-// //! that `usize` can capture all the information that makes up a pointer.
-// //! Bare-metal platforms can also require the synthesis of a pointer "out of thin air" without
-// //! anywhere to obtain proper provenance from.
-// //!
-// //! Rust's model for dealing with integer-to-pointer casts is called *Exposed Provenance*. However,
-// //! the semantics of Exposed Provenance are on much less solid footing than Strict Provenance, and
-// //! at this point it is not yet clear whether a satisfying unambiguous semantics can be defined for
-// //! Exposed Provenance. (If that sounds bad, be reassured that other popular languages that provide
-// //! integer-to-pointer casts are not faring any better.) Furthermore, Exposed Provenance will not
-// //! work (well) with tools like [Miri] and [CHERI].
-// //!
-// //! Exposed Provenance is provided by the [`expose_provenance`] and [`with_exposed_provenance`] methods,
-// //! which are equivalent to `as` casts between pointers and integers.
-// //! - [`expose_provenance`] is a lot like [`addr`], but additionally adds the provenance of the
-// //!   pointer to a global list of 'exposed' provenances. (This list is purely conceptual, it exists
-// //!   for the purpose of specifying Rust but is not materialized in actual executions, except in
-// //!   tools like [Miri].)
-// //!   Memory which is outside the control of the Rust abstract machine (MMIO registers, for example)
-// //!   is always considered to be exposed, so long as this memory is disjoint from memory that will
-// //!   be used by the abstract machine such as the stack, heap, and statics.
-// //! - [`with_exposed_provenance`] can be used to construct a pointer with one of these previously
-// //!   'exposed' provenances. [`with_exposed_provenance`] takes only `addr: usize` as arguments, so
-// //!   unlike in [`with_addr`] there is no indication of what the correct provenance for the returned
-// //!   pointer is -- and that is exactly what makes integer-to-pointer casts so tricky to rigorously
-// //!   specify! The compiler will do its best to pick the right provenance for you, but currently we
-// //!   cannot provide any guarantees about which provenance the resulting pointer will have. Only one
-// //!   thing is clear: if there is *no* previously 'exposed' provenance that justifies the way the
-// //!   returned pointer will be used, the program has undefined behavior.
-// //!
-// //! If at all possible, we encourage code to be ported to [Strict Provenance] APIs, thus avoiding
-// //! the need for Exposed Provenance. Maximizing the amount of such code is a major win for avoiding
-// //! specification complexity and to facilitate adoption of tools like [CHERI] and [Miri] that can be
-// //! a big help in increasing the confidence in (unsafe) Rust code. However, we acknowledge that this
-// //! is not always possible, and offer Exposed Provenance as a way to explicit "opt out" of the
-// //! well-defined semantics of Strict Provenance, and "opt in" to the unclear semantics of
-// //! integer-to-pointer casts.
-// //!
-// //! [aliasing]: ../../nomicon/aliasing.html
-// //! [allocation]: #allocation
-// //! [provenance]: #provenance
-// //! [book]: ../../book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer
-// //! [ub]: ../../reference/behavior-considered-undefined.html
-// //! [zst]: ../../nomicon/exotic-sizes.html#zero-sized-types-zsts
-// //! [atomic operations]: crate::sync::atomic
-// //! [`offset`]: pointer::offset
-// //! [`offset_from`]: pointer::offset_from
-// //! [`wrapping_offset`]: pointer::wrapping_offset
-// //! [`with_addr`]: pointer::with_addr
-// //! [`map_addr`]: pointer::map_addr
-// //! [`addr`]: pointer::addr
-// //! [`AtomicUsize`]: crate::sync::atomic::AtomicUsize
-// //! [`AtomicPtr`]: crate::sync::atomic::AtomicPtr
-// //! [`expose_provenance`]: pointer::expose_provenance
-// //! [`with_exposed_provenance`]: with_exposed_provenance
-// //! [Miri]: https://github.com/rust-lang/miri
-// //! [CHERI]: https://www.cl.cam.ac.uk/research/security/ctsrd/cheri/
-// //! [Strict Provenance]: #strict-provenance
-// //! [`UnsafeCell`]: core::cell::UnsafeCell
+//!
+//! As discussed above, integer-to-pointer casts are not possible with Strict Provenance APIs.
+//! This is by design: the goal of Strict Provenance is to provide a clear specification that we are
+//! confident can be formalized unambiguously and can be subject to precise formal reasoning.
+//! Integer-to-pointer casts do not (currently) have such a clear specification.
+//!
+//! However, there exist situations where integer-to-pointer casts cannot be avoided, or
+//! where avoiding them would require major refactoring. Legacy platform APIs also regularly assume
+//! that `usize` can capture all the information that makes up a pointer.
+//! Bare-metal platforms can also require the synthesis of a pointer "out of thin air" without
+//! anywhere to obtain proper provenance from.
+//!
+//! Rust's model for dealing with integer-to-pointer casts is called *Exposed Provenance*. However,
+//! the semantics of Exposed Provenance are on much less solid footing than Strict Provenance, and
+//! at this point it is not yet clear whether a satisfying unambiguous semantics can be defined for
+//! Exposed Provenance. (If that sounds bad, be reassured that other popular languages that provide
+//! integer-to-pointer casts are not faring any better.) Furthermore, Exposed Provenance will not
+//! work (well) with tools like [Miri] and [CHERI].
+//!
+//! Exposed Provenance is provided by the [`expose_provenance`] and [`with_exposed_provenance`] methods,
+//! which are equivalent to `as` casts between pointers and integers.
+//! - [`expose_provenance`] is a lot like [`addr`], but additionally adds the provenance of the
+//!   pointer to a global list of 'exposed' provenances. (This list is purely conceptual, it exists
+//!   for the purpose of specifying Rust but is not materialized in actual executions, except in
+//!   tools like [Miri].)
+//!   Memory which is outside the control of the Rust abstract machine (MMIO registers, for example)
+//!   is always considered to be exposed, so long as this memory is disjoint from memory that will
+//!   be used by the abstract machine such as the stack, heap, and statics.
+//! - [`with_exposed_provenance`] can be used to construct a pointer with one of these previously
+//!   'exposed' provenances. [`with_exposed_provenance`] takes only `addr: usize` as arguments, so
+//!   unlike in [`with_addr`] there is no indication of what the correct provenance for the returned
+//!   pointer is -- and that is exactly what makes integer-to-pointer casts so tricky to rigorously
+//!   specify! The compiler will do its best to pick the right provenance for you, but currently we
+//!   cannot provide any guarantees about which provenance the resulting pointer will have. Only one
+//!   thing is clear: if there is *no* previously 'exposed' provenance that justifies the way the
+//!   returned pointer will be used, the program has undefined behavior.
+//!
+//! If at all possible, we encourage code to be ported to [Strict Provenance] APIs, thus avoiding
+//! the need for Exposed Provenance. Maximizing the amount of such code is a major win for avoiding
+//! specification complexity and to facilitate adoption of tools like [CHERI] and [Miri] that can be
+//! a big help in increasing the confidence in (unsafe) Rust code. However, we acknowledge that this
+//! is not always possible, and offer Exposed Provenance as a way to explicit "opt out" of the
+//! well-defined semantics of Strict Provenance, and "opt in" to the unclear semantics of
+//! integer-to-pointer casts.
+//!
+//! [aliasing]: ../../nomicon/aliasing.html
+//! [allocation]: #allocation
+//! [provenance]: #provenance
+//! [book]: ../../book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer
+//! [ub]: ../../reference/behavior-considered-undefined.html
+//! [zst]: ../../nomicon/exotic-sizes.html#zero-sized-types-zsts
+//! [atomic operations]: crate::sync::atomic
+//! [`offset`]: pointer::offset
+//! [`offset_from`]: pointer::offset_from
+//! [`wrapping_offset`]: pointer::wrapping_offset
+//! [`with_addr`]: pointer::with_addr
+//! [`map_addr`]: pointer::map_addr
+//! [`addr`]: pointer::addr
+//! [`AtomicUsize`]: crate::sync::atomic::AtomicUsize
+//! [`AtomicPtr`]: crate::sync::atomic::AtomicPtr
+//! [`expose_provenance`]: pointer::expose_provenance
+//! [`with_exposed_provenance`]: with_exposed_provenance
+//! [Miri]: https://github.com/rust-lang/miri
+//! [CHERI]: https://www.cl.cam.ac.uk/research/security/ctsrd/cheri/
+//! [Strict Provenance]: #strict-provenance
+//! [`UnsafeCell`]: core::cell::UnsafeCell
 
 #![stable(feature = "rust1", since = "1.0.0")]
 // There are many unsafe functions taking pointers that don't dereference them.

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -879,18 +879,18 @@ pub const fn null_mut<T: ?Sized + Thin>() -> *mut T {
 
 /// Creates a pointer with the given address and no [provenance][crate::ptr#provenance].
 // FIXME(pvdrz): fix docs
-// ///
-// /// This is equivalent to `ptr::null().with_addr(addr)`.
-// ///
-// /// Without provenance, this pointer is not associated with any actual allocation. Such a
-// /// no-provenance pointer may be used for zero-sized memory accesses (if suitably aligned), but
-// /// non-zero-sized memory accesses with a no-provenance pointer are UB. No-provenance pointers are
-// /// little more than a `usize` address in disguise.
-// ///
-// /// This is different from `addr as *const T`, which creates a pointer that picks up a previously
-// /// exposed provenance. See [`with_exposed_provenance`] for more details on that operation.
-// ///
-// /// This is a [Strict Provenance][crate::ptr#strict-provenance] API.
+///
+/// This is equivalent to `ptr::null().with_addr(addr)`.
+///
+/// Without provenance, this pointer is not associated with any actual allocation. Such a
+/// no-provenance pointer may be used for zero-sized memory accesses (if suitably aligned), but
+/// non-zero-sized memory accesses with a no-provenance pointer are UB. No-provenance pointers are
+/// little more than a `usize` address in disguise.
+///
+/// This is different from `addr as *const T`, which creates a pointer that picks up a previously
+/// exposed provenance. See [`with_exposed_provenance`] for more details on that operation.
+///
+/// This is a [Strict Provenance][crate::ptr#strict-provenance] API.
 #[inline(always)]
 #[must_use]
 #[stable(feature = "strict_provenance", since = "1.84.0")]
@@ -919,18 +919,18 @@ pub const fn dangling<T>() -> *const T {
 
 /// Creates a pointer with the given address and no [provenance][crate::ptr#provenance].
 // FIXME(pvdrz): fix docs
-// ///
-// /// This is equivalent to `ptr::null_mut().with_addr(addr)`.
-// ///
-// /// Without provenance, this pointer is not associated with any actual allocation. Such a
-// /// no-provenance pointer may be used for zero-sized memory accesses (if suitably aligned), but
-// /// non-zero-sized memory accesses with a no-provenance pointer are UB. No-provenance pointers are
-// /// little more than a `usize` address in disguise.
-// ///
-// /// This is different from `addr as *mut T`, which creates a pointer that picks up a previously
-// /// exposed provenance. See [`with_exposed_provenance_mut`] for more details on that operation.
-// ///
-// /// This is a [Strict Provenance][crate::ptr#strict-provenance] API.
+///
+/// This is equivalent to `ptr::null_mut().with_addr(addr)`.
+///
+/// Without provenance, this pointer is not associated with any actual allocation. Such a
+/// no-provenance pointer may be used for zero-sized memory accesses (if suitably aligned), but
+/// non-zero-sized memory accesses with a no-provenance pointer are UB. No-provenance pointers are
+/// little more than a `usize` address in disguise.
+///
+/// This is different from `addr as *mut T`, which creates a pointer that picks up a previously
+/// exposed provenance. See [`with_exposed_provenance_mut`] for more details on that operation.
+///
+/// This is a [Strict Provenance][crate::ptr#strict-provenance] API.
 #[inline(always)]
 #[must_use]
 #[stable(feature = "strict_provenance", since = "1.84.0")]
@@ -1622,109 +1622,109 @@ pub const unsafe fn replace<T>(dst: *mut T, src: T) -> T {
 /// Reads the value from `src` without moving it. This leaves the
 /// memory in `src` unchanged.
 // FIXME(pvdrz): fix docs
-// ///
-// /// # Safety
-// ///
-// /// Behavior is undefined if any of the following conditions are violated:
-// ///
-// /// * `src` must be [valid] for reads.
-// ///
-// /// * `src` must be properly aligned. Use [`read_unaligned`] if this is not the
-// ///   case.
-// ///
-// /// * `src` must point to a properly initialized value of type `T`.
-// ///
-// /// Note that even if `T` has size `0`, the pointer must be properly aligned.
-// ///
+///
+/// # Safety
+///
+/// Behavior is undefined if any of the following conditions are violated:
+///
+/// * `src` must be [valid] for reads.
+///
+/// * `src` must be properly aligned. Use [`read_unaligned`] if this is not the
+///   case.
+///
+/// * `src` must point to a properly initialized value of type `T`.
+///
+/// Note that even if `T` has size `0`, the pointer must be properly aligned.
+///
 // // /// # Examples
-// ///
-// /// Basic usage:
-// ///
-// /// ```
-// /// let x = 12;
-// /// let y = &x as *const i32;
-// ///
-// /// unsafe {
-// ///     assert_eq!(std::ptr::read(y), 12);
-// /// }
-// /// ```
-// ///
-// /// Manually implement [`mem::swap`]:
-// ///
-// /// ```
-// /// use std::ptr;
-// ///
-// /// fn swap<T>(a: &mut T, b: &mut T) {
-// ///     unsafe {
-// ///         // Create a bitwise copy of the value at `a` in `tmp`.
-// ///         let tmp = ptr::read(a);
-// ///
-// ///         // Exiting at this point (either by explicitly returning or by
-// ///         // calling a function which panics) would cause the value in `tmp` to
-// ///         // be dropped while the same value is still referenced by `a`. This
-// ///         // could trigger undefined behavior if `T` is not `Copy`.
-// ///
-// ///         // Create a bitwise copy of the value at `b` in `a`.
-// ///         // This is safe because mutable references cannot alias.
-// ///         ptr::copy_nonoverlapping(b, a, 1);
-// ///
-// ///         // As above, exiting here could trigger undefined behavior because
-// ///         // the same value is referenced by `a` and `b`.
-// ///
-// ///         // Move `tmp` into `b`.
-// ///         ptr::write(b, tmp);
-// ///
-// ///         // `tmp` has been moved (`write` takes ownership of its second argument),
-// ///         // so nothing is dropped implicitly here.
-// ///     }
-// /// }
-// ///
-// /// let mut foo = "foo".to_owned();
-// /// let mut bar = "bar".to_owned();
-// ///
-// /// swap(&mut foo, &mut bar);
-// ///
-// /// assert_eq!(foo, "bar");
-// /// assert_eq!(bar, "foo");
-// /// ```
-// ///
+///
+/// Basic usage:
+///
+/// ```
+/// let x = 12;
+/// let y = &x as *const i32;
+///
+/// unsafe {
+///     assert_eq!(std::ptr::read(y), 12);
+/// }
+/// ```
+///
+/// Manually implement [`mem::swap`]:
+///
+/// ```
+/// use std::ptr;
+///
+/// fn swap<T>(a: &mut T, b: &mut T) {
+///     unsafe {
+///         // Create a bitwise copy of the value at `a` in `tmp`.
+///         let tmp = ptr::read(a);
+///
+///         // Exiting at this point (either by explicitly returning or by
+///         // calling a function which panics) would cause the value in `tmp` to
+///         // be dropped while the same value is still referenced by `a`. This
+///         // could trigger undefined behavior if `T` is not `Copy`.
+///
+///         // Create a bitwise copy of the value at `b` in `a`.
+///         // This is safe because mutable references cannot alias.
+///         ptr::copy_nonoverlapping(b, a, 1);
+///
+///         // As above, exiting here could trigger undefined behavior because
+///         // the same value is referenced by `a` and `b`.
+///
+///         // Move `tmp` into `b`.
+///         ptr::write(b, tmp);
+///
+///         // `tmp` has been moved (`write` takes ownership of its second argument),
+///         // so nothing is dropped implicitly here.
+///     }
+/// }
+///
+/// let mut foo = "foo".to_owned();
+/// let mut bar = "bar".to_owned();
+///
+/// swap(&mut foo, &mut bar);
+///
+/// assert_eq!(foo, "bar");
+/// assert_eq!(bar, "foo");
+/// ```
+///
 /// ## Ownership of the Returned Value
-// ///
-// /// `read` creates a bitwise copy of `T`, regardless of whether `T` is [`Copy`].
-// /// If `T` is not [`Copy`], using both the returned value and the value at
-// /// `*src` can violate memory safety. Note that assigning to `*src` counts as a
-// /// use because it will attempt to drop the value at `*src`.
-// ///
-// /// [`write()`] can be used to overwrite data without causing it to be dropped.
-// ///
-// /// ```
-// /// use std::ptr;
-// ///
-// /// let mut s = String::from("foo");
-// /// unsafe {
-// ///     // `s2` now points to the same underlying memory as `s`.
-// ///     let mut s2: String = ptr::read(&s);
-// ///
-// ///     assert_eq!(s2, "foo");
-// ///
-// ///     // Assigning to `s2` causes its original value to be dropped. Beyond
-// ///     // this point, `s` must no longer be used, as the underlying memory has
-// ///     // been freed.
-// ///     s2 = String::default();
-// ///     assert_eq!(s2, "");
-// ///
-// ///     // Assigning to `s` would cause the old value to be dropped again,
-// ///     // resulting in undefined behavior.
-// ///     // s = String::from("bar"); // ERROR
-// ///
-// ///     // `ptr::write` can be used to overwrite a value without dropping it.
-// ///     ptr::write(&mut s, String::from("bar"));
-// /// }
-// ///
-// /// assert_eq!(s, "bar");
-// /// ```
-// ///
-// /// [valid]: self#safety
+///
+/// `read` creates a bitwise copy of `T`, regardless of whether `T` is [`Copy`].
+/// If `T` is not [`Copy`], using both the returned value and the value at
+/// `*src` can violate memory safety. Note that assigning to `*src` counts as a
+/// use because it will attempt to drop the value at `*src`.
+///
+/// [`write()`] can be used to overwrite data without causing it to be dropped.
+///
+/// ```
+/// use std::ptr;
+///
+/// let mut s = String::from("foo");
+/// unsafe {
+///     // `s2` now points to the same underlying memory as `s`.
+///     let mut s2: String = ptr::read(&s);
+///
+///     assert_eq!(s2, "foo");
+///
+///     // Assigning to `s2` causes its original value to be dropped. Beyond
+///     // this point, `s` must no longer be used, as the underlying memory has
+///     // been freed.
+///     s2 = String::default();
+///     assert_eq!(s2, "");
+///
+///     // Assigning to `s` would cause the old value to be dropped again,
+///     // resulting in undefined behavior.
+///     // s = String::from("bar"); // ERROR
+///
+///     // `ptr::write` can be used to overwrite a value without dropping it.
+///     ptr::write(&mut s, String::from("bar"));
+/// }
+///
+/// assert_eq!(s, "bar");
+/// ```
+///
+/// [valid]: self#safety
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(feature = "const_ptr_read", since = "1.71.0")]
@@ -1877,72 +1877,72 @@ pub const unsafe fn read_unaligned<T>(src: *const T) -> T {
 /// memory that has previously been [`read`] from.
 ///
 // FIXME(pvdrz): fix docs
-// /// # Safety
-// ///
-// /// Behavior is undefined if any of the following conditions are violated:
-// ///
-// /// * `dst` must be [valid] for writes.
-// ///
-// /// * `dst` must be properly aligned. Use [`write_unaligned`] if this is not the
-// ///   case.
-// ///
-// /// Note that even if `T` has size `0`, the pointer must be properly aligned.
-// ///
-// /// [valid]: self#safety
-// ///
-// /// # Examples
-// ///
-// /// Basic usage:
-// ///
-// /// ```
-// /// let mut x = 0;
-// /// let y = &mut x as *mut i32;
-// /// let z = 12;
-// ///
-// /// unsafe {
-// ///     std::ptr::write(y, z);
-// ///     assert_eq!(std::ptr::read(y), 12);
-// /// }
-// /// ```
-// ///
-// /// Manually implement [`mem::swap`]:
-// ///
-// /// ```
-// /// use std::ptr;
-// ///
-// /// fn swap<T>(a: &mut T, b: &mut T) {
-// ///     unsafe {
-// ///         // Create a bitwise copy of the value at `a` in `tmp`.
-// ///         let tmp = ptr::read(a);
-// ///
-// ///         // Exiting at this point (either by explicitly returning or by
-// ///         // calling a function which panics) would cause the value in `tmp` to
-// ///         // be dropped while the same value is still referenced by `a`. This
-// ///         // could trigger undefined behavior if `T` is not `Copy`.
-// ///
-// ///         // Create a bitwise copy of the value at `b` in `a`.
-// ///         // This is safe because mutable references cannot alias.
-// ///         ptr::copy_nonoverlapping(b, a, 1);
-// ///
-// ///         // As above, exiting here could trigger undefined behavior because
-// ///         // the same value is referenced by `a` and `b`.
-// ///
-// ///         // Move `tmp` into `b`.
-// ///         ptr::write(b, tmp);
-// ///
-// ///         // `tmp` has been moved (`write` takes ownership of its second argument),
-// ///         // so nothing is dropped implicitly here.
-// ///     }
-// /// }
-// ///
-// /// let mut foo = "foo".to_owned();
-// /// let mut bar = "bar".to_owned();
-// ///
-// /// swap(&mut foo, &mut bar);
-// ///
-// /// assert_eq!(foo, "bar");
-// /// assert_eq!(bar, "foo");
-// /// ```
+/// # Safety
+///
+/// Behavior is undefined if any of the following conditions are violated:
+///
+/// * `dst` must be [valid] for writes.
+///
+/// * `dst` must be properly aligned. Use [`write_unaligned`] if this is not the
+///   case.
+///
+/// Note that even if `T` has size `0`, the pointer must be properly aligned.
+///
+/// [valid]: self#safety
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// let mut x = 0;
+/// let y = &mut x as *mut i32;
+/// let z = 12;
+///
+/// unsafe {
+///     std::ptr::write(y, z);
+///     assert_eq!(std::ptr::read(y), 12);
+/// }
+/// ```
+///
+/// Manually implement [`mem::swap`]:
+///
+/// ```
+/// use std::ptr;
+///
+/// fn swap<T>(a: &mut T, b: &mut T) {
+///     unsafe {
+///         // Create a bitwise copy of the value at `a` in `tmp`.
+///         let tmp = ptr::read(a);
+///
+///         // Exiting at this point (either by explicitly returning or by
+///         // calling a function which panics) would cause the value in `tmp` to
+///         // be dropped while the same value is still referenced by `a`. This
+///         // could trigger undefined behavior if `T` is not `Copy`.
+///
+///         // Create a bitwise copy of the value at `b` in `a`.
+///         // This is safe because mutable references cannot alias.
+///         ptr::copy_nonoverlapping(b, a, 1);
+///
+///         // As above, exiting here could trigger undefined behavior because
+///         // the same value is referenced by `a` and `b`.
+///
+///         // Move `tmp` into `b`.
+///         ptr::write(b, tmp);
+///
+///         // `tmp` has been moved (`write` takes ownership of its second argument),
+///         // so nothing is dropped implicitly here.
+///     }
+/// }
+///
+/// let mut foo = "foo".to_owned();
+/// let mut bar = "bar".to_owned();
+///
+/// swap(&mut foo, &mut bar);
+///
+/// assert_eq!(foo, "bar");
+/// assert_eq!(bar, "foo");
+/// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(feature = "const_ptr_write", since = "1.83.0")]

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -80,456 +80,456 @@
 //! functions that may encounter errors but don't otherwise return a
 //! useful value.
 //!
-// //! Consider the [`write_all`] method defined for I/O types
-// //! by the [`Write`] trait:
-// //!
-// //! ```
-// //! use std::io;
-// //!
-// //! trait Write {
-// //!     fn write_all(&mut self, bytes: &[u8]) -> Result<(), io::Error>;
-// //! }
-// //! ```
-// //!
-// //! *Note: The actual definition of [`Write`] uses [`io::Result`], which
-// //! is just a synonym for <code>[Result]<T, [io::Error]></code>.*
-// //!
-// //! This method doesn't produce a value, but the write may
-// //! fail. It's crucial to handle the error case, and *not* write
-// //! something like this:
-// //!
-// //! ```no_run
-// //! # #![allow(unused_must_use)] // \o/
-// //! use std::fs::File;
-// //! use std::io::prelude::*;
-// //!
-// //! let mut file = File::create("valuable_data.txt").unwrap();
-// //! // If `write_all` errors, then we'll never know, because the return
-// //! // value is ignored.
-// //! file.write_all(b"important message");
-// //! ```
-// //!
-// //! If you *do* write that in Rust, the compiler will give you a
-// //! warning (by default, controlled by the `unused_must_use` lint).
-// //!
-// //! You might instead, if you don't want to handle the error, simply
-// //! assert success with [`expect`]. This will panic if the
-// //! write fails, providing a marginally useful message indicating why:
-// //!
-// //! ```no_run
-// //! use std::fs::File;
-// //! use std::io::prelude::*;
-// //!
-// //! let mut file = File::create("valuable_data.txt").unwrap();
-// //! file.write_all(b"important message").expect("failed to write message");
-// //! ```
-// //!
-// //! You might also simply assert success:
-// //!
-// //! ```no_run
-// //! # use std::fs::File;
-// //! # use std::io::prelude::*;
-// //! # let mut file = File::create("valuable_data.txt").unwrap();
-// //! assert!(file.write_all(b"important message").is_ok());
-// //! ```
-// //!
-// //! Or propagate the error up the call stack with [`?`]:
-// //!
-// //! ```
-// //! # use std::fs::File;
-// //! # use std::io::prelude::*;
-// //! # use std::io;
-// //! # #[allow(dead_code)]
-// //! fn write_message() -> io::Result<()> {
-// //!     let mut file = File::create("valuable_data.txt")?;
-// //!     file.write_all(b"important message")?;
-// //!     Ok(())
-// //! }
-// //! ```
-// //!
+//! Consider the [`write_all`] method defined for I/O types
+//! by the [`Write`] trait:
+//!
+//! ```
+//! use std::io;
+//!
+//! trait Write {
+//!     fn write_all(&mut self, bytes: &[u8]) -> Result<(), io::Error>;
+//! }
+//! ```
+//!
+//! *Note: The actual definition of [`Write`] uses [`io::Result`], which
+//! is just a synonym for <code>[Result]<T, [io::Error]></code>.*
+//!
+//! This method doesn't produce a value, but the write may
+//! fail. It's crucial to handle the error case, and *not* write
+//! something like this:
+//!
+//! ```no_run
+//! # #![allow(unused_must_use)] // \o/
+//! use std::fs::File;
+//! use std::io::prelude::*;
+//!
+//! let mut file = File::create("valuable_data.txt").unwrap();
+//! // If `write_all` errors, then we'll never know, because the return
+//! // value is ignored.
+//! file.write_all(b"important message");
+//! ```
+//!
+//! If you *do* write that in Rust, the compiler will give you a
+//! warning (by default, controlled by the `unused_must_use` lint).
+//!
+//! You might instead, if you don't want to handle the error, simply
+//! assert success with [`expect`]. This will panic if the
+//! write fails, providing a marginally useful message indicating why:
+//!
+//! ```no_run
+//! use std::fs::File;
+//! use std::io::prelude::*;
+//!
+//! let mut file = File::create("valuable_data.txt").unwrap();
+//! file.write_all(b"important message").expect("failed to write message");
+//! ```
+//!
+//! You might also simply assert success:
+//!
+//! ```no_run
+//! # use std::fs::File;
+//! # use std::io::prelude::*;
+//! # let mut file = File::create("valuable_data.txt").unwrap();
+//! assert!(file.write_all(b"important message").is_ok());
+//! ```
+//!
+//! Or propagate the error up the call stack with [`?`]:
+//!
+//! ```
+//! # use std::fs::File;
+//! # use std::io::prelude::*;
+//! # use std::io;
+//! # #[allow(dead_code)]
+//! fn write_message() -> io::Result<()> {
+//!     let mut file = File::create("valuable_data.txt")?;
+//!     file.write_all(b"important message")?;
+//!     Ok(())
+//! }
+//! ```
+//!
 //! # The question mark operator, `?`
-// //!
-// //! When writing code that calls many functions that return the
-// //! [`Result`] type, the error handling can be tedious. The question mark
-// //! operator, [`?`], hides some of the boilerplate of propagating errors
-// //! up the call stack.
-// //!
-// //! It replaces this:
-// //!
-// //! ```
-// //! # #![allow(dead_code)]
-// //! use std::fs::File;
-// //! use std::io::prelude::*;
-// //! use std::io;
-// //!
-// //! struct Info {
-// //!     name: String,
-// //!     age: i32,
-// //!     rating: i32,
-// //! }
-// //!
-// //! fn write_info(info: &Info) -> io::Result<()> {
-// //!     // Early return on error
-// //!     let mut file = match File::create("my_best_friends.txt") {
-// //!            Err(e) => return Err(e),
-// //!            Ok(f) => f,
-// //!     };
-// //!     if let Err(e) = file.write_all(format!("name: {}\n", info.name).as_bytes()) {
-// //!         return Err(e)
-// //!     }
-// //!     if let Err(e) = file.write_all(format!("age: {}\n", info.age).as_bytes()) {
-// //!         return Err(e)
-// //!     }
-// //!     if let Err(e) = file.write_all(format!("rating: {}\n", info.rating).as_bytes()) {
-// //!         return Err(e)
-// //!     }
-// //!     Ok(())
-// //! }
-// //! ```
-// //!
-// //! With this:
-// //!
-// //! ```
-// //! # #![allow(dead_code)]
-// //! use std::fs::File;
-// //! use std::io::prelude::*;
-// //! use std::io;
-// //!
-// //! struct Info {
-// //!     name: String,
-// //!     age: i32,
-// //!     rating: i32,
-// //! }
-// //!
-// //! fn write_info(info: &Info) -> io::Result<()> {
-// //!     let mut file = File::create("my_best_friends.txt")?;
-// //!     // Early return on error
-// //!     file.write_all(format!("name: {}\n", info.name).as_bytes())?;
-// //!     file.write_all(format!("age: {}\n", info.age).as_bytes())?;
-// //!     file.write_all(format!("rating: {}\n", info.rating).as_bytes())?;
-// //!     Ok(())
-// //! }
-// //! ```
-// //!
-// //! *It's much nicer!*
-// //!
-// //! Ending the expression with [`?`] will result in the [`Ok`]'s unwrapped value, unless the result
-// //! is [`Err`], in which case [`Err`] is returned early from the enclosing function.
-// //!
-// //! [`?`] can be used in functions that return [`Result`] because of the
-// //! early return of [`Err`] that it provides.
-// //!
-// //! [`expect`]: Result::expect
-// //! [`Write`]: ../../std/io/trait.Write.html "io::Write"
-// //! [`write_all`]: ../../std/io/trait.Write.html#method.write_all "io::Write::write_all"
-// //! [`io::Result`]: ../../std/io/type.Result.html "io::Result"
-// //! [`?`]: crate::ops::Try
+//!
+//! When writing code that calls many functions that return the
+//! [`Result`] type, the error handling can be tedious. The question mark
+//! operator, [`?`], hides some of the boilerplate of propagating errors
+//! up the call stack.
+//!
+//! It replaces this:
+//!
+//! ```
+//! # #![allow(dead_code)]
+//! use std::fs::File;
+//! use std::io::prelude::*;
+//! use std::io;
+//!
+//! struct Info {
+//!     name: String,
+//!     age: i32,
+//!     rating: i32,
+//! }
+//!
+//! fn write_info(info: &Info) -> io::Result<()> {
+//!     // Early return on error
+//!     let mut file = match File::create("my_best_friends.txt") {
+//!            Err(e) => return Err(e),
+//!            Ok(f) => f,
+//!     };
+//!     if let Err(e) = file.write_all(format!("name: {}\n", info.name).as_bytes()) {
+//!         return Err(e)
+//!     }
+//!     if let Err(e) = file.write_all(format!("age: {}\n", info.age).as_bytes()) {
+//!         return Err(e)
+//!     }
+//!     if let Err(e) = file.write_all(format!("rating: {}\n", info.rating).as_bytes()) {
+//!         return Err(e)
+//!     }
+//!     Ok(())
+//! }
+//! ```
+//!
+//! With this:
+//!
+//! ```
+//! # #![allow(dead_code)]
+//! use std::fs::File;
+//! use std::io::prelude::*;
+//! use std::io;
+//!
+//! struct Info {
+//!     name: String,
+//!     age: i32,
+//!     rating: i32,
+//! }
+//!
+//! fn write_info(info: &Info) -> io::Result<()> {
+//!     let mut file = File::create("my_best_friends.txt")?;
+//!     // Early return on error
+//!     file.write_all(format!("name: {}\n", info.name).as_bytes())?;
+//!     file.write_all(format!("age: {}\n", info.age).as_bytes())?;
+//!     file.write_all(format!("rating: {}\n", info.rating).as_bytes())?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! *It's much nicer!*
+//!
+//! Ending the expression with [`?`] will result in the [`Ok`]'s unwrapped value, unless the result
+//! is [`Err`], in which case [`Err`] is returned early from the enclosing function.
+//!
+//! [`?`] can be used in functions that return [`Result`] because of the
+//! early return of [`Err`] that it provides.
+//!
+//! [`expect`]: Result::expect
+//! [`Write`]: ../../std/io/trait.Write.html "io::Write"
+//! [`write_all`]: ../../std/io/trait.Write.html#method.write_all "io::Write::write_all"
+//! [`io::Result`]: ../../std/io/type.Result.html "io::Result"
+//! [`?`]: crate::ops::Try
 //! [`Ok(T)`]: Ok
 //! [`Err(E)`]: Err
-// //! [io::Error]: ../../std/io/struct.Error.html "io::Error"
-// //!
+//! [io::Error]: ../../std/io/struct.Error.html "io::Error"
+//!
 //! # Representation
-// //!
-// //! In some cases, [`Result<T, E>`] will gain the same size, alignment, and ABI
-// //! guarantees as [`Option<U>`] has. One of either the `T` or `E` type must be a
-// //! type that qualifies for the `Option` [representation guarantees][opt-rep],
-// //! and the *other* type must meet all of the following conditions:
-// //! * Is a zero-sized type with alignment 1 (a "1-ZST").
-// //! * Has no fields.
-// //! * Does not have the `#[non_exhaustive]` attribute.
-// //!
-// //! For example, `NonZeroI32` qualifies for the `Option` representation
-// //! guarantees, and `()` is a zero-sized type with alignment 1, no fields, and
-// //! it isn't `non_exhaustive`. This means that both `Result<NonZeroI32, ()>` and
-// //! `Result<(), NonZeroI32>` have the same size, alignment, and ABI guarantees
-// //! as `Option<NonZeroI32>`. The only difference is the implied semantics:
-// //! * `Option<NonZeroI32>` is "a non-zero i32 might be present"
-// //! * `Result<NonZeroI32, ()>` is "a non-zero i32 success result, if any"
-// //! * `Result<(), NonZeroI32>` is "a non-zero i32 error result, if any"
-// //!
-// //! [opt-rep]: ../option/index.html#representation "Option Representation"
-// //!
-// //! # Method overview
-// //!
-// //! In addition to working with pattern matching, [`Result`] provides a
-// //! wide variety of different methods.
-// //!
-// //! ## Querying the variant
-// //!
-// //! The [`is_ok`] and [`is_err`] methods return [`true`] if the [`Result`]
-// //! is [`Ok`] or [`Err`], respectively.
-// //!
-// //! The [`is_ok_and`] and [`is_err_and`] methods apply the provided function
-// //! to the contents of the [`Result`] to produce a boolean value. If the [`Result`] does not have the expected variant
-// //! then [`false`] is returned instead without executing the function.
-// //!
-// //! [`is_err`]: Result::is_err
-// //! [`is_ok`]: Result::is_ok
-// //! [`is_ok_and`]: Result::is_ok_and
-// //! [`is_err_and`]: Result::is_err_and
-// //!
-// //! ## Adapters for working with references
-// //!
-// //! * [`as_ref`] converts from `&Result<T, E>` to `Result<&T, &E>`
-// //! * [`as_mut`] converts from `&mut Result<T, E>` to `Result<&mut T, &mut E>`
-// //! * [`as_deref`] converts from `&Result<T, E>` to `Result<&T::Target, &E>`
-// //! * [`as_deref_mut`] converts from `&mut Result<T, E>` to
-// //!   `Result<&mut T::Target, &mut E>`
-// //!
-// //! [`as_deref`]: Result::as_deref
-// //! [`as_deref_mut`]: Result::as_deref_mut
-// //! [`as_mut`]: Result::as_mut
-// //! [`as_ref`]: Result::as_ref
-// //!
-// //! ## Extracting contained values
-// //!
-// //! These methods extract the contained value in a [`Result<T, E>`] when it
-// //! is the [`Ok`] variant. If the [`Result`] is [`Err`]:
-// //!
-// //! * [`expect`] panics with a provided custom message
-// //! * [`unwrap`] panics with a generic message
-// //! * [`unwrap_or`] returns the provided default value
-// //! * [`unwrap_or_default`] returns the default value of the type `T`
-// //!   (which must implement the [`Default`] trait)
-// //! * [`unwrap_or_else`] returns the result of evaluating the provided
-// //!   function
-// //! * [`unwrap_unchecked`] produces *[undefined behavior]*
-// //!
-// //! The panicking methods [`expect`] and [`unwrap`] require `E` to
-// //! implement the [`Debug`] trait.
-// //!
-// //! [`Debug`]: crate::fmt::Debug
-// //! [`expect`]: Result::expect
-// //! [`unwrap`]: Result::unwrap
-// //! [`unwrap_or`]: Result::unwrap_or
-// //! [`unwrap_or_default`]: Result::unwrap_or_default
-// //! [`unwrap_or_else`]: Result::unwrap_or_else
-// //! [`unwrap_unchecked`]: Result::unwrap_unchecked
-// //! [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
-// //!
-// //! These methods extract the contained value in a [`Result<T, E>`] when it
-// //! is the [`Err`] variant. They require `T` to implement the [`Debug`]
-// //! trait. If the [`Result`] is [`Ok`]:
-// //!
-// //! * [`expect_err`] panics with a provided custom message
-// //! * [`unwrap_err`] panics with a generic message
-// //! * [`unwrap_err_unchecked`] produces *[undefined behavior]*
-// //!
-// //! [`Debug`]: crate::fmt::Debug
-// //! [`expect_err`]: Result::expect_err
-// //! [`unwrap_err`]: Result::unwrap_err
-// //! [`unwrap_err_unchecked`]: Result::unwrap_err_unchecked
-// //! [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
-// //!
-// //! ## Transforming contained values
-// //!
-// //! These methods transform [`Result`] to [`Option`]:
-// //!
-// //! * [`err`][Result::err] transforms [`Result<T, E>`] into [`Option<E>`],
-// //!   mapping [`Err(e)`] to [`Some(e)`] and [`Ok(v)`] to [`None`]
-// //! * [`ok`][Result::ok] transforms [`Result<T, E>`] into [`Option<T>`],
-// //!   mapping [`Ok(v)`] to [`Some(v)`] and [`Err(e)`] to [`None`]
-// //! * [`transpose`] transposes a [`Result`] of an [`Option`] into an
-// //!   [`Option`] of a [`Result`]
-// //!
-// // Do NOT add link reference definitions for `err` or `ok`, because they
-// // will generate numerous incorrect URLs for `Err` and `Ok` elsewhere, due
-// // to case folding.
-// //!
-// //! [`Err(e)`]: Err
-// //! [`Ok(v)`]: Ok
-// //! [`Some(e)`]: Option::Some
-// //! [`Some(v)`]: Option::Some
-// //! [`transpose`]: Result::transpose
-// //!
-// //! These methods transform the contained value of the [`Ok`] variant:
-// //!
-// //! * [`map`] transforms [`Result<T, E>`] into [`Result<U, E>`] by applying
-// //!   the provided function to the contained value of [`Ok`] and leaving
-// //!   [`Err`] values unchanged
-// //! * [`inspect`] takes ownership of the [`Result`], applies the
-// //!   provided function to the contained value by reference,
-// //!   and then returns the [`Result`]
-// //!
-// //! [`map`]: Result::map
-// //! [`inspect`]: Result::inspect
-// //!
-// //! These methods transform the contained value of the [`Err`] variant:
-// //!
-// //! * [`map_err`] transforms [`Result<T, E>`] into [`Result<T, F>`] by
-// //!   applying the provided function to the contained value of [`Err`] and
-// //!   leaving [`Ok`] values unchanged
-// //! * [`inspect_err`] takes ownership of the [`Result`], applies the
-// //!   provided function to the contained value of [`Err`] by reference,
-// //!   and then returns the [`Result`]
-// //!
-// //! [`map_err`]: Result::map_err
-// //! [`inspect_err`]: Result::inspect_err
-// //!
-// //! These methods transform a [`Result<T, E>`] into a value of a possibly
-// //! different type `U`:
-// //!
-// //! * [`map_or`] applies the provided function to the contained value of
-// //!   [`Ok`], or returns the provided default value if the [`Result`] is
-// //!   [`Err`]
-// //! * [`map_or_else`] applies the provided function to the contained value
-// //!   of [`Ok`], or applies the provided default fallback function to the
-// //!   contained value of [`Err`]
-// //!
-// //! [`map_or`]: Result::map_or
-// //! [`map_or_else`]: Result::map_or_else
-// //!
-// //! ## Boolean operators
-// //!
-// //! These methods treat the [`Result`] as a boolean value, where [`Ok`]
-// //! acts like [`true`] and [`Err`] acts like [`false`]. There are two
-// //! categories of these methods: ones that take a [`Result`] as input, and
-// //! ones that take a function as input (to be lazily evaluated).
-// //!
-// //! The [`and`] and [`or`] methods take another [`Result`] as input, and
-// //! produce a [`Result`] as output. The [`and`] method can produce a
-// //! [`Result<U, E>`] value having a different inner type `U` than
-// //! [`Result<T, E>`]. The [`or`] method can produce a [`Result<T, F>`]
-// //! value having a different error type `F` than [`Result<T, E>`].
-// //!
-// //! | method  | self     | input     | output   |
-// //! |---------|----------|-----------|----------|
-// //! | [`and`] | `Err(e)` | (ignored) | `Err(e)` |
-// //! | [`and`] | `Ok(x)`  | `Err(d)`  | `Err(d)` |
-// //! | [`and`] | `Ok(x)`  | `Ok(y)`   | `Ok(y)`  |
-// //! | [`or`]  | `Err(e)` | `Err(d)`  | `Err(d)` |
-// //! | [`or`]  | `Err(e)` | `Ok(y)`   | `Ok(y)`  |
-// //! | [`or`]  | `Ok(x)`  | (ignored) | `Ok(x)`  |
-// //!
-// //! [`and`]: Result::and
-// //! [`or`]: Result::or
-// //!
-// //! The [`and_then`] and [`or_else`] methods take a function as input, and
-// //! only evaluate the function when they need to produce a new value. The
-// //! [`and_then`] method can produce a [`Result<U, E>`] value having a
-// //! different inner type `U` than [`Result<T, E>`]. The [`or_else`] method
-// //! can produce a [`Result<T, F>`] value having a different error type `F`
-// //! than [`Result<T, E>`].
-// //!
-// //! | method       | self     | function input | function result | output   |
-// //! |--------------|----------|----------------|-----------------|----------|
-// //! | [`and_then`] | `Err(e)` | (not provided) | (not evaluated) | `Err(e)` |
-// //! | [`and_then`] | `Ok(x)`  | `x`            | `Err(d)`        | `Err(d)` |
-// //! | [`and_then`] | `Ok(x)`  | `x`            | `Ok(y)`         | `Ok(y)`  |
-// //! | [`or_else`]  | `Err(e)` | `e`            | `Err(d)`        | `Err(d)` |
-// //! | [`or_else`]  | `Err(e)` | `e`            | `Ok(y)`         | `Ok(y)`  |
-// //! | [`or_else`]  | `Ok(x)`  | (not provided) | (not evaluated) | `Ok(x)`  |
-// //!
-// //! [`and_then`]: Result::and_then
-// //! [`or_else`]: Result::or_else
-// //!
-// //! ## Comparison operators
-// //!
-// //! If `T` and `E` both implement [`PartialOrd`] then [`Result<T, E>`] will
-// //! derive its [`PartialOrd`] implementation.  With this order, an [`Ok`]
-// //! compares as less than any [`Err`], while two [`Ok`] or two [`Err`]
-// //! compare as their contained values would in `T` or `E` respectively.  If `T`
-// //! and `E` both also implement [`Ord`], then so does [`Result<T, E>`].
-// //!
-// //! ```
-// //! assert!(Ok(1) < Err(0));
-// //! let x: Result<i32, ()> = Ok(0);
-// //! let y = Ok(1);
-// //! assert!(x < y);
-// //! let x: Result<(), i32> = Err(0);
-// //! let y = Err(1);
-// //! assert!(x < y);
-// //! ```
-// //!
-// //! ## Iterating over `Result`
-// //!
-// //! A [`Result`] can be iterated over. This can be helpful if you need an
-// //! iterator that is conditionally empty. The iterator will either produce
-// //! a single value (when the [`Result`] is [`Ok`]), or produce no values
-// //! (when the [`Result`] is [`Err`]). For example, [`into_iter`] acts like
-// //! [`once(v)`] if the [`Result`] is [`Ok(v)`], and like [`empty()`] if the
-// //! [`Result`] is [`Err`].
-// //!
-// //! [`Ok(v)`]: Ok
-// //! [`empty()`]: crate::iter::empty
-// //! [`once(v)`]: crate::iter::once
-// //!
-// //! Iterators over [`Result<T, E>`] come in three types:
-// //!
-// //! * [`into_iter`] consumes the [`Result`] and produces the contained
-// //!   value
-// //! * [`iter`] produces an immutable reference of type `&T` to the
-// //!   contained value
-// //! * [`iter_mut`] produces a mutable reference of type `&mut T` to the
-// //!   contained value
-// //!
-// //! See [Iterating over `Option`] for examples of how this can be useful.
-// //!
-// //! [Iterating over `Option`]: crate::option#iterating-over-option
-// //! [`into_iter`]: Result::into_iter
-// //! [`iter`]: Result::iter
-// //! [`iter_mut`]: Result::iter_mut
-// //!
-// //! You might want to use an iterator chain to do multiple instances of an
-// //! operation that can fail, but would like to ignore failures while
-// //! continuing to process the successful results. In this example, we take
-// //! advantage of the iterable nature of [`Result`] to select only the
-// //! [`Ok`] values using [`flatten`][Iterator::flatten].
-// //!
-// //! ```
-// //! # use std::str::FromStr;
-// //! let mut results = vec![];
-// //! let mut errs = vec![];
-// //! let nums: Vec<_> = ["17", "not a number", "99", "-27", "768"]
-// //!    .into_iter()
-// //!    .map(u8::from_str)
-// //!    // Save clones of the raw `Result` values to inspect
-// //!    .inspect(|x| results.push(x.clone()))
-// //!    // Challenge: explain how this captures only the `Err` values
-// //!    .inspect(|x| errs.extend(x.clone().err()))
-// //!    .flatten()
-// //!    .collect();
-// //! assert_eq!(errs.len(), 3);
-// //! assert_eq!(nums, [17, 99]);
-// //! println!("results {results:?}");
-// //! println!("errs {errs:?}");
-// //! println!("nums {nums:?}");
-// //! ```
-// //!
-// //! ## Collecting into `Result`
-// //!
-// //! [`Result`] implements the [`FromIterator`][impl-FromIterator] trait,
-// //! which allows an iterator over [`Result`] values to be collected into a
-// //! [`Result`] of a collection of each contained value of the original
-// //! [`Result`] values, or [`Err`] if any of the elements was [`Err`].
-// //!
-// //! [impl-FromIterator]: Result#impl-FromIterator%3CResult%3CA,+E%3E%3E-for-Result%3CV,+E%3E
-// //!
-// //! ```
-// //! let v = [Ok(2), Ok(4), Err("err!"), Ok(8)];
-// //! let res: Result<Vec<_>, &str> = v.into_iter().collect();
-// //! assert_eq!(res, Err("err!"));
-// //! let v = [Ok(2), Ok(4), Ok(8)];
-// //! let res: Result<Vec<_>, &str> = v.into_iter().collect();
-// //! assert_eq!(res, Ok(vec![2, 4, 8]));
-// //! ```
-// //!
-// //! [`Result`] also implements the [`Product`][impl-Product] and
-// //! [`Sum`][impl-Sum] traits, allowing an iterator over [`Result`] values
-// //! to provide the [`product`][Iterator::product] and
-// //! [`sum`][Iterator::sum] methods.
-// //!
-// //! [impl-Product]: Result#impl-Product%3CResult%3CU,+E%3E%3E-for-Result%3CT,+E%3E
-// //! [impl-Sum]: Result#impl-Sum%3CResult%3CU,+E%3E%3E-for-Result%3CT,+E%3E
-// //!
-// //! ```
-// //! let v = [Err("error!"), Ok(1), Ok(2), Ok(3), Err("foo")];
-// //! let res: Result<i32, &str> = v.into_iter().sum();
-// //! assert_eq!(res, Err("error!"));
-// //! let v = [Ok(1), Ok(2), Ok(21)];
-// //! let res: Result<i32, &str> = v.into_iter().product();
-// //! assert_eq!(res, Ok(42));
-// //! ```
+//!
+//! In some cases, [`Result<T, E>`] will gain the same size, alignment, and ABI
+//! guarantees as [`Option<U>`] has. One of either the `T` or `E` type must be a
+//! type that qualifies for the `Option` [representation guarantees][opt-rep],
+//! and the *other* type must meet all of the following conditions:
+//! * Is a zero-sized type with alignment 1 (a "1-ZST").
+//! * Has no fields.
+//! * Does not have the `#[non_exhaustive]` attribute.
+//!
+//! For example, `NonZeroI32` qualifies for the `Option` representation
+//! guarantees, and `()` is a zero-sized type with alignment 1, no fields, and
+//! it isn't `non_exhaustive`. This means that both `Result<NonZeroI32, ()>` and
+//! `Result<(), NonZeroI32>` have the same size, alignment, and ABI guarantees
+//! as `Option<NonZeroI32>`. The only difference is the implied semantics:
+//! * `Option<NonZeroI32>` is "a non-zero i32 might be present"
+//! * `Result<NonZeroI32, ()>` is "a non-zero i32 success result, if any"
+//! * `Result<(), NonZeroI32>` is "a non-zero i32 error result, if any"
+//!
+//! [opt-rep]: ../option/index.html#representation "Option Representation"
+//!
+//! # Method overview
+//!
+//! In addition to working with pattern matching, [`Result`] provides a
+//! wide variety of different methods.
+//!
+//! ## Querying the variant
+//!
+//! The [`is_ok`] and [`is_err`] methods return [`true`] if the [`Result`]
+//! is [`Ok`] or [`Err`], respectively.
+//!
+//! The [`is_ok_and`] and [`is_err_and`] methods apply the provided function
+//! to the contents of the [`Result`] to produce a boolean value. If the [`Result`] does not have the expected variant
+//! then [`false`] is returned instead without executing the function.
+//!
+//! [`is_err`]: Result::is_err
+//! [`is_ok`]: Result::is_ok
+//! [`is_ok_and`]: Result::is_ok_and
+//! [`is_err_and`]: Result::is_err_and
+//!
+//! ## Adapters for working with references
+//!
+//! * [`as_ref`] converts from `&Result<T, E>` to `Result<&T, &E>`
+//! * [`as_mut`] converts from `&mut Result<T, E>` to `Result<&mut T, &mut E>`
+//! * [`as_deref`] converts from `&Result<T, E>` to `Result<&T::Target, &E>`
+//! * [`as_deref_mut`] converts from `&mut Result<T, E>` to
+//!   `Result<&mut T::Target, &mut E>`
+//!
+//! [`as_deref`]: Result::as_deref
+//! [`as_deref_mut`]: Result::as_deref_mut
+//! [`as_mut`]: Result::as_mut
+//! [`as_ref`]: Result::as_ref
+//!
+//! ## Extracting contained values
+//!
+//! These methods extract the contained value in a [`Result<T, E>`] when it
+//! is the [`Ok`] variant. If the [`Result`] is [`Err`]:
+//!
+//! * [`expect`] panics with a provided custom message
+//! * [`unwrap`] panics with a generic message
+//! * [`unwrap_or`] returns the provided default value
+//! * [`unwrap_or_default`] returns the default value of the type `T`
+//!   (which must implement the [`Default`] trait)
+//! * [`unwrap_or_else`] returns the result of evaluating the provided
+//!   function
+//! * [`unwrap_unchecked`] produces *[undefined behavior]*
+//!
+//! The panicking methods [`expect`] and [`unwrap`] require `E` to
+//! implement the [`Debug`] trait.
+//!
+//! [`Debug`]: crate::fmt::Debug
+//! [`expect`]: Result::expect
+//! [`unwrap`]: Result::unwrap
+//! [`unwrap_or`]: Result::unwrap_or
+//! [`unwrap_or_default`]: Result::unwrap_or_default
+//! [`unwrap_or_else`]: Result::unwrap_or_else
+//! [`unwrap_unchecked`]: Result::unwrap_unchecked
+//! [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
+//!
+//! These methods extract the contained value in a [`Result<T, E>`] when it
+//! is the [`Err`] variant. They require `T` to implement the [`Debug`]
+//! trait. If the [`Result`] is [`Ok`]:
+//!
+//! * [`expect_err`] panics with a provided custom message
+//! * [`unwrap_err`] panics with a generic message
+//! * [`unwrap_err_unchecked`] produces *[undefined behavior]*
+//!
+//! [`Debug`]: crate::fmt::Debug
+//! [`expect_err`]: Result::expect_err
+//! [`unwrap_err`]: Result::unwrap_err
+//! [`unwrap_err_unchecked`]: Result::unwrap_err_unchecked
+//! [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
+//!
+//! ## Transforming contained values
+//!
+//! These methods transform [`Result`] to [`Option`]:
+//!
+//! * [`err`][Result::err] transforms [`Result<T, E>`] into [`Option<E>`],
+//!   mapping [`Err(e)`] to [`Some(e)`] and [`Ok(v)`] to [`None`]
+//! * [`ok`][Result::ok] transforms [`Result<T, E>`] into [`Option<T>`],
+//!   mapping [`Ok(v)`] to [`Some(v)`] and [`Err(e)`] to [`None`]
+//! * [`transpose`] transposes a [`Result`] of an [`Option`] into an
+//!   [`Option`] of a [`Result`]
+//!
+// Do NOT add link reference definitions for `err` or `ok`, because they
+// will generate numerous incorrect URLs for `Err` and `Ok` elsewhere, due
+// to case folding.
+//!
+//! [`Err(e)`]: Err
+//! [`Ok(v)`]: Ok
+//! [`Some(e)`]: Option::Some
+//! [`Some(v)`]: Option::Some
+//! [`transpose`]: Result::transpose
+//!
+//! These methods transform the contained value of the [`Ok`] variant:
+//!
+//! * [`map`] transforms [`Result<T, E>`] into [`Result<U, E>`] by applying
+//!   the provided function to the contained value of [`Ok`] and leaving
+//!   [`Err`] values unchanged
+//! * [`inspect`] takes ownership of the [`Result`], applies the
+//!   provided function to the contained value by reference,
+//!   and then returns the [`Result`]
+//!
+//! [`map`]: Result::map
+//! [`inspect`]: Result::inspect
+//!
+//! These methods transform the contained value of the [`Err`] variant:
+//!
+//! * [`map_err`] transforms [`Result<T, E>`] into [`Result<T, F>`] by
+//!   applying the provided function to the contained value of [`Err`] and
+//!   leaving [`Ok`] values unchanged
+//! * [`inspect_err`] takes ownership of the [`Result`], applies the
+//!   provided function to the contained value of [`Err`] by reference,
+//!   and then returns the [`Result`]
+//!
+//! [`map_err`]: Result::map_err
+//! [`inspect_err`]: Result::inspect_err
+//!
+//! These methods transform a [`Result<T, E>`] into a value of a possibly
+//! different type `U`:
+//!
+//! * [`map_or`] applies the provided function to the contained value of
+//!   [`Ok`], or returns the provided default value if the [`Result`] is
+//!   [`Err`]
+//! * [`map_or_else`] applies the provided function to the contained value
+//!   of [`Ok`], or applies the provided default fallback function to the
+//!   contained value of [`Err`]
+//!
+//! [`map_or`]: Result::map_or
+//! [`map_or_else`]: Result::map_or_else
+//!
+//! ## Boolean operators
+//!
+//! These methods treat the [`Result`] as a boolean value, where [`Ok`]
+//! acts like [`true`] and [`Err`] acts like [`false`]. There are two
+//! categories of these methods: ones that take a [`Result`] as input, and
+//! ones that take a function as input (to be lazily evaluated).
+//!
+//! The [`and`] and [`or`] methods take another [`Result`] as input, and
+//! produce a [`Result`] as output. The [`and`] method can produce a
+//! [`Result<U, E>`] value having a different inner type `U` than
+//! [`Result<T, E>`]. The [`or`] method can produce a [`Result<T, F>`]
+//! value having a different error type `F` than [`Result<T, E>`].
+//!
+//! | method  | self     | input     | output   |
+//! |---------|----------|-----------|----------|
+//! | [`and`] | `Err(e)` | (ignored) | `Err(e)` |
+//! | [`and`] | `Ok(x)`  | `Err(d)`  | `Err(d)` |
+//! | [`and`] | `Ok(x)`  | `Ok(y)`   | `Ok(y)`  |
+//! | [`or`]  | `Err(e)` | `Err(d)`  | `Err(d)` |
+//! | [`or`]  | `Err(e)` | `Ok(y)`   | `Ok(y)`  |
+//! | [`or`]  | `Ok(x)`  | (ignored) | `Ok(x)`  |
+//!
+//! [`and`]: Result::and
+//! [`or`]: Result::or
+//!
+//! The [`and_then`] and [`or_else`] methods take a function as input, and
+//! only evaluate the function when they need to produce a new value. The
+//! [`and_then`] method can produce a [`Result<U, E>`] value having a
+//! different inner type `U` than [`Result<T, E>`]. The [`or_else`] method
+//! can produce a [`Result<T, F>`] value having a different error type `F`
+//! than [`Result<T, E>`].
+//!
+//! | method       | self     | function input | function result | output   |
+//! |--------------|----------|----------------|-----------------|----------|
+//! | [`and_then`] | `Err(e)` | (not provided) | (not evaluated) | `Err(e)` |
+//! | [`and_then`] | `Ok(x)`  | `x`            | `Err(d)`        | `Err(d)` |
+//! | [`and_then`] | `Ok(x)`  | `x`            | `Ok(y)`         | `Ok(y)`  |
+//! | [`or_else`]  | `Err(e)` | `e`            | `Err(d)`        | `Err(d)` |
+//! | [`or_else`]  | `Err(e)` | `e`            | `Ok(y)`         | `Ok(y)`  |
+//! | [`or_else`]  | `Ok(x)`  | (not provided) | (not evaluated) | `Ok(x)`  |
+//!
+//! [`and_then`]: Result::and_then
+//! [`or_else`]: Result::or_else
+//!
+//! ## Comparison operators
+//!
+//! If `T` and `E` both implement [`PartialOrd`] then [`Result<T, E>`] will
+//! derive its [`PartialOrd`] implementation.  With this order, an [`Ok`]
+//! compares as less than any [`Err`], while two [`Ok`] or two [`Err`]
+//! compare as their contained values would in `T` or `E` respectively.  If `T`
+//! and `E` both also implement [`Ord`], then so does [`Result<T, E>`].
+//!
+//! ```
+//! assert!(Ok(1) < Err(0));
+//! let x: Result<i32, ()> = Ok(0);
+//! let y = Ok(1);
+//! assert!(x < y);
+//! let x: Result<(), i32> = Err(0);
+//! let y = Err(1);
+//! assert!(x < y);
+//! ```
+//!
+//! ## Iterating over `Result`
+//!
+//! A [`Result`] can be iterated over. This can be helpful if you need an
+//! iterator that is conditionally empty. The iterator will either produce
+//! a single value (when the [`Result`] is [`Ok`]), or produce no values
+//! (when the [`Result`] is [`Err`]). For example, [`into_iter`] acts like
+//! [`once(v)`] if the [`Result`] is [`Ok(v)`], and like [`empty()`] if the
+//! [`Result`] is [`Err`].
+//!
+//! [`Ok(v)`]: Ok
+//! [`empty()`]: crate::iter::empty
+//! [`once(v)`]: crate::iter::once
+//!
+//! Iterators over [`Result<T, E>`] come in three types:
+//!
+//! * [`into_iter`] consumes the [`Result`] and produces the contained
+//!   value
+//! * [`iter`] produces an immutable reference of type `&T` to the
+//!   contained value
+//! * [`iter_mut`] produces a mutable reference of type `&mut T` to the
+//!   contained value
+//!
+//! See [Iterating over `Option`] for examples of how this can be useful.
+//!
+//! [Iterating over `Option`]: crate::option#iterating-over-option
+//! [`into_iter`]: Result::into_iter
+//! [`iter`]: Result::iter
+//! [`iter_mut`]: Result::iter_mut
+//!
+//! You might want to use an iterator chain to do multiple instances of an
+//! operation that can fail, but would like to ignore failures while
+//! continuing to process the successful results. In this example, we take
+//! advantage of the iterable nature of [`Result`] to select only the
+//! [`Ok`] values using [`flatten`][Iterator::flatten].
+//!
+//! ```
+//! # use std::str::FromStr;
+//! let mut results = vec![];
+//! let mut errs = vec![];
+//! let nums: Vec<_> = ["17", "not a number", "99", "-27", "768"]
+//!    .into_iter()
+//!    .map(u8::from_str)
+//!    // Save clones of the raw `Result` values to inspect
+//!    .inspect(|x| results.push(x.clone()))
+//!    // Challenge: explain how this captures only the `Err` values
+//!    .inspect(|x| errs.extend(x.clone().err()))
+//!    .flatten()
+//!    .collect();
+//! assert_eq!(errs.len(), 3);
+//! assert_eq!(nums, [17, 99]);
+//! println!("results {results:?}");
+//! println!("errs {errs:?}");
+//! println!("nums {nums:?}");
+//! ```
+//!
+//! ## Collecting into `Result`
+//!
+//! [`Result`] implements the [`FromIterator`][impl-FromIterator] trait,
+//! which allows an iterator over [`Result`] values to be collected into a
+//! [`Result`] of a collection of each contained value of the original
+//! [`Result`] values, or [`Err`] if any of the elements was [`Err`].
+//!
+//! [impl-FromIterator]: Result#impl-FromIterator%3CResult%3CA,+E%3E%3E-for-Result%3CV,+E%3E
+//!
+//! ```
+//! let v = [Ok(2), Ok(4), Err("err!"), Ok(8)];
+//! let res: Result<Vec<_>, &str> = v.into_iter().collect();
+//! assert_eq!(res, Err("err!"));
+//! let v = [Ok(2), Ok(4), Ok(8)];
+//! let res: Result<Vec<_>, &str> = v.into_iter().collect();
+//! assert_eq!(res, Ok(vec![2, 4, 8]));
+//! ```
+//!
+//! [`Result`] also implements the [`Product`][impl-Product] and
+//! [`Sum`][impl-Sum] traits, allowing an iterator over [`Result`] values
+//! to provide the [`product`][Iterator::product] and
+//! [`sum`][Iterator::sum] methods.
+//!
+//! [impl-Product]: Result#impl-Product%3CResult%3CU,+E%3E%3E-for-Result%3CT,+E%3E
+//! [impl-Sum]: Result#impl-Sum%3CResult%3CU,+E%3E%3E-for-Result%3CT,+E%3E
+//!
+//! ```
+//! let v = [Err("error!"), Ok(1), Ok(2), Ok(3), Err("foo")];
+//! let res: Result<i32, &str> = v.into_iter().sum();
+//! assert_eq!(res, Err("error!"));
+//! let v = [Ok(1), Ok(2), Ok(21)];
+//! let res: Result<i32, &str> = v.into_iter().product();
+//! assert_eq!(res, Ok(42));
+//! ```
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -80,7 +80,6 @@
 //! functions that may encounter errors but don't otherwise return a
 //! useful value.
 //!
-// FIXME(pvdrz): fix docs
 // //! Consider the [`write_all`] method defined for I/O types
 // //! by the [`Write`] trait:
 // //!
@@ -1186,7 +1185,6 @@ impl<T, E> Result<T, E> {
     /// Consumes the `self` argument then, if [`Ok`], returns the contained
     /// value, otherwise if [`Err`], returns the default value for that
     /// type.
-    // FIXME(pvdrz): fix docs
     // ///
     // /// # Examples
     // ///

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1185,26 +1185,26 @@ impl<T, E> Result<T, E> {
     /// Consumes the `self` argument then, if [`Ok`], returns the contained
     /// value, otherwise if [`Err`], returns the default value for that
     /// type.
-    // ///
-    // /// # Examples
-    // ///
-    // /// Converts a string to an integer, turning poorly-formed strings
-    // /// into 0 (the default value for integers). [`parse`] converts
-    // /// a string to any other type that implements [`FromStr`], returning an
-    // /// [`Err`] on error.
-    // ///
-    // /// ```
-    // /// let good_year_from_input = "1909";
-    // /// let bad_year_from_input = "190blarg";
-    // /// let good_year = good_year_from_input.parse().unwrap_or_default();
-    // /// let bad_year = bad_year_from_input.parse().unwrap_or_default();
-    // ///
-    // /// assert_eq!(1909, good_year);
-    // /// assert_eq!(0, bad_year);
-    // /// ```
-    // ///
-    // /// [`parse`]: str::parse
-    // /// [`FromStr`]: crate::str::FromStr
+    ///
+    /// # Examples
+    ///
+    /// Converts a string to an integer, turning poorly-formed strings
+    /// into 0 (the default value for integers). [`parse`] converts
+    /// a string to any other type that implements [`FromStr`], returning an
+    /// [`Err`] on error.
+    ///
+    /// ```
+    /// let good_year_from_input = "1909";
+    /// let bad_year_from_input = "190blarg";
+    /// let good_year = good_year_from_input.parse().unwrap_or_default();
+    /// let bad_year = bad_year_from_input.parse().unwrap_or_default();
+    ///
+    /// assert_eq!(1909, good_year);
+    /// assert_eq!(0, bad_year);
+    /// ```
+    ///
+    /// [`parse`]: str::parse
+    /// [`FromStr`]: crate::str::FromStr
     #[inline]
     #[stable(feature = "result_unwrap_or_default", since = "1.16.0")]
     pub fn unwrap_or_default(self) -> T

--- a/library/core/src/ub_checks.rs
+++ b/library/core/src/ub_checks.rs
@@ -4,7 +4,6 @@
 use crate::intrinsics::{self, const_eval_select};
 
 /// Checks that the preconditions of an unsafe function are followed.
-// FIXME(pvdrz): fix docs
 ///
 /// The check is enabled at runtime if debug assertions are enabled when the
 /// caller is monomorphized. In const-eval/Miri checks implemented with this

--- a/library/core/src/ub_checks.rs
+++ b/library/core/src/ub_checks.rs
@@ -5,49 +5,49 @@ use crate::intrinsics::{self, const_eval_select};
 
 /// Checks that the preconditions of an unsafe function are followed.
 // FIXME(pvdrz): fix docs
-// ///
-// /// The check is enabled at runtime if debug assertions are enabled when the
-// /// caller is monomorphized. In const-eval/Miri checks implemented with this
-// /// macro for language UB are always ignored.
-// ///
-// /// This macro should be called as
-// /// `assert_unsafe_precondition!(check_{library,language}_ub, "message", (ident: type = expr, ident: type = expr) => check_expr)`
-// /// where each `expr` will be evaluated and passed in as function argument `ident: type`. Then all
-// /// those arguments are passed to a function with the body `check_expr`.
-// /// Pick `check_language_ub` when this is guarding a violation of language UB, i.e., immediate UB
-// /// according to the Rust Abstract Machine. Pick `check_library_ub` when this is guarding a violation
-// /// of a documented library precondition that does not *immediately* lead to language UB.
-// ///
-// /// If `check_library_ub` is used but the check is actually guarding language UB, the check will
-// /// slow down const-eval/Miri and we'll get the panic message instead of the interpreter's nice
-// /// diagnostic, but our ability to detect UB is unchanged.
-// /// But if `check_language_ub` is used when the check is actually for library UB, the check is
-// /// omitted in const-eval/Miri and thus if we eventually execute language UB which relies on the
-// /// library UB, the backtrace Miri reports may be far removed from original cause.
-// ///
-// /// These checks are behind a condition which is evaluated at codegen time, not expansion time like
-// /// [`debug_assert`]. This means that a standard library built with optimizations and debug
-// /// assertions disabled will have these checks optimized out of its monomorphizations, but if a
-// /// caller of the standard library has debug assertions enabled and monomorphizes an expansion of
-// /// this macro, that monomorphization will contain the check.
-// ///
-// /// Since these checks cannot be optimized out in MIR, some care must be taken in both call and
-// /// implementation to mitigate their compile-time overhead. Calls to this macro always expand to
-// /// this structure:
-// /// ```ignore (pseudocode)
-// /// if ::core::intrinsics::check_language_ub() {
-// ///     precondition_check(args)
-// /// }
-// /// ```
-// /// where `precondition_check` is monomorphic with the attributes `#[rustc_nounwind]`, `#[inline]` and
-// /// `#[rustc_no_mir_inline]`. This combination of attributes ensures that the actual check logic is
-// /// compiled only once and generates a minimal amount of IR because the check cannot be inlined in
-// /// MIR, but *can* be inlined and fully optimized by a codegen backend.
-// ///
-// /// Callers should avoid introducing any other `let` bindings or any code outside this macro in
-// /// order to call it. Since the precompiled standard library is built with full debuginfo and these
-// /// variables cannot be optimized out in MIR, an innocent-looking `let` can produce enough
-// /// debuginfo to have a measurable compile-time impact on debug builds.
+///
+/// The check is enabled at runtime if debug assertions are enabled when the
+/// caller is monomorphized. In const-eval/Miri checks implemented with this
+/// macro for language UB are always ignored.
+///
+/// This macro should be called as
+/// `assert_unsafe_precondition!(check_{library,language}_ub, "message", (ident: type = expr, ident: type = expr) => check_expr)`
+/// where each `expr` will be evaluated and passed in as function argument `ident: type`. Then all
+/// those arguments are passed to a function with the body `check_expr`.
+/// Pick `check_language_ub` when this is guarding a violation of language UB, i.e., immediate UB
+/// according to the Rust Abstract Machine. Pick `check_library_ub` when this is guarding a violation
+/// of a documented library precondition that does not *immediately* lead to language UB.
+///
+/// If `check_library_ub` is used but the check is actually guarding language UB, the check will
+/// slow down const-eval/Miri and we'll get the panic message instead of the interpreter's nice
+/// diagnostic, but our ability to detect UB is unchanged.
+/// But if `check_language_ub` is used when the check is actually for library UB, the check is
+/// omitted in const-eval/Miri and thus if we eventually execute language UB which relies on the
+/// library UB, the backtrace Miri reports may be far removed from original cause.
+///
+/// These checks are behind a condition which is evaluated at codegen time, not expansion time like
+/// [`debug_assert`]. This means that a standard library built with optimizations and debug
+/// assertions disabled will have these checks optimized out of its monomorphizations, but if a
+/// caller of the standard library has debug assertions enabled and monomorphizes an expansion of
+/// this macro, that monomorphization will contain the check.
+///
+/// Since these checks cannot be optimized out in MIR, some care must be taken in both call and
+/// implementation to mitigate their compile-time overhead. Calls to this macro always expand to
+/// this structure:
+/// ```ignore (pseudocode)
+/// if ::core::intrinsics::check_language_ub() {
+///     precondition_check(args)
+/// }
+/// ```
+/// where `precondition_check` is monomorphic with the attributes `#[rustc_nounwind]`, `#[inline]` and
+/// `#[rustc_no_mir_inline]`. This combination of attributes ensures that the actual check logic is
+/// compiled only once and generates a minimal amount of IR because the check cannot be inlined in
+/// MIR, but *can* be inlined and fully optimized by a codegen backend.
+///
+/// Callers should avoid introducing any other `let` bindings or any code outside this macro in
+/// order to call it. Since the precompiled standard library is built with full debuginfo and these
+/// variables cannot be optimized out in MIR, an innocent-looking `let` can produce enough
+/// debuginfo to have a measurable compile-time impact on debug builds.
 #[macro_export]
 #[unstable(feature = "ub_checks", issue = "none")]
 macro_rules! assert_unsafe_precondition {


### PR DESCRIPTION
Thanks to the `allow(rustdoc::broken_intra_doc_links)` which was added in https://github.com/ferrocene/ferrocene/pull/1541, we can just add back all doc-comments as rustdoc will not complain about broken links anymore.

Generating docs for full libcore and for the subset work (tested locally) and include the whole doc-comment:

```console
$ ./x doc library/core
$ ./x doc library/core --set rust.std-features="['ferrocene_certified']"
```