### PR TITLE
Add thumbv7em certified targets

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2066,6 +2066,8 @@ supported_targets! {
     ("thumbv7em-ferrocenecoretest-eabihf", thumbv7em_ferrocenecoretest_eabihf),
     ("x86_64-unknown-none.certified", x86_64_unknown_none_certified),
     ("aarch64-unknown-none.certified", aarch64_unknown_none_certified),
+    ("thumbv7em-none-eabi.certified", thumbv7em_none_eabi_certified),
+    ("thumbv7em-none-eabihf.certified", thumbv7em_none_eabihf_certified),
 
     ("aarch64-unknown-linux-ohos", aarch64_unknown_linux_ohos),
     ("armv7-unknown-linux-ohos", armv7_unknown_linux_ohos),

--- a/compiler/rustc_target/src/spec/targets/thumbv7em_none_eabi_certified.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7em_none_eabi_certified.rs
@@ -1,0 +1,13 @@
+use crate::spec::Target;
+
+pub(crate) fn target() -> Target {
+    let mut target = super::thumbv7em_none_eabi::target();
+
+    target.metadata.description =
+        target.metadata.description.map(|v| format!("{v} (certified)").into());
+    target.metadata.host_tools = Some(false);
+    target.metadata.tier = None;
+    target.metadata.std = Some(false);
+
+    target
+}

--- a/compiler/rustc_target/src/spec/targets/thumbv7em_none_eabihf_certified.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7em_none_eabihf_certified.rs
@@ -1,0 +1,13 @@
+use crate::spec::Target;
+
+pub(crate) fn target() -> Target {
+    let mut target = super::thumbv7em_none_eabihf::target();
+
+    target.metadata.description =
+        target.metadata.description.map(|v| format!("{v} (certified)").into());
+    target.metadata.host_tools = Some(false);
+    target.metadata.tier = None;
+    target.metadata.std = Some(false);
+
+    target
+}

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -39,6 +39,8 @@ const STAGE0_MISSING_TARGETS: &[&str] = &[
     "thumbv7em-ferrocenecoretest-eabihf",
     "aarch64-unknown-none.certified",
     "x86_64-unknown-none.certified",
+    "thumbv7em-none-eabi.certified",
+    "thumbv7em-none-eabihf.certified",
     // just a dummy comment so the list doesn't get onelined
 ];
 

--- a/tests/assembly/targets/targets-elf.rs
+++ b/tests/assembly/targets/targets-elf.rs
@@ -730,6 +730,12 @@
 //@ revisions: x86_64_unknown_none_certified
 //@ [x86_64_unknown_none_certified] compile-flags: --target x86_64-unknown-none.certified
 //@ [x86_64_unknown_none_certified] needs-llvm-components: x86_64
+//@ revisions: thumbv7em_none_eabi_certified
+//@ [thumbv7em_none_eabi_certified] compile-flags: --target thumbv7m-none-eabi.certified
+//@ [thumbv7em_none_eabi_certified] needs-llvm-components: arm
+//@ revisions: thumbv7em_none_eabihf_certified
+//@ [thumbv7em_none_eabihf_certified] compile-flags: --target thumbv7m-none-eabihf.certified
+//@ [thumbv7em_none_eabihf_certified] needs-llvm-components: arm
 
 // Sanity-check that each target can produce assembly code.
 


### PR DESCRIPTION
This PR adds the `thumbv7em-none-eabi.certified` and `thumbv7em-none-eabihf.certified` targets. Which are libcore-certified counterparts of `thumbv7em-none-eabi` and `thumbv7em-none-eabihf` respectively.