### PR TITLE
Add the most minimal CI for certified libcore

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -179,6 +179,22 @@ jobs:
           qnx: true
           restore-from-job: x86_64-linux-build
 
+  # A basic check to ensure the certified libcore subset builds
+  # Will be replaced by https://github.com/ferrocene/ferrocene/pull/1550
+  x86_64-linux-certified:
+    executor: docker-x86_64-ubuntu-20
+    resource_class: large # 4-core
+    environment:
+      FERROCENE_HOST: x86_64-unknown-linux-gnu
+      # Certified targets only
+      FERROCENE_TARGETS: aarch64-unknown-none,x86_64-unknown-linux-gnu,thumbv7em-none-eabi,thumbv7em-none-eabihf
+      SCRIPT: |
+        ./x.py build --stage 1 library/core --set rust.std-features='["ferrocene_certified"]'
+        ./x.py doc library/core --set rust.std-features='["ferrocene_certified"]'
+    steps:
+      - ferrocene-job-test-container:
+          restore-from-job: x86_64-linux-build
+
   x86_64-linux-dist-src:
     executor: docker-x86_64-ubuntu-20
     resource_class: medium # 2-core
@@ -844,6 +860,9 @@ workflows:
       - x86_64-linux-build:
           requires:
             - x86_64-linux-llvm
+      - x86_64-linux-certified:
+          requires:
+            - x86_64-linux-build
       - x86_64-linux-docs:
           requires: &test-outcomes-dependencies
             # Need to depend on all of the test builders to include test
@@ -1103,6 +1122,7 @@ workflows:
 
       - finish-build:
           requires:
+            - x86_64-linux-certified
             - x86_64-linux-docs
             - x86_64-linux-dist-src
             - x86_64-linux-traceability-matrix


### PR DESCRIPTION
Add simple build/doc checks for certified libcore, no artifacts or anything (that's left for #1550 which should remove this job)