### PR TITLE
Fix linker arguments in mixed language example in user manual

### DIFF
--- a/ferrocene/doc/user-manual/src/rustc/mixed-language.rst
+++ b/ferrocene/doc/user-manual/src/rustc/mixed-language.rst
@@ -159,7 +159,7 @@ To create an executable that links against our static library, run:
 
 .. code-block::
 
-   $ gcc -o call_factorial_from_c -L . -l factorial call_factorial_from_c.c
+   $ gcc -o call_factorial_from_c -L . call_factorial_from_c.c -l factorial
 
 Or if you want to create an executable that links against out dynamic library,
 run:


### PR DESCRIPTION
On my system (Ubuntu 25.04) the static linking example gives

```console
$ gcc -o call_factorial_from_c -L . -l factorial call_factorial_from_c.c
/usr/bin/ld: /tmp/ccWY29f0.o: in function `main':
call_factorial_from_c.c:(.text+0xe): undefined reference to `factorial'
collect2: error: ld returned 1 exit status
```

Reordering arguments fixes the issue.