### PR TITLE
Distribute `miri`

### DIFF
--- a/ferrocene/packages.toml
+++ b/ferrocene/packages.toml
@@ -65,6 +65,10 @@ subset = "default"
 name = "flip-link"
 subset = "default"
 
+[[groups.hosts.packages]]
+name = "miri"
+subset = "default"
+
 [groups.cross-compilation]
 targets = [
   "aarch64-unknown-linux-gnu",

--- a/src/bootstrap/defaults/bootstrap.ferrocene-dist.toml
+++ b/src/bootstrap/defaults/bootstrap.ferrocene-dist.toml
@@ -38,7 +38,7 @@ extended = true
 #
 # NOTE: If you add a new tool here, make sure to also change `ferrocene/packages.toml` to include it
 # in new releases.
-tools = ["rustdoc", "cargo", "llvm-tools", "rustfmt", "rust-analyzer", "rust-analyzer-proc-macro-srv", "clippy"]
+tools = ["rustdoc", "cargo", "llvm-tools", "rustfmt", "rust-analyzer", "rust-analyzer-proc-macro-srv", "clippy", "miri"]
 
 # Build and enable the profiler runtime.
 #


### PR DESCRIPTION
We've bumped into some KPs that can be detected by `miri`. So, let's distribute it so that folks can use it without needing to reach for upstream.