### PR TITLE
Set build folders for Ferrocene annotations

### DIFF
--- a/src/bootstrap/src/ferrocene/doc/mod.rs
+++ b/src/bootstrap/src/ferrocene/doc/mod.rs
@@ -15,7 +15,7 @@ use crate::ferrocene::sign::signature_files::CacheSignatureFiles;
 use crate::ferrocene::test_outcomes::TestOutcomesDir;
 use crate::ferrocene::uv_command;
 use crate::utils::exec::BootstrapCommand;
-use crate::{FileType, t};
+use crate::{Compiler, FileType, t};
 
 pub(crate) trait IsSphinxBook {
     const SOURCE: &'static str;
@@ -690,6 +690,7 @@ sphinx_books! [
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub(crate) struct TraceabilityMatrix {
     target: TargetSelection,
+    compiler: Compiler,
 }
 
 impl Step for TraceabilityMatrix {
@@ -702,11 +703,15 @@ impl Step for TraceabilityMatrix {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(TraceabilityMatrix { target: run.target });
+        let compiler = run.builder.compiler(run.builder.top_stage, run.build_triple());
+        run.builder.ensure(TraceabilityMatrix { target: run.target, compiler });
     }
 
     fn run(self, builder: &Builder<'_>) -> Self::Output {
-        builder.ensure(crate::ferrocene::run::TraceabilityMatrix { target: self.target });
+        builder.ensure(crate::ferrocene::run::TraceabilityMatrix {
+            target: self.target,
+            compiler: self.compiler,
+        });
     }
 }
 

--- a/src/bootstrap/src/ferrocene/run.rs
+++ b/src/bootstrap/src/ferrocene/run.rs
@@ -51,7 +51,7 @@ impl Step for TraceabilityMatrix {
             BootstrapCommand::new(&compiletest)
                 .env("FERROCENE_COLLECT_ANNOTATIONS", "1")
                 .env("FERROCENE_DEST", dest)
-                .env("FERROCENE_SRC_BASE", builder.src.join(suite))
+                .env("FERROCENE_SRC_TEST_SUITE_ROOT", builder.src.join(suite))
                 .env("FERROCENE_MODE", mode)
                 .env("FERROCENE_SUITE", suite)
                 .run(builder);

--- a/src/bootstrap/src/ferrocene/run.rs
+++ b/src/bootstrap/src/ferrocene/run.rs
@@ -51,6 +51,7 @@ impl Step for TraceabilityMatrix {
             BootstrapCommand::new(&compiletest)
                 .env("FERROCENE_COLLECT_ANNOTATIONS", "1")
                 .env("FERROCENE_DEST", dest)
+                .env("FERROCENE_SRC_ROOT", &builder.src)
                 .env("FERROCENE_SRC_TEST_SUITE_ROOT", builder.src.join(suite))
                 .env("FERROCENE_MODE", mode)
                 .env("FERROCENE_SUITE", suite)

--- a/src/tools/compiletest/src/ferrocene_annotations.rs
+++ b/src/tools/compiletest/src/ferrocene_annotations.rs
@@ -169,6 +169,8 @@ fn sample_config() -> Config {
         mode: env("FERROCENE_MODE"),
         src_root: env("FERROCENE_SRC_ROOT"),
         src_test_suite_root: env("FERROCENE_SRC_TEST_SUITE_ROOT"),
+        build_root: env("FERROCENE_BUILD_ROOT"),
+        build_test_suite_root: env("FERROCENE_BUILD_TEST_SUITE_ROOT"),
         suite: env("FERROCENE_SUITE"),
         ..Config::default()
     }

--- a/src/tools/compiletest/src/ferrocene_annotations.rs
+++ b/src/tools/compiletest/src/ferrocene_annotations.rs
@@ -167,7 +167,7 @@ fn sample_config() -> Config {
         color: crate::ColorConfig::NeverColor,
         format: crate::OutputFormat::Json,
         mode: env("FERROCENE_MODE"),
-        src_test_suite_root: env("FERROCENE_SRC_BASE"),
+        src_test_suite_root: env("FERROCENE_SRC_TEST_SUITE_ROOT"),
         suite: env("FERROCENE_SUITE"),
         ..Config::default()
     }

--- a/src/tools/compiletest/src/ferrocene_annotations.rs
+++ b/src/tools/compiletest/src/ferrocene_annotations.rs
@@ -167,6 +167,7 @@ fn sample_config() -> Config {
         color: crate::ColorConfig::NeverColor,
         format: crate::OutputFormat::Json,
         mode: env("FERROCENE_MODE"),
+        src_root: env("FERROCENE_SRC_ROOT"),
         src_test_suite_root: env("FERROCENE_SRC_TEST_SUITE_ROOT"),
         suite: env("FERROCENE_SUITE"),
         ..Config::default()


### PR DESCRIPTION
This PR fixes a very annoying bug where a bunch of new empty folders were created in the root of the repository when getting the traceability matrix:
- **Rename `FERROCENE_SRC_BASE` to `FERROCENE_SRC_TEST_SUITE_ROOT`**
- **Set `Config::src_root` as well.**
- **Set `Config::build_root` and `Config::build_test_suite_root`**

cc: @hoverbear @tshepang
