### PR TITLE
Include `backtrace-rs` and `libc` in `rust-src`

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1022,6 +1022,15 @@ impl Step for Src {
             &dst_src,
         );
 
+        // Ferrocene addition: We have a different libc location, we need to copy that in:
+        copy_src_dirs(
+            builder,
+            &builder.src,
+            &["ferrocene/library/libc", "ferrocene/library/backtrace-rs"],
+            &[],
+            &dst_src,
+        );
+
         tarball.generate()
     }
 


### PR DESCRIPTION
Includes `backtrace-rs` and `libc` in main. 

This along with #1574 enables you to use `miri` with Ferrocene:

```
$ cargo miri run
   Compiling boops-and-snoops v0.1.0 (/home/ana/git/ferrocene/boops-and-snoops)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
     Running `/home/ana/.local/share/criticalup/toolchains/b237cbfeb95516ca31f47fc060d06540df26ef4c330d37a41de30164e31c2bad/bin/cargo-miri runner target/miri/x86_64-unknown-linux-gnu/debug/boops-and-snoops`
Hello, world!
```

To reproduce, smuggle a locally built (`./x.py --stage 2 dist rust-src`) expanded `rust-src` tarballs `lib/rustlib/src/rust/ferrocene` into the criticalup toolchain folder and then try to run `miri` as usual. (`cargo new ...` then `cargo +ferrocene run miri` if you have links set up, I used a `rust-toolchain.toml` to do this)