### PR TITLE
Add miri to release notes

### DIFF
--- a/ferrocene/doc/release-notes/src/next.rst
+++ b/ferrocene/doc/release-notes/src/next.rst
@@ -9,6 +9,20 @@ Next Ferrocene release
 This page contains the changes to be introduced in the upcoming Ferrocene
 release.
 
+New experimental features
+-------------------------
+
+Experimental features are not qualified for safety critical use, and are
+shipped as a preview.
+
+* Experimental support has been added for ``cargo miri``, an unstable undefined
+  behavior detection tool. Other than installation, usage is
+  `according to upstream documentation <https://github.com/rust-lang/miri>`_.
+  
+  The package is available as:
+
+  * ``miri-${rustc-host}``
+
 Removed experimental features
 -----------------------------
 


### PR DESCRIPTION
https://github.com/ferrocene/ferrocene/pull/1574 https://github.com/ferrocene/ferrocene/pull/1575 & https://github.com/ferrocene/ferrocene/pull/1566 enabled `miri`. This adds it to the release notes now that we've validated it works.

For now, we just defer to the upstream docs.