### PR TITLE
Add `trpl` vendor to ferrocene-src

### DIFF
--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -141,6 +141,7 @@ impl Step for SourceTarball {
             "src/tools/rust-analyzer/Cargo.toml",
             "src/tools/rustc-perf/site/Cargo.toml",
             "src/tools/rustbook/Cargo.toml",
+            "src/doc/book/packages/trpl/Cargo.toml",
         ];
         const UV_PROJECTS: &[&str] = &["ferrocene/doc"];
 


### PR DESCRIPTION
Following the ideas in #1513, we now add `trpl` as a customer who wants an offline vendor tarball now depends on it.