### PR TITLE
Only report library coverage for libcore

### DIFF
--- a/src/bootstrap/src/ferrocene/doc/code_coverage.rs
+++ b/src/bootstrap/src/ferrocene/doc/code_coverage.rs
@@ -118,6 +118,14 @@ impl Step for SingleCoverageReport {
         // grcov to strip it.
         cmd.arg("--prefix-dir").arg(&self.metadata.path_prefix);
 
+        // If collecting library coverage, ignore all directories that are not
+        // part of libcore. Otherwise things like compiler-builtins, coretests
+        // etc. will be included. portable-simd and stdarch are kept as well,
+        // since parts of them are included into libcore via a path attribute.
+        if self.name.starts_with("library") {
+            cmd.args(["--keep-only", "library/{core,portable-simd,stdarch}/**"]);
+        }
+
         builder.info(&format!("Generating coverage report for {}", self.name));
         cmd.fail_fast().run(builder);
 


### PR DESCRIPTION
If collecting library coverage, ignore all directories that are not part of libcore. Otherwise things like compiler-builtins, coretests etc. will be included. portable-simd and stdarch are kept as well, since parts of them are included into libcore via a path attribute.

This changes the report from this:

<img width="1000" height="1088" alt="Screenshot from 2025-07-20 18-22-37" src="https://github.com/user-attachments/assets/050cf852-ae80-4a74-85c3-d22cf1a855ce" />

to this:

<img width="1000" height="1088" alt="Screenshot from 2025-07-20 18-37-20" src="https://github.com/user-attachments/assets/ddb89893-8928-411f-9cbd-85d2d107bb85" />



