### PR TITLE
Fix `ferrocene/ci/scripts/fix-stage0-branch.py` not closing file

### DIFF
--- a/ferrocene/ci/scripts/fix-stage0-branch.py
+++ b/ferrocene/ci/scripts/fix-stage0-branch.py
@@ -77,7 +77,11 @@ def fix():
     stage0 = parse_stage0()
     expected = expected_branch()
 
-    STAGE0_PATH.open("w").write(f"{stage0.before_raw}{BRANCH_KEY}={expected}{stage0.after_raw}")
+    stage0_file = STAGE0_PATH.open("w")
+    stage0_file.write(f"{stage0.before_raw}{BRANCH_KEY}={expected}{stage0.after_raw}")
+    stage0_file.close()
+
+    
 
 
 @dataclass


### PR DESCRIPTION
Fixes this warning from `./ferrocene/ci/scripts/fix-stage0-branch.py`:

```
/home/ana/git/ferrocene/ferrocene/ferrocene/ci/scripts/fix-stage0-branch.py:80: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/ana/git/ferrocene/ferrocene/src/stage0' mode='w' encoding='UTF-8'>
```