### PR TITLE
Miri should be in the tools tasks

### DIFF
--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -87,7 +87,7 @@ JOBS_DEFINITION: JobsDefinition = {
 
         "oxidos": ["ferrocene-oxidos"],
 
-        "tools": ["clippy", "rustfmt", "flip-link"],
+        "tools": ["clippy", "rustfmt", "flip-link", "miri"],
     },
 
     "test": {


### PR DESCRIPTION
We recently landed miri (#1566), however it would be better served in the `tools` tasks. 