### PR TITLE
Add "ferrocene_certified" feature to libcore and add minimal CI

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -178,6 +178,22 @@ jobs:
           qnx: true
           restore-from-job: x86_64-linux-build
 
+  # A basic check to ensure the certified libcore subset builds
+  # Will be replaced by a more sophisticated mechanism
+  x86_64-linux-certified:
+    executor: docker-x86_64-ubuntu-20
+    resource_class: large # 4-core
+    environment:
+      FERROCENE_HOST: x86_64-unknown-linux-gnu
+      # Certified targets only
+      FERROCENE_TARGETS: aarch64-unknown-none,x86_64-unknown-linux-gnu,thumbv7em-none-eabi,thumbv7em-none-eabihf
+      SCRIPT: |
+        ./x.py build --stage 1 library/core --set rust.std-features='["ferrocene_certified"]'
+        ./x.py doc library/core --set rust.std-features='["ferrocene_certified"]'
+    steps:
+      - ferrocene-job-test-container:
+          restore-from-job: x86_64-linux-build
+
   x86_64-linux-dist-src:
     executor: docker-x86_64-ubuntu-20
     resource_class: medium # 2-core
@@ -849,6 +865,9 @@ workflows:
       - x86_64-linux-build:
           requires:
             - x86_64-linux-llvm
+      - x86_64-linux-certified:
+          requires:
+            - x86_64-linux-build
       - x86_64-linux-docs:
           requires: &test-outcomes-dependencies
             # Need to depend on all of the test builders to include test
@@ -1110,6 +1129,7 @@ workflows:
 
       - finish-build:
           requires:
+            - x86_64-linux-certified
             - x86_64-linux-docs
             - x86_64-linux-dist-src
             - x86_64-linux-traceability-matrix

--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -21,6 +21,8 @@ test = false
 bench = false
 
 [features]
+# Ferrocene addition: only include certified code
+ferrocene_certified = []
 # Ferrocene addition: only add the explicit dependency to profiler_builtins when we are building
 # core specifically for profiling.
 ferrocene_inject_profiler_builtins = ["dep:profiler_builtins"]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -127,6 +127,9 @@ std_detect_dlsym_getauxval = ["std_detect/std_detect_dlsym_getauxval"]
 # This will eventually be the default.
 windows_raw_dylib = ["windows-targets/windows_raw_dylib"]
 
+# Ferrocene addition: enable "ferrocene_certified" feature in libcore
+ferrocene_certified = ["core/ferrocene_certified"]
+
 [package.metadata.fortanix-sgx]
 # Maximum possible number of threads when testing
 threads = 125

--- a/library/sysroot/Cargo.toml
+++ b/library/sysroot/Cargo.toml
@@ -40,3 +40,6 @@ profiler = ["dep:profiler_builtins"]
 std_detect_file_io = ["std/std_detect_file_io"]
 std_detect_dlsym_getauxval = ["std/std_detect_dlsym_getauxval"]
 windows_raw_dylib = ["std/windows_raw_dylib"]
+
+# Ferrocene addition: enable "ferrocene_certified" feature in libcore
+ferrocene_certified = ["std/ferrocene_certified"]


### PR DESCRIPTION
> [!NOTE]
> This is the first PR, of four expected ones, to merge the changes from libcore-cert into main.

Add the "ferrocene_certified" feature to libcore and add the most minimal CI which just ensures the certified subset builds and can produce docs.

You can test it locally by executing the same commands the CI is executing:

```console
$ ./x build library/core --set rust.std-features='["ferrocene_certified"]'
$ ./x doc   library/core --set rust.std-features='["ferrocene_certified"]'
```

The next PR will add the subset annotations.