### PR TITLE
Improve `core::fmt` coverage

### DIFF
--- a/library/coretests/tests/fmt/builders.rs
+++ b/library/coretests/tests/fmt/builders.rs
@@ -173,6 +173,21 @@ mod debug_struct {
             format!("{Bar:#?}")
         );
     }
+
+    #[test]
+    fn test_field_with() {
+        struct Foo;
+        impl fmt::Debug for Foo {
+            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt.debug_struct("Foo")
+                    .field_with("bar", |f| f.write_str("true"))
+                    .field_with("baz", |f| f.write_str("false"))
+                    .finish()
+            }
+        }
+
+        assert_eq!("Foo {\n    bar: true,\n    baz: false,\n}", format!("{Foo:#?}"))
+    }
 }
 
 mod debug_tuple {

--- a/library/coretests/tests/fmt/mod.rs
+++ b/library/coretests/tests/fmt/mod.rs
@@ -58,6 +58,36 @@ fn test_fmt_debug_of_raw_pointers() {
 }
 
 #[test]
+fn test_fmt_debug_of_mut_reference() {
+    let mut x: u32 = 0;
+
+    assert_eq!(format!("{:?}", &mut x), "0");
+}
+
+#[test]
+fn test_default_write_impls() {
+    use core::fmt::Write;
+
+    struct Buf(String);
+
+    impl Write for Buf {
+        fn write_str(&mut self, s: &str) -> core::fmt::Result {
+            self.0.write_str(s)
+        }
+    }
+
+    let mut buf = Buf(String::new());
+    buf.write_char('a').unwrap();
+
+    assert_eq!(buf.0, "a");
+
+    let mut buf = Buf(String::new());
+    buf.write_fmt(format_args!("a")).unwrap();
+
+    assert_eq!(buf.0, "a");
+}
+
+#[test]
 fn test_estimated_capacity() {
     assert_eq!(format_args!("").estimated_capacity(), 0);
     assert_eq!(format_args!("{}", { "" }).estimated_capacity(), 0);

--- a/library/coretests/tests/fmt/num.rs
+++ b/library/coretests/tests/fmt/num.rs
@@ -324,3 +324,9 @@ fn test_format_debug_hex() {
     assert_eq!(format!("{:02x?}", b"Foo\0"), "[46, 6f, 6f, 00]");
     assert_eq!(format!("{:02X?}", b"Foo\0"), "[46, 6F, 6F, 00]");
 }
+
+#[test]
+#[should_panic = "Formatting argument out of range"]
+fn test_rt_width_too_long() {
+    let _ = format!("Hello {:width$}!", "x", width = u16::MAX as usize + 1);
+}

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -111,6 +111,7 @@
 // Features we add so we can have better coverage:
 // tidy-alphabetical-start
 #![feature(char_internals)]
+#![feature(debug_closure_helpers)]
 #![feature(one_sided_range)]
 // tidy-alphabetical-end
 


### PR DESCRIPTION
This brings line coverage for `core::fmt` to 100%

- **Cover `core::fmt::builder`**
- **Cover `core::fmt::rt`**
- **Cover `core::fmt`**
