### PR TITLE
[1.88] add test: inline assembly label operand

### DIFF
--- a/tests/ui/asm/label-operand.rs
+++ b/tests/ui/asm/label-operand.rs
@@ -1,0 +1,50 @@
+//@ run-pass
+//@ needs-asm-support
+//@ reference: asm.operand-type.supported-operands.label
+
+use std::arch::asm;
+
+#[cfg(any(target_arch = "arm", target_arch = "aarch64", target_arch = "arm64ec"))]
+fn make_true(value: &mut bool) {
+    unsafe {
+        asm!(
+            "b {}",
+            label {
+                *value = true;
+            }
+        );
+    }
+}
+
+#[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+fn make_true(value: &mut bool) {
+    unsafe {
+        asm!(
+            "j {}",
+            label {
+                *value = true;
+            }
+        );
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn make_true(value: &mut bool) {
+    unsafe {
+        asm!(
+            "jmp {}",
+            label {
+                *value = true;
+            }
+        );
+    }
+}
+
+fn main() {
+    let mut value = false;
+    make_true(&mut value);
+    assert!(value);
+}
+
+// ferrocene-annotations: fls_mw7mth5ooeq1
+// Label block


### PR DESCRIPTION
Backports https://github.com/rust-lang/rust/pull/143227 as we need it for satisfying traceability matrix.