### PR TITLE
Fix `src/bootstrap/src/ferrocene` license

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -248,19 +248,7 @@ SPDX-FileCopyrightText = "Jeremy Thomas"
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]
-path = "requirements.txt"
-precedence = "override"
-SPDX-FileCopyrightText = "The Ferrocene Developers"
-SPDX-License-Identifier = "MIT OR Apache-2.0"
-
-[[annotations]]
-path = ".python-version"
-precedence = "override"
-SPDX-FileCopyrightText = "The Ferrocene Developers"
-SPDX-License-Identifier = "MIT OR Apache-2.0"
-
-[[annotations]]
-path = "src/bootstrap/src/ferrocene/**"
+path = ["requirements.txt", ".python-version", "src/bootstrap/src/ferrocene/**"]
 precedence = "override"
 SPDX-FileCopyrightText = "The Ferrocene Developers"
 SPDX-License-Identifier = "MIT OR Apache-2.0"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -258,3 +258,9 @@ path = ".python-version"
 precedence = "override"
 SPDX-FileCopyrightText = "The Ferrocene Developers"
 SPDX-License-Identifier = "MIT OR Apache-2.0"
+
+[[annotations]]
+path = "src/bootstrap/src/ferrocene/**"
+precedence = "override"
+SPDX-FileCopyrightText = "The Ferrocene Developers"
+SPDX-License-Identifier = "MIT OR Apache-2.0"

--- a/license-metadata.json
+++ b/license-metadata.json
@@ -447,7 +447,8 @@
           },
           {
             "directories": [
-              ".circleci"
+              ".circleci",
+              "src/bootstrap/src/ferrocene"
             ],
             "files": [
               ".dockerignore",

--- a/src/bootstrap/src/ferrocene/code_coverage.rs
+++ b/src/bootstrap/src/ferrocene/code_coverage.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: The Ferrocene Developers
+
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;

--- a/src/bootstrap/src/ferrocene/dist/flip_link.rs
+++ b/src/bootstrap/src/ferrocene/dist/flip_link.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: The Ferrocene Developers
+
 use crate::FileType;
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::core::config::TargetSelection;

--- a/src/bootstrap/src/ferrocene/install.rs
+++ b/src/bootstrap/src/ferrocene/install.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: The Ferrocene Developers
+
 // Based off ../core/build_steps/install.rs
 
 //! Implementation of the install aspects of the compiler.

--- a/src/bootstrap/src/ferrocene/secret_sauce.rs
+++ b/src/bootstrap/src/ferrocene/secret_sauce.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: The Ferrocene Developers
+
 use std::path::PathBuf;
 
 use crate::TargetSelection;

--- a/src/bootstrap/src/ferrocene/sign/signature_files.rs
+++ b/src/bootstrap/src/ferrocene/sign/signature_files.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: The Ferrocene Developers
+
 use std::collections::HashMap;
 use std::error::Error;
 use std::fs::File;

--- a/src/bootstrap/src/ferrocene/test_variants.rs
+++ b/src/bootstrap/src/ferrocene/test_variants.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: The Ferrocene Developers
+
 //! Test variants are a mechanism to run test suites for a target multiple times, each time varying
 //! some of the parameters passed to the suite.
 //!

--- a/src/bootstrap/src/ferrocene/tool.rs
+++ b/src/bootstrap/src/ferrocene/tool.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: The Ferrocene Developers
+
 pub(crate) mod flip_link;
 
 use std::path::PathBuf;

--- a/src/bootstrap/src/ferrocene/tool/flip_link.rs
+++ b/src/bootstrap/src/ferrocene/tool/flip_link.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: The Ferrocene Developers
+
 use std::path::PathBuf;
 
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};


### PR DESCRIPTION
Problem: All files in `src/**` have their copyright attributed to the Rust project. Files in `src/bootstrap/src/ferrocene` should (also) have their copyright attributed to Ferrocene. Usually this is done by adding the license header. But unfortunately this was forgotten a few times and `reuse` does not detect this problem, since it only detects if a file has no copyright at all. 

Solution: Therefore we modify REUSE.toml to attribute all files in `src/bootstrap/src/ferrocene` to Ferrocene as well. We still aim to add the copyright header. But in case we forget, the copyright is still there.