### PR TITLE
Add libcore certified targets

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -178,22 +178,6 @@ jobs:
           qnx: true
           restore-from-job: x86_64-linux-build
 
-  # A basic check to ensure the certified libcore subset builds
-  # Will be replaced by a more sophisticated mechanism
-  x86_64-linux-certified:
-    executor: docker-x86_64-ubuntu-20
-    resource_class: large # 4-core
-    environment:
-      FERROCENE_HOST: x86_64-unknown-linux-gnu
-      # Certified targets only
-      FERROCENE_TARGETS: aarch64-unknown-none,x86_64-unknown-linux-gnu,thumbv7em-none-eabi,thumbv7em-none-eabihf
-      SCRIPT: |
-        ./x.py build --stage 1 library/core --set rust.std-features='["ferrocene_certified"]'
-        ./x.py doc --stage 1 library/core --set rust.std-features='["ferrocene_certified"]'
-    steps:
-      - ferrocene-job-test-container:
-          restore-from-job: x86_64-linux-build
-
   x86_64-linux-dist-src:
     executor: docker-x86_64-ubuntu-20
     resource_class: medium # 2-core
@@ -866,9 +850,6 @@ workflows:
       - x86_64-linux-build:
           requires:
             - x86_64-linux-llvm
-      - x86_64-linux-certified:
-          requires:
-            - x86_64-linux-build
       - x86_64-linux-docs:
           requires: &test-outcomes-dependencies
             # Need to depend on all of the test builders to include test
@@ -1130,7 +1111,6 @@ workflows:
 
       - finish-build:
           requires:
-            - x86_64-linux-certified
             - x86_64-linux-docs
             - x86_64-linux-dist-src
             - x86_64-linux-traceability-matrix

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2088,6 +2088,8 @@ supported_targets! {
     ("thumbv7em-ferrocenecoretest-eabihf", thumbv7em_ferrocenecoretest_eabihf),
     ("x86_64-unknown-none.certified", x86_64_unknown_none_certified),
     ("aarch64-unknown-none.certified", aarch64_unknown_none_certified),
+    ("thumbv7em-none-eabi.certified", thumbv7em_none_eabi_certified),
+    ("thumbv7em-none-eabihf.certified", thumbv7em_none_eabihf_certified),
 
     ("aarch64-unknown-linux-ohos", aarch64_unknown_linux_ohos),
     ("armv7-unknown-linux-ohos", armv7_unknown_linux_ohos),

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2086,6 +2086,8 @@ supported_targets! {
     ("aarch64-unknown-ferrocenecoretest", aarch64_unknown_ferrocenecoretest),
     ("thumbv7em-ferrocenecoretest-eabi", thumbv7em_ferrocenecoretest_eabi),
     ("thumbv7em-ferrocenecoretest-eabihf", thumbv7em_ferrocenecoretest_eabihf),
+    ("x86_64-unknown-none.certified", x86_64_unknown_none_certified),
+    ("aarch64-unknown-none.certified", aarch64_unknown_none_certified),
 
     ("aarch64-unknown-linux-ohos", aarch64_unknown_linux_ohos),
     ("armv7-unknown-linux-ohos", armv7_unknown_linux_ohos),

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_none_certified.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_none_certified.rs
@@ -1,0 +1,13 @@
+use crate::spec::Target;
+
+pub(crate) fn target() -> Target {
+    let mut target = super::aarch64_unknown_none::target();
+
+    target.metadata.description =
+        target.metadata.description.map(|v| format!("{v} (certified)").into());
+    target.metadata.host_tools = Some(false);
+    target.metadata.tier = None;
+    target.metadata.std = Some(false);
+
+    target
+}

--- a/compiler/rustc_target/src/spec/targets/thumbv7em_none_eabi_certified.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7em_none_eabi_certified.rs
@@ -1,0 +1,13 @@
+use crate::spec::Target;
+
+pub(crate) fn target() -> Target {
+    let mut target = super::thumbv7em_none_eabi::target();
+
+    target.metadata.description =
+        target.metadata.description.map(|v| format!("{v} (certified)").into());
+    target.metadata.host_tools = Some(false);
+    target.metadata.tier = None;
+    target.metadata.std = Some(false);
+
+    target
+}

--- a/compiler/rustc_target/src/spec/targets/thumbv7em_none_eabihf_certified.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7em_none_eabihf_certified.rs
@@ -1,0 +1,13 @@
+use crate::spec::Target;
+
+pub(crate) fn target() -> Target {
+    let mut target = super::thumbv7em_none_eabihf::target();
+
+    target.metadata.description =
+        target.metadata.description.map(|v| format!("{v} (certified)").into());
+    target.metadata.host_tools = Some(false);
+    target.metadata.tier = None;
+    target.metadata.std = Some(false);
+
+    target
+}

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_none_certified.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_none_certified.rs
@@ -1,0 +1,13 @@
+use crate::spec::Target;
+
+pub(crate) fn target() -> Target {
+    let mut target = super::x86_64_unknown_none::target();
+
+    target.metadata.description =
+        target.metadata.description.map(|v| format!("{v} (certified)").into());
+    target.metadata.host_tools = Some(false);
+    target.metadata.tier = None;
+    target.metadata.std = Some(false);
+
+    target
+}

--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -121,6 +121,9 @@ add --set target.x86_64-pc-nto-qnx710.profiler=false # Build failures were noted
 add --set target.aarch64-unknown-ferrocenecoretest.cc=aarch64-linux-gnu-gcc
 add --set target.thumbv7em-ferrocenecoretest-eabi.cc=arm-none-eabi-gcc
 add --set target.thumbv7em-ferrocenecoretest-eabihf.cc=arm-none-eabi-gcc
+add --set target."aarch64-unknown-none\.certified".cc=aarch64-linux-gnu-gcc
+add --set target."thumbv7em-none-eabi\.certified".cc=arm-none-eabi-gcc
+add --set target."thumbv7em-none-eabihf\.certified".cc=arm-none-eabi-gcc
 
 # experiment to enable code coverage
 add --set target.thumbv7em-ferrocenecoretest-eabihf.profiler=true

--- a/ferrocene/ci/scripts/calculate_parameters.py
+++ b/ferrocene/ci/scripts/calculate_parameters.py
@@ -64,6 +64,10 @@ GENERIC_BUILD_STD_TARGETS = [
     "wasm32-unknown-unknown",
     "armv7r-none-eabihf",
     "armebv7r-none-eabihf",
+    "x86_64-unknown-none.certified",
+    "aarch64-unknown-none.certified",
+    "thumbv7em-none-eabi.certified",
+    "thumbv7em-none-eabihf.certified",
 ]
 
 # Targets only built (and self-tested!) on Linux.

--- a/ferrocene/ci/scripts/validate-packages-toml.py
+++ b/ferrocene/ci/scripts/validate-packages-toml.py
@@ -37,6 +37,8 @@ IGNORE_PATTERNS = [
     "rust-docs-json-*.tar.*",
     "rustc-dev-*.tar.*",
     "rust-dev-*.tar.*",
+    # Skip x86_64 as it is only used for local testing
+    "rust-std-x86_64-unknown-none.certified-*.tar.*",
 ]
 
 

--- a/ferrocene/packages.toml
+++ b/ferrocene/packages.toml
@@ -87,6 +87,9 @@ targets = [
   "thumbv8m.main-none-eabi",
   "thumbv8m.main-none-eabihf",
   "wasm32-unknown-unknown",
+  "aarch64-unknown-none.certified",
+  "thumbv7em-none-eabi.certified",
+  "thumbv7em-none-eabihf.certified",
 ]
 
 [[groups.cross-compilation.packages]]

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -28,6 +28,8 @@ compiler-builtins-mangled-names = ["compiler_builtins/mangled-names"]
 panic_immediate_abort = ["core/panic_immediate_abort"]
 # Choose algorithms that are optimized for binary size instead of runtime performance
 optimize_for_size = ["core/optimize_for_size"]
+# Ferrocene addition
+ferrocene_certified = ["compiler_builtins/ferrocene_certified", "core/ferrocene_certified"]
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -202,6 +202,9 @@
 // that the feature-gate isn't enabled. Ideally, it wouldn't check for the feature gate for docs
 // from other crates, but since this can only appear for lang items, it doesn't seem worth fixing.
 #![cfg_attr(not(feature = "ferrocene_certified"), feature(intra_doc_pointers))]
+//
+// Ferrocene lints/features:
+#![cfg_attr(feature = "ferrocene_certified", allow(rustdoc::broken_intra_doc_links))]
 
 // Module with internal macros used by other modules (needs to be included before other modules).
 #[macro_use]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -90,123 +90,129 @@
 #![deny(ffi_unwind_calls)]
 #![warn(unreachable_pub)]
 //
+// Ferrocene addition: We removed the tidy directives for alphabetical ordering to reduce the number
+// of conflicts we have when merging main.
+//
 // Library features:
-// tidy-alphabetical-start
-#![feature(alloc_layout_extra)]
-#![feature(allocator_api)]
-#![feature(array_chunks)]
-#![feature(array_into_iter_constructors)]
-#![feature(array_windows)]
-#![feature(ascii_char)]
-#![feature(assert_matches)]
-#![feature(async_fn_traits)]
-#![feature(async_iterator)]
-#![feature(bstr)]
-#![feature(bstr_internals)]
-#![feature(char_internals)]
-#![feature(char_max_len)]
-#![feature(clone_to_uninit)]
-#![feature(coerce_unsized)]
-#![feature(const_default)]
-#![feature(const_eval_select)]
-#![feature(const_heap)]
-#![feature(const_trait_impl)]
-#![feature(core_intrinsics)]
-#![feature(deprecated_suggestion)]
-#![feature(deref_pure_trait)]
-#![feature(dispatch_from_dyn)]
-#![feature(ergonomic_clones)]
-#![feature(error_generic_member_access)]
-#![feature(exact_size_is_empty)]
-#![feature(extend_one)]
-#![feature(extend_one_unchecked)]
-#![feature(fmt_internals)]
-#![feature(fn_traits)]
-#![feature(formatting_options)]
-#![feature(generic_atomic)]
-#![feature(hasher_prefixfree_extras)]
-#![feature(inplace_iteration)]
-#![feature(iter_advance_by)]
-#![feature(iter_next_chunk)]
-#![feature(layout_for_ptr)]
-#![feature(legacy_receiver_trait)]
-#![feature(local_waker)]
-#![feature(maybe_uninit_slice)]
-#![feature(maybe_uninit_uninit_array_transpose)]
-#![feature(panic_internals)]
-#![feature(pattern)]
-#![feature(pin_coerce_unsized_trait)]
-#![feature(ptr_alignment_type)]
-#![feature(ptr_internals)]
-#![feature(ptr_metadata)]
-#![feature(set_ptr_value)]
-#![feature(sized_type_properties)]
-#![feature(slice_from_ptr_range)]
-#![feature(slice_index_methods)]
-#![feature(slice_iter_mut_as_mut_slice)]
-#![feature(slice_ptr_get)]
-#![feature(slice_range)]
-#![feature(std_internals)]
-#![feature(str_internals)]
-#![feature(temporary_niche_types)]
-#![feature(trusted_fused)]
-#![feature(trusted_len)]
-#![feature(trusted_random_access)]
-#![feature(try_trait_v2)]
-#![feature(try_with_capacity)]
-#![feature(tuple_trait)]
-#![feature(ub_checks)]
-#![feature(unicode_internals)]
-#![feature(unsize)]
-#![feature(unwrap_infallible)]
-// tidy-alphabetical-end
+// not-alphabetical-start
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(alloc_layout_extra))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(allocator_api))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(array_chunks))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(array_into_iter_constructors))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(array_windows))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(ascii_char))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(assert_matches))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(async_fn_traits))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(async_iterator))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(bstr))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(bstr_internals))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(char_internals))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(char_max_len))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(clone_to_uninit))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(coerce_unsized))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(const_default))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(const_eval_select))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(const_heap))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(const_trait_impl))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(core_intrinsics))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(deprecated_suggestion))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(deref_pure_trait))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(dispatch_from_dyn))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(ergonomic_clones))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(error_generic_member_access))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(exact_size_is_empty))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(extend_one))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(extend_one_unchecked))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(fmt_internals))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(fn_traits))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(formatting_options))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(generic_atomic))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(hasher_prefixfree_extras))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(inplace_iteration))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(iter_advance_by))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(iter_next_chunk))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(layout_for_ptr))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(legacy_receiver_trait))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(local_waker))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(maybe_uninit_slice))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(maybe_uninit_uninit_array_transpose))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(panic_internals))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(pattern))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(pin_coerce_unsized_trait))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(ptr_alignment_type))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(ptr_internals))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(ptr_metadata))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(set_ptr_value))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(sized_type_properties))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(slice_from_ptr_range))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(slice_index_methods))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(slice_iter_mut_as_mut_slice))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(slice_ptr_get))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(slice_range))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(std_internals))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(str_internals))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(temporary_niche_types))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(trusted_fused))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(trusted_len))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(trusted_random_access))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(try_trait_v2))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(try_with_capacity))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(tuple_trait))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(ub_checks))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(unicode_internals))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(unsize))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(unwrap_infallible))]
+// not-alphabetical-end
 //
 // Language features:
-// tidy-alphabetical-start
+// not-alphbetical-start
 #![feature(allocator_internals)]
-#![feature(allow_internal_unstable)]
-#![feature(cfg_sanitize)]
-#![feature(const_precise_live_drops)]
-#![feature(coroutine_trait)]
-#![feature(decl_macro)]
-#![feature(dropck_eyepatch)]
-#![feature(fundamental)]
-#![feature(hashmap_internals)]
-#![feature(intrinsics)]
-#![feature(lang_items)]
-#![feature(min_specialization)]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(allow_internal_unstable))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(cfg_sanitize))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(const_precise_live_drops))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(coroutine_trait))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(decl_macro))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(dropck_eyepatch))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(fundamental))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(hashmap_internals))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(intrinsics))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(lang_items))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(min_specialization))]
 #![feature(multiple_supertrait_upcastable)]
-#![feature(negative_impls)]
-#![feature(never_type)]
-#![feature(optimize_attribute)]
-#![feature(rustc_allow_const_fn_unstable)]
-#![feature(rustc_attrs)]
-#![feature(slice_internals)]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(negative_impls))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(never_type))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(optimize_attribute))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(rustc_allow_const_fn_unstable))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(rustc_attrs))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(slice_internals))]
 #![feature(staged_api)]
-#![feature(stmt_expr_attributes)]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(stmt_expr_attributes))]
 #![feature(strict_provenance_lints)]
-#![feature(unboxed_closures)]
-#![feature(unsized_fn_params)]
-#![feature(with_negative_coherence)]
-#![rustc_preserve_ub_checks]
-// tidy-alphabetical-end
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(unboxed_closures))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(unsized_fn_params))]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(with_negative_coherence))]
+#![cfg_attr(not(feature = "ferrocene_certified"), rustc_preserve_ub_checks)]
+// not-alphbetical-end
 //
 // Rustdoc features:
-#![feature(doc_cfg)]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(doc_cfg))]
 #![feature(doc_cfg_hide)]
 // Technically, this is a bug in rustdoc: rustdoc sees the documentation on `#[lang = slice_alloc]`
 // blocks is for `&[T]`, which also has documentation using this feature in `core`, and gets mad
 // that the feature-gate isn't enabled. Ideally, it wouldn't check for the feature gate for docs
 // from other crates, but since this can only appear for lang items, it doesn't seem worth fixing.
-#![feature(intra_doc_pointers)]
+#![cfg_attr(not(feature = "ferrocene_certified"), feature(intra_doc_pointers))]
 
 // Module with internal macros used by other modules (needs to be included before other modules).
 #[macro_use]
+#[cfg(not(feature = "ferrocene_certified"))]
 mod macros;
 
+#[cfg(not(feature = "ferrocene_certified"))]
 mod raw_vec;
 
 // Heaps provided for low-level allocation strategies
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod alloc;
 
 // Primitive types using the heaps above
@@ -214,27 +220,41 @@ pub mod alloc;
 // Need to conditionally define the mod from `boxed.rs` to avoid
 // duplicating the lang-items when building in test cfg; but also need
 // to allow code to have `use boxed::Box;` declarations.
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod borrow;
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod boxed;
 #[unstable(feature = "bstr", issue = "134915")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod bstr;
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod collections;
 #[cfg(all(not(no_rc), not(no_sync), not(no_global_oom_handling)))]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod ffi;
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod fmt;
 #[cfg(not(no_rc))]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod rc;
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod slice;
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod str;
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod string;
 #[cfg(all(not(no_rc), not(no_sync), target_has_atomic = "ptr"))]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod sync;
 #[cfg(all(not(no_global_oom_handling), not(no_rc), not(no_sync)))]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod task;
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod vec;
 
 #[doc(hidden)]
 #[unstable(feature = "liballoc_internals", issue = "none", reason = "implementation detail")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod __export {
     pub use core::format_args;
     pub use core::hint::must_use;

--- a/library/compiler-builtins/compiler-builtins/Cargo.toml
+++ b/library/compiler-builtins/compiler-builtins/Cargo.toml
@@ -59,3 +59,6 @@ rustc-dep-of-std = ["compiler-builtins", "dep:core"]
 # This makes certain traits and function specializations public that
 # are not normally public but are required by the `builtins-test`
 unstable-public-internals = []
+
+# Ferrocene addition
+ferrocene_certified = []

--- a/library/compiler-builtins/compiler-builtins/src/lib.rs
+++ b/library/compiler-builtins/compiler-builtins/src/lib.rs
@@ -41,26 +41,36 @@
 // AAPCS calling convention (`extern "aapcs"`) because that's how LLVM will call them.
 
 #[cfg(test)]
+#[cfg(not(feature = "ferrocene_certified"))]
 extern crate core;
 
 #[macro_use]
+#[cfg(not(feature = "ferrocene_certified"))]
 mod macros;
 
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod float;
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod int;
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod math;
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod mem;
 
 // `libm` expects its `support` module to be available in the crate root.
+#[cfg(not(feature = "ferrocene_certified"))]
 use math::libm_math::support;
 
 #[cfg(target_arch = "arm")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod arm;
 
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod aarch64;
 
 #[cfg(all(target_arch = "aarch64", target_os = "linux", not(feature = "no-asm"),))]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod aarch64_linux;
 
 #[cfg(all(
@@ -68,23 +78,30 @@ pub mod aarch64_linux;
     any(target_os = "linux", target_os = "android"),
     target_arch = "arm"
 ))]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod arm_linux;
 
 #[cfg(target_arch = "avr")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod avr;
 
 #[cfg(target_arch = "hexagon")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod hexagon;
 
 #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod riscv;
 
 #[cfg(target_arch = "x86")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod x86;
 
 #[cfg(target_arch = "x86_64")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod x86_64;
 
+#[cfg(not(feature = "ferrocene_certified"))]
 pub mod probestack;
 
 // ferrocene addition: symbol needed by profiler-builtins on 32-bit ARM

--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -22,7 +22,7 @@ bench = false
 
 [features]
 # Ferrocene addition: only include certified code
-ferrocene_certified = ["panic_immediate_abort"]
+ferrocene_certified = []
 # Ferrocene addition: only add the explicit dependency to profiler_builtins when we are building
 # core specifically for profiling.
 ferrocene_inject_profiler_builtins = ["dep:profiler_builtins"]

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -3,7 +3,6 @@
 #![stable(feature = "core_panic_info", since = "1.41.0")]
 
 mod location;
-#[cfg(not(feature = "ferrocene_certified"))]
 mod panic_info;
 #[cfg(not(feature = "ferrocene_certified"))]
 mod unwind_safe;
@@ -11,7 +10,6 @@ mod unwind_safe;
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 pub use self::location::Location;
 #[stable(feature = "panic_hooks", since = "1.10.0")]
-#[cfg(not(feature = "ferrocene_certified"))]
 pub use self::panic_info::PanicInfo;
 #[stable(feature = "panic_info_message", since = "1.81.0")]
 #[cfg(not(feature = "ferrocene_certified"))]
@@ -55,7 +53,7 @@ pub macro panic_2015 {
 #[allow_internal_unstable(panic_internals, const_format_args)]
 #[rustc_diagnostic_item = "core_panic_2021_macro"]
 #[rustc_macro_transparency = "semitransparent"]
-#[cfg(all(feature = "ferrocene_certified", feature = "panic_immediate_abort"))]
+#[cfg(feature = "ferrocene_certified")]
 pub macro panic_2021($($t:tt)*) {{ $crate::panicking::panic("explicit panic") }}
 
 #[doc(hidden)]

--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -1,5 +1,8 @@
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::fmt::{self, Display};
+#[cfg(not(feature = "ferrocene_certified"))]
 use crate::panic::Location;
+use crate::panicking::PanicFmt;
 
 /// A struct providing information about a panic.
 ///
@@ -10,11 +13,15 @@ use crate::panic::Location;
 /// [`std::panic::PanicHookInfo`]: ../../std/panic/struct.PanicHookInfo.html
 #[lang = "panic_info"]
 #[stable(feature = "panic_hooks", since = "1.10.0")]
-#[derive(Debug)]
+#[cfg_attr(not(feature = "ferrocene_certified"), derive(Debug))]
 pub struct PanicInfo<'a> {
-    message: &'a fmt::Arguments<'a>,
+    #[cfg_attr(feature = "ferrocene_certified", allow(dead_code))]
+    message: &'a PanicFmt<'a>,
+    #[cfg(not(feature = "ferrocene_certified"))]
     location: &'a Location<'a>,
+    #[cfg(not(feature = "ferrocene_certified"))]
     can_unwind: bool,
+    #[cfg(not(feature = "ferrocene_certified"))]
     force_no_backtrace: bool,
 }
 
@@ -25,14 +32,27 @@ pub struct PanicInfo<'a> {
 ///
 /// See [`PanicInfo::message`].
 #[stable(feature = "panic_info_message", since = "1.81.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 pub struct PanicMessage<'a> {
     message: &'a fmt::Arguments<'a>,
 }
 
+// Ferrocene addition: When `ferrocene_certified` is enabled, `PanicInfo` only holds a reference to
+// a static string with the panic message. This `impl` adds a new builder to reflect that.
+#[cfg(feature = "ferrocene_certified")]
+impl<'a> PanicInfo<'a> {
+    #[inline]
+    pub(crate) fn new(message: &'a PanicFmt<'a>) -> Self {
+        PanicInfo { message }
+    }
+}
+
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a> PanicInfo<'a> {
     #[inline]
     pub(crate) fn new(
-        message: &'a fmt::Arguments<'a>,
+        // Ferrocene annotation: Replace `fmt::Arguments` by the `PanicFmt` alias.
+        message: &'a PanicFmt<'a>,
         location: &'a Location<'a>,
         can_unwind: bool,
         force_no_backtrace: bool,
@@ -141,6 +161,7 @@ impl<'a> PanicInfo<'a> {
 }
 
 #[stable(feature = "panic_hook_display", since = "1.26.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl Display for PanicInfo<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("panicked at ")?;
@@ -151,6 +172,7 @@ impl Display for PanicInfo<'_> {
     }
 }
 
+#[cfg(not(feature = "ferrocene_certified"))]
 impl<'a> PanicMessage<'a> {
     /// Gets the formatted message, if it has no arguments to be formatted at runtime.
     ///
@@ -174,6 +196,7 @@ impl<'a> PanicMessage<'a> {
 }
 
 #[stable(feature = "panic_info_message", since = "1.81.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl Display for PanicMessage<'_> {
     #[inline]
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -182,6 +205,7 @@ impl Display for PanicMessage<'_> {
 }
 
 #[stable(feature = "panic_info_message", since = "1.81.0")]
+#[cfg(not(feature = "ferrocene_certified"))]
 impl fmt::Debug for PanicMessage<'_> {
     #[inline]
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -31,8 +31,16 @@
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::fmt;
 use crate::intrinsics::const_eval_select;
+#[cfg(feature = "ferrocene_certified")]
+use crate::panic::PanicInfo;
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::panic::{Location, PanicInfo};
+
+/// Ferrocene addition: Alias used in our panic-related patches to avoid having to certify `fmt`.
+#[cfg(not(feature = "ferrocene_certified"))]
+pub(crate) type PanicFmt<'a> = fmt::Arguments<'a>;
+#[cfg(feature = "ferrocene_certified")]
+pub(crate) type PanicFmt<'a> = &'a &'static str;
 
 #[cfg(feature = "panic_immediate_abort")]
 #[cfg(not(feature = "ferrocene_certified"))] /* blocked on `assert` */
@@ -55,8 +63,7 @@ const _: () = assert!(cfg!(panic = "abort"), "panic_immediate_abort requires -C 
 #[lang = "panic_fmt"] // needed for const-evaluated panics
 #[rustc_do_not_const_check] // hooked by const-eval
 #[rustc_const_stable_indirect] // must follow stable const rules since it is exposed to stable
-#[cfg(not(feature = "ferrocene_certified"))]
-pub const fn panic_fmt(fmt: fmt::Arguments<'_>) -> ! {
+pub const fn panic_fmt(fmt: PanicFmt<'_>) -> ! {
     if cfg!(feature = "panic_immediate_abort") {
         super::intrinsics::abort()
     }
@@ -68,26 +75,17 @@ pub const fn panic_fmt(fmt: fmt::Arguments<'_>) -> ! {
         fn panic_impl(pi: &PanicInfo<'_>) -> !;
     }
 
+    #[cfg(not(feature = "ferrocene_certified"))]
     let pi = PanicInfo::new(
         &fmt,
         Location::caller(),
         /* can_unwind */ true,
         /* force_no_backtrace */ false,
     );
-
+    #[cfg(feature = "ferrocene_certified")]
+    let pi = PanicInfo::new(&fmt);
     // SAFETY: `panic_impl` is defined in safe Rust code and thus is safe to call.
     unsafe { panic_impl(&pi) }
-}
-
-/// FIXME(pvdrz): This is just a hack so we can get `panic` working.
-#[inline]
-#[track_caller]
-#[lang = "panic_fmt"] // needed for const-evaluated panics
-#[rustc_do_not_const_check] // hooked by const-eval
-#[rustc_const_stable_indirect] // must follow stable const rules since it is exposed to stable
-#[cfg(all(feature = "ferrocene_certified", feature = "panic_immediate_abort"))]
-const fn panic_fmt(_expr: &'static str) -> ! {
-    super::intrinsics::abort()
 }
 
 /// Like `panic_fmt`, but for non-unwinding panics.
@@ -102,10 +100,9 @@ const fn panic_fmt(_expr: &'static str) -> ! {
 #[rustc_nounwind]
 #[rustc_const_stable_indirect] // must follow stable const rules since it is exposed to stable
 #[rustc_allow_const_fn_unstable(const_eval_select)]
-#[cfg(not(feature = "ferrocene_certified"))]
-pub const fn panic_nounwind_fmt(fmt: fmt::Arguments<'_>, force_no_backtrace: bool) -> ! {
+pub const fn panic_nounwind_fmt(fmt: PanicFmt<'_>, _force_no_backtrace: bool) -> ! {
     const_eval_select!(
-        @capture { fmt: fmt::Arguments<'_>, force_no_backtrace: bool } -> !:
+        @capture { fmt: PanicFmt<'_>, _force_no_backtrace: bool } -> !:
         if const #[track_caller] {
             // We don't unwind anyway at compile-time so we can call the regular `panic_fmt`.
             panic_fmt(fmt)
@@ -122,37 +119,18 @@ pub const fn panic_nounwind_fmt(fmt: fmt::Arguments<'_>, force_no_backtrace: boo
             }
 
             // PanicInfo with the `can_unwind` flag set to false forces an abort.
+            #[cfg(not(feature = "ferrocene_certified"))]
             let pi = PanicInfo::new(
                 &fmt,
                 Location::caller(),
                 /* can_unwind */ false,
-                force_no_backtrace,
+                _force_no_backtrace,
             );
+            #[cfg(feature = "ferrocene_certified")]
+            let pi = PanicInfo::new(&fmt);
 
             // SAFETY: `panic_impl` is defined in safe Rust code and thus is safe to call.
             unsafe { panic_impl(&pi) }
-        }
-    )
-}
-
-/// FIXME(pvdrz): This is just a hack so we can get `panic_nounwind` working.
-#[inline]
-#[track_caller]
-// This attribute has the key side-effect that if the panic handler ignores `can_unwind`
-// and unwinds anyway, we will hit the "unwinding out of nounwind function" guard,
-// which causes a "panic in a function that cannot unwind".
-#[rustc_nounwind]
-#[rustc_const_stable_indirect] // must follow stable const rules since it is exposed to stable
-#[rustc_allow_const_fn_unstable(const_eval_select)]
-#[cfg(all(feature = "ferrocene_certified", feature = "panic_immediate_abort"))]
-pub const fn panic_nounwind_fmt(_expr: &'static str, _force_no_backtrace: bool) -> ! {
-    const_eval_select!(
-        @capture { _expr: &'static str, _force_no_backtrace: bool } -> !:
-        if const #[track_caller] {
-            // We don't unwind anyway at compile-time so we can call the regular `panic_fmt`.
-            panic_fmt(_expr)
-        } else #[track_caller] {
-            super::intrinsics::abort()
         }
     )
 }
@@ -183,7 +161,7 @@ pub const fn panic(expr: &'static str) -> ! {
     #[cfg(not(feature = "ferrocene_certified"))]
     panic_fmt(fmt::Arguments::new_const(&[expr]));
     #[cfg(feature = "ferrocene_certified")]
-    panic_fmt(expr)
+    panic_fmt(&expr)
 }
 
 // We generate functions for usage by compiler-generated assertions.
@@ -268,7 +246,7 @@ pub const fn panic_nounwind(expr: &'static str) -> ! {
     #[cfg(not(feature = "ferrocene_certified"))]
     panic_nounwind_fmt(fmt::Arguments::new_const(&[expr]), /* force_no_backtrace */ false);
     #[cfg(feature = "ferrocene_certified")]
-    panic_nounwind_fmt(expr, /* force_no_backtrace */ false);
+    panic_nounwind_fmt(&expr, /* force_no_backtrace */ false);
 }
 
 /// Like `panic_nounwind`, but also inhibits showing a backtrace.

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -409,12 +409,9 @@ use crate::num::NonZero;
 #[cfg(not(feature = "ferrocene_certified"))]
 use crate::{fmt, hash, intrinsics, ub_checks};
 #[cfg(feature = "ferrocene_certified")]
-use crate::{
-    intrinsics,
-    marker::PointeeSized,
-    mem::{self, SizedTypeProperties},
-    ub_checks,
-};
+use crate::{intrinsics, marker::PointeeSized, mem};
+#[cfg(all(debug_assertions, feature = "ferrocene_certified"))]
+use crate::{mem::SizedTypeProperties, ub_checks};
 
 mod alignment;
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]

--- a/library/core/src/ub_checks.rs
+++ b/library/core/src/ub_checks.rs
@@ -119,6 +119,10 @@ pub(crate) const fn check_language_ub() -> bool {
 /// check is anyway not executed in `const`.
 #[inline]
 #[rustc_allow_const_fn_unstable(const_eval_select)]
+#[cfg(any(
+    not(feature = "ferrocene_certified"),
+    all(feature = "ferrocene_certified", debug_assertions)
+))]
 pub(crate) const fn maybe_is_aligned_and_not_null(
     ptr: *const (),
     align: usize,

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -661,6 +661,9 @@ pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, stage: u32, car
             features.push_str(compiler_builtins_c_feature);
         }
 
+        if target.ends_with(".certified") {
+            features += " ferrocene_certified";
+        }
         // for no-std targets we only compile a few no_std crates
         cargo
             .args(["-p", "alloc"])

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -37,6 +37,8 @@ const STAGE0_MISSING_TARGETS: &[&str] = &[
     "aarch64-unknown-ferrocenecoretest",
     "thumbv7em-ferrocenecoretest-eabi",
     "thumbv7em-ferrocenecoretest-eabihf",
+    "aarch64-unknown-none.certified",
+    "x86_64-unknown-none.certified",
     // just a dummy comment so the list doesn't get onelined
 ];
 

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -39,6 +39,8 @@ const STAGE0_MISSING_TARGETS: &[&str] = &[
     "thumbv7em-ferrocenecoretest-eabihf",
     "aarch64-unknown-none.certified",
     "x86_64-unknown-none.certified",
+    "thumbv7em-none-eabi.certified",
+    "thumbv7em-none-eabihf.certified",
     // just a dummy comment so the list doesn't get onelined
 ];
 

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -105,27 +105,28 @@ pub fn fill_target_compiler(build: &mut Build, target: TargetSelection) {
         cfg.compiler(cc);
     }
 
-    // Ferrocene annotation: cc 1.1.32 and newer does not support custom targets outside of
-    // build script context (rust-lang/cc-rs#1225). Map `ferrocenecoretest` targets back to the
-    // targets they are test doubles for, and temporarily pass that triple to `cc` to determine
-    // the C compiler.
-    let ferrocenecoretest_compiler = if target.triple.contains("-ferrocenecoretest") {
-        let sub = target.triple.replace("ferrocenecoretest", "none");
-        cfg.target(&sub);
-        let compiler = cfg.get_compiler();
+    // Ferrocene annotation: cc 1.1.32 and newer does not support custom targets outside of build
+    // script context (rust-lang/cc-rs#1225). Map `ferrocenecoretest` and `.certified` targets back
+    // to the targets they are test doubles for, and temporarily pass that triple to `cc` to
+    // determine the C compiler.
+    let ferrocenecoretest_compiler =
+        if target.triple.contains("-ferrocenecoretest") || target.triple.ends_with(".certified") {
+            let sub = target.triple.replace("ferrocenecoretest", "none").replace(".certified", "");
+            cfg.target(&sub);
+            let compiler = cfg.get_compiler();
 
-        cfg.target(&target.triple);
+            cfg.target(&target.triple);
 
-        Some(compiler)
-    } else {
-        None
-    };
+            Some(compiler)
+        } else {
+            None
+        };
     let compiler = ferrocenecoretest_compiler.clone().unwrap_or_else(|| cfg.get_compiler());
     let ar = if let ar @ Some(..) = config.and_then(|c| c.ar.clone()) {
         ar
     } else {
         if ferrocenecoretest_compiler.is_some() {
-            let sub = target.triple.replace("ferrocenecoretest", "none");
+            let sub = target.triple.replace("ferrocenecoretest", "none").replace(".certified", "");
             cfg.target(&sub);
         }
         cfg.try_get_archiver().map(|c| PathBuf::from(c.get_program())).ok()

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -441,6 +441,10 @@ target | std | host | notes
 `aarch64-unknown-ferrocenecoretest` | ✓ | ✓ | Internal target for tests
 `thumbv7em-ferrocenecoretest-eabi` | ✓ | ✓ | Internal target for tests
 `thumbv7em-ferrocenecoretest-eabihf` | ✓ | ✓ | Internal target for tests
+`x86_64-unknown-none.certified` | * |  | Freestanding/bare-metal x86_64, softfloat (certified)
+`aarch64-unknown-none.certified` | * |  | Bare ARM64, hardfloat (certified)
+`thumbv7em-none-eabi.certified` | * |  | Bare Armv7E-M (certified)
+`thumbv7em-none-eabihf.certified` | * |  | Bare Armv7E-M, hardfloat (certified)
 
 [runs on NVIDIA GPUs]: https://github.com/japaric-archived/nvptx#targets
 [the AMD GPU]: https://llvm.org/docs/AMDGPUUsage.html#processors

--- a/src/tools/tier-check/src/main.rs
+++ b/src/tools/tier-check/src/main.rs
@@ -52,6 +52,10 @@ fn main() {
         "thumbv8m.base-nuttx-eabi",
         "thumbv8m.main-nuttx-eabi",
         "thumbv8m.main-nuttx-eabihf",
+        "x86_64-unknown-none.certified",
+        "aarch64-unknown-none.certified",
+        "thumbv7em-none-eabi.certified",
+        "thumbv7em-none-eabihf.certified",
     ];
     let mut invalid_target_name_found = false;
     for target in &target_list {

--- a/tests/assembly/targets/targets-elf.rs
+++ b/tests/assembly/targets/targets-elf.rs
@@ -730,6 +730,12 @@
 //@ revisions: thumbv7em_ferrocenecoretest_eabihf
 //@ [thumbv7em_ferrocenecoretest_eabihf] compile-flags: --target thumbv7em-ferrocenecoretest-eabihf
 //@ [thumbv7em_ferrocenecoretest_eabihf] needs-llvm-components: arm
+//@ revisions: aarch64_unknown_none_certified
+//@ [aarch64_unknown_none_certified] compile-flags: --target aarch64-unknown-none.certified
+//@ [aarch64_unknown_none_certified] needs-llvm-components: aarch64
+//@ revisions: x86_64_unknown_none_certified
+//@ [x86_64_unknown_none_certified] compile-flags: --target x86_64-unknown-none.certified
+//@ [x86_64_unknown_none_certified] needs-llvm-components: x86_64
 
 // Sanity-check that each target can produce assembly code.
 

--- a/tests/assembly/targets/targets-elf.rs
+++ b/tests/assembly/targets/targets-elf.rs
@@ -736,6 +736,12 @@
 //@ revisions: x86_64_unknown_none_certified
 //@ [x86_64_unknown_none_certified] compile-flags: --target x86_64-unknown-none.certified
 //@ [x86_64_unknown_none_certified] needs-llvm-components: x86_64
+//@ revisions: thumbv7em_none_eabi_certified
+//@ [thumbv7em_none_eabi_certified] compile-flags: --target thumbv7m-none-eabi.certified
+//@ [thumbv7em_none_eabi_certified] needs-llvm-components: arm
+//@ revisions: thumbv7em_none_eabihf_certified
+//@ [thumbv7em_none_eabihf_certified] compile-flags: --target thumbv7m-none-eabihf.certified
+//@ [thumbv7em_none_eabihf_certified] needs-llvm-components: arm
 
 // Sanity-check that each target can produce assembly code.
 

--- a/tests/assembly/targets/targets-elf.rs
+++ b/tests/assembly/targets/targets-elf.rs
@@ -737,10 +737,10 @@
 //@ [x86_64_unknown_none_certified] compile-flags: --target x86_64-unknown-none.certified
 //@ [x86_64_unknown_none_certified] needs-llvm-components: x86_64
 //@ revisions: thumbv7em_none_eabi_certified
-//@ [thumbv7em_none_eabi_certified] compile-flags: --target thumbv7m-none-eabi.certified
+//@ [thumbv7em_none_eabi_certified] compile-flags: --target thumbv7em-none-eabi.certified
 //@ [thumbv7em_none_eabi_certified] needs-llvm-components: arm
 //@ revisions: thumbv7em_none_eabihf_certified
-//@ [thumbv7em_none_eabihf_certified] compile-flags: --target thumbv7m-none-eabihf.certified
+//@ [thumbv7em_none_eabihf_certified] compile-flags: --target thumbv7em-none-eabihf.certified
 //@ [thumbv7em_none_eabihf_certified] needs-llvm-components: arm
 
 // Sanity-check that each target can produce assembly code.


### PR DESCRIPTION
> [!NOTE]
> This is the fourth PR to merge the changes from libcore-cert into main.

This PR introduces "certified targets". They will only include parts of libcore that are certified. This allows building and linking against certified libcore, as well as building the docs for certified libcore more easily.

Following targets are added:
- x86_64-unknown-none.certified
- aarch64-unknown-none.certified
- thumbv7em-none-eabi.certified
- thumbv7em-none-eabihf.certified

Note this was originally implemented by @pvdrz in:
- #1547
- #1551 
- #1550


