### PR TITLE
Make coverage-of-subset not introduce newlines

### DIFF
--- a/ferrocene/tools/coverage-of-subset/src/main.rs
+++ b/ferrocene/tools/coverage-of-subset/src/main.rs
@@ -12,7 +12,7 @@ const TO_BE_INSERTED: &str = "#[coverage(off)]";
 // Note: Has to be a lock to be used in a static. Will only ever be called from
 // one thread, so it should not be blocking in reality.
 static MARKER_PLUS_TO_BE_INSERTED: LazyLock<String> =
-    LazyLock::new(|| format!("{MARKER}\n{TO_BE_INSERTED}"));
+    LazyLock::new(|| format!("{MARKER} {TO_BE_INSERTED}"));
 
 fn main() {
     // The path to inject the coverage(off) attributes.
@@ -114,23 +114,19 @@ impl F {
 "#;
 
     const TEST_FILE_CORRECT: &str = r#"
-#[cfg(not(feature = "ferrocene_certified"))]
-#[coverage(off)]
+#[cfg(not(feature = "ferrocene_certified"))] #[coverage(off)]
 fn a{} {}
 
-#[cfg(not(feature = "ferrocene_certified"))]
-#[coverage(off)]
+#[cfg(not(feature = "ferrocene_certified"))] #[coverage(off)]
 fn b() {}
 
 #[cfg(feature = "ferrocene_certified")]
 fn b() {}
 
-#[cfg(not(feature = "ferrocene_certified"))]
-#[coverage(off)]
+#[cfg(not(feature = "ferrocene_certified"))] #[coverage(off)]
 mod c;
 
-#[cfg(not(feature = "ferrocene_certified"))]
-#[coverage(off)]
+#[cfg(not(feature = "ferrocene_certified"))] #[coverage(off)]
 impl D {
     fn e() {}
 }
@@ -138,8 +134,7 @@ impl D {
 impl F {
     fn g() {}
 
-    #[cfg(not(feature = "ferrocene_certified"))]
-#[coverage(off)]
+    #[cfg(not(feature = "ferrocene_certified"))] #[coverage(off)]
     fn h() {}
 }
 "#;


### PR DESCRIPTION
We noticed that the coverage lines seemed wrong in some measurements and I noticed that our coverage report in CI is using outcomes from a version of core with `coverage-of-subset` run, which [introduces new lines to the code](https://github.com/ferrocene/ferrocene/blob/cddbe05d4e0223ec24085522c63b386db674ca0f/ferrocene/tools/coverage-of-subset/src/main.rs#L118), but [the coverage report uses the actual libcore](https://github.com/ferrocene/ferrocene/blob/82e625f38c11d4ca03adbfbf230bec4ef22b5411/.circleci/workflows.yml#L138). This is a problem.

This seems to resolve it.

Before:

<img width="1359" height="547" alt="image" src="https://github.com/user-attachments/assets/75270b39-ec34-4788-bd91-7159c6a34a94" />

After

<img width="1359" height="547" alt="image" src="https://github.com/user-attachments/assets/0fea6ce3-45da-4dd5-8e63-b01beea24b1c" />
