### PR TITLE
Improve `library/core/src` coverage

### DIFF
--- a/library/coretests/tests/cmp.rs
+++ b/library/coretests/tests/cmp.rs
@@ -215,6 +215,13 @@ fn cmp_default() {
     assert_eq!(Fool(false), Fool(true));
 }
 
+#[test]
+fn clamp() {
+    assert_eq!((-3).clamp(-2, 1), -2);
+    assert_eq!(0.clamp(-2, 1), 0);
+    assert_eq!(2.clamp(-2, 1), 1);
+}
+
 /* FIXME(#110395)
 mod const_cmp {
     use super::*;

--- a/library/coretests/tests/option.rs
+++ b/library/coretests/tests/option.rs
@@ -251,6 +251,12 @@ fn test_unwrap_or_else() {
 }
 
 #[test]
+fn test_unwrap_or_default() {
+    assert_eq!(Some(666u32).unwrap_or_default(), 666);
+    assert_eq!(None::<u32>.unwrap_or_default(), 0);
+}
+
+#[test]
 fn test_unwrap_unchecked() {
     assert_eq!(unsafe { Some(1).unwrap_unchecked() }, 1);
     let s = unsafe { Some("hello".to_string()).unwrap_unchecked() };

--- a/library/coretests/tests/result.rs
+++ b/library/coretests/tests/result.rs
@@ -45,6 +45,18 @@ fn test_or_else() {
 }
 
 #[test]
+fn test_map_or() {
+    assert_eq!(op1().map_or(667, |x| x), 666);
+    assert_eq!(op2().map_or(666, |_| panic!()), 666);
+}
+
+#[test]
+fn test_copied() {
+    assert!(Ok::<&isize, isize>(&1).copied() == Ok(1));
+    assert!(Err::<&isize, isize>(1).copied() == Err(1));
+}
+
+#[test]
 fn test_impl_map() {
     assert!(Ok::<isize, isize>(1).map(|x| x + 1) == Ok(2));
     assert!(Err::<isize, isize>(1).map(|x| x + 1) == Err(1));


### PR DESCRIPTION
This improves the coverage of all the single file modules inside `library/core/src`:
- **Cover `core::cmp`**
- **Cover `core::result`**
- **Cover `core::option`**
