### PR TITLE
Support dev containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: The Ferrocene Developers
+
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ferrocene CI (Ubuntu 20.04)",
+
+	"build": {
+		"dockerfile": "../ferrocene/ci/docker-images/ubuntu-20/Dockerfile",
+		"context": ".."
+	},
+
+	"mounts": [
+		"source=${localEnv:HOME}/.aws,target=/home/ci/.aws,type=bind,consistency=cached"
+	],
+
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"chat.agent.enabled": false,
+				"telemetry.feedback.enabled": false
+			},
+			"extensions": [
+				"rust-lang.rust-analyzer",
+				"tamasfe.even-better-toml"
+			]
+		}
+	}
+}

--- a/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
@@ -46,6 +46,10 @@ RUN <<-EOF
     # Update all the dependencies
     apt-get upgrade -y
 
+    # Update Git to support ssh signing
+    apt install software-properties-common --yes
+    add-apt-repository ppa:git-core/ppa --yes
+
     # Install required packages
     apt-install \
         git \

--- a/license-metadata.json
+++ b/license-metadata.json
@@ -448,6 +448,7 @@
           {
             "directories": [
               ".circleci",
+              ".devcontainer",
               "src/bootstrap/src/ferrocene"
             ],
             "files": [


### PR DESCRIPTION
Does the needful to support running our `ubuntu-20` CI image as a dev container. This is sufficient to build every dist artifact.

This is kind of an experiment right now, so no docs or anything high effort.

You can try with https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
