### PR TITLE
[1.88] Fixup code coverage

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -276,6 +276,8 @@ jobs:
       FERROCENE_CODE_COV: 1
       SCRIPT: |
         ferrocene/ci/scripts/llvm_cache.py download
+        sed -i -e "s/profile = 'ferrocene-dist'/profile = 'compiler'/g" bootstrap.toml
+        sed -i -e "s/^\\[build\\]/[build]\\nprofiler = true\\nmetrics=true/g" bootstrap.toml
         ./x.py run ferrocene/tools/coverage-of-subset
         ./x.py test --no-doc --coverage=library library/core -v
     steps:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -273,10 +273,9 @@ jobs:
     resource_class: medium # 2-core
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
+      FERROCENE_CODE_COV: 1
       SCRIPT: |
         ferrocene/ci/scripts/llvm_cache.py download
-        sed -i -e "s/profile = 'ferrocene-dist'/profile = 'compiler'/g" bootstrap.toml
-        sed -i -e "s/^\\[build\\]/[build]\\nprofiler = true\\nmetrics=true/g" bootstrap.toml
         ./x.py run ferrocene/tools/coverage-of-subset
         ./x.py test --no-doc --coverage=library library/core -v
     steps:

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -840,6 +840,15 @@ pub macro version($early_dcx: expr, $binary: literal, $matches: expr) {
     fn unw(x: Option<&str>) -> &str {
         x.unwrap_or("unknown")
     }
+
+    // Ferrocene annotation: During libcore certification we determined there were coverage inaccuracies
+    // when the `channel` is not set to `nightly`. Our research so far has shown this as the most minimal fix.
+    // First half (second below)
+    let cfg_release = unw(option_env!("CFG_RELEASE"));
+    let replaced_cfg_release = cfg_release.replace("-dev", "-nightly")
+            .replace("-beta", "-nightly")
+            .replace("-stable", "-nightly");
+
     $crate::version_at_macro_invocation(
         $early_dcx,
         $binary,
@@ -847,7 +856,14 @@ pub macro version($early_dcx: expr, $binary: literal, $matches: expr) {
         unw(option_env!("CFG_VERSION")),
         unw(option_env!("CFG_VER_HASH")),
         unw(option_env!("CFG_VER_DATE")),
-        unw(option_env!("CFG_RELEASE")),
+        // Ferrocene annotation: During libcore certification we determined there were coverage inaccuracies
+        // when the `channel` is not set to `nightly`. Our research so far has shown this as the most minimal fix.
+        // Second half (first above)
+        if env::var("FERROCENE_CODE_COV").is_ok() {
+            &replaced_cfg_release
+        } else {
+            cfg_release
+        }
     )
 }
 


### PR DESCRIPTION
This repairs code coverage inaccuracies on branches where `channel` is not set to `nightly`.

It's not determined why this is the case yet, but it fixes it for us locally.

Thanks @japaric for finding the line and confirming the fix.

If this works (we need to validate the artifacts) we will forward port this to main.