### PR TITLE
[1.88] Use LLD by default on x64 regardless of channel

### DIFF
--- a/ferrocene/ignored-tests.toml
+++ b/ferrocene/ignored-tests.toml
@@ -2,6 +2,11 @@
 # SPDX-FileCopyrightText: The Ferrocene Developers
 
 [["tests/run-make"]]
+tests = ["tests/run-make/rust-lld-by-default-beta-stable"]
+targets = ["x86_64-unknown-linux-gnu"]
+reason = "We use lld by default on stable"
+
+[["tests/run-make"]]
 tests = [
     "tests/run-coverage",
     "tests/run-coverage-rustdoc",

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1382,9 +1382,7 @@ pub fn rustc_cargo_env(
     }
 
     // Enable rustc's env var for `rust-lld` when requested.
-    if builder.config.lld_enabled
-        && (builder.config.channel == "dev" || builder.config.channel == "nightly")
-    {
+    if builder.config.lld_enabled {
         cargo.env("CFG_USE_SELF_CONTAINED_LINKER", "1");
     }
 


### PR DESCRIPTION
Cherry pick a fix that was causing us not to use `lld` as the default on x86_64 Linux (*not* any of our qualified bare metal targets).

This should also get backported to other releases.