### PR TITLE
Remove irrelevant libraries from lcov-*.info file

### DIFF
--- a/src/bootstrap/src/ferrocene/code_coverage.rs
+++ b/src/bootstrap/src/ferrocene/code_coverage.rs
@@ -116,6 +116,7 @@ pub(crate) fn generate_coverage_report(builder: &Builder<'_>) {
     };
 
     let ignored_path_regexes: &[&str] = match state.coverage_for {
+        #[rustfmt::skip]
         FerroceneCoverageFor::Library => &[
             // Ignore Cargo dependencies:
             "\\.cargo/registry", // Without remap-path-prefix


### PR DESCRIPTION
Before the libraries were in the info file but excluded when generating the report. Now they are not even in the info file. Also all removed paths are in one place now.

This is mostly a cleanup. The generated report stays the same.