### PR TITLE
Upstream pull automation can handle `^M` in commits

### DIFF
--- a/ferrocene/tools/pull-upstream/generate_pr_body.py
+++ b/ferrocene/tools/pull-upstream/generate_pr_body.py
@@ -56,6 +56,7 @@ def render_changes(origin, base_branch, new_branch):
         [
             "git",
             "log",
+            "-z",
             "--format=%H|%P|%s",
             "--reverse",
             f"{origin}/{base_branch}..{new_branch}",
@@ -72,7 +73,7 @@ def render_changes(origin, base_branch, new_branch):
     # Recreate the commit graph
     commits = {}
     last = None
-    for line in changes.split("\n"):
+    for line in changes.split("\0"):
         if not line:
             continue
         hash, parents, message = line.split("|", 2)


### PR DESCRIPTION
Okay this is a funny/weird one.

In the commit message of https://github.com/rust-lang/rust/commit/41d8d85549fc90967912a32b5604801bf25d8ea7 there is a `^M`, but if you look at https://github.com/rust-lang/rust/pull/145644/ that commmit looks totally fine and non-suspect.

The funny part is Python enjoys interpreting this as a newline.

```python
>>> import subprocess
>>> out = subprocess.run(["git", "log", "--format='%H|%P|%s'", "--reverse", "-n", "1", "41d8d85549fc90967912a32b5604801bf25d8ea7"], text=True, stdout=subprocess.PIPE).stdout.strip()
>>> out.split("\n")
["'41d8d85549fc90967912a32b5604801bf25d8ea7|1ddb4d0062fbe55b88e55cffc00fe8b898512536|Remove ", "hs_abs_cmp examples'"]
>>> out.splitlines()
["'41d8d85549fc90967912a32b5604801bf25d8ea7|1ddb4d0062fbe55b88e55cffc00fe8b898512536|Remove ", "hs_abs_cmp examples'"]
```

Isn't that fun.

Now in here we split on newlines, which, as we've seen above, `^M` is (according to Python), so it broke because we magically started getting lines with only 1 column.

https://github.com/ferrocene/ferrocene/blob/e463bfc942b9535e43ece3ef77d38f5b37bed12c/ferrocene/tools/pull-upstream/generate_pr_body.py#L55-L75

So the solution is to pass `-z` to Git and split on `\0` instead.