### PR TITLE
do not break local users who run qnx scripts

### DIFF
--- a/ferrocene/ci/scripts/emulated-aarch64-qnx-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-aarch64-qnx-test-runner.sh
@@ -113,7 +113,7 @@ cmd_prepare() {
 
     echo
     echo "===> building remote-test-server"
-    stage="${REMOTE_TEST_SERVER_STAGE-0}"
+    stage="${REMOTE_TEST_SERVER_STAGE-1}"
     ./x build src/tools/remote-test-server --target "${nto_target}" --stage "${stage}"
     cp build/host/"stage${stage}-tools"/"${nto_target}"/release/remote-test-server "${emulatordir}"/src/install/aarch64le/sbin
 

--- a/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
@@ -114,7 +114,7 @@ lib/libpci.so.2.3|' "${ifsbuild}"
 
     echo
     echo "===> building and copying remote-test-server into rootfs"
-    stage="${REMOTE_TEST_SERVER_STAGE-0}"
+    stage="${REMOTE_TEST_SERVER_STAGE-1}"
     ./x build src/tools/remote-test-server --target "${nto_target}" --stage "${stage}"
     mkdir -p "${emulatordir}"/shared/
     cp build/host/"stage${stage}-tools"/"${nto_target}"/release/remote-test-server "${emulatordir}"/shared/


### PR DESCRIPTION
REMOTE_TEST_SERVER_STAGE envvar is set in CI, and less likely to be set locally, so have a default that works for those cases. This is needed because --stage 0 no longer works, since the bootstrap change that does not allow in-tree libs to be built with downloaded rustc.