### PR TITLE
Show all primitive types in core library API docs

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -312,7 +312,6 @@ mod prim_bool {}
 /// [2024 edition]: <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
 ///
 #[unstable(feature = "never_type", issue = "35121")]
-#[cfg(not(feature = "ferrocene_certified"))]
 mod prim_never {}
 
 // Required to make auto trait impls render.
@@ -449,7 +448,6 @@ impl ! {}
 /// assert_eq!(32, size_of_val(&v[..]));
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg(not(feature = "ferrocene_certified"))]
 mod prim_char {}
 
 #[rustc_doc_primitive = "unit"]
@@ -491,13 +489,11 @@ mod prim_char {}
 /// ```
 ///
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg(not(feature = "ferrocene_certified"))]
 mod prim_unit {}
 
 // Required to make auto trait impls render.
 // See src/librustdoc/passes/collect_trait_impls.rs:collect_trait_impls
 #[doc(hidden)]
-#[cfg(not(feature = "ferrocene_certified"))]
 impl () {}
 
 #[rustc_doc_primitive = "pointer"]
@@ -620,7 +616,6 @@ impl () {}
 /// [`write`]: ptr::write
 /// [valid]: ptr#safety
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg(not(feature = "ferrocene_certified"))]
 mod prim_pointer {}
 
 #[rustc_doc_primitive = "array"]
@@ -947,7 +942,6 @@ mod prim_array {}
 /// [`.chunks`]: slice::chunks
 /// [`.windows`]: slice::windows
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg(not(feature = "ferrocene_certified"))]
 mod prim_slice {}
 
 #[rustc_doc_primitive = "str"]
@@ -1021,7 +1015,6 @@ mod prim_slice {}
 /// called on a string slice may assume that it is valid UTF-8, which means that a non-UTF-8 string
 /// slice can lead to undefined behavior down the road.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg(not(feature = "ferrocene_certified"))]
 mod prim_str {}
 
 #[rustc_doc_primitive = "tuple"]
@@ -1149,7 +1142,6 @@ mod prim_str {}
 /// ```
 ///
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg(not(feature = "ferrocene_certified"))]
 mod prim_tuple {}
 
 // Required to make auto trait impls render.
@@ -1175,7 +1167,6 @@ impl<T> (T,) {}
 ///
 /// [wikipedia]: https://en.wikipedia.org/wiki/Half-precision_floating-point_format
 #[unstable(feature = "f16", issue = "116909")]
-#[cfg(not(feature = "ferrocene_certified"))]
 mod prim_f16 {}
 
 #[rustc_doc_primitive = "f32"]
@@ -1410,7 +1401,6 @@ mod prim_f64 {}
 ///
 /// [wikipedia]: https://en.wikipedia.org/wiki/Quadruple-precision_floating-point_format
 #[unstable(feature = "f128", issue = "116909")]
-#[cfg(not(feature = "ferrocene_certified"))]
 mod prim_f128 {}
 
 #[rustc_doc_primitive = "i8"]
@@ -1939,7 +1929,6 @@ mod prim_ref {}
 /// In addition, all *safe* function pointers implement [`Fn`], [`FnMut`], and [`FnOnce`], because
 /// these traits are specially known to the compiler.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg(not(feature = "ferrocene_certified"))]
 mod prim_fn {}
 
 // Required to make auto trait impls render.


### PR DESCRIPTION
Some primitive types, like slice or pointer, have been omitted from the documentation. They were part of the subset, but just did not show up in the docs. This was not intended and is fixed by this PR. 

Before on the left, after on the right:

<img width="49%" height="554" alt="Screenshot from 2025-08-28 13-57-10" src="https://github.com/user-attachments/assets/b6c7f3d9-c706-4f5c-94fb-ce2fbb4b96e0" />
<img width="49%" height="846" alt="Screenshot from 2025-08-28 13-54-13" src="https://github.com/user-attachments/assets/ba91a23f-2c79-4a14-9070-b02561654eb1" />
