### PR TITLE
Distribute the certified core library API docs

### DIFF
--- a/ferrocene/doc/core-certification/src/_static/api-docs/core/index.html
+++ b/ferrocene/doc/core-certification/src/_static/api-docs/core/index.html
@@ -1,1 +1,0 @@
-Intentionally left blank.

--- a/ferrocene/doc/core-certification/src/conf.py
+++ b/ferrocene/doc/core-certification/src/conf.py
@@ -20,7 +20,6 @@ ferrocene_id = "CLC"
 html_theme = "ferrocene"
 html_title = "Ferrocene Core Library Certification"
 html_short_title = "Core Library Certification"
-html_static_path = ["_static"]
 
 # Do not generate the index pages. We don't need them, and they cause
 # linkchecker to fail due to them including *all* glossary entries, including

--- a/ferrocene/doc/core-certification/src/subset-api-docs.rst
+++ b/ferrocene/doc/core-certification/src/subset-api-docs.rst
@@ -4,4 +4,4 @@
 Core Library API docs
 =====================
 
-Please find the API docs of the certified core library `here <./_static/api-docs/core/index.html>`_.
+Please find the API docs of the certified core library `here <../api-docs/core/index.html>`_.

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -629,6 +629,12 @@ impl Std {
     ) -> Self {
         Std { build_compiler, target, format, crates: vec![] }
     }
+
+    // Ferrocene addition
+    pub(crate) fn with_crates(mut self, crates: Vec<String>) -> Self {
+        self.crates = crates;
+        self
+    }
 }
 
 impl Step for Std {
@@ -823,6 +829,7 @@ fn doc_std(
     // Ferrocene addition
     if target.contains("ferrocene.certified") {
         cargo.rustdocflag("--cfg=ferrocene_certified");
+        cargo.arg("--features").arg("ferrocene_certified");
     }
 
     if builder.config.library_docs_private_items {

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1202,6 +1202,7 @@ impl<'a> Builder<'a> {
                 crate::ferrocene::doc::CompilerTechnicalReport,
                 crate::ferrocene::doc::CoreTechnicalReport,
                 crate::ferrocene::doc::code_coverage::AllCoverageReports,
+                crate::ferrocene::doc::certified_api_docs::CertifiedApiDocs,
                 // QMS Document
                 crate::ferrocene::doc::InternalProcedures,
             ),

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -1156,6 +1156,7 @@ mod snapshot {
         [doc] style-guide (book) <host>
         [build] rustc 0 <host> -> Compiletest 1 <host>
         [build] rustc 0 <host> -> FerroceneTraceabilityMatrix 1 <host>
+        [doc] rustc 2 <host> -> std 2 <x86_64-unknown-ferrocene.certified> crates=[core]
         "###
         );
     }
@@ -1293,6 +1294,7 @@ mod snapshot {
         [doc] style-guide (book) <host>
         [build] rustc 0 <host> -> Compiletest 1 <host>
         [build] rustc 0 <host> -> FerroceneTraceabilityMatrix 1 <host>
+        [doc] rustc 2 <host> -> std 2 <x86_64-unknown-ferrocene.certified> crates=[core]
         "###);
     }
 
@@ -1367,6 +1369,7 @@ mod snapshot {
         [doc] style-guide (book) <target1>
         [build] rustc 0 <host> -> Compiletest 1 <host>
         [build] rustc 0 <host> -> FerroceneTraceabilityMatrix 1 <host>
+        [doc] rustc 2 <host> -> std 2 <x86_64-unknown-ferrocene.certified> crates=[core]
         "###
         );
     }
@@ -1432,6 +1435,7 @@ mod snapshot {
         [doc] style-guide (book) <host>
         [build] rustc 0 <host> -> Compiletest 1 <host>
         [build] rustc 0 <host> -> FerroceneTraceabilityMatrix 1 <host>
+        [doc] rustc 2 <host> -> std 2 <x86_64-unknown-ferrocene.certified> crates=[core]
         "###
         );
     }
@@ -1516,6 +1520,7 @@ mod snapshot {
         [doc] style-guide (book) <target1>
         [build] rustc 0 <host> -> Compiletest 1 <host>
         [build] rustc 0 <host> -> FerroceneTraceabilityMatrix 1 <host>
+        [doc] rustc 2 <host> -> std 2 <x86_64-unknown-ferrocene.certified> crates=[core]
         "###
         );
     }
@@ -1740,6 +1745,7 @@ mod snapshot {
         [doc] style-guide (book) <host>
         [build] rustc 0 <host> -> Compiletest 1 <host>
         [build] rustc 0 <host> -> FerroceneTraceabilityMatrix 1 <host>
+        [doc] rustc 2 <host> -> std 2 <x86_64-unknown-ferrocene.certified> crates=[core]
         "###);
     }
 
@@ -2928,6 +2934,7 @@ mod snapshot {
         [doc] style-guide (book) <host>
         [build] rustc 0 <host> -> Compiletest 1 <host>
         [build] rustc 0 <host> -> FerroceneTraceabilityMatrix 1 <host>
+        [doc] rustc 2 <host> -> std 2 <x86_64-unknown-ferrocene.certified> crates=[core]
         "###);
     }
 

--- a/src/bootstrap/src/core/config/target_selection.rs
+++ b/src/bootstrap/src/core/config/target_selection.rs
@@ -110,6 +110,20 @@ impl TargetSelection {
         }
     }
 
+    // Ferrocene addition
+    /// Map the target to the certified target that is based on it, if there is one
+    pub fn certified_equivalent(&self) -> Option<TargetSelection> {
+        let target_tuple = match self.triple.as_ref() {
+            "x86_64-unknown-linux-gnu" => "x86_64-unknown-ferrocene.certified",
+            "aarch64-unknown-none" => "aarch64-unknown-ferrocene.certified",
+            "thumbv7em-none-eabi" => "thumbv7em-ferrocene.certified-eabi",
+            "thumbv7em-none-eabihf" => "thumbv7em-ferrocene.certified-eabihf",
+            target if target.contains("ferrocene.certified") => target,
+            _ => return None,
+        };
+        Some(TargetSelection::from_user(target_tuple))
+    }
+
     /// Path to the file defining the custom target, if any.
     pub fn filepath(&self) -> Option<&Path> {
         self.file.as_ref().map(Path::new)

--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -17,7 +17,7 @@ use crate::ferrocene::code_coverage::CoverageOutcomesDir;
 use crate::ferrocene::doc::certified_api_docs::CertifiedApiDocs;
 use crate::ferrocene::doc::ensure_all_xml_doctrees;
 use crate::ferrocene::test_outcomes::TestOutcomesDir;
-use crate::ferrocene::{target_to_certified_target, uv_command};
+use crate::ferrocene::uv_command;
 use crate::utils::exec::command;
 use crate::utils::tarball::{GeneratedTarball, Tarball};
 use crate::{FileType, t};
@@ -50,7 +50,7 @@ impl Step for Docs {
         //
         // NOTE: must be called before .add_directory, since it places the
         // certified API docs in the doc_out
-        if target_to_certified_target(&self.target).is_some() {
+        if self.target.certified_equivalent().is_some() {
             builder.ensure(CertifiedApiDocs { target: self.target });
         } else {
             builder.info(&format!("skipping Build certified-core-docs ({})", self.target));

--- a/src/bootstrap/src/ferrocene/doc/certified_api_docs.rs
+++ b/src/bootstrap/src/ferrocene/doc/certified_api_docs.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use crate::core::build_steps::doc;
 use crate::core::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::core::config::TargetSelection;
-use crate::ferrocene::target_to_certified_target;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub(crate) struct CertifiedApiDocs {
@@ -24,7 +23,9 @@ impl Step for CertifiedApiDocs {
 
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         let certified_crates = vec!["core".into()];
-        let certified_target = target_to_certified_target(&self.target)
+        let certified_target = self
+            .target
+            .certified_equivalent()
             .expect(&format!("no certified equivalent exists for target \"{}\"", &self.target));
 
         // Build the docs for the certified target

--- a/src/bootstrap/src/ferrocene/doc/certified_api_docs.rs
+++ b/src/bootstrap/src/ferrocene/doc/certified_api_docs.rs
@@ -1,0 +1,50 @@
+use std::path::PathBuf;
+
+use crate::core::build_steps::doc;
+use crate::core::builder::{Builder, RunConfig, ShouldRun, Step};
+use crate::core::config::TargetSelection;
+use crate::ferrocene::target_to_certified_target;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub(crate) struct CertifiedApiDocs {
+    pub(crate) target: TargetSelection,
+}
+
+impl Step for CertifiedApiDocs {
+    type Output = PathBuf;
+    const DEFAULT: bool = false;
+
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+        run.alias("ferrocene-certified-api-docs")
+    }
+
+    fn make_run(run: RunConfig<'_>) {
+        run.builder.ensure(CertifiedApiDocs { target: run.target });
+    }
+
+    fn run(self, builder: &Builder<'_>) -> Self::Output {
+        let certified_crates = vec!["core".into()];
+        let certified_target = target_to_certified_target(&self.target)
+            .expect(&format!("no certified equivalent exists for target \"{}\"", &self.target));
+
+        // Build the docs for the certified target
+        let certified_target_doc_out = builder.ensure(
+            doc::Std::from_build_compiler(
+                builder.compiler(builder.top_stage, builder.host_target),
+                certified_target,
+                doc::DocumentationFormat::Html,
+            )
+            .with_crates(certified_crates),
+        );
+
+        // Remove unwanted files/dirs
+        builder.remove(&certified_target_doc_out.join("index.html"));
+
+        // Copy the files from the certified target to the host target
+        let host_target_doc_out = builder.doc_out(self.target).join("certification/api-docs");
+        builder.create_dir(&host_target_doc_out);
+        builder.cp_link_r(&certified_target_doc_out, &host_target_doc_out);
+
+        host_target_doc_out
+    }
+}

--- a/src/bootstrap/src/ferrocene/doc/mod.rs
+++ b/src/bootstrap/src/ferrocene/doc/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: The Ferrocene Developers
 
+pub(crate) mod certified_api_docs;
 pub(crate) mod code_coverage;
 
 use std::collections::HashMap;

--- a/src/bootstrap/src/ferrocene/doc/mod.rs
+++ b/src/bootstrap/src/ferrocene/doc/mod.rs
@@ -9,6 +9,7 @@ use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::{Path, PathBuf, absolute};
 
+use self::certified_api_docs::CertifiedApiDocs;
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::core::build_steps::run::GenerateCopyright;
 use crate::core::config::TargetSelection;
@@ -577,6 +578,9 @@ macro_rules! sphinx_books {
                         fresh_build: false,
                     });
                 )*
+
+                // Generate the API docs for the certified crates
+                builder.ensure(CertifiedApiDocs {target: self.target});
 
                 // Also regenerate the index file, so that the "Ferrocene documentation" link in
                 // the breadcrumbs doesn't break.

--- a/src/bootstrap/src/ferrocene/mod.rs
+++ b/src/bootstrap/src/ferrocene/mod.rs
@@ -202,15 +202,3 @@ fn download_and_extract_ci_outcomes(builder: &Builder<'_>, kind: &str) -> PathBu
 
     extracted_dir.join("share").join("ferrocene").join(&name)
 }
-
-/// Map the target to the certified target that is based on it, if there is one
-pub(crate) fn target_to_certified_target(target: &TargetSelection) -> Option<TargetSelection> {
-    let target_tuple = match target.triple.as_ref() {
-        "x86_64-unknown-linux-gnu" => "x86_64-unknown-ferrocene.certified",
-        "aarch64-unknown-none" => "aarch64-unknown-ferrocene.certified",
-        "thumbv7em-none-eabi" => "thumbv7em-ferrocene.certified-eabi",
-        "thumbv7em-none-eabihf" => "thumbv7em-ferrocene.certified-eabihf",
-        _ => return None,
-    };
-    Some(TargetSelection::from_user(target_tuple))
-}

--- a/src/bootstrap/src/ferrocene/mod.rs
+++ b/src/bootstrap/src/ferrocene/mod.rs
@@ -202,3 +202,15 @@ fn download_and_extract_ci_outcomes(builder: &Builder<'_>, kind: &str) -> PathBu
 
     extracted_dir.join("share").join("ferrocene").join(&name)
 }
+
+/// Map the target to the certified target that is based on it, if there is one
+pub(crate) fn target_to_certified_target(target: &TargetSelection) -> Option<TargetSelection> {
+    let target_tuple = match target.triple.as_ref() {
+        "x86_64-unknown-linux-gnu" => "x86_64-unknown-ferrocene.certified",
+        "aarch64-unknown-none" => "aarch64-unknown-ferrocene.certified",
+        "thumbv7em-none-eabi" => "thumbv7em-ferrocene.certified-eabi",
+        "thumbv7em-none-eabihf" => "thumbv7em-ferrocene.certified-eabihf",
+        _ => return None,
+    };
+    Some(TargetSelection::from_user(target_tuple))
+}

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -26,6 +26,7 @@ use std::iter;
 use std::path::{Path, PathBuf};
 
 use crate::core::config::TargetSelection;
+use crate::ferrocene::target_to_certified_target;
 use crate::utils::cache::Interned;
 use crate::utils::exec::{BootstrapCommand, command};
 use crate::{Build, CLang, GitRepo};
@@ -74,6 +75,9 @@ pub fn fill_compilers(build: &mut Build) {
         }
 
         _ => {
+            // Ferrocene addition: Load the matching certified target
+            let certified_target = target_to_certified_target(&build.host_target);
+
             // For all targets we're going to need a C compiler for building some shims
             // and such as well as for being a linker for Rust code.
             build
@@ -82,6 +86,8 @@ pub fn fill_compilers(build: &mut Build) {
                 .chain(&build.hosts)
                 .cloned()
                 .chain(iter::once(build.host_target))
+                // Ferrocene addition: see above
+                .chain(certified_target)
                 .collect()
         }
     };

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -26,7 +26,6 @@ use std::iter;
 use std::path::{Path, PathBuf};
 
 use crate::core::config::TargetSelection;
-use crate::ferrocene::target_to_certified_target;
 use crate::utils::cache::Interned;
 use crate::utils::exec::{BootstrapCommand, command};
 use crate::{Build, CLang, GitRepo};
@@ -76,7 +75,7 @@ pub fn fill_compilers(build: &mut Build) {
 
         _ => {
             // Ferrocene addition: Load the matching certified target
-            let certified_target = target_to_certified_target(&build.host_target);
+            let certified_target = build.host_target.certified_equivalent();
 
             // For all targets we're going to need a C compiler for building some shims
             // and such as well as for being a linker for Rust code.

--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -84,6 +84,10 @@ const LINKCHECK_EXCEPTIONS: &[(&str, &[&str])] = &[
     // This is fine though, because that section is hidden by the build system with `display: none`
     // when the link is missing. We thus ignore it to avoid a linkchecker complaint.
     ("index.html", &["qualification/technical-report.pdf", "certification/core/technical-report.pdf"]),
+    // The index.html here would be the upstream Rust index.html, which is removed when generating
+    // the certified API docs.
+    ("certification/api-docs/help.html", &["certification/api-docs/index.html"]),
+    ("certification/api-docs/settings.html", &["certification/api-docs/index.html"]),
 ];
 
 #[rustfmt::skip]
@@ -575,6 +579,11 @@ fn load_html_file(file: &Path, report: &mut Report) -> FileEntry {
 }
 
 fn is_intra_doc_exception(file: &Path, link: &str) -> bool {
+    // Ferrocene addition
+    if is_ferrocene_exception(file, link) {
+        return true;
+    }
+
     if let Some(entry) = INTRA_DOC_LINK_EXCEPTIONS.iter().find(|&(f, _)| file.ends_with(f)) {
         entry.1.is_empty() || entry.1.contains(&link)
     } else {
@@ -583,9 +592,11 @@ fn is_intra_doc_exception(file: &Path, link: &str) -> bool {
 }
 
 fn is_exception(file: &Path, link: &str) -> bool {
+    // Ferrocene addition
     if is_ferrocene_exception(file, link) {
         return true;
     }
+
     if let Some(entry) = LINKCHECK_EXCEPTIONS.iter().find(|&(f, _)| file.ends_with(f)) {
         entry.1.contains(&link)
     } else {
@@ -726,11 +737,17 @@ fn is_not_found_error(path: &Path, error: &std::io::Error) -> bool {
             && path.as_os_str().to_str().map_or(false, |s| s.contains("::")))
 }
 
+/// Check if `link` in `file` should be exempted from being linkchecked
 fn is_ferrocene_exception(file: &Path, link: &str) -> bool {
+    let is_certified_docs = file.to_string_lossy().contains("certification/api-docs/");
+
     if FERROCENE_GLOBAL_EXCEPTIONS.contains(&link) {
         true
     } else if file.ends_with("certification/core/subset.html") && link.starts_with("#id") {
         // The links in the csv-table are not expected to work
+        true
+    } else if is_certified_docs {
+        // The certified API docs have many broken links, because of subsetting
         true
     } else {
         false


### PR DESCRIPTION
This PR automates building the API docs for the certified libraries, that is only the core library at the moment. This removes the need for the static HTML copy of the certified core API docs.

It introduces a new bootstrap command: `./x doc ferrocene-certified-api-docs`.

Also it makes the existing commands `./x doc ferrocene/doc` and `./x dist ferrocene-docs` also create the certified API docs. 