### PR TITLE
Add error if out-of-tree dependencies are not found

### DIFF
--- a/src/tools/generate-copyright/src/main.rs
+++ b/src/tools/generate-copyright/src/main.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use anyhow::Error;
+use anyhow::{Error, anyhow};
 use askama::Template;
 
 mod cargo_metadata;
@@ -71,6 +71,11 @@ fn main() -> Result<(), Error> {
             .trim_clone(&src_dir.join("library"), &src_dir)
             .unwrap(),
     };
+    if collected_cargo_metadata.is_empty() {
+        return Err(anyhow!(
+            "Did not find any out-of-tree dependencies. Maybe your `CARGO_HOME` is being excluded?"
+        ));
+    }
 
     // Output main file
     let template = CopyrightTemplate {


### PR DESCRIPTION
Add a simple sanity check to ensure that we actually populate the out of tree deps and aren't impacted by #1491