### PR TITLE
Validate `-fuse-ld=lld` is passed, enable on aarch64

### DIFF
--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -105,6 +105,14 @@ if [[ "${FERROCENE_BUILD_HOST:-}" = "x86_64-pc-windows-msvc" ]]; then
     add --set target.wasm32-unknown-unknown.ar=lld-ar
 fi
 
+# We default to the self-contained lld linker on all targets we can,
+# On targets with other settings as well, set that that there.
+add --set 'target.x86_64-unknown-linux-gnu.default-linker-linux-override=self-contained-lld-cc'
+add --set 'target.x86_64-unknown-linux-musl.default-linker-linux-override=self-contained-lld-cc'
+
+add --set 'target.aarch-unknown-linux-gnu.default-linker-linux-override=self-contained-lld-cc'
+add --set 'target.aarch-unknown-linux-musl.default-linker-linux-override=self-contained-lld-cc'
+
 # QNX toolchains aren't automatically inferred, set them explicitly.
 #
 # Assumes `qnxsdp-env.sh` has been sourced or the binaries are otherwise

--- a/ferrocene/ci/configure.sh
+++ b/ferrocene/ci/configure.sh
@@ -105,14 +105,6 @@ if [[ "${FERROCENE_BUILD_HOST:-}" = "x86_64-pc-windows-msvc" ]]; then
     add --set target.wasm32-unknown-unknown.ar=lld-ar
 fi
 
-# We default to the self-contained lld linker on all targets we can,
-# On targets with other settings as well, set that that there.
-add --set 'target.x86_64-unknown-linux-gnu.default-linker-linux-override=self-contained-lld-cc'
-add --set 'target.x86_64-unknown-linux-musl.default-linker-linux-override=self-contained-lld-cc'
-
-add --set 'target.aarch-unknown-linux-gnu.default-linker-linux-override=self-contained-lld-cc'
-add --set 'target.aarch-unknown-linux-musl.default-linker-linux-override=self-contained-lld-cc'
-
 # QNX toolchains aren't automatically inferred, set them explicitly.
 #
 # Assumes `qnxsdp-env.sh` has been sourced or the binaries are otherwise

--- a/ferrocene/tools/self-test/src/error.rs
+++ b/ferrocene/tools/self-test/src/error.rs
@@ -37,6 +37,8 @@ pub(crate) enum Error {
     BinaryVersionMismatch { binary: String, field: String, expected: String, found: String },
     #[error("library {library} is missing from target {target}")]
     TargetLibraryMissing { target: String, library: String },
+    #[error("default link arg {link_arg} is missing from target {target}")]
+    TargetDefaultLinkArgMissing { target: String, link_arg: String },
     #[error("there are conflicting copies of library {library} for target {target}")]
     DuplicateTargetLibrary { target: String, library: String },
     #[error("failed to access {} while discovering target libraries", path.display())]
@@ -128,6 +130,7 @@ impl Error {
             Error::WrongLinkerArgs { .. } => 24,
             Error::RunningSampleProgramFailed { .. } => 25,
             Error::SampleProgramOutputWrong { .. } => 26,
+            Error::TargetDefaultLinkArgMissing { .. } => 27,
         }
     }
 

--- a/ferrocene/tools/self-test/src/main.rs
+++ b/ferrocene/tools/self-test/src/main.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: The Ferrocene Developers
-
 mod binaries;
 mod compile;
 mod env;

--- a/ferrocene/tools/self-test/src/targets.rs
+++ b/ferrocene/tools/self-test/src/targets.rs
@@ -441,10 +441,7 @@ mod tests {
         assert_fail("libcore-0123456789abcdef"); // No extension
     }
 
-    #[cfg(all(target_os = "linux", target_arch = "x86_64"))] // Only on x86_64 Linux since the test is specific to that.
-    #[test]
-    fn test_check_target_default_link_args() -> Result<(), Error> {
-        let tuple = "x86_64-unknown-linux-gnu";
+    fn check_target_default_link_args(tuple: &'static str) -> Result<(), Error> {
         let target = TargetSpec { tuple, std: true, linker: Linker::HostCc };
 
         let utils = TestUtils::new();
@@ -455,5 +452,17 @@ mod tests {
             .stdout("-fuse-ld=lld")
             .create();
         check_default_link_args(utils.sysroot(), &target)
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    #[test]
+    fn test_check_target_default_link_args_x86_64() -> Result<(), Error> {
+        check_target_default_link_args("x86_64-unknown-linux-gnu")
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    #[test]
+    fn test_check_target_default_link_args_x86_64() -> Result<(), Error> {
+        check_target_default_link_args("aarch64-unknown-linux-gnu")
     }
 }

--- a/ferrocene/tools/self-test/src/targets.rs
+++ b/ferrocene/tools/self-test/src/targets.rs
@@ -141,7 +141,12 @@ fn check_default_link_args(sysroot: &Path, target: &TargetSpec) -> Result<(), Er
         Linker::HostCc => (),
         Linker::BundledLld | Linker::CrossCc(_) => return Ok(()), // No default link args expected
     }
-    if target.tuple.contains("apple-darwin") || target.tuple.contains("windows-msvc") {
+    // Rust currently only supports using `lld` on GNU Linux
+    if target.tuple.contains("-apple-darwin") || target.tuple.contains("-windows-msvc") {
+        return Ok(());
+    }
+    // `compiler/rustc_target/src/spec/base/linux_musl.rs` specifies `LinkSelfContainedDefault::InferredForMusl`
+    if target.tuple.contains("-musl") {
         return Ok(());
     }
 

--- a/ferrocene/tools/self-test/src/targets.rs
+++ b/ferrocene/tools/self-test/src/targets.rs
@@ -28,7 +28,7 @@ static SUPPORTED_TARGETS: &[TargetSpec] = &[
         linker: Linker::CrossCc(&["aarch64-linux-musl-"]),
     },
     #[cfg(target_arch = "aarch64")]
-    TargetSpec { tuple: "aarch64-unknown-linux-musl", std: true, linker: Linker::BundledLld },
+    TargetSpec { tuple: "aarch64-unknown-linux-musl", std: true, linker: Linker::HostCc },
     #[cfg(target_arch = "aarch64")]
     TargetSpec {
         tuple: "x86_64-unknown-linux-gnu",
@@ -44,7 +44,7 @@ static SUPPORTED_TARGETS: &[TargetSpec] = &[
         linker: Linker::CrossCc(&["x86_64-linux-musl-"]),
     },
     #[cfg(target_arch = "x86_64")]
-    TargetSpec { tuple: "x86_64-unknown-linux-musl", std: true, linker: Linker::BundledLld },
+    TargetSpec { tuple: "x86_64-unknown-linux-musl", std: true, linker: Linker::HostCc },
     // Targets without architecture specific tuning
     TargetSpec { tuple: "aarch64-apple-darwin", std: true, linker: Linker::BundledLld },
     TargetSpec { tuple: "aarch64-unknown-none", std: false, linker: Linker::BundledLld },
@@ -140,6 +140,9 @@ fn check_default_link_args(sysroot: &Path, target: &TargetSpec) -> Result<(), Er
     match target.linker {
         Linker::HostCc => (),
         Linker::BundledLld | Linker::CrossCc(_) => return Ok(()), // No default link args expected
+    }
+    if target.tuple.contains("apple-darwin") || target.tuple.contains("windows-msvc") {
+        return Ok(());
     }
 
     let rustc = sysroot.join("bin").join("rustc");

--- a/ferrocene/tools/self-test/src/targets.rs
+++ b/ferrocene/tools/self-test/src/targets.rs
@@ -444,6 +444,7 @@ mod tests {
         assert_fail("libcore-0123456789abcdef"); // No extension
     }
 
+    #[cfg_attr(not(target_os = "linux"), allow(unused))]
     fn check_target_default_link_args(tuple: &'static str) -> Result<(), Error> {
         let target = TargetSpec { tuple, std: true, linker: Linker::HostCc };
 

--- a/src/bootstrap/defaults/bootstrap.ferrocene-dist.toml
+++ b/src/bootstrap/defaults/bootstrap.ferrocene-dist.toml
@@ -170,6 +170,10 @@ channel = "auto-detect"
 
 
 [target]
+# We default to the self-contained lld linker on Linux GNU targets.
+x86_64-unknown-linux-gnu.default-linker-linux-override = 'self-contained-lld-cc'
+aarch-unknown-linux-gnu.default-linker-linux-override = 'self-contained-lld-cc'
+
 # Disable the profiler runtime for WASM. The profiler runtime depends on libc, which is not
 # available on WASM bare metal.
 #


### PR DESCRIPTION
Also needed to edit the test harness to allow non-strict args.

[I am upstreaming the aarch64 enablement as well.](https://github.com/rust-lang/rust/pull/146604). -- I do not expect it to merge as is, as Upstream is changing some stuff to make this story better. :)

This is manually backported to 1.90/25.11: https://github.com/ferrocene/ferrocene/pull/1804

A basic smoke test:

```bash
#! /usr/bin/env bash

# Run from repo root
set +eux

SCRATCH=/tmp/dummy-scratch
DIST=build/dist

rm -rf $SCRATCH
mkdir $SCRATCH

rm -rf $DIST

RUST_BACKTRACE=1 ./x.py --stage 2 dist rustc cargo llvm-tools rust-std ferrocene-self-test

for folder in build/dist/*.tar.xz; do
    tar xvf $folder -C $SCRATCH
done
cd $SCRATCH
./bin/ferrocene-self-test
```