### PR TITLE
Fix lima setup in MacOs section of the "testing other targets" doc

### DIFF
--- a/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
+++ b/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
@@ -23,17 +23,6 @@ Host Setup
 Unless otherwise noted, all bare-metal targets are tested via QEMU on a Linux host.
 On macOS, a tool like Lima or Docker must be used. On Windows, WSL2 must be used.
 
-:target-with-triple:`x86_64-unknown-linux-gnu`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-You need to have all the normal prerequisites from :doc:`internal-procedures:setup-local-env`
-installed, as well as a few extras:
-
-.. code-block:: bash
-
-   sudo apt install qemu-user-static binfmt-support
-
-
 :target-with-triple:`aarch64-apple-darwin`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -186,6 +175,16 @@ Currently bare metal targets have a similar procedure for testing.
 
    Currently, these targets use our *secret sauce*.
    This will eventually be an open source component, but for now, it's our little bit of arcane magic.
+
+:target-with-triple:`x86_64-unknown-linux-gnu`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You need to have all the normal prerequisites from :doc:`internal-procedures:setup-local-env`
+installed, as well as a few extras:
+
+.. code-block:: bash
+
+   sudo apt install qemu-user-static binfmt-support
 
 :target-with-triple:`aarch64-unknown-none`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
+++ b/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
@@ -32,7 +32,7 @@ Install Lima, if you don't have it:
 
     brew install lima
 
-You can create a guest with the following:
+You can create a guest with the following command:
 
 .. code-block:: yaml
 
@@ -166,16 +166,6 @@ Finally, ensure the guest is configured according to :doc:`internal-procedures:s
 
     Please ensure you always work from the guest-local repository.
 
-Target Procedures
------------------
-
-Currently bare metal targets have a similar procedure for testing.
-
-.. note::
-
-   Currently, these targets use our *secret sauce*.
-   This will eventually be an open source component, but for now, it's our little bit of arcane magic.
-
 :target-with-triple:`x86_64-unknown-linux-gnu`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -185,6 +175,20 @@ installed, as well as a few extras:
 .. code-block:: bash
 
    sudo apt install qemu-user-static binfmt-support
+
+.. Note::
+
+    These packages must also be installed in the VMs used on MacOS and Windows.
+
+Target Procedures
+-----------------
+
+Currently bare metal targets have a similar procedure for testing.
+
+.. note::
+
+   Currently, these targets use our *secret sauce*.
+   This will eventually be an open source component, but for now, it's our little bit of arcane magic.
 
 :target-with-triple:`aarch64-unknown-none`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
+++ b/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
@@ -50,15 +50,15 @@ You can create a guest with the following:
     cat <<EOF | limactl create --name=ferrocene -
     minimumLimaVersion: "1.0.0"
     images:
-    - location: "https://cloud-images.ubuntu.com/releases/24.10/release-20241212/ubuntu-24.10-server-cloudimg-arm64.img"
-      arch: "aarch64"
-      digest: "sha256:fb39312ffd2b47b97eaef6ff197912eaa3e0a215eb3eecfbf2a24acd96ee1125"
-    - location: "https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-arm64.img"
-      arch: "aarch64"
+      - location: "https://cloud-images.ubuntu.com/releases/24.10/release-20241212/ubuntu-24.10-server-cloudimg-arm64.img"
+        arch: "aarch64"
+        digest: "sha256:fb39312ffd2b47b97eaef6ff197912eaa3e0a215eb3eecfbf2a24acd96ee1125"
+      - location: "https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-arm64.img"
+        arch: "aarch64"
     mounts:
-    - location: "~"
-    - location: "/tmp/lima"
-    writable: true
+      - location: "~"
+      - location: "/tmp/lima"
+        writable: true
     ssh:
       forwardAgent: true
     cpus: 8

--- a/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
+++ b/ferrocene/doc/internal-procedures/src/testing-other-targets.rst
@@ -47,23 +47,23 @@ You can create a guest with the following:
 
 .. code-block:: yaml
 
-    cat <<- EOF | limactl create --name=ferrocene
-        minimumLimaVersion: "1.0.0"
-        images:
-        - location: "https://cloud-images.ubuntu.com/releases/24.10/release-20241212/ubuntu-24.10-server-cloudimg-arm64.img"
-            arch: "aarch64"
-            digest: "sha256:fb39312ffd2b47b97eaef6ff197912eaa3e0a215eb3eecfbf2a24acd96ee1125"
-        - location: "https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-arm64.img"
-            arch: "aarch64"
-        mounts:
-        - location: "~"
-        - location: "/tmp/lima"
-        writable: true
-        ssh:
-        forwardAgent: true
-        cpus: 8
-        memory: "8GiB"
-        mountTypesUnsupported: ["9p"]
+    cat <<EOF | limactl create --name=ferrocene -
+    minimumLimaVersion: "1.0.0"
+    images:
+    - location: "https://cloud-images.ubuntu.com/releases/24.10/release-20241212/ubuntu-24.10-server-cloudimg-arm64.img"
+      arch: "aarch64"
+      digest: "sha256:fb39312ffd2b47b97eaef6ff197912eaa3e0a215eb3eecfbf2a24acd96ee1125"
+    - location: "https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-arm64.img"
+      arch: "aarch64"
+    mounts:
+    - location: "~"
+    - location: "/tmp/lima"
+    writable: true
+    ssh:
+      forwardAgent: true
+    cpus: 8
+    memory: "8GiB"
+    mountTypesUnsupported: ["9p"]
     EOF
 
 Start the guest:


### PR DESCRIPTION
The lima command to create a VM on MacOS had wrong indentation,
so lima was ignoring it and used the default settings.

This PR also adds a ssh host configuration that works in combination with 1Password as identity agent and agent forwarding for the VM.

The Linux section is moved below MacOS and Windows to make it more obvious that the Linux packages must also be installed in the created VMs on MacOS and Windows. Having the Linux section at the top breaks reading flow for MacOS and Windows, because it required to scroll down to the respective section, then up again to the Linux one, and then down again to the target procedures.