### PR TITLE
Add zlib1g-dev as required package for ubuntu 24.10

### DIFF
--- a/ferrocene/doc/internal-procedures/src/setup-local-env.rst
+++ b/ferrocene/doc/internal-procedures/src/setup-local-env.rst
@@ -27,7 +27,7 @@ On Ubuntu 24.10, install the software requirements by running:
 
 .. code-block:: bash
 
-   sudo apt install ninja-build bzip2 cmake gcc g++ awscli
+   sudo apt install ninja-build bzip2 cmake gcc g++ awscli zlib1g-dev
    curl -LsSf https://astral.sh/uv/install.sh | sh
 
 .. note::


### PR DESCRIPTION
This is needed to solve `-lz` linker errors on Ubuntu 24.10.

I can only really validate this for Ubuntu, so not sure if this would also be missing for macOS, Arch, Windows, ...

But I don't remember having this problem on macOS, so it might already be installed by default.