### PR TITLE
25.08 is released

### DIFF
--- a/ferrocene/doc/release-notes/src/25.08.0.rst
+++ b/ferrocene/doc/release-notes/src/25.08.0.rst
@@ -1,8 +1,6 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-:upcoming-release:
-
 Ferrocene 25.08.0
 =================
 

--- a/ferrocene/doc/release-notes/src/25.08.0.rst
+++ b/ferrocene/doc/release-notes/src/25.08.0.rst
@@ -4,6 +4,16 @@
 Ferrocene 25.08.0
 =================
 
+New experimental features
+-------------------------
+
+Experimental features are not qualified for safety critical use, and are
+shipped as a preview.
+
+* A subset of the ``core`` library is being certified to IEC-61508 SIL 2.
+  This is currently in pre-release and uncertified. For more information,
+  see the :doc:`user-manual:core/index` and :doc:`core-certification:index`.
+
 Removed experimental features
 -----------------------------
 
@@ -13,10 +23,6 @@ shipped as a preview. In some circumstances, these features are removed.
 * Experimental support has been removed for the following platforms:
 
   * :target-with-tuple:`x86_64-apple-darwin`
-
-* A subset of the ``core`` library is being certified to IEC-61508 SIL 2.
-  This is currently in pre-release and uncertified. For more information,
-  see the :doc:`user-manual:core/index` and :doc:`core-certification:index`.
 
 Fixed known problems
 --------------------

--- a/ferrocene/doc/release-notes/src/25.08.0.rst
+++ b/ferrocene/doc/release-notes/src/25.08.0.rst
@@ -6,12 +6,6 @@
 Ferrocene 25.08.0
 =================
 
-New features
-------------
-
-A subset of the ``core`` library has been certified to IEC-61508 SIL 2. For more information,
-see the :doc:`user-manual:core/index` and :doc:`core-certification:index`.
-
 Removed experimental features
 -----------------------------
 
@@ -21,6 +15,10 @@ shipped as a preview. In some circumstances, these features are removed.
 * Experimental support has been removed for the following platforms:
 
   * :target-with-tuple:`x86_64-apple-darwin`
+
+* A subset of the ``core`` library is being certified to IEC-61508 SIL 2.
+  This is currently in pre-release and uncertified. For more information,
+  see the :doc:`user-manual:core/index` and :doc:`core-certification:index`.
 
 Fixed known problems
 --------------------


### PR DESCRIPTION
Follows through on https://public-docs.ferrocene.dev/main/qualification/internal-procedures/release/stable.html#publishing-a-stable-release and https://public-docs.ferrocene.dev/main/qualification/internal-procedures/release/stable.html#remove-upcoming-notes-in-the-main-branch

Pulls in https://github.com/ferrocene/ferrocene/pull/1768 https://github.com/ferrocene/ferrocene/pull/1774