### PR TITLE
Pin reuse to 5.1.1

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -106,7 +106,8 @@ jobs:
       - setup-uv
       - run:
           name: Perform licensing checks
-          command: uvx reuse --include-submodules lint
+          command: |
+            uvx reuse@5.1.1 --include-submodules lint
       - ferrocene-ci
 
   # x86_64-unknown-linux-gnu jobs

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -59,7 +59,7 @@ jobs:
           INSTALL_LLVM: 1
 
       - name: Install licensing tool
-        run: uv tool install reuse
+        run: uv tool install reuse@5.1.1
 
       # We deliberately avoid using docker containers as that would require either adding
       # a couple minutes to the build, or doing auth/trust related things that would impact


### PR DESCRIPTION
Recently the default `reuse` rose to 6.0.0 and we noticed we weren't pinned.