### PR TITLE
[1.90] Enable LLD on aarch64-unknown-linux-gnu

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -752,10 +752,11 @@
 #rust.codegen-backends = ["llvm"]
 
 # Indicates whether LLD will be compiled and made available in the sysroot for rustc to execute, and
-# whether to set it as rustc's default linker on `x86_64-unknown-linux-gnu`. This will also only be
-# when *not* building an external LLVM (so only when using `download-ci-llvm` or building LLVM from
-# the in-tree source): setting `llvm-config` in the `[target.x86_64-unknown-linux-gnu]` section will
-# make this default to false.
+# whether to set it as rustc's default linker on `x86_64-unknown-linux-gnu` and
+# `aarch64-unknown-linux-gnu`. This will also only be when *not* building an external LLVM (so only
+# when using `download-ci-llvm` or building LLVM from the in-tree source): setting `llvm-config` in
+# the `[target.x86_64-unknown-linux-gnu]` or `[target.aarch64-unknown-linux-gnu`] section will make
+# this default to false.
 #rust.lld = false in all cases, except on `x86_64-unknown-linux-gnu` as described above, where it is true
 
 # Indicates whether LLD will be used to link Rust crates during bootstrap on

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu.rs
@@ -1,8 +1,37 @@
 use crate::spec::{
-    FramePointer, SanitizerSet, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Cc, FramePointer, LinkerFlavor, Lld, SanitizerSet, StackProbeType, Target, TargetMetadata,
+    TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
+    let mut base = TargetOptions {
+        features: "+v8a,+outline-atomics".into(),
+        // the AAPCS64 expects use of non-leaf frame pointers per
+        // https://github.com/ARM-software/abi-aa/blob/4492d1570eb70c8fd146623e0db65b2d241f12e7/aapcs64/aapcs64.rst#the-frame-pointer
+        // and we tend to encounter interesting bugs in AArch64 unwinding code if we do not
+        frame_pointer: FramePointer::NonLeaf,
+        mcount: "\u{1}_mcount".into(),
+        max_atomic_width: Some(128),
+        stack_probes: StackProbeType::Inline,
+        supported_sanitizers: SanitizerSet::ADDRESS
+            | SanitizerSet::CFI
+            | SanitizerSet::KCFI
+            | SanitizerSet::LEAK
+            | SanitizerSet::MEMORY
+            | SanitizerSet::MEMTAG
+            | SanitizerSet::THREAD
+            | SanitizerSet::HWADDRESS,
+        supports_xray: true,
+        ..base::linux_gnu::opts()
+    };
+
+    // When we're asked to use the `rust-lld` linker by default, set the appropriate lld-using
+    // linker flavor, and self-contained linker component.
+    if option_env!("CFG_USE_SELF_CONTAINED_LINKER").is_some() {
+        base.linker_flavor = LinkerFlavor::Gnu(Cc::Yes, Lld::Yes);
+        base.link_self_contained = crate::spec::LinkSelfContainedDefault::with_linker();
+    }
+
     Target {
         llvm_target: "aarch64-unknown-linux-gnu".into(),
         metadata: TargetMetadata {
@@ -14,25 +43,6 @@ pub(crate) fn target() -> Target {
         pointer_width: 64,
         data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32".into(),
         arch: "aarch64".into(),
-        options: TargetOptions {
-            features: "+v8a,+outline-atomics".into(),
-            // the AAPCS64 expects use of non-leaf frame pointers per
-            // https://github.com/ARM-software/abi-aa/blob/4492d1570eb70c8fd146623e0db65b2d241f12e7/aapcs64/aapcs64.rst#the-frame-pointer
-            // and we tend to encounter interesting bugs in AArch64 unwinding code if we do not
-            frame_pointer: FramePointer::NonLeaf,
-            mcount: "\u{1}_mcount".into(),
-            max_atomic_width: Some(128),
-            stack_probes: StackProbeType::Inline,
-            supported_sanitizers: SanitizerSet::ADDRESS
-                | SanitizerSet::CFI
-                | SanitizerSet::KCFI
-                | SanitizerSet::LEAK
-                | SanitizerSet::MEMORY
-                | SanitizerSet::MEMTAG
-                | SanitizerSet::THREAD
-                | SanitizerSet::HWADDRESS,
-            supports_xray: true,
-            ..base::linux_gnu::opts()
-        },
+        options: base,
     }
 }

--- a/ferrocene/tools/self-test/src/error.rs
+++ b/ferrocene/tools/self-test/src/error.rs
@@ -37,6 +37,8 @@ pub(crate) enum Error {
     BinaryVersionMismatch { binary: String, field: String, expected: String, found: String },
     #[error("library {library} is missing from target {target}")]
     TargetLibraryMissing { target: String, library: String },
+    #[error("default link arg {link_arg} is missing from target {target}")]
+    TargetDefaultLinkArgMissing { target: String, link_arg: String },
     #[error("there are conflicting copies of library {library} for target {target}")]
     DuplicateTargetLibrary { target: String, library: String },
     #[error("failed to access {} while discovering target libraries", path.display())]
@@ -128,6 +130,7 @@ impl Error {
             Error::WrongLinkerArgs { .. } => 24,
             Error::RunningSampleProgramFailed { .. } => 25,
             Error::SampleProgramOutputWrong { .. } => 26,
+            Error::TargetDefaultLinkArgMissing { .. } => 27,
         }
     }
 

--- a/ferrocene/tools/self-test/src/main.rs
+++ b/ferrocene/tools/self-test/src/main.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: The Ferrocene Developers
-
 mod binaries;
 mod compile;
 mod env;

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -491,4 +491,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "Added `build.compiletest-allow-stage0` flag instead of `COMPILETEST_FORCE_STAGE0` env var, and reject running `compiletest` self tests against stage 0 rustc unless explicitly allowed.",
     },
+    ChangeInfo {
+        change_id: 146604,
+        severity: ChangeSeverity::Info,
+        summary: "Setting `rust.lld = true` when building rustc for the `aarch64-unknown-linux-gnu` target will now also cause that rustc to use the LLD linker by default.",
+    },
 ];


### PR DESCRIPTION
We're doing this in https://github.com/ferrocene/ferrocene/pull/1733 which upstream has looked at and decided they'd like to do some greater changes to accomodate.

That said, we'd like the `lld` validation check on 1.90 and the aarch64 change needs to come with it if we want CI to pass.