### PR TITLE
Don't generate a metrics report if the build fails

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1462,7 +1462,6 @@ commands:
 
       - run:
           name: Generate resource usage report
-          when: always
           command: |
             mkdir -p /tmp/metrics
             ferrocene/ci/scripts/generate-resources-usage-report.py build/metrics.json > /tmp/metrics/report.html


### PR DESCRIPTION
Bootstrap doesn't generate metrics.json when it fails. Don't try uselessly to copy it.

See https://app.circleci.com/pipelines/github/ferrocene/ferrocene/13965/workflows/58a0c496-4178-4351-a27e-7a94028276ba/jobs/95493/parallel-runs/0/steps/0-110 for an example failure this would have avoided.