### PR TITLE
Add `diff-upstream` tool

### DIFF
--- a/ferrocene/doc/internal-procedures/src/docs/sphinx-extensions.rst
+++ b/ferrocene/doc/internal-procedures/src/docs/sphinx-extensions.rst
@@ -164,7 +164,7 @@ action.
 ``ferrocene_domain_cli`` extension
 ----------------------------------
 
-The extension adds a custoom ``cli`` `Sphinx domain`_ that can be used to
+The extension adds a custom ``cli`` `Sphinx domain`_ that can be used to
 document the CLI options of a program. Compared to Sphinx's builtin domain, our
 ``cli`` domain supports options with spaces in their name (like ``-C option``),
 and emits metadata compatible with our traceability matrix tooling.

--- a/ferrocene/doc/qualification-report/src/requirements-traceability.rst
+++ b/ferrocene/doc/qualification-report/src/requirements-traceability.rst
@@ -15,3 +15,18 @@ this page.
 Note that the reporting tool only considers tests that were actually executed
 as part of the :doc:`test results <rustc/index>`. Ignored tests are not
 considered when determining the traceability.
+
+Self-tests
+~~~~~~~~~~
+
+We have tests that check the validity of the traceability suite itself.
+
+``diff-upstream``
+"""""""""""""""""
+
+This tool verifies that:
+1. All `// ferrocene-annotations` in the test suite correspond to a section in the Ferrocene Language Specification or `Traceability Matrix <../traceability-matrix.html>`_.
+2. All `// ferrocene-annotations` in the test suite are either followed by the name of that section, or correspond to a CLI-only unnamed section.
+
+It can also be run manually to view all differences between the Ferrocene compiler and the upstream Rust Project compiler.
+We plan in the future to inspect this diff on a regular basis to verify that there are no unintended differences from the upstream compiler.

--- a/ferrocene/doc/qualification-report/src/requirements-traceability.rst
+++ b/ferrocene/doc/qualification-report/src/requirements-traceability.rst
@@ -29,4 +29,3 @@ This tool verifies that:
 2. All `// ferrocene-annotations` in the test suite are either followed by the name of that section, or correspond to a CLI-only unnamed section.
 
 It can also be run manually to view all differences between the Ferrocene compiler and the upstream Rust Project compiler.
-We plan in the future to inspect this diff on a regular basis to verify that there are no unintended differences from the upstream compiler.

--- a/ferrocene/tools/diff-upstream/diff.py
+++ b/ferrocene/tools/diff-upstream/diff.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env -S uv run
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["ignorelib ~= 0.3", "more-itertools ~= 10.8", "automations-common"]
+#
+# [tool.uv.sources]
+# automations-common = { path = "../automations-common", editable = true }
+# ///
+
+import argparse
+import re
+import os
+from collections import defaultdict, namedtuple
+from pathlib import Path
+
+from ignorelib import IgnoreFilterManager
+from more_itertools import peekable
+
+from automations_common import cmd_capture
+
+had_error = False
+def error(msg):
+    print('error: ')
+    had_error = True
+
+parser = argparse.ArgumentParser(prog='diff-upstream', description="Diff ferrocene from upstream Rust project")
+parser.add_argument('--hide-diff', action='store_true', help="Only test ferrocene-annotations; don't run the diff")
+args = parser.parse_args()
+
+#### Diff all test annotations. ####
+
+base_commit = cmd_capture("git log -n1 --author=bors@rust-lang.org --pretty=%H".split())
+
+diff_tests = f"git diff -U0 --no-prefix --diff-filter=M {base_commit} -- tests/".split()
+test_changes = peekable(cmd_capture(diff_tests).splitlines())
+
+file = None
+lineno = 0
+changes = []
+test_changemap = {}
+missing_annotations = {}
+annotations = {}
+
+Span = namedtuple('Span', ['file', 'line'])
+
+for line in test_changes:
+    if line.startswith("diff --git"):
+        # Record the file we just finished parsing.
+        if changes:
+            assert file, "saw changes for unknown file"
+            test_changemap[file] = changes
+        # Now parse the header for the new file.
+        file, changes, lineno = line.split()[2], [], 0
+        for _ in range(4):
+            next(test_changes)  # discard `index ...`
+        continue
+
+    lineno += 1
+    kind, change = line[0], line[1:]
+    if (not change or change == '//'
+            or change.startswith('//@ ignore-ferrocene.facade')):
+        continue
+
+    if change.startswith('// ferrocene-annotations: '):
+        id = next(reversed(change.split(' ')))
+        if id.startswith('um_rustc'):
+            annotations[id] = span, ''
+            continue
+        # Next line is the section name it corresponds to.
+        section = test_changes.peek()
+        span = Span(file, lineno)
+        if not section.startswith('+// '):
+            missing_annotations[span] = id
+        else:
+            annotations[id] = span, section.split(' ', 1)[1]
+            next(test_changes)  # discard section
+        continue
+
+    changes.append([kind, change])
+
+if missing_annotations:
+    error(f'error: found {len(missing_annotations)} ferrocene-annotations not followed by section name!')
+    for span, annotation in missing_annotations.items():
+        print('%s:%d' % span, annotation)
+
+# load all section titles
+def load_sections(fd, sections):
+    for line in fd:
+        if line.startswith('.. _fls'):
+            # Get id, truncating trailing colon.
+            id = line.strip().split('.. _', 1)[1][:-1]
+            n = next(fd)
+            assert n.strip() == '', n
+            sections[id.lower()] = next(fd).strip().replace('`', '')
+
+sections = {}
+for dir, _subdirs, files in os.walk('ferrocene/doc/specification'):
+    for file in files:
+        if file.endswith('.rst'):
+            with open(dir + '/' + file) as fd:
+                load_sections(fd, sections)
+
+cli_ids = set()
+with open('build/host/doc/qualification/traceability-matrix.html') as fd:
+    for line in fd:
+        if m := re.search(r'id="(um_rustc_[^"]*)"', line):
+            cli_ids.add(m.group(1))
+
+for id, (span, name) in annotations.items():
+    if id.startswith('um_rustc_'):
+        if id not in cli_ids:
+            error("Unknown CLI spec id:", id)
+        continue
+    if id not in sections:
+        error(f"Unknown section '{id}'!")
+    elif name.lower() != sections[id].lower():
+        error("Incorrect section name on %s:%d:" % span,
+              f"Expected '{sections[id]}', found '{name}'")
+
+if args.hide_diff:
+    if not had_error:
+        print("All good!")
+    exit(had_error)
+
+#### Diff all other changes. ####
+
+root_dir = Path(cmd_capture("git rev-parse --show-toplevel".split()))
+
+ignored = []
+with open(root_dir / ".gitattributes") as fd:
+    for line in fd:
+        parts = line.split()
+        if parts and parts[-1] == "ferrocene-avoid-pulling-from-upstream":
+            ignored.append(parts[0])
+
+filterer = IgnoreFilterManager.build(path=root_dir, global_patterns=ignored)
+
+all_changed = cmd_capture(f"git diff {base_commit} --name-status".split()).splitlines()
+changemap = defaultdict(list)
+
+class DiffKind:
+    ADDED = 'A'
+    MODIFIED = 'M'
+    DELETED = 'D'
+    RENAMED = 'R'
+
+IGNORED_ADDITIONS = [
+        ".dockerignore",
+        ".python-version",
+        "bors.toml",
+        "src/bootstrap/defaults/bootstrap.ferrocene-dist.toml",
+        "src/bootstrap/src/core/config/toml/ferrocene.rs",
+        "src/tools/compiletest/src/ferrocene_annotations.rs",
+]
+
+for line in all_changed:
+    kind, rest = line[0], line[1:]
+    match kind:
+        case DiffKind.DELETED:
+            path = rest.lstrip()
+            if filterer.is_ignored(path):
+                continue
+            val = path
+        case DiffKind.ADDED:
+            path = rest.lstrip()
+            # Assume files in ferrocene/ directories are always ok
+            if (path.startswith("ferrocene/") or path.endswith("/ferrocene-annotations")
+                    or path.startswith('.github') or path.startswith(".circleci")
+                    or path.startswith("compiler/rustc_target/src/spec/targets/")
+                    or '/ferrocene/' in path or path in IGNORED_ADDITIONS):
+                continue
+            val = path
+        case DiffKind.MODIFIED:
+            val = rest.lstrip()
+        case DiffKind.RENAMED:
+            val = rest.split()
+        case _:
+            raise ValueError(f"Don't know how to handle diff kind {kind}")
+    changemap[kind].append(val)
+
+
+for kind in ['A', 'D', 'R']:
+    for p in changemap[kind]:
+        print(f'{kind}\t{p}')
+    if changemap[kind]:
+        print()
+
+for f, changes in test_changemap.items():
+    print(f)
+    print('\n'.join(kind + change for kind, change in changes))
+
+print(f"\ngit diff {base_commit} --name-status -- ':!tests/' ':!.github' ':!**/.github/**' ':!ferrocene'")
+
+for p in changemap['M']:
+    if p.startswith('tests/'):
+        continue
+    print(f'M\t{p}')
+
+exit(had_error)

--- a/ferrocene/tools/diff-upstream/diff.py
+++ b/ferrocene/tools/diff-upstream/diff.py
@@ -45,7 +45,7 @@ test_changes = peekable(cmd_capture(diff_tests).splitlines())
 
 file = None
 lineno = 0
-changes = []
+changes: list[DiffKind, str] = []
 test_changemap = {}
 missing_annotations = {}
 annotations = {}
@@ -71,13 +71,13 @@ for line in test_changes:
         continue
 
     if re.search('^\s*// ferrocene-annotations: ', change):
+        span = Span(file, lineno)
         id = next(reversed(change.split(' ')))
         if id.startswith('um_rustc'):
             annotations[id] = span, ''
             continue
         # Next line is the section name it corresponds to.
         section = test_changes.peek()
-        span = Span(file, lineno)
         if not section.startswith('+// '):
             missing_annotations[span] = id
         else:
@@ -120,8 +120,7 @@ def validate_annotations():
         if id.startswith('um_rustc_'):
             if id not in cli_ids:
                 error("Unknown CLI spec id:", id)
-            continue
-        if id not in sections:
+        elif id not in sections:
             error(f"Unknown section '{id}'!")
         elif name.lower() != sections[id].lower():
             error("Incorrect section name on %s:%d:" % span,
@@ -166,12 +165,12 @@ DIFF_NAMES = {
 }
 
 IGNORED_ADDITIONS = [
-        ".dockerignore",
-        ".python-version",
-        "bors.toml",
-        "src/bootstrap/defaults/bootstrap.ferrocene-dist.toml",
-        "src/bootstrap/src/core/config/toml/ferrocene.rs",
-        "src/tools/compiletest/src/ferrocene_annotations.rs",
+    ".dockerignore",
+    ".python-version",
+    "bors.toml",
+    "src/bootstrap/defaults/bootstrap.ferrocene-dist.toml",
+    "src/bootstrap/src/core/config/toml/ferrocene.rs",
+    "src/tools/compiletest/src/ferrocene_annotations.rs",
 ]
 
 for line in all_changed:

--- a/ferrocene/tools/diff-upstream/diff.py
+++ b/ferrocene/tools/diff-upstream/diff.py
@@ -38,6 +38,19 @@ if args.hide_diff:
 
 #### Diff all test annotations. ####
 
+class DiffKind:
+    ADDED = 'A'
+    MODIFIED = 'M'
+    DELETED = 'D'
+    RENAMED = 'R'
+
+DIFF_NAMES = {
+        DiffKind.ADDED: 'added',
+        DiffKind.MODIFIED: 'modified',
+        DiffKind.DELETED: 'deleted',
+        DiffKind.RENAMED: 'renamed',
+}
+
 base_commit = cmd_capture("git log -n1 --author=bors@rust-lang.org --pretty=%H".split())
 
 diff_tests = f"git diff -U0 --no-prefix --diff-filter=M {base_commit} -- tests/".split()
@@ -70,7 +83,7 @@ for line in test_changes:
             or change.startswith('//@ ignore-ferrocene.facade')):
         continue
 
-    if re.search('^\s*// ferrocene-annotations: ', change):
+    if re.search(r'^\s*// ferrocene-annotations: ', change):
         span = Span(file, lineno)
         id = next(reversed(change.split(' ')))
         if id.startswith('um_rustc'):
@@ -111,10 +124,14 @@ def validate_annotations():
                     load_sections(fd, sections)
 
     cli_ids = set()
-    with open('build/host/doc/qualification/traceability-matrix.html') as fd:
-        for line in fd:
-            if m := re.search(r'id="(um_rustc_[^"]*)"', line):
-                cli_ids.add(m.group(1))
+    matrix = 'build/host/doc/qualification/traceability-matrix.html'
+    try:
+        with open(matrix) as fd:
+            for line in fd:
+                if m := re.search(r'id="(um_rustc_[^"]*)"', line):
+                    cli_ids.add(m.group(1))
+    except FileNotFoundError:
+        exit(f"error: {matrix} not found. try running './x build traceaqbility-matrix'.")
 
     for id, (span, name) in annotations.items():
         if id.startswith('um_rustc_'):
@@ -127,7 +144,7 @@ def validate_annotations():
                 f"Expected '{sections[id]}', found '{name}'")
 
 if args.test:
-    print("Validating Ferrocene annotations")
+    print("Validating Ferrocene annotations against traceability matrix")
     validate_annotations()
     if not had_error:
         print("All annotations match the spec!")
@@ -150,19 +167,6 @@ filterer = IgnoreFilterManager.build(path=root_dir, global_patterns=ignored)
 
 all_changed = cmd_capture(f"git -c color.ui=never diff {base_commit} --name-status".split()).splitlines()
 changemap = defaultdict(list)
-
-class DiffKind:
-    ADDED = 'A'
-    MODIFIED = 'M'
-    DELETED = 'D'
-    RENAMED = 'R'
-
-DIFF_NAMES = {
-        DiffKind.ADDED: 'added',
-        DiffKind.MODIFIED: 'modified',
-        DiffKind.DELETED: 'deleted',
-        DiffKind.RENAMED: 'renamed',
-}
 
 IGNORED_ADDITIONS = [
     ".dockerignore",
@@ -216,7 +220,7 @@ for f, changes in test_changemap.items():
     print(f)
     print('\n'.join(kind + change for kind, change in changes))
 
-print(f"\ngit diff {base_commit} --name-status --diff-filter=M -I'#\[ferrocene::' -- ':!tests/' ':!.github' ':!**/.github/**' ':!ferrocene'")
+print(fr"\ngit diff {base_commit} --name-status --diff-filter=M -I'#\[ferrocene::' -- ':!tests/' ':!.github' ':!**/.github/**' ':!ferrocene'")
 
 for p in changemap['M']:
     if p.startswith('tests/'):

--- a/ferrocene/tools/diff-upstream/diff.py
+++ b/ferrocene/tools/diff-upstream/diff.py
@@ -27,7 +27,7 @@ def error(msg):
     global had_error
     had_error = True
 
-parser = argparse.ArgumentParser(prog='diff-upstream', description="Diff ferrocene from upstream Rust project")
+parser = argparse.ArgumentParser(prog='diff-upstream', description="Diff Ferrocene from upstream Rust project")
 parser.add_argument('--hide-diff', action='store_true', help="Only test "
                     "ferrocene-annotations; don't run the diff. Implies --test.")
 parser.add_argument('--test', action='store_true', help="Test ferrocene-annotations")

--- a/ferrocene/tools/diff-upstream/diff.py
+++ b/ferrocene/tools/diff-upstream/diff.py
@@ -172,9 +172,12 @@ IGNORED_ADDITIONS = [
     ".dockerignore",
     ".python-version",
     "bors.toml",
-    "src/bootstrap/defaults/bootstrap.ferrocene-dist.toml",
-    "src/bootstrap/src/core/config/toml/ferrocene.rs",
-    "src/tools/compiletest/src/ferrocene_annotations.rs",
+]
+IGNORED_ADDITIONS_DIRS = [
+    ".github",
+    ".circleci",
+    "compiler/rustc_target/src/spec/targets",
+    "tests/run-make/symbol-report",
 ]
 
 for line in all_changed:
@@ -187,14 +190,12 @@ for line in all_changed:
             val = path
         case DiffKind.ADDED:
             path = rest.lstrip()
-            # Assume files in ferrocene/ directories are always ok
-            if (path.startswith("ferrocene/") or path.endswith("/ferrocene-annotations")
-                    or path.endswith('/ferrocene.rs' )
-                    or path.startswith('.github') or path.startswith(".circleci")
-                    or path.startswith("compiler/rustc_target/src/spec/targets/")
-                    or path.startswith("tests/run-make/symbol-report/")
-                    or '/ferrocene/' in path or '/ferrocene_test.rs' in path
-                    or path in IGNORED_ADDITIONS):
+            if (
+                # Assume files in ferrocene/ directories are always ok
+                "ferrocene" in path
+                or path in IGNORED_ADDITIONS
+                or any(path.startswith(dir) for dir in IGNORED_ADDITIONS_DIRS)
+            ):
                 continue
             val = path
         case DiffKind.MODIFIED:

--- a/ferrocene/tools/diff-upstream/diff.py
+++ b/ferrocene/tools/diff-upstream/diff.py
@@ -23,12 +23,18 @@ from automations_common import cmd_capture
 
 had_error = False
 def error(msg):
-    print('error: ')
+    print('error:', msg)
+    global had_error
     had_error = True
 
 parser = argparse.ArgumentParser(prog='diff-upstream', description="Diff ferrocene from upstream Rust project")
-parser.add_argument('--hide-diff', action='store_true', help="Only test ferrocene-annotations; don't run the diff")
+parser.add_argument('--hide-diff', action='store_true', help="Only test "
+                    "ferrocene-annotations; don't run the diff. Implies --test.")
+parser.add_argument('--test', action='store_true', help="Test ferrocene-annotations")
 args = parser.parse_args()
+
+if args.hide_diff:
+    args.test = True
 
 #### Diff all test annotations. ####
 
@@ -64,7 +70,7 @@ for line in test_changes:
             or change.startswith('//@ ignore-ferrocene.facade')):
         continue
 
-    if change.startswith('// ferrocene-annotations: '):
+    if re.search('^\s*// ferrocene-annotations: ', change):
         id = next(reversed(change.split(' ')))
         if id.startswith('um_rustc'):
             annotations[id] = span, ''
@@ -82,7 +88,7 @@ for line in test_changes:
     changes.append([kind, change])
 
 if missing_annotations:
-    error(f'error: found {len(missing_annotations)} ferrocene-annotations not followed by section name!')
+    error(f'found {len(missing_annotations)} ferrocene-annotations not followed by section name!')
     for span, annotation in missing_annotations.items():
         print('%s:%d' % span, annotation)
 
@@ -96,33 +102,38 @@ def load_sections(fd, sections):
             assert n.strip() == '', n
             sections[id.lower()] = next(fd).strip().replace('`', '')
 
-sections = {}
-for dir, _subdirs, files in os.walk('ferrocene/doc/specification'):
-    for file in files:
-        if file.endswith('.rst'):
-            with open(dir + '/' + file) as fd:
-                load_sections(fd, sections)
+def validate_annotations():
+    sections = {}
+    for dir, _subdirs, files in os.walk('ferrocene/doc/specification'):
+        for file in files:
+            if file.endswith('.rst'):
+                with open(dir + '/' + file) as fd:
+                    load_sections(fd, sections)
 
-cli_ids = set()
-with open('build/host/doc/qualification/traceability-matrix.html') as fd:
-    for line in fd:
-        if m := re.search(r'id="(um_rustc_[^"]*)"', line):
-            cli_ids.add(m.group(1))
+    cli_ids = set()
+    with open('build/host/doc/qualification/traceability-matrix.html') as fd:
+        for line in fd:
+            if m := re.search(r'id="(um_rustc_[^"]*)"', line):
+                cli_ids.add(m.group(1))
 
-for id, (span, name) in annotations.items():
-    if id.startswith('um_rustc_'):
-        if id not in cli_ids:
-            error("Unknown CLI spec id:", id)
-        continue
-    if id not in sections:
-        error(f"Unknown section '{id}'!")
-    elif name.lower() != sections[id].lower():
-        error("Incorrect section name on %s:%d:" % span,
-              f"Expected '{sections[id]}', found '{name}'")
+    for id, (span, name) in annotations.items():
+        if id.startswith('um_rustc_'):
+            if id not in cli_ids:
+                error("Unknown CLI spec id:", id)
+            continue
+        if id not in sections:
+            error(f"Unknown section '{id}'!")
+        elif name.lower() != sections[id].lower():
+            error("Incorrect section name on %s:%d:" % span,
+                f"Expected '{sections[id]}', found '{name}'")
+
+if args.test:
+    print("Validating Ferrocene annotations")
+    validate_annotations()
+    if not had_error:
+        print("All annotations match the spec!")
 
 if args.hide_diff:
-    if not had_error:
-        print("All good!")
     exit(had_error)
 
 #### Diff all other changes. ####
@@ -138,7 +149,7 @@ with open(root_dir / ".gitattributes") as fd:
 
 filterer = IgnoreFilterManager.build(path=root_dir, global_patterns=ignored)
 
-all_changed = cmd_capture(f"git diff {base_commit} --name-status".split()).splitlines()
+all_changed = cmd_capture(f"git -c color.ui=never diff {base_commit} --name-status".split()).splitlines()
 changemap = defaultdict(list)
 
 class DiffKind:
@@ -146,6 +157,13 @@ class DiffKind:
     MODIFIED = 'M'
     DELETED = 'D'
     RENAMED = 'R'
+
+DIFF_NAMES = {
+        DiffKind.ADDED: 'added',
+        DiffKind.MODIFIED: 'modified',
+        DiffKind.DELETED: 'deleted',
+        DiffKind.RENAMED: 'renamed',
+}
 
 IGNORED_ADDITIONS = [
         ".dockerignore",
@@ -168,13 +186,19 @@ for line in all_changed:
             path = rest.lstrip()
             # Assume files in ferrocene/ directories are always ok
             if (path.startswith("ferrocene/") or path.endswith("/ferrocene-annotations")
+                    or path.endswith('/ferrocene.rs' )
                     or path.startswith('.github') or path.startswith(".circleci")
                     or path.startswith("compiler/rustc_target/src/spec/targets/")
-                    or '/ferrocene/' in path or path in IGNORED_ADDITIONS):
+                    or path.startswith("tests/run-make/symbol-report/")
+                    or '/ferrocene/' in path or '/ferrocene_test.rs' in path
+                    or path in IGNORED_ADDITIONS):
                 continue
             val = path
         case DiffKind.MODIFIED:
-            val = rest.lstrip()
+            path = rest.lstrip()
+            if path.startswith("src/etc/completions"):
+                continue
+            val = path
         case DiffKind.RENAMED:
             val = rest.split()
         case _:
@@ -183,16 +207,17 @@ for line in all_changed:
 
 
 for kind in ['A', 'D', 'R']:
+    if changemap[kind]:
+        print(f"\nPrinting all {DIFF_NAMES[kind]} files")
     for p in changemap[kind]:
         print(f'{kind}\t{p}')
-    if changemap[kind]:
-        print()
 
+print("\nPrinting all changed tests")
 for f, changes in test_changemap.items():
     print(f)
     print('\n'.join(kind + change for kind, change in changes))
 
-print(f"\ngit diff {base_commit} --name-status -- ':!tests/' ':!.github' ':!**/.github/**' ':!ferrocene'")
+print(f"\ngit diff {base_commit} --name-status --diff-filter=M -I'#\[ferrocene::' -- ':!tests/' ':!.github' ':!**/.github/**' ':!ferrocene'")
 
 for p in changemap['M']:
     if p.startswith('tests/'):

--- a/ferrocene/tools/diff-upstream/diff.py
+++ b/ferrocene/tools/diff-upstream/diff.py
@@ -22,15 +22,23 @@ from more_itertools import peekable
 from automations_common import cmd_capture
 
 had_error = False
+
+
 def error(msg):
-    print('error:', msg)
+    print("error:", msg)
     global had_error
     had_error = True
 
-parser = argparse.ArgumentParser(prog='diff-upstream', description="Diff Ferrocene from upstream Rust project")
-parser.add_argument('--hide-diff', action='store_true', help="Only test "
-                    "ferrocene-annotations; don't run the diff. Implies --test.")
-parser.add_argument('--test', action='store_true', help="Test ferrocene-annotations")
+
+parser = argparse.ArgumentParser(
+    prog="diff-upstream", description="Diff Ferrocene from upstream Rust project"
+)
+parser.add_argument(
+    "--hide-diff",
+    action="store_true",
+    help="Only test " "ferrocene-annotations; don't run the diff. Implies --test.",
+)
+parser.add_argument("--test", action="store_true", help="Test ferrocene-annotations")
 args = parser.parse_args()
 
 if args.hide_diff:
@@ -38,17 +46,19 @@ if args.hide_diff:
 
 #### Diff all test annotations. ####
 
+
 class DiffKind:
-    ADDED = 'A'
-    MODIFIED = 'M'
-    DELETED = 'D'
-    RENAMED = 'R'
+    ADDED = "A"
+    MODIFIED = "M"
+    DELETED = "D"
+    RENAMED = "R"
+
 
 DIFF_NAMES = {
-        DiffKind.ADDED: 'added',
-        DiffKind.MODIFIED: 'modified',
-        DiffKind.DELETED: 'deleted',
-        DiffKind.RENAMED: 'renamed',
+    DiffKind.ADDED: "added",
+    DiffKind.MODIFIED: "modified",
+    DiffKind.DELETED: "deleted",
+    DiffKind.RENAMED: "renamed",
 }
 
 base_commit = cmd_capture("git log -n1 --author=bors@rust-lang.org --pretty=%H".split())
@@ -63,7 +73,7 @@ test_changemap = {}
 missing_annotations = {}
 annotations = {}
 
-Span = namedtuple('Span', ['file', 'line'])
+Span = namedtuple("Span", ["file", "line"])
 
 for line in test_changes:
     if line.startswith("diff --git"):
@@ -79,69 +89,77 @@ for line in test_changes:
 
     lineno += 1
     kind, change = line[0], line[1:]
-    if (not change or change == '//'
-            or change.startswith('//@ ignore-ferrocene.facade')):
+    if not change or change == "//" or change.startswith("//@ ignore-ferrocene.facade"):
         continue
 
-    if re.search(r'^\s*// ferrocene-annotations: ', change):
+    if re.search(r"^\s*// ferrocene-annotations: ", change):
         span = Span(file, lineno)
-        id = next(reversed(change.split(' ')))
-        if id.startswith('um_rustc'):
-            annotations[id] = span, ''
+        id = next(reversed(change.split(" ")))
+        if id.startswith("um_rustc"):
+            annotations[id] = span, ""
             continue
         # Next line is the section name it corresponds to.
         section = test_changes.peek()
-        if not section.startswith('+// '):
+        if not section.startswith("+// "):
             missing_annotations[span] = id
         else:
-            annotations[id] = span, section.split(' ', 1)[1]
+            annotations[id] = span, section.split(" ", 1)[1]
             next(test_changes)  # discard section
         continue
 
     changes.append([kind, change])
 
 if missing_annotations:
-    error(f'found {len(missing_annotations)} ferrocene-annotations not followed by section name!')
+    error(
+        f"found {len(missing_annotations)} ferrocene-annotations not followed by section name!"
+    )
     for span, annotation in missing_annotations.items():
-        print('%s:%d' % span, annotation)
+        print("%s:%d" % span, annotation)
+
 
 # load all section titles
 def load_sections(fd, sections):
     for line in fd:
-        if line.startswith('.. _fls'):
+        if line.startswith(".. _fls"):
             # Get id, truncating trailing colon.
-            id = line.strip().split('.. _', 1)[1][:-1]
+            id = line.strip().split(".. _", 1)[1][:-1]
             n = next(fd)
-            assert n.strip() == '', n
-            sections[id.lower()] = next(fd).strip().replace('`', '')
+            assert n.strip() == "", n
+            sections[id.lower()] = next(fd).strip().replace("`", "")
+
 
 def validate_annotations():
     sections = {}
-    for dir, _subdirs, files in os.walk('ferrocene/doc/specification'):
+    for dir, _subdirs, files in os.walk("ferrocene/doc/specification"):
         for file in files:
-            if file.endswith('.rst'):
-                with open(dir + '/' + file) as fd:
+            if file.endswith(".rst"):
+                with open(dir + "/" + file) as fd:
                     load_sections(fd, sections)
 
     cli_ids = set()
-    matrix = 'build/host/doc/qualification/traceability-matrix.html'
+    matrix = "build/host/doc/qualification/traceability-matrix.html"
     try:
         with open(matrix) as fd:
             for line in fd:
                 if m := re.search(r'id="(um_rustc_[^"]*)"', line):
                     cli_ids.add(m.group(1))
     except FileNotFoundError:
-        exit(f"error: {matrix} not found. try running './x build traceaqbility-matrix'.")
+        exit(
+            f"error: {matrix} not found. try running './x build traceaqbility-matrix'."
+        )
 
     for id, (span, name) in annotations.items():
-        if id.startswith('um_rustc_'):
+        if id.startswith("um_rustc_"):
             if id not in cli_ids:
                 error("Unknown CLI spec id:", id)
         elif id not in sections:
             error(f"Unknown section '{id}'!")
         elif name.lower() != sections[id].lower():
-            error("Incorrect section name on %s:%d:" % span,
-                f"Expected '{sections[id]}', found '{name}'")
+            error(
+                "Incorrect section name on %s:%d:" % span,
+                f"Expected '{sections[id]}', found '{name}'",
+            )
+
 
 if args.test:
     print("Validating Ferrocene annotations against traceability matrix")
@@ -165,7 +183,9 @@ with open(root_dir / ".gitattributes") as fd:
 
 filterer = IgnoreFilterManager.build(path=root_dir, global_patterns=ignored)
 
-all_changed = cmd_capture(f"git -c color.ui=never diff {base_commit} --name-status".split()).splitlines()
+all_changed = cmd_capture(
+    f"git -c color.ui=never diff {base_commit} --name-status".split()
+).splitlines()
 changemap = defaultdict(list)
 
 IGNORED_ADDITIONS = [
@@ -210,22 +230,24 @@ for line in all_changed:
     changemap[kind].append(val)
 
 
-for kind in ['A', 'D', 'R']:
+for kind in ["A", "D", "R"]:
     if changemap[kind]:
         print(f"\nPrinting all {DIFF_NAMES[kind]} files")
     for p in changemap[kind]:
-        print(f'{kind}\t{p}')
+        print(f"{kind}\t{p}")
 
 print("\nPrinting all changed tests")
 for f, changes in test_changemap.items():
     print(f)
-    print('\n'.join(kind + change for kind, change in changes))
+    print("\n".join(kind + change for kind, change in changes))
 
-print(fr"\ngit diff {base_commit} --name-status --diff-filter=M -I'#\[ferrocene::' -- ':!tests/' ':!.github' ':!**/.github/**' ':!ferrocene'")
+print(
+    rf"\ngit diff {base_commit} --name-status --diff-filter=M -I'#\[ferrocene::' -- ':!tests/' ':!.github' ':!**/.github/**' ':!ferrocene'"
+)
 
-for p in changemap['M']:
-    if p.startswith('tests/'):
+for p in changemap["M"]:
+    if p.startswith("tests/"):
         continue
-    print(f'M\t{p}')
+    print(f"M\t{p}")
 
 exit(had_error)

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test.snap
@@ -11,6 +11,9 @@ expression: test
 [Test] bootstrap::ferrocene::test::GenerateTarball
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::ferrocene/tools/generate-tarball})
+[Test] bootstrap::ferrocene::test::DiffUpstream
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::ferrocene/tools/diff-upstream})
 [Test] test::Tidy
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/tools/tidy})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage.snap
@@ -11,6 +11,9 @@ expression: test --skip=coverage
 [Test] bootstrap::ferrocene::test::GenerateTarball
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::ferrocene/tools/generate-tarball})
+[Test] bootstrap::ferrocene::test::DiffUpstream
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::ferrocene/tools/diff-upstream})
 [Test] test::Tidy
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/tools/tidy})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests.snap
@@ -11,6 +11,9 @@ expression: test --skip=tests
 [Test] bootstrap::ferrocene::test::GenerateTarball
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::ferrocene/tools/generate-tarball})
+[Test] bootstrap::ferrocene::test::DiffUpstream
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::ferrocene/tools/diff-upstream})
 [Test] test::Tidy
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/tools/tidy})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_etc.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_etc.snap
@@ -11,6 +11,9 @@ expression: test --skip=tests --skip=coverage-map --skip=coverage-run --skip=lib
 [Test] bootstrap::ferrocene::test::GenerateTarball
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::ferrocene/tools/generate-tarball})
+[Test] bootstrap::ferrocene::test::DiffUpstream
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::ferrocene/tools/diff-upstream})
 [Test] test::Tidy
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/tools/tidy})

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -871,6 +871,7 @@ impl<'a> Builder<'a> {
                 crate::ferrocene::test::SelfTest,
                 crate::ferrocene::test::CheckDocumentSignatures,
                 crate::ferrocene::test::GenerateTarball,
+                crate::ferrocene::test::DiffUpstream,
                 crate::ferrocene::test::certified_core_symbols::CertifiedCoreSymbols,
                 crate::core::build_steps::toolstate::ToolStateCheck,
                 test::Tidy,

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -2079,14 +2079,15 @@ mod snapshot {
         let ctx = TestCtx::new();
         insta::assert_snapshot!(
             prepare_test_config(&ctx)
-                .render_steps(), @"
+                .render_steps(), @r"
         [build] rustdoc 0 <host>
-        [build] rustc 0 <host> -> Tidy 1 <host>
-        [test] tidy <>
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
-        [build] rustc 1 <host> -> std 1 <host>
         [build] rustc 0 <host> -> Compiletest 1 <host>
+        [build] rustc 0 <host> -> FerroceneTraceabilityMatrix 1 <host>
+        [build] rustc 0 <host> -> Tidy 1 <host>
+        [test] tidy <>
+        [build] rustc 1 <host> -> std 1 <host>
         [test] compiletest-ui 1 <host>
         [test] compiletest-crashes 1 <host>
         [build] rustc 0 <host> -> CoverageDump 1 <host>
@@ -2134,7 +2135,6 @@ mod snapshot {
         [doc] edition-guide (book) <host>
         [doc] style-guide (book) <host>
         [build] rustc 0 <host> -> GenerateCopyright 1 <host>
-        [build] rustc 0 <host> -> FerroceneTraceabilityMatrix 1 <host>
         [build] rustc 0 <host> -> Linkchecker 1 <host>
         [test] link-check <host>
         [test] tier-check <host>
@@ -2257,16 +2257,17 @@ mod snapshot {
         insta::assert_snapshot!(
             prepare_test_config(&ctx)
                 .stage(2)
-                .render_steps(), @"
+                .render_steps(), @r"
         [build] rustdoc 0 <host>
-        [build] rustc 0 <host> -> Tidy 1 <host>
-        [test] tidy <>
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
         [build] rustc 1 <host> -> rustc 2 <host>
-        [build] rustc 2 <host> -> std 2 <host>
         [build] rustc 0 <host> -> Compiletest 1 <host>
+        [build] rustc 0 <host> -> FerroceneTraceabilityMatrix 1 <host>
+        [build] rustc 0 <host> -> Tidy 1 <host>
+        [test] tidy <>
+        [build] rustc 2 <host> -> std 2 <host>
         [test] compiletest-ui 2 <host>
         [test] compiletest-crashes 2 <host>
         [build] rustc 0 <host> -> CoverageDump 1 <host>
@@ -2315,7 +2316,6 @@ mod snapshot {
         [doc] edition-guide (book) <host>
         [doc] style-guide (book) <host>
         [build] rustc 0 <host> -> GenerateCopyright 1 <host>
-        [build] rustc 0 <host> -> FerroceneTraceabilityMatrix 1 <host>
         [build] rustc 0 <host> -> Linkchecker 1 <host>
         [test] link-check <host>
         [test] tier-check <host>

--- a/src/bootstrap/src/ferrocene/doc/mod.rs
+++ b/src/bootstrap/src/ferrocene/doc/mod.rs
@@ -734,8 +734,8 @@ sphinx_books! [
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub(crate) struct TraceabilityMatrix {
-    target: TargetSelection,
-    compiler: Compiler,
+    pub(in crate::ferrocene) target: TargetSelection,
+    pub(in crate::ferrocene) compiler: Compiler,
 }
 
 impl Step for TraceabilityMatrix {

--- a/src/bootstrap/src/ferrocene/test.rs
+++ b/src/bootstrap/src/ferrocene/test.rs
@@ -7,6 +7,7 @@ use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::core::build_steps::tool::{self, SourceType};
 use crate::core::config::TargetSelection;
 use crate::ferrocene::sign::error_when_signatures_are_ignored;
+use crate::utils::exec::BootstrapCommand;
 use crate::{Kind, Mode};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -170,5 +171,35 @@ impl Step for GenerateTarball {
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Self { target: run.target });
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct DiffUpstream {}
+impl Step for DiffUpstream {
+    type Output = ();
+    const IS_HOST: bool = true;
+
+    fn is_default_step(_builder: &Builder<'_>) -> bool {
+        true
+    }
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+        run.path("ferrocene/tools/diff-upstream")
+    }
+
+    fn make_run(run: RunConfig<'_>) {
+        run.builder.ensure(Self {});
+    }
+    fn run(self, builder: &Builder<'_>) {
+        let host = builder.host_target;
+        builder.ensure(crate::ferrocene::doc::TraceabilityMatrix {
+            target: host,
+            compiler: builder.compiler(builder.top_stage, host),
+        });
+
+        builder.info("test diff-upstream");
+        let mut cmd = BootstrapCommand::new("ferrocene/tools/diff-upstream/diff.py");
+        cmd.arg("--hide-diff");
+        cmd.run(builder);
     }
 }

--- a/tests/ui/borrowck/borrowck-borrow-overloaded-deref.rs
+++ b/tests/ui/borrowck/borrowck-borrow-overloaded-deref.rs
@@ -44,6 +44,7 @@ pub fn main() {}
 
 //
 // ferrocene-annotations: fls_v5x85lt5ulva
+// Attribute export_name
 //
 // ferrocene-annotations: fls_5cm4gkt55hjh
 // Dereference Expression/ References

--- a/tests/ui/cast/cast-to-infer-ty.rs
+++ b/tests/ui/cast/cast-to-infer-ty.rs
@@ -8,4 +8,4 @@ pub fn main() {
 }
 
 // ferrocene-annotations: fls_s45k21yn4qur
-// Inferred Type
+// Inferred Types

--- a/tests/ui/const-generics/early/invalid-const-arguments.rs
+++ b/tests/ui/const-generics/early/invalid-const-arguments.rs
@@ -27,3 +27,4 @@ impl<const F: u8, const H: u32> Foo for D<F, Q, D> {}
 //~| ERROR unresolved item provided when a constant was expected
 
 // ferrocene-annotations: fls_utuu8mdbuyxm
+// Generic Arguments

--- a/tests/ui/functions-closures/fn-item-type-zero-sized.rs
+++ b/tests/ui/functions-closures/fn-item-type-zero-sized.rs
@@ -13,7 +13,7 @@ fn main() {
 }
 
 // ferrocene-annotations: fls_airvr79xkcag
-// Function Item Type
+// Function Item Types
 //
 // ferrocene-annotations: fls_g1z6bpyjqxkz
 // Type Layout

--- a/tests/ui/unsafe/inline_asm.rs
+++ b/tests/ui/unsafe/inline_asm.rs
@@ -7,4 +7,4 @@ fn main() {
 }
 
 // ferrocene-annotations: fls_qezwyridmjob
-// Macros asm and global_asm
+// Macros: asm, global_asm, and naked_asm

--- a/tests/ui/use/issue-18986.rs
+++ b/tests/ui/use/issue-18986.rs
@@ -28,7 +28,7 @@ fn main() {
 // Record Struct Patterns
 //
 // ferrocene-annotations: fls_asj8rgccvkoe
-// Struct Pattern Matching
+// Record Struct Pattern Matching
 //
 // ferrocene-annotations: fls_151r19d7xbgz
 // Entities

--- a/tests/ui/where-clauses/where-clauses-cross-crate.rs
+++ b/tests/ui/where-clauses/where-clauses-cross-crate.rs
@@ -13,7 +13,7 @@ fn main() {
 }
 
 // ferrocene-annotations: fls_gklst7joeo33
-// External Crates
+// Crate Imports
 //
 // ferrocene-annotations: fls_9gprp17h6t1q
 // Use Imports


### PR DESCRIPTION
This does the following things:
- Prints files that were added, removed, or renamed. Some files that have "ferrocene" in the name are hidden under the assumption we don't care about them.
- Print all files outside the test suite that were modified, other than autogenerated completions.
- For all tests in the test suite, ignoring `ferrocene-annotation` changes, print a full diff of the changes.
- For all `ferrocene-annotation` changes, verify that the identifier corresponds to a part of the spec, and that the name of the section matches.

Additionally, `x test diff-upstream` now verifies that last bullet point, i.e. that all our annotations correspond to a part of the spec.