### PR TITLE
Forward port of 1.95 coverage work

### DIFF
--- a/ferrocene/doc/symbol-report.csv
+++ b/ferrocene/doc/symbol-report.csv
@@ -7509,6 +7509,8 @@ core::slice::<impl [T]>::split_at_mut_unchecked::precondition_check
 core::slice::<impl [T]>::split_at_unchecked
 core::slice::<impl [T]>::split_at_unchecked::precondition_check
 core::slice::<impl [T]>::split_first
+core::slice::<impl [T]>::split_first_chunk
+core::slice::<impl [T]>::split_first_chunk_mut
 core::slice::<impl [T]>::split_first_mut
 core::slice::<impl [T]>::split_last
 core::slice::<impl [T]>::split_last_mut

--- a/ferrocene/tools/symbol-report/src/main.rs
+++ b/ferrocene/tools/symbol-report/src/main.rs
@@ -149,6 +149,10 @@ fn extract_all_functions<'tcx>(tcx: TyCtxt<'tcx>, mut vis: Vis<'tcx>) -> Vis<'tc
 
         let qualified_name = get_qualified_name(tcx, def);
 
+        if should_filter_out(&qualified_name) {
+            continue;
+        }
+
         let (filename, mut start_line, end_line) = get_span(tcx, &mut vis, def);
 
         // We don't check for annotations those inside the `Visitor` implementation so we do it
@@ -170,6 +174,13 @@ fn extract_all_functions<'tcx>(tcx: TyCtxt<'tcx>, mut vis: Vis<'tcx>) -> Vis<'tc
 
 fn get_qualified_name(tcx: TyCtxt<'_>, def: LocalDefId) -> String {
     with_no_visible_paths!(with_resolve_crate_name!(with_no_trimmed_paths!(tcx.def_path_str(def))))
+}
+
+/// Filter out functions that are marked prevalidated for internal use only
+fn should_filter_out(qualified_name: &str) -> bool {
+    const FILTER_LIST: &[&str] = &["<core::ferrocene_test::", "core::ferrocene_test::"];
+
+    FILTER_LIST.iter().any(|filter| qualified_name.starts_with(filter))
 }
 
 fn get_span(tcx: TyCtxt<'_>, vis: &mut Vis<'_>, def: LocalDefId) -> (String, usize, usize) {

--- a/library/core/src/ferrocene_test.rs
+++ b/library/core/src/ferrocene_test.rs
@@ -101,10 +101,12 @@ pub(crate) mod println {
         fn dprintf(fd: i32, s: *const u8, ...);
     }
 
+    #[ferrocene::prevalidated]
     pub fn eprintln_str(s: &str) {
         eprintln_args(format_args!("{s}"));
     }
 
+    #[ferrocene::prevalidated]
     pub fn eprintln_args(args: fmt::Arguments<'_>) {
         let mut buf = Buffer::new();
         let mut f = fmt::Formatter::new(&mut buf, fmt::FormattingOptions::new());
@@ -121,16 +123,19 @@ pub(crate) mod println {
     }
 
     impl Buffer {
+        #[ferrocene::prevalidated]
         fn new() -> Self {
             Self { buf: [0; _], i: 0 }
         }
 
+        #[ferrocene::prevalidated]
         fn read(&self) -> &[u8] {
             &self.buf[..self.i]
         }
     }
 
     impl fmt::Write for Buffer {
+        #[ferrocene::prevalidated]
         fn write_str(&mut self, s: &str) -> fmt::Result {
             for byte in s.as_bytes() {
                 self.buf[self.i] = *byte;

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -848,6 +848,10 @@ where
 
     impl<T> Drop for DropOnPanic<T> {
         #[ferrocene::prevalidated]
+        #[ferrocene::annotation(
+            "This drop implementation is being executed, as proven by `coretests::ferrocene::hint::test_select_unpredictable_runs_destructor`. \
+            The fact that is shown as uncovered is a bug in our coverage tooling."
+        )]
         fn drop(&mut self) {
             // SAFETY: Must be guaranteed on construction of local type `DropOnPanic`.
             unsafe { self.inner.drop_in_place() }

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1539,12 +1539,15 @@ pub const unsafe fn conjure_zst<T>() -> T {
     #[ferrocene::annotation(
         "This assertion only runs in compilation, meaning that it cannot be covered in runtime"
     )]
-    const_assert!(
-        size_of::<T>() == 0,
-        "mem::conjure_zst invoked on a non-zero-sized type",
-        "mem::conjure_zst invoked on type {name}, which is not zero-sized",
-        name: &str = crate::any::type_name::<T>()
-    );
+    // Ferrocene addition: add curly braces in order to apply annotation to whole const_assert.
+    {
+        const_assert!(
+            size_of::<T>() == 0,
+            "mem::conjure_zst invoked on a non-zero-sized type",
+            "mem::conjure_zst invoked on type {name}, which is not zero-sized",
+            name: &str = crate::any::type_name::<T>()
+        );
+    }
 
     // SAFETY: because the caller must guarantee that it's inhabited and zero-sized,
     // there's nothing in the representation that needs to be set.

--- a/library/core/src/num/imp/flt2dec/strategy/dragon.rs
+++ b/library/core/src/num/imp/flt2dec/strategy/dragon.rs
@@ -249,6 +249,19 @@ pub fn format_shortest<'a>(
     // i) only the rounding-up condition was triggered, or
     // ii) both conditions were triggered and tie breaking prefers rounding up.
     if up && (!down || *mant.mul_pow2(1) >= scale) {
+        #[ferrocene::annotation(
+            "If we get here, that means three things:
+                1. Our input `d` is within 1 ULP of `10.pow(k) * .999...` repeating, for some k.
+                2. We chose to round up and represent the string as `1.00000...` repeating, for `i` significant digits.
+                3. Since we are in `format_shortest`, we did something wrong. The correct representation here is `1.0`, not `1.0000...` repeating.
+
+            Therefore correctness is already out the window.
+            If the implementation is correct, this block is unreachable.
+            If it's incorrect, we do a best-effort attempt to avoid panics and memory corruption, but do not make any guarantees about the output (we can't).
+
+            Memory safety: `c` is initialized, and `buf[i]` will panic if `i` is out of bounds.
+            Panics: We statically know that `i` is in-bounds because of the `assert!(buf.len() >= MAX_SIG_DIGITS)` at the top of this function."
+        )]
         // if rounding up changes the length, the exponent should also change.
         // it seems that this condition is very hard to satisfy (possibly impossible),
         // but we are just being safe and consistent here.
@@ -257,6 +270,9 @@ pub fn format_shortest<'a>(
             buf[i] = MaybeUninit::new(c);
             i += 1;
             k += 1;
+
+            #[cfg(feature = "ferrocene_test")]
+            unreachable!();
         }
     }
 

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -404,6 +404,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "slice_first_last_chunk", since = "1.77.0")]
     #[rustc_const_stable(feature = "slice_first_last_chunk", since = "1.77.0")]
+    #[ferrocene::prevalidated]
     pub const fn split_first_chunk<const N: usize>(&self) -> Option<(&[T; N], &[T])> {
         let Some((first, tail)) = self.split_at_checked(N) else { return None };
 
@@ -434,6 +435,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "slice_first_last_chunk", since = "1.77.0")]
     #[rustc_const_stable(feature = "const_slice_first_last_chunk", since = "1.83.0")]
+    #[ferrocene::prevalidated]
     pub const fn split_first_chunk_mut<const N: usize>(
         &mut self,
     ) -> Option<(&mut [T; N], &mut [T])> {

--- a/library/core/src/str/count.rs
+++ b/library/core/src/str/count.rs
@@ -140,3 +140,8 @@ fn sum_bytes_in_usize(values: usize) -> usize {
 fn char_count_general_case(s: &[u8]) -> usize {
     s.iter().filter(|&&byte| !super::validations::utf8_is_cont_byte(byte)).count()
 }
+
+/// Ferrocene addition: Hidden module to test crate-internal functionality
+#[doc(hidden)]
+#[unstable(feature = "ferrocene_test", issue = "none")]
+pub(crate) mod ferrocene_test;

--- a/library/core/src/str/count/ferrocene_test.rs
+++ b/library/core/src/str/count/ferrocene_test.rs
@@ -1,0 +1,5 @@
+use super::*;
+
+pub fn test_do_count_chars(s: &str, count: usize) {
+    assert_eq!(do_count_chars(s), count)
+}

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -29,6 +29,9 @@ pub use converts::{from_raw_parts, from_raw_parts_mut};
 pub use converts::{from_utf8, from_utf8_unchecked};
 #[stable(feature = "str_mut_extras", since = "1.20.0")]
 pub use converts::{from_utf8_mut, from_utf8_unchecked_mut};
+#[doc(hidden)]
+#[unstable(feature = "ferrocene_test", issue = "none")]
+pub use count::ferrocene_test::test_do_count_chars;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use error::{ParseBoolError, Utf8Error};
 #[stable(feature = "encode_utf16", since = "1.8.0")]

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -470,6 +470,18 @@ unsafe impl<'a> Searcher<'a> for CharSearcher<'a> {
                         if slice == &self.utf8_encoded[0..self.utf8_size()] {
                             return Some((found_char, self.finger));
                         }
+                    } else {
+                        #[ferrocene::annotation(
+                            "This branch is unreachable: `found_char..self.finger` is always within bounds of `self.haystack.as_bytes()`. \
+                            `self.finger` is bounded because it starts at a valid index and only advances within the haystack (by `index + 1` from `memchr`). \
+                            `found_char` is bounded because it equals `self.finger - self.utf8_size()`, and we only reach here when `self.finger >= self.utf8_size()`."
+                        )]
+                        {
+                            #[cfg(feature = "ferrocene_test")]
+                            unreachable!();
+                            #[cfg(not(feature = "ferrocene_test"))]
+                            {}
+                        }
                     }
                 }
             } else {

--- a/library/coretests/tests/ferrocene/hint.rs
+++ b/library/coretests/tests/ferrocene/hint.rs
@@ -1,0 +1,20 @@
+/// This test proves that the destructor
+/// `<core::hint::select_unpredictable::DropOnPanic<T> as core::ops::drop::Drop>::drop`
+/// is being executed, even if it is not shown as covered in the coverage report.
+#[test]
+#[should_panic = "0"]
+fn test_select_unpredictable_runs_destructor() {
+    struct Foo(i32);
+
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            if self.0 == 0 {
+                panic!("0");
+            }
+        }
+    }
+
+    core::hint::select_unpredictable(true, Foo(0), Foo(1));
+
+    unreachable!("the destructor will panic before");
+}

--- a/library/coretests/tests/ferrocene/hint.rs
+++ b/library/coretests/tests/ferrocene/hint.rs
@@ -2,14 +2,14 @@
 /// `<core::hint::select_unpredictable::DropOnPanic<T> as core::ops::drop::Drop>::drop`
 /// is being executed, even if it is not shown as covered in the coverage report.
 #[test]
-#[should_panic = "0"]
+#[should_panic = "drop is reached"]
 fn test_select_unpredictable_runs_destructor() {
     struct Foo(i32);
 
     impl Drop for Foo {
         fn drop(&mut self) {
             if self.0 == 0 {
-                panic!("0");
+                panic!("drop is reached");
             }
         }
     }

--- a/library/coretests/tests/ferrocene/mod.rs
+++ b/library/coretests/tests/ferrocene/mod.rs
@@ -10,6 +10,7 @@ mod cmp;
 mod floats;
 mod fmt;
 mod hash;
+mod hint;
 mod intrinsics;
 mod iter;
 mod macros;

--- a/library/coretests/tests/ferrocene/ops.rs
+++ b/library/coretests/tests/ferrocene/ops.rs
@@ -104,3 +104,15 @@ fn test_try_into_slice_range_end_excluded_gt_len() {
     use core::slice::SliceIndex;
     assert_eq!((Bound::Unbounded, Bound::Excluded(10)).get([0, 1].as_slice()), None);
 }
+
+// Covers `<core::ops::range::Range<T> as core::iter::range::RangeIteratorImpl>::spec_nth`
+#[test]
+fn test_range_spec_nth() {
+    assert_eq!((0..5_u16).nth(u32::MAX as usize), None);
+}
+
+// Covers `<core::ops::range::Range<T> as core::iter::range::RangeIteratorImpl>::spec_nth_back`
+#[test]
+fn test_range_spec_nth_back() {
+    assert_eq!((0..5_u16).nth_back(u32::MAX as usize), None);
+}

--- a/library/coretests/tests/ferrocene/result.rs
+++ b/library/coretests/tests/ferrocene/result.rs
@@ -78,3 +78,11 @@ fn clone_from() {
     res.clone_from(&Err(2));
     assert_eq!(res, Err(2));
 }
+
+// covers `core::result::Result::<T, E>::unwrap`.
+#[test]
+#[should_panic = "this is an error!"]
+fn unwrap_err() {
+    let err = Result::<i32, &str>::Err("this is an error!");
+    err.unwrap();
+}

--- a/library/coretests/tests/ferrocene/slice.rs
+++ b/library/coretests/tests/ferrocene/slice.rs
@@ -296,3 +296,12 @@ fn slice_escape_byte_call_once_success() {
 fn slice_escape_byte_call_once_failure() {
     core::slice::ferrocene_test::test_escape_byte_call_once(30, 31);
 }
+
+// covers `core::slice::<impl [T]>::split_first_chunk`
+#[test]
+fn slice_split_first_chunk() {
+    let slice = [1, 2, 3, 4, 5].as_slice();
+
+    assert_eq!(slice.split_first_chunk::<3>(), Some((&[1, 2, 3], [4, 5].as_slice())));
+    assert_eq!(slice.split_first_chunk::<10>(), None);
+}

--- a/library/coretests/tests/ferrocene/str.rs
+++ b/library/coretests/tests/ferrocene/str.rs
@@ -278,3 +278,9 @@ fn foo() {
 
     assert_eq!(format!("{x:?}"), "Utf8Chunks { source: \"hello\" }");
 }
+
+// covers `core::str::count::do_count_chars`.
+#[test]
+fn test_do_count_chars_unlikely() {
+    core::str::test_do_count_chars("", 0);
+}

--- a/library/coretests/tests/num/flt2dec/strategy/dragon.rs
+++ b/library/coretests/tests/num/flt2dec/strategy/dragon.rs
@@ -68,3 +68,32 @@ fn test_to_exact_exp_str() {
 fn test_to_exact_fixed_str() {
     to_exact_fixed_str_test(format_exact);
 }
+
+#[test]
+/// This test tries to detect incorrect rounding in `format_shortest`.
+/// It tests:
+/// - for each `0.1`, `0.01`, `0.001`, ..., for offset = 1..=20 digits:
+/// - for each p = `10.pow(1)`, `10.pow(2)`, from k = -300..=300:
+/// - Run `format_shortest` on `f = p - .0000....1`.
+///
+/// If the algorithm is incorrect, the annotated block will be hit, generating a coverage line, and
+/// `blanket` will error that we have an unused annotation.
+fn test_dragon_rounding_edge_cases() {
+    let mut buf = Vec::with_capacity(MAX_SIG_DIGITS);
+    let slice = buf.spare_capacity_mut();
+
+    for k in -300..=300 {
+        let p = 10f64.powi(k);
+        if p.is_infinite() {
+            continue;
+        }
+        let bits = p.to_bits();
+        for offset in 1..=20u64 {
+            let f = f64::from_bits(bits - offset);
+            let (_negative, full_decoded) = decode(f);
+            if let FullDecoded::Finite(decoded) = full_decoded {
+                format_shortest(&decoded, slice);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Is merged into `release/1.95`:
- [x] https://github.com/ferrocene/ferrocene/pull/2262
  - https://github.com/ferrocene/ferrocene/pull/2277/commits/70d7c1845fe2ce8509bcf2518f6475b4094a42f0 is slightly different, because on `main` the `fn should_filter_out` was removed, while in `release/1.95` it still exists
- [x] https://github.com/ferrocene/ferrocene/pull/2275
- [x] https://github.com/ferrocene/ferrocene/pull/2276