### PR TITLE
Qualify proc macros

### DIFF
--- a/ferrocene/doc/evaluation-plan/src/qualification-scope.rst
+++ b/ferrocene/doc/evaluation-plan/src/qualification-scope.rst
@@ -15,7 +15,9 @@ by end-use code is outside the scope of the current Ferrocene
 qualification. It is the end-user responsibility to certify these libraries if
 they are used in their code.
 
-Additionally a subset of the ``core`` library is certified for use in end-use code.
+A subset of the ``core`` library is certified for use in end-use code. See :doc:`core-certification:index`.
+
+The ``proc_macro`` library is qualified for use in end-use proc-macro crates. It is qualified and not certified because it must only be used during compilation and not execution of a program.
 
 Qualified tools
 ---------------

--- a/ferrocene/doc/evaluation-report/src/rustc/tool-analysis.rst
+++ b/ferrocene/doc/evaluation-report/src/rustc/tool-analysis.rst
@@ -48,65 +48,83 @@ Rust Driver
      - Mitigation
      - Detectable
    * - .. id:: RUSTC_ERR_DRIVER_02
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - An used environment variable is set to an incorrect value
      - Undefined behavior
      - :id:`RUSTC_AVD_CHECK_CLEAN_ENV_002`
      - YES
    * - .. id:: RUSTC_ERR_DRIVER_03
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - An invalid option is passed
      - Undefined behavior
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - YES
    * - .. id:: RUSTC_ERR_DRIVER_04
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - Error diagnostics are not correctly emited
      - Undefined behavior
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003` AND :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_05
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - The output is generated with missing part
      - Wrong code
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_06
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - The behavior is incorrect because of concurrent modification
      - Undefined behavior
      - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_07
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - A warning is generated instead of an error
      - Undefined behavior
      - :id:`RUSTC_AVD_WARNING_AS_ERROR_005`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_08
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - The compilation has a wrong behavior
      - Wrong code
      - :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_DRIVER_09
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - An incomplete input is accepted leading to an undefined behavior
      - Undefined behavior
      - :id:`RUSTC_AVD_TEST_007`
      - YES
    * - .. id:: RUSTC_ERR_DRIVER_10
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - Some object files are silently not generated
      - Use an artifact from a previous build
      - :id:`RUSTC_AVD_CLEAN_004`
+     - NO
+   * - .. id:: RUSTC_ERR_DRIVER_29
+     - :id:`RUSTC_UC6_PROC_MACRO`
+     - An shared object file of a incorrect or outdated ``proc-macro`` crate is passed to rustc
+     - Wrong code
+     - :id:`RUSTC_AVD_CLEAN_004`
+     - NO
+   * - .. id:: RUSTC_ERR_DRIVER_31
+     - :id:`RUSTC_UC6_PROC_MACRO`
+     - A proc-macro crate uses a dynamic library which is different than the one it was validated with, such as an updated library provided by a system package
+     - Wrong code
+     - :id:`RUSTC_AVD_TEST_007`
+     - NO
+   * - .. id:: RUSTC_ERR_DRIVER_32
+     - :id:`RUSTC_UC6_PROC_MACRO`
+     - A proc-macro contains Undefined Behavior, which corrupts the memory space of the compiler
+     - Wrong code
+     - :id:`RUSTC_AVD_MITIGATE_KPS_009`, :id:`RUSTC_AVD_ENSURE_MEMORY_SAFETY_010`
      - NO
 
 .. end of table
 
 
 Rust Front-End
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^
 
 .. list-table::
    :align: left
@@ -120,40 +138,46 @@ Rust Front-End
      - Mitigation
      - Detectable
    * - .. id:: RUSTC_ERR_RUST_FE_11
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - Input has invalid contents
      - Invalid code generated
      - :id:`RUSTC_AVD_TEST_007`
      - YES
    * - .. id:: RUSTC_ERR_RUST_FE_12
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - Error diagnostics is invalid
      - Invalid code generated
      - :id:`RUSTC_AVD_WARNING_AS_ERROR_005`
      - NO
    * - .. id:: RUSTC_ERR_RUST_FE_13
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - Invalid output generated from valid input
      - Invalid code generated
      - :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_RUST_FE_14
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - The behavior is incorrect because of concurrent modifications
      - Invalid code generated
      - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
      - NO
    * - .. id:: RUSTC_ERR_RUST_FE_15
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - Invalid input is accepted
      - Undefined behavior
      - :id:`RUSTC_AVD_TEST_007`
      - YES
    * - .. id:: RUSTC_ERR_RUST_FE_16
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - Incorrect number of inputs are accepted
      - Undefined behavior
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
+     - YES
+   * - .. id:: RUSTC_ERR_RUST_FE_30
+     - :id:`RUSTC_UC6_PROC_MACRO`
+     - A proc macro implementation function is invoked incorrectly by rustc.
+     - Undefined behavior
+     - :id:`RUSTC_AVD_TEST_007`, :id:`RUSTC_AVD_PROC_MACRO_NO_LINKER_SCRIPTS_011`
      - YES
 
 .. end of table
@@ -174,37 +198,37 @@ LLVM
      - Mitigation
      - Detectable
    * - .. id:: RUSTC_ERR_LLVM_17
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - Input parameter has invalid value
      - Most likely LLVM will crash. Invalid code could also be generated
      - :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_LLVM_18
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - An object file is invalid
      - Invalid code generated
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - NO
    * - .. id:: RUSTC_ERR_LLVM_19
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - An object file or static library is not correctly translated to machine code
      - Undefined behavior
      - :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_LLVM_20
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - The behavior is incorrect because of concurrent modifications
      - Invalid code generated
      - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
      - NO
    * - .. id:: RUSTC_ERR_LLVM_21
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - An object or static library exposes additional symbols
      - Internal functionality might become callable from the outside
      - :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_LLVM_22
-     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC1_RLIB`, :id:`RUSTC_UC2_STATICLIB`, :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - Output does not contain expected variables or functions
      - Invalid code generated
      - :id:`RUSTC_AVD_CHECK_CLEAN_ENV_002` AND :id:`RUSTC_AVD_CLEAN_004` AND :id:`RUSTC_AVD_TEST_007`
@@ -228,37 +252,37 @@ Linking
      - Mitigation
      - Detectable
    * - .. id:: RUSTC_ERR_LINK_23
-     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - Invalid input is accepted
      - Undefined behavior
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - NO
    * - .. id:: RUSTC_ERR_LINK_24
-     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - Invalid executable or library produced
      - Undefined behavior
      - :id:`RUSTC_AVD_TEST_007`
      - NO
    * - .. id:: RUSTC_ERR_LINK_25
-     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - The behavior is incorrect because of concurrent modifications
      - Undefined behavior
      - :id:`RUSTC_AVD_PARALLEL_BUILD_006`
      - NO
    * - .. id:: RUSTC_ERR_LINK_26
-     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - Incorrect number of inputs are accepted
      - Undefined behavior
      - :id:`RUSTC_AVD_CHECK_BUILD_SCRIPT_003`
      - YES
    * - .. id:: RUSTC_ERR_LINK_27
-     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - An input is missing
      - Invalid code generated but won't run
      - :id:`RUSTC_AVD_CHECK_INSTALL_001`
      - YES
    * - .. id:: RUSTC_ERR_LINK_28
-     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`
+     - :id:`RUSTC_UC3_EXEC`, :id:`RUSTC_UC4_EXEC_RLIB`, :id:`RUSTC_UC5_EXEC_CLIB`, :id:`RUSTC_UC6_PROC_MACRO`
      - Error diagnostics not emmited
      - Invalid or missing code not detected by user may be linked against subsequent stage
      - :id:`RUSTC_AVD_TEST_007`
@@ -325,6 +349,14 @@ Detection Measures and Usage Restriction
      - Concurrent file updates during the build operations are prohibited.
    * - .. id:: RUSTC_AVD_TEST_007
      - Testing must be performed on the final application or libraries, or on any parts built, using an environment as close as possible to the final build.
+   * - .. id:: RUSTC_AVD_PROC_MACRO_NO_ATTRIBUTE_008
+     - The user shall ensure that no attributes are used on a macro implementation function. The only exceptions are ``proc_macro``, ``proc_macro_derive`` or ``proc_macro_attribute``.
+   * - .. id:: RUSTC_AVD_MITIGATE_KPS_009
+     - The user shall implement mitigation strategies for known problems documented in the :ref:`known-problems:Known Problems` manual.
+   * - .. id:: RUSTC_AVD_ENSURE_MEMORY_SAFETY_010
+     - The user shall identify and evaluate the risks related to all instances of unsafe code as defined in :doc:`specification:unsafety`, and follow the guidelines outlined in :doc:`Handling Unsafety <safety-manual:rustc/unsafety>`.
+   * - .. id:: RUSTC_AVD_PROC_MACRO_NO_LINKER_SCRIPTS_011
+     - The user shall ensure that no linker scripts are used when compiling a proc-macro crate.
    * - .. id:: CORE_AVD_SUBSET_001
      - User must verify that only the certified subset of the core library is used.
    * - .. id:: CORE_AVD_MACROS_002

--- a/ferrocene/doc/evaluation-report/src/rustc/use-cases.rst
+++ b/ferrocene/doc/evaluation-report/src/rustc/use-cases.rst
@@ -108,7 +108,6 @@ environment is correctly set.
 
 8. (Optional): If the ``user`` is building a certified library, the ``user`` must verify that only certified functions from the core library are used.
 
-
 Building an Executable
 ----------------------
 
@@ -256,3 +255,85 @@ unique within the set of all directories included by compiler argument ``-L``.
 10. The linker generates a Rust executable that links to a C library.
 
 11. (Optional): If the ``user`` is building a certified executable, the ``user`` must verify that only certified functions from the core library are used.
+
+Building a procedural macro and using it in another crate
+---------------------------------------------------------
+
+.. note::
+   
+   The second part "Use the ``proc-macro`` crate" can be done for any crate type.
+   It will be done on the example of an ``rlib``, but this can be adapted by changing the passed ``--crate-type``.
+   For the purpose of analysing potential errors related to procedural macros, the crate type of the second part does not matter.
+
+.. id:: RUSTC_UC6_PROC_MACRO
+
+**Actor(s):** User, rustc.
+
+**Input:** Two Rust compilation units.
+
+**Output:** A static Rust library.
+
+**Environment constraints:** Ferrocene is correctly installed and the environment is correctly set.
+
+**Description:**
+
+1. Compile the ``proc-macro`` crate
+
+   1. The ``user`` calls ``rustc`` with the following command line arguments
+
+      .. code-block:: console
+
+         --edition 2021
+         --crate-name <name>
+         --crate-type proc-macro
+         --extern proc_macro
+         <proc_macro_path>
+         # <proc_macro_path> is the path to the root of the first compilation unit, as a positional argument.
+         # <name> is the name given to the proc-macro library 
+
+   2. ``rustc`` parses the command line arguments.
+
+   3. ``rustc`` parses the Rust compilation unit.
+
+   4. ``rustc`` analyzes the Rust compilation unit.
+
+   5. ``rustc`` generates LLVM IR for the Rust compilation unit.
+
+   6. ``rustc`` invokes ``LLVM``, passing the generated LLVM IR along with LLVM-related arguments.
+
+   7. ``LLVM`` generates an object file.
+
+   8. ``rustc`` invokes the linker, passing the generated object file along with linker-related arguments.
+
+   9. The linker generates a dynamic Rust library ``lib<name>.so`` that links to the ``proc_macro`` library.
+
+2. Use the ``proc-macro`` crate
+
+   1. The ``user`` calls ``rustc`` with the following command line arguments
+
+      .. code-block:: console
+
+         --edition 2021
+         --crate-type rlib
+         --extern <name>=lib<name>.so
+         <path>
+         # <path> is the path to the root of the second compilation unit, as a positional argument.
+         # <name> is the name given to the proc-macro library in the step before
+
+   2. ``rustc`` parses the command line arguments.
+
+   3. ``rustc`` parses the Rust compilation unit.
+
+   4. ``rustc`` dynamically loads ``lib<name>.so``
+
+   5. ``rustc`` executes all procedural macros on the syntax tree.
+
+   6. ``rustc`` analyzes the Rust compilation unit.
+
+   7. ``rustc`` generates LLVM IR for the Rust compilation unit.
+
+   8. ``rustc`` invokes `LLVM`, passing the generated LLVM IR along with LLVM-related arguments.
+
+   9. ``LLVM`` generates a static Rust library.
+
+   10. (Optional): If the ``user`` is building a certified executable, the ``user`` must verify that only certified functions from the ``core`` library are used.

--- a/ferrocene/doc/safety-manual/src/rustc/constraints.rst
+++ b/ferrocene/doc/safety-manual/src/rustc/constraints.rst
@@ -93,6 +93,8 @@ Problem mitigation
 
 .. id:: RUSTC_CSTR_0080_KP
 
+Associated requirement ID: :id:`RUSTC_AVD_MITIGATE_KPS_009`
+
 The user shall implement mitigation strategies for known problems
 documented in the :ref:`known-problems:Known Problems` manual.
 
@@ -111,6 +113,8 @@ Ensuring memory safety
 ----------------------
 
 .. id:: RUSTC_CSTR_0100_UNSAFETY
+
+Associated requirement ID: :id:`RUSTC_AVD_ENSURE_MEMORY_SAFETY_010`
 
 The user shall identify and evaluate the risks related to all instances
 of unsafe code as defined in :doc:`specification:unsafety`, and follow
@@ -131,3 +135,29 @@ Verifying linker scripts
 .. id:: RUSTC_CSTR_0120_LINKER_SCRIPTS
 
 The user shall ensure that the linker scripts they use are interpreted correctly by ``rust-lld``.
+
+No attributes on a proc macro implementation function
+-----------------------------------------------------
+
+.. id:: RUSTC_CSTR_0130_PROC_MACRO_NO_ATTRIBUTE
+
+Associated requirement ID: :id:`RUSTC_AVD_PROC_MACRO_NO_ATTRIBUTE_008`
+
+The user shall ensure that no attributes are used on a proc macro implementation function. The only exceptions are ``proc_macro``, ``proc_macro_derive`` or ``proc_macro_attribute``.
+
+.. note::
+
+   This is a precautionary measure and will be lifted or widened in the future.
+
+No linker scripts with proc-macro crates
+----------------------------------------
+
+.. id:: RUSTC_CSTR_0150_PROC_MACRO_NO_LINKER_SCRIPT
+
+Associated requirement ID: :id:`RUSTC_AVD_PROC_MACRO_NO_LINKER_SCRIPTS_011`
+
+The user shall ensure that no linker scripts are used when compiling a proc-macro crate.
+
+.. note::
+
+   This is a precautionary measure and will be lifted or widened in the future.

--- a/ferrocene/doc/safety-manual/src/rustc/usage.rst
+++ b/ferrocene/doc/safety-manual/src/rustc/usage.rst
@@ -60,3 +60,7 @@ Performing System Calls
 
 Refer to the User Manual - :doc:`user-manual:rustc/system-calls`.
 
+Building and using procedural macros
+------------------------------------
+
+Refer to the User Manual - :doc:`user-manual:rustc/proc-macro`.

--- a/ferrocene/doc/safety-manual/src/scope.rst
+++ b/ferrocene/doc/safety-manual/src/scope.rst
@@ -20,36 +20,43 @@ This qualification is restricted to the following environment:
      - Target
      - Certified Libraries
      - Uncertified Libraries
+     - Qualified Libraries
 
    * - :target:`x86_64-unknown-linux-gnu`
      - :target:`aarch64-unknown-none`
      - ``core``
      - ``alloc``
+     -
 
    * - :target:`x86_64-unknown-linux-gnu`
      - :target:`aarch64-unknown-nto-qnx710`
      - ``core``
-     - ``alloc``, ``std``, ``proc_macro``, ``test``
+     - ``alloc``, ``std``, ``test``
+     - ``proc_macro``
 
    * - :target:`x86_64-unknown-linux-gnu`
      - :target:`thumbv7em-none-eabi`
      - ``core``
      - ``alloc``
+     -
 
    * - :target:`x86_64-unknown-linux-gnu`
      - :target:`thumbv7em-none-eabihf`
      - ``core``
      - ``alloc``
+     -
 
    * - :target:`x86_64-unknown-linux-gnu`
      - :target:`x86_64-unknown-linux-gnu`
      - ``core``
-     - ``alloc``, ``std``, ``proc_macro``, ``test``
+     - ``alloc``, ``std``, ``test``
+     - ``proc_macro``
 
    * - :target:`x86_64-unknown-linux-gnu`
      - :target:`x86_64-pc-nto-qnx710`
      - ``core``
-     - ``alloc``, ``std``, ``proc_macro``, ``test``
+     - ``alloc``, ``std``, ``test``
+     - ``proc_macro``
 
 
 The uncertified libraries provided are evaluated and tested within the scope of
@@ -60,6 +67,8 @@ their code.
 
 The certified libraries provided are evaluated and tested to be used in other
 projects by users of the Ferrocene compiler.
+
+The qualified libraries provided are evaluated and tested to be used in other projects by users of the Ferrocene compiler, but only on the host platform.
 
 User responsibility
 -------------------

--- a/ferrocene/doc/user-manual/src/index.rst
+++ b/ferrocene/doc/user-manual/src/index.rst
@@ -23,6 +23,7 @@ Ferrocene User Manual
    rustc/executable
    rustc/mixed-language
    rustc/system-calls
+   rustc/proc-macro
    rustc/floating-points
    rustc/testing-facades
 

--- a/ferrocene/doc/user-manual/src/rustc/cli.rst
+++ b/ferrocene/doc/user-manual/src/rustc/cli.rst
@@ -642,8 +642,9 @@
 
       .. caution::
 
-         Only the ``bin``, ``lib``, ``rlib`` and ``staticlib`` crate types can
-         be used in a safety critical context.
+         Only the ``bin``, ``lib``, ``proc-macro``, ``rlib`` and ``staticlib`` crate types can be used in a safety critical context.
+
+         For usage of ``--crate-type proc-macro`` see the next entry.
 
       Compiler argument ``--crate-type`` specifies the type of crate to build.
 
@@ -681,6 +682,15 @@
       .. code-block::
 
          $ rustc --crate-type dylib --crate-type rlib my_library.rs
+
+   .. cli:option:: --crate-type proc-macro
+      :category: narrow
+
+      All of :cli:option:`--crate-type \<types\> <rustc --crate-type <types>>` applies to ``--crate-type proc-macro`` as well.
+
+      The crate type ``proc-macro`` allows to use the ``proc_macro`` library and the proc macro attributes ``#[proc_macro]``, ``#[proc_macro_attribute]`` and ``#[proc_macro_derive]``.
+
+      The crate type ``proc-macro`` cannot be used in combination with other crate types.
 
    .. cli:option:: -D <lints>
       :category: narrow

--- a/ferrocene/doc/user-manual/src/rustc/file-formats.rst
+++ b/ferrocene/doc/user-manual/src/rustc/file-formats.rst
@@ -45,3 +45,12 @@ produces an executable with name ``name``, without a file extension.
 
 The file format of an executable is target-dependent. Consult the documentation
 of your specific target.
+
+Proc macro library
+------------------
+
+A proc macro library is a Rust library of crate type ``proc-macro``.
+If used by another Rust library or executable it will be invoked by rustc to transform parts of the AST.
+
+Compiling a source file with name ``name`` using rustc produces a proc macro library with name ``libname``, with the ``so`` file extension for a native dynamic library.
+The ``so`` file format is target-dependent. Consult the documentation of your specific target.

--- a/ferrocene/doc/user-manual/src/rustc/proc-macro.rst
+++ b/ferrocene/doc/user-manual/src/rustc/proc-macro.rst
@@ -1,0 +1,106 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Building and using procedural macros
+====================================
+
+Procedural macros are specified in the :doc:`chapter "Macros" of the FLS <specification:macros>`.
+
+See the `"Procedual macros" chapter of Rust reference <../../reference/procedural-macros.html>`_ as informational background on procedural macros.
+
+If another crate called ``my_bin`` uses a procedural macro from a ``proc-macro`` crate called ``my_proc_macro``, the procedural macro is only executed during the compilation of the other crate, not during the runtime of the other crate. The object file generated from ``my_proc_macro`` will not be part of the binary produced from compiling ``my_bin``. Instead the procedural macro generates new tokens in the AST that are then compiled by rustc.
+
+Because procedural macros are only executed during compilation and not during runtime, they have to be qualified as a tool and not certified as a library.
+
+It is the end-user responsibility to qualify procedural macros if they are used in their code.
+
+``proc-macro`` crates by default are linked to ``proc_macro`` and ``std``. They can be marked as ``no_std`` in order to not be linked to ``std`` but only to ``proc_macro`` and ``core``.
+
+The ``proc_macro`` compile-time library
+---------------------------------------
+
+The ``proc_macro`` library defines the interface between the compiler and a procedural macro. Most notable is the ``proc_macro::TokenStream`` type. The ``proc_macro`` library is available in ``proc-macro`` crates only. If a crate of another crate type tries to use the ``proc_macro`` library, the compiler will error.
+
+Because of this and because its code is not included in the final binary, the ``proc_macro`` library is qualified as part of the compiler qualification and not certified as a standalone library.
+
+Building a ``proc-macro`` crate
+-------------------------------
+
+This section describes how to compile a ``proc-macro`` crate and use it from another crate.
+
+The examples in this section assume the following directory structure:
+
+.. code-block:: console
+
+   $ tree .
+   .
+   ├── my_bin.rs
+   └── my_lib.rs
+   └── my_proc_macro.rs
+   $
+   $ cat my_proc_macro.rs
+   #[proc_macro]
+   pub fn my_fn_like_macro(_item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+      "fn add(left: i32, right: i32) -> i32 { left + right }".parse().unwrap()
+   }
+   $
+   $ cat my_lib.rs
+   my_proc_macro::my_fn_like_macro!();
+   pub fn run() { assert_eq!(add(1, 2), 3); }
+   $
+   $ cat my_bin.rs
+   my_proc_macro::my_fn_like_macro!();
+   pub fn main() { assert_eq!(add(1, 2), 3); }
+
+Building a simple ``proc-macro`` crate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To build a ``proc-macro`` crate which only depends on ``proc_macro`` and ``std`` (or ``core``), execute the following:
+
+.. code-block:: console
+
+   $ rustc \
+      --edition=2021 \
+      --crate-name my_proc_macro \
+      --crate-type proc-macro \
+      --extern proc_macro \
+      my_proc_macro.rs
+   $ # Produces libmy_proc_macro.so
+
+Building a ``proc-macro`` crate with dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To build a ``proc-macro`` crate which depends on other libraries additionally to ``proc_macro`` and ``std``, first build the other libraries following :doc:`library`. Afterwards execute the following:
+
+.. code-block:: console
+
+   $ rustc \
+      --edition=2021 \
+      --crate-name my_proc_macro \
+      --crate-type proc-macro \
+      --extern other_lib=libother_lib.rlib \
+      --extern proc_macro \
+      my_proc_macro.rs
+   $ # Produces libmy_proc_macro.so
+
+Building a library/executable with a ``proc-macro`` crate as dependency
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After you have compiled a ``proc-macro`` crate you can use it from another library or executable like this:
+
+.. code-block:: console
+
+   $ # executable
+   $ rustc \
+      --edition=2021 \
+      --crate-name my_bin \
+      --crate-type bin \
+      --extern my_proc_macro=libmy_proc_macro.so \
+      my_bin.rs
+   $ # library
+   $ rustc \
+      --edition=2021 \
+      --crate-name my_lib \
+      --crate-type lib \
+      --extern my_proc_macro=libmy_proc_macro.so \
+      my_lib.rs

--- a/tests/ui/ferrocene/compiler-arguments/crate-type/crate-type_proc-macro-no-proc-macro.rs
+++ b/tests/ui/ferrocene/compiler-arguments/crate-type/crate-type_proc-macro-no-proc-macro.rs
@@ -11,3 +11,4 @@ pub fn foo(input: TokenStream) -> TokenStream { //~ ERROR `proc-macro` crate
 }
 
 // ferrocene-annotations: um_rustc_crate_type
+// ferrocene-annotations: um_rustc_crate_type_proc_macro

--- a/tests/ui/ferrocene/compiler-arguments/crate-type/crate-type_proc-macro.rs
+++ b/tests/ui/ferrocene/compiler-arguments/crate-type/crate-type_proc-macro.rs
@@ -12,3 +12,4 @@ pub fn foo(input: TokenStream) -> TokenStream {
 }
 
 // ferrocene-annotations: um_rustc_crate_type
+// ferrocene-annotations: um_rustc_crate_type_proc_macro

--- a/tests/ui/proc-macro/ferrocene-annotations
+++ b/tests/ui/proc-macro/ferrocene-annotations
@@ -12,3 +12,5 @@
 //
 // ferrocene-annotations: fls_gvwd0kf72jt
 // Attributes
+//
+// ferrocene-annotations: um_rustc_crate_type_proc_macro


### PR DESCRIPTION
This PR updates the Ferrocene qualification documentation to include the `proc-macro` crate type and the `proc_macro` library into its scope.

It documents the results of a HazOp of the usecase of building a proc macro crate and using it in another crate and traces the UI tests related to proc macros to the `rustc --crate-type proc-macro` CLI arg. See `um_rustc_crate_type_proc_macro` in the traceability matrix.
