### PR TITLE
add release notes stub for 26.08

### DIFF
--- a/ferrocene/doc/release-notes/src/index.rst
+++ b/ferrocene/doc/release-notes/src/index.rst
@@ -10,6 +10,12 @@ This document contains the list of new features, changes and bug fixes included
 in Ferrocene releases.
 
 .. toctree::
+   :caption: Ferrocene 26.08 series
+   :maxdepth: 1
+
+   next
+
+.. toctree::
    :caption: Ferrocene 26.05 series:
    :maxdepth: 1
 

--- a/ferrocene/doc/release-notes/src/next.rst
+++ b/ferrocene/doc/release-notes/src/next.rst
@@ -1,0 +1,10 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+:upcoming-release:
+
+Next Ferrocene release
+======================
+
+This page contains the changes to be introduced in the upcoming Ferrocene
+release.


### PR DESCRIPTION
builds on https://github.com/ferrocene/ferrocene/pull/2298. see https://public-docs.ferrocene.dev/main/qualification/internal-procedures/release/stable.html#version-bump-release-notes