### PR TITLE
Make some `//@ only-x86` tests target-independent

### DIFF
--- a/tests/ui/ferrocene/compiler-arguments/print/print_cfg.rs
+++ b/tests/ui/ferrocene/compiler-arguments/print/print_cfg.rs
@@ -1,6 +1,6 @@
 //@ check-pass
-//@ compile-flags: --print cfg
-//@ only-x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
+//@ compile-flags: --print cfg --target x86_64-unknown-linux-gnu
 
 fn main() {}
 

--- a/tests/ui/ferrocene/compiler-arguments/sysroot/sysroot_no-option.rs
+++ b/tests/ui/ferrocene/compiler-arguments/sysroot/sysroot_no-option.rs
@@ -1,12 +1,11 @@
+//~ ERROR can't find crate for `std`
+
 // Test when --sysroot set the path to a empty sysroot. sysroot should be the
 // current path.
 //
 //@ check-fail
-//@ ignore-cross-compile The error message is different when cross-compiling
-//@ compile-flags: --sysroot=
-//@ only-x86_64 Tested stderr is x86_64-linux-gnu specific
-//@ only-linux Tested stderr is x86_64-linux-gnu specific
-//~^^^^^^^^ ERROR can't find crate for `std`
+//@ needs-llvm-components: x86
+//@ compile-flags: --sysroot= --target=x86_64-unknown-linux-gnu
 
 fn main() {}
 

--- a/tests/ui/ferrocene/compiler-arguments/sysroot/sysroot_non-existent-with-space.rs
+++ b/tests/ui/ferrocene/compiler-arguments/sysroot/sysroot_non-existent-with-space.rs
@@ -1,11 +1,10 @@
+//~ ERROR can't find crate for `std`
+
 // Test when --sysroot set the path to a non-existent sysroot
 //
 //@ check-fail
-//@ ignore-cross-compile The error message is different when cross-compiling
-//@ only-x86_64 Tested stderr is x86_64-linux-gnu specific
-//@ only-linux Tested stderr is x86_64-linux-gnu specific
-//@ compile-flags: --sysroot /non/existent/sysroot
-//~^^^^^^^ ERROR can't find crate for `std`
+//@ needs-llvm-components: x86
+//@ compile-flags: --sysroot /non/existent/sysroot --target=x86_64-unknown-linux-gnu
 
 fn main() {}
 

--- a/tests/ui/ferrocene/compiler-arguments/sysroot/sysroot_non-existent.rs
+++ b/tests/ui/ferrocene/compiler-arguments/sysroot/sysroot_non-existent.rs
@@ -1,11 +1,10 @@
+//~ ERROR can't find crate for `std`
+
 // Test when --sysroot set the path to a non-existent sysroot
 //
 //@ check-fail
-//@ compile-flags: --sysroot=/non/existent/sysroot
-//@ only-x86_64 Tested stderr is x86_64-linux-gnu specific
-//@ only-linux Tested stderr is x86_64-linux-gnu specific
-//@ ignore-cross-compile The error message is different when cross-compiling
-//~^^^^^^^ ERROR can't find crate for `std`
+//@ needs-llvm-components: x86
+//@ compile-flags: --sysroot=/non/existent/sysroot --target=x86_64-unknown-linux-gnu
 
 fn main() {}
 


### PR DESCRIPTION
This makes it easier to test them when doing upstream pulls, without having to be on an x86 host.