### PR TITLE
tidy: Add back `find_base_commit`

### DIFF
--- a/src/tools/tidy/src/diagnostics.rs
+++ b/src/tools/tidy/src/diagnostics.rs
@@ -48,7 +48,7 @@ impl TidyCtx {
             None => CiEnv::current(),
         };
 
-        let tidy_ctx = Self {
+        let mut tidy_ctx = Self {
             diag_ctx: Arc::new(Mutex::new(DiagCtxInner {
                 running_checks: Default::default(),
                 finished_checks: Default::default(),
@@ -59,10 +59,7 @@ impl TidyCtx {
             ci_env,
             base_commit: None,
         };
-
-        // Ferrocene addition: Disable this, since our CI doesn't have enough history checked out.
-        // This only affects the check for rustdoc_types::FORMAT_VERSION anyway.
-        // tidy_ctx.base_commit = find_base_commit(&tidy_ctx);
+        tidy_ctx.base_commit = find_base_commit(&tidy_ctx);
 
         tidy_ctx
     }
@@ -103,7 +100,7 @@ impl TidyCtx {
     }
 }
 
-fn _find_base_commit(tidy_ctx: &TidyCtx) -> Option<String> {
+fn find_base_commit(tidy_ctx: &TidyCtx) -> Option<String> {
     let mut check = tidy_ctx.start_check("CI history");
 
     let stage0 = parse_stage0_file();
@@ -119,15 +116,15 @@ fn _find_base_commit(tidy_ctx: &TidyCtx) -> Option<String> {
     ) {
         Ok(Some(commit)) => Some(commit),
         Ok(None) => {
-            _error_if_in_ci("no base commit found", tidy_ctx.is_running_on_ci(), &mut check);
+            // Ferrocene addition: Make this a warning instead of a hard error, since our CI doesn't
+            // have enough history checked out.
+            // This only affects the check for rustdoc_types::FORMAT_VERSION anyway.
+            error_if_in_ci("no base commit found", false, &mut check);
             None
         }
         Err(error) => {
-            _error_if_in_ci(
-                &format!("failed to retrieve base commit: {error}"),
-                tidy_ctx.is_running_on_ci(),
-                &mut check,
-            );
+            // Ferrocene addition: warning instead of hard error.
+            error_if_in_ci(&format!("failed to retrieve base commit: {error}"), false, &mut check);
             None
         }
     };
@@ -135,7 +132,7 @@ fn _find_base_commit(tidy_ctx: &TidyCtx) -> Option<String> {
     base_commit
 }
 
-fn _error_if_in_ci(msg: &str, is_ci: bool, check: &mut RunningCheck) {
+fn error_if_in_ci(msg: &str, is_ci: bool, check: &mut RunningCheck) {
     if is_ci {
         check.error(msg);
     } else {


### PR DESCRIPTION
This makes tidy avoid checking untracked files locally. There is no change when running in CI, except a warning printed to stderr.