### PR TITLE
Rhivos2 qualification tests

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1289,7 +1289,7 @@ workflows:
             - build-docker-rhivos2-test-server-aarch64
       - aarch64-linux-rhivos2-test-container:
           name: aarch64-linux-rhivos2-compiletest
-          job: test:compiletest
+          job: qnx:compiletest-no-only-hosts
           resource-class: ferrocene/k8s-arm64-large # 8-core
           test-variant: "2021"
           requires:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -387,6 +387,8 @@ jobs:
         ferrocene/ci/scripts/llvm_cache.py download
         ./x.py --stage 2 build library src/tools/rustdoc
         ./x.py --stage 1 build src/tools/rustdoc
+        ./x build src/tools/remote-test-server --target "aarch64-unknown-linux-gnu" --stage "2"
+        ./x build src/tools/remote-test-server --target "aarch64-rhivos2-linux-gnu" --stage "2"
     steps: [ferrocene-job-build]
 
   aarch64-linux-dist:
@@ -775,6 +777,58 @@ jobs:
       - run:
           name: Empty step to make sure the job always has steps
           command: echo
+
+  # The image gets built for every job because it needs to contain build results per job
+  build-docker-rhivos2-test-server-aarch64:
+    description: Job that builds and uploads a Docker image for a rhivos2 container with a remote testserver.
+    docker:
+      - image: cimg/base:current
+    resource_class: arm.medium # 2-core
+    steps:
+      - aws-cli/install
+      - aws-oidc-auth
+      - ferrocene-git-shallow-clone:
+          depth: 1
+      - setup_remote_docker:
+          version: default # Only default and edge are supported: https://circleci.com/docs/building-docker-images/#docker-version
+      - run:
+          name: Install required packages
+          command: sudo apt update && sudo apt install zstd
+      - run:
+          name: Restore files from the aarch64-linux-build job
+          command: ferrocene/ci/scripts/persist-between-jobs.sh restore aarch64-linux-build
+      - run:
+          name: Build and upload the Docker image
+          command: ferrocene/ci/scripts/build-and-push-docker-image.sh
+          environment:
+            IMAGE_NAME: rhivos-2.0-test-server
+            IMAGE_TAG: run-id.<< pipeline.parameters.stable-workflow-id >>.rhivos-2.0-test-server
+
+  # The image gets built for every job because it needs to contain build results per job
+  build-docker-rhel-test-server-aarch64:
+    description: Job that builds and uploads a Docker image for a rhel container with a remote testserver.
+    docker:
+      - image: cimg/base:current
+    resource_class: arm.medium # 2-core
+    steps:
+      - aws-cli/install
+      - aws-oidc-auth
+      - ferrocene-git-shallow-clone:
+          depth: 1
+      - setup_remote_docker:
+          version: default # Only default and edge are supported: https://circleci.com/docs/building-docker-images/#docker-version
+      - run:
+          name: Install required packages
+          command: sudo apt update && sudo apt install zstd
+      - run:
+          name: Restore files from the aarch64-linux-build job
+          command: ferrocene/ci/scripts/persist-between-jobs.sh restore aarch64-linux-build
+      - run:
+          name: Build and upload the Docker image
+          command: ferrocene/ci/scripts/build-and-push-docker-image.sh
+          environment:
+            IMAGE_NAME: rhel-10.1-test-server
+            IMAGE_TAG: run-id.<< pipeline.parameters.stable-workflow-id >>.rhel-10.1-test-server
 
   # Misc jobs
   wasm-dist-oxidos:
@@ -1167,6 +1221,16 @@ workflows:
             - aarch64-linux-dist-tools
             - x86_64-linux-dist-targets
             - x86_64-linux-dist
+
+      # RHEL Test Infrastructure
+      - build-docker-rhel-test-server-aarch64:
+          requires:
+            - aarch64-linux-build
+
+      # RHIVOS2 Test Infrastructure
+      - build-docker-rhivos2-test-server-aarch64:
+          requires:
+            - aarch64-linux-build
 
       - aarch64-darwin-llvm: {}
       - aarch64-darwin-build:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1396,7 +1396,7 @@ workflows:
       - aarch64-linux-rhivos2-test-container:
           name: aarch64-linux-rhivos2-compiletest
           job: qnx:compiletest-no-only-hosts
-          resource-class: ferrocene/k8s-rhel-10-arm64-large
+          resource-class: ferrocene/k8s-arm64-large
           test-variant: "2021"
           requires:
             - aarch64-linux-build

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1716,6 +1716,46 @@ executors:
       - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
         aws_auth:
           oidc_role_arn: $AWS_ROLE_ARN
+  # This executor spins up a secondary container with the remote testserver running in a RHIVOS2 image
+  # The image is built specifically for this run.
+  docker-aarch64-ubuntu-20-rhivos2-test-server:
+    docker:
+      - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+        aws_auth:
+          # Self-Hosted Runners can't do OIDC auth at the moment
+          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
+          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
+      - name: rhivos-test-server
+        image: 886866542769.dkr.ecr.us-east-1.amazonaws.com/ci-docker-images:run-id.<< pipeline.parameters.stable-workflow-id >>.rhivos-2.0-test-server
+        command:
+          - "/bin/test-server/aarch64-rhivos2-linux-gnu/remote-test-server"
+          - "-v"
+          - "--bind"
+          - "127.0.0.1:12345"
+        aws_auth:
+          # Self-Hosted Runners can't do OIDC auth at the moment
+          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
+          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
+  # This executor spins up a secondary container with the remote testserver running in a RHEL 10.1 image
+  # The image is built specifically for this run.
+  docker-aarch64-ubuntu-20-rhel-10-1-test-server:
+    docker:
+      - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+        aws_auth:
+          # Self-Hosted Runners can't do OIDC auth at the moment
+          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
+          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
+      - name: rhel-test-server
+        image: 886866542769.dkr.ecr.us-east-1.amazonaws.com/ci-docker-images:run-id.<< pipeline.parameters.stable-workflow-id >>.rhel-10.1-test-server
+        command:
+          - "/bin/test-server/aarch64-unknown-linux-gnu/remote-test-server"
+          - "-v"
+          - "--bind"
+          - "127.0.0.1:12345"
+        aws_auth:
+          # Self-Hosted Runners can't do OIDC auth at the moment
+          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
+          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
   docker-x86_64-ubuntu-24:
     docker:
       - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--x86_64--ubuntu-24 >>

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -284,7 +284,7 @@ jobs:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       SCRIPT: |
         ferrocene/ci/scripts/llvm_cache.py download
-        ./x.py test --coverage=library library/core library/alloc --tests
+        ./x.py test --stage=1 --coverage=library library/core library/alloc --tests
     steps:
       - aws-oidc-auth
       - ferrocene-checkout:
@@ -461,7 +461,7 @@ jobs:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
       SCRIPT: |
         ferrocene/ci/scripts/llvm_cache.py download
-        ./x.py test --coverage=library library/core library/alloc --tests
+        ./x.py test --stage=1 --coverage=library library/core library/alloc --tests
     steps:
       - aws-oidc-auth
       - ferrocene-checkout:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1367,7 +1367,7 @@ workflows:
             - aarch64-linux-build
       - aarch64-linux-library-coverage:
           requires:
-            - aarch64-inux-build
+            - aarch64-linux-build
       - aarch64-linux-self-test:
           requires:
             - aarch64-linux-dist

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -397,18 +397,6 @@ jobs:
         ./x build src/tools/remote-test-server --target "aarch64-unknown-linux-gnu,aarch64-rhivos2-linux-gnu" --stage "2"
     steps: [ferrocene-job-build]
 
-  aarch64-linux-dist:
-    executor: docker-aarch64-ubuntu-20
-    resource_class: arm.xlarge # 8-core
-    environment:
-      FERROCENE_HOST: aarch64-unknown-linux-gnu
-      SCRIPT: |
-        # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
-        ./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist)
-    steps:
-      - ferrocene-job-dist:
-          restore-from-job: aarch64-linux-build
-
   aarch64-linux-dist-tools:
     executor: docker-aarch64-ubuntu-20
     resource_class: arm.xlarge # 8-core
@@ -420,33 +408,6 @@ jobs:
     steps:
       - ferrocene-job-dist:
           restore-from-job: aarch64-linux-build
-
-  aarch64-linux-dist-targets:
-    executor: docker-aarch64-ubuntu-20
-    resource_class: ferrocene/k8s-arm64-medium
-    environment:
-      FERROCENE_HOST: aarch64-unknown-linux-gnu
-      FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-unknown-linux-gnu--std >>
-      SCRIPT: |
-        ./x.py --stage 2 dist rust-std
-    steps:
-      - ferrocene-job-dist:
-          qnx: true
-          restore-from-job: aarch64-linux-build
-
-  aarch64-linux-dist-src:
-    executor: docker-aarch64-ubuntu-20
-    resource_class: ferrocene/k8s-arm64-small
-    environment:
-      FERROCENE_HOST: aarch64-unknown-linux-gnu
-      SCRIPT: |
-        ./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist:src)
-    steps:
-      - ferrocene-job-dist:
-          restore-from-job: aarch64-linux-build
-          # We need the whole LLVM clone to be able to include the full source
-          # code into the tarball we ship to customers.
-          llvm-subset: false
 
   aarch64-linux-generic-test-container:
     executor: docker-aarch64-ubuntu-20
@@ -1360,9 +1321,6 @@ workflows:
       - aarch64-linux-dist-tools:
           requires:
             - aarch64-linux-build
-      - aarch64-linux-dist-targets:
-          requires:
-            - aarch64-linux-build
       - aarch64-linux-generic-test-container:
           name: aarch64-linux-test
           job: test
@@ -1402,7 +1360,6 @@ workflows:
           requires:
             - aarch64-linux-dist
             - aarch64-linux-dist-tools
-            - aarch64-linux-dist-targets
             - x86_64-linux-dist-targets
             - x86_64-linux-dist
 

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -397,6 +397,18 @@ jobs:
         ./x build src/tools/remote-test-server --target "aarch64-unknown-linux-gnu,aarch64-rhivos2-linux-gnu" --stage "2"
     steps: [ferrocene-job-build]
 
+  aarch64-linux-dist:
+    executor: docker-aarch64-ubuntu-20
+    resource_class: arm.xlarge # 8-core
+    environment:
+      FERROCENE_HOST: aarch64-unknown-linux-gnu
+      SCRIPT: |
+        # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
+        ./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist)
+    steps:
+      - ferrocene-job-dist:
+          restore-from-job: aarch64-linux-build
+
   aarch64-linux-dist-tools:
     executor: docker-aarch64-ubuntu-20
     resource_class: arm.xlarge # 8-core

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -437,7 +437,7 @@ jobs:
 
   aarch64-linux-rhivos2-test-library-std:
     executor: docker-aarch64-ubuntu-20-rhivos2-test-server
-    resource_class: ferrocene/k8s-arm64-medium # 4-core
+    resource_class: ferrocene/k8s-rhel-10-arm64-medium # 4-core
     parameters:
       test-variant:
         type: string
@@ -1288,7 +1288,7 @@ workflows:
       - aarch64-linux-rhivos2-test-container:
           name: aarch64-linux-rhivos2-test-library
           job: test:library
-          resource-class: ferrocene/k8s-arm64-medium # 4-core
+          resource-class: ferrocene/k8s-rhel-10-arm64-medium
           test-variant: "2021"
           requires:
             - aarch64-linux-build
@@ -1296,7 +1296,7 @@ workflows:
       - aarch64-linux-rhivos2-test-container:
           name: aarch64-linux-rhivos2-compiletest
           job: qnx:compiletest-no-only-hosts
-          resource-class: ferrocene/k8s-arm64-large # 8-core
+          resource-class: ferrocene/k8s-rhel-10-arm64-medium
           test-variant: "2021"
           requires:
             - aarch64-linux-build

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -85,6 +85,9 @@ parameters:
   targets--x86_64-pc-windows-msvc--self-test:
     type: string
     default: ""
+  workflow-id:
+    type: string
+    default: ""
 
 orbs:
   aws-cli: circleci/aws-cli@4.0

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -421,9 +421,75 @@ jobs:
       - ferrocene-job-dist:
           restore-from-job: aarch64-linux-build
 
+  aarch64-linux-dist-targets:
+    executor: docker-aarch64-ubuntu-20
+    resource_class: ferrocene/k8s-arm64-medium
+    environment:
+      FERROCENE_HOST: aarch64-unknown-linux-gnu
+      FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-unknown-linux-gnu--std >>
+      SCRIPT: |
+        ./x.py --stage 2 dist rust-std
+    steps:
+      - ferrocene-job-dist:
+          qnx: true
+          restore-from-job: aarch64-linux-build
+
+  aarch64-linux-dist-src:
+    executor: docker-aarch64-ubuntu-20
+    resource_class: ferrocene/k8s-arm64-small
+    environment:
+      FERROCENE_HOST: aarch64-unknown-linux-gnu
+      SCRIPT: |
+        ./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist:src)
+    steps:
+      - ferrocene-job-dist:
+          restore-from-job: aarch64-linux-build
+          # We need the whole LLVM clone to be able to include the full source
+          # code into the tarball we ship to customers.
+          llvm-subset: false
+
+  aarch64-linux-generic-test-container:
+    executor: docker-aarch64-ubuntu-20
+    parameters:
+      job:
+        type: string
+      test-variant:
+        type: string
+      resource-class:
+        type: string
+    resource_class: << parameters.resource-class >>
+    environment:
+      FERROCENE_HOST: aarch64-unknown-linux-gnu
+      SCRIPT: |
+        # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
+        ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
+    steps:
+      - ferrocene-job-test-container:
+          restore-from-job: aarch64-linux-build
+
+    # aarch64-linux-test-library-std:
+    # executor: docker-aarch64-ubuntu-20
+    # resource_class: ferrocene/k8s-arm64-medium # 4-core
+    # parameters:
+    #   test-variant:
+    #     type: string
+    # environment:
+    #   FERROCENE_HOST: aarch64-unknown-linux-gnu
+    #   SCRIPT: |
+    #     env | grep TEST_DEVICE_ADDR
+    #     ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py test:library-std) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
+    # steps:
+    #   - aws-oidc-auth
+    #   - ferrocene-checkout:
+    #       llvm-subset: true
+    #   - run:
+    #       name: Restore files from the aarch64-linux-build job
+    #       command: ferrocene/ci/scripts/persist-between-jobs.sh restore aarch64-linux-build
+    #   - ferrocene-ci
+
   aarch64-linux-self-test:
     executor: docker-aarch64-ubuntu-20
-    resource_class: arm.medium # 2-core
+    resource_class: ferrocene/k8s-arm64-small # 2-core
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
       FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-unknown-linux-gnu--self-test >>
@@ -434,6 +500,23 @@ jobs:
       - run:
           name: Download dist artifacts and run the self-test tool
           command: ferrocene/ci/scripts/run-self-test.sh
+
+  aarch64-linux-library-coverage:
+    executor: docker-aarch64-ubuntu-20
+    resource_class: ferrocene/k8s-arm64-large
+    environment:
+      FERROCENE_HOST: aarch64-unknown-linux-gnu
+      SCRIPT: |
+        ferrocene/ci/scripts/llvm_cache.py download
+        ./x.py test --coverage=library library/core library/alloc --tests
+    steps:
+      - aws-oidc-auth
+      - ferrocene-checkout:
+          llvm-subset: true
+      # - run:
+      #     name: Restore files from the aarch64-linux-build job
+      #     command: ferrocene/ci/scripts/persist-between-jobs.sh restore aarch64-linux-build
+      - ferrocene-ci
 
   aarch64-linux-rhivos2-test-library-std:
     executor: docker-aarch64-ubuntu-20-rhivos2-test-server
@@ -1010,6 +1093,14 @@ workflows:
             - thumbv7em-eabihf-test-compiletest
             - thumbv7em-eabi-test-library
             - thumbv7em-eabi-test-compiletest
+            - aarch64-linux-test
+            - aarch64-linux-test-library
+            - aarch64-linux-test-library-std
+            - aarch64-linux-compiletest
+            - aarch64-linux-library-coverage
+            - aarch64-linux-rhivos2-test-library
+            - aarch64-linux-rhivos2-test-library-std
+            - aarch64-linux-rhivos2-compiletest
       - x86_64-linux-traceability-matrix:
           requires: *test-outcomes-dependencies
       - x86_64-linux-dist:
@@ -1269,10 +1360,49 @@ workflows:
       - aarch64-linux-dist-tools:
           requires:
             - aarch64-linux-build
+      - aarch64-linux-dist-targets:
+          requires:
+            - aarch64-linux-build
+      - aarch64-linux-generic-test-container:
+          name: aarch64-linux-test
+          job: test
+          resource-class: ferrocene/k8s-arm64-medium
+          test-variant: "2021"
+          requires:
+            - aarch64-linux-build
+      - aarch64-linux-generic-test-container:
+          name: aarch64-linux-test-library
+          job: test:library
+          resource-class: ferrocene/k8s-arm64-medium
+          test-variant: "2021"
+          requires:
+            - aarch64-linux-build
+      - aarch64-linux-generic-test-container:
+          name: aarch64-linux-test-library-std
+          job: test:library-std
+          resource-class: ferrocene/k8s-arm64-medium
+          test-variant: "2021"
+          requires:
+            - aarch64-linux-build
+      # - aarch64-linux-test-library-std:
+      #     test-variant: "2021"
+      #     requires:
+      #       - aarch64-linux-build
+      - aarch64-linux-generic-test-container:
+          name: aarch64-linux-compiletest
+          job: test:compiletest
+          resource-class: ferrocene/k8s-arm64-large
+          test-variant: "2021"
+          requires:
+            - aarch64-linux-build
+      - aarch64-linux-library-coverage:
+          requires:
+            - aarch64-inux-build
       - aarch64-linux-self-test:
           requires:
             - aarch64-linux-dist
             - aarch64-linux-dist-tools
+            - aarch64-linux-dist-targets
             - x86_64-linux-dist-targets
             - x86_64-linux-dist
 
@@ -1786,12 +1916,14 @@ executors:
     docker:
       - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
         aws_auth:
-          oidc_role_arn: $AWS_ROLE_ARN
+          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
+          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
   docker-aarch64-ubuntu-20:
     docker:
       - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
         aws_auth:
-          oidc_role_arn: $AWS_ROLE_ARN
+          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
+          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
   # This executor spins up a secondary container with the remote testserver running in a RHIVOS2 image
   # The image is built specifically for this run.
   docker-aarch64-ubuntu-20-rhivos2-test-server:
@@ -1836,12 +1968,14 @@ executors:
     docker:
       - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--x86_64--ubuntu-24 >>
         aws_auth:
-          oidc_role_arn: $AWS_ROLE_ARN
+          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
+          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
   docker-aarch64-ubuntu-24:
     docker:
       - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--aarch64--ubuntu-24 >>
         aws_auth:
-          oidc_role_arn: $AWS_ROLE_ARN
+          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
+          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
   linux-vm:
     machine:
       image: default

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -85,7 +85,11 @@ parameters:
   targets--x86_64-pc-windows-msvc--self-test:
     type: string
     default: ""
-  workflow-id:
+  # This is a stable workflow id that doesn't change on rerun
+  #
+  # In practice, we take the setup workflow id, because its convenient, but any random id would work
+  # The stable workflow id is used to identify intermediary container used by this workflow.
+  stable-workflow-id:
     type: string
     default: ""
 

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -429,6 +429,54 @@ jobs:
           name: Download dist artifacts and run the self-test tool
           command: ferrocene/ci/scripts/run-self-test.sh
 
+  aarch64-linux-rhivos2-test-library-std:
+    executor: docker-aarch64-ubuntu-20-rhivos2-test-server
+    resource_class: ferrocene/k8s-arm64-medium # 4-core
+    parameters:
+      test-variant:
+        type: string
+    environment:
+      FERROCENE_HOST: aarch64-unknown-linux-gnu
+      FERROCENE_TARGETS: aarch64-rhivos2-linux-gnu
+      TEST_DEVICE_ADDR: localhost:12345
+      # Standard library tests need IPv6, which is not available in container
+      # jobs. Because of that we need to run *just* standard library tests in a
+      # virtual machine.
+      # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
+      SCRIPT: |
+        env | grep TEST_DEVICE_ADDR
+        ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py test:library-std) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
+    steps:
+      - aws-oidc-auth
+      - ferrocene-checkout:
+          llvm-subset: true
+      - run:
+          name: Restore files from the aarch64-linux-build job
+          command: ferrocene/ci/scripts/persist-between-jobs.sh restore aarch64-linux-build
+      - ferrocene-ci
+
+  aarch64-linux-rhivos2-test-container:
+    executor: docker-aarch64-ubuntu-20-rhivos2-test-server
+    parameters:
+      job:
+        type: string
+      test-variant:
+        type: string
+      resource-class:
+        type: string
+    resource_class: << parameters.resource-class >>
+    environment:
+      FERROCENE_HOST: aarch64-unknown-linux-gnu
+      FERROCENE_TARGETS: aarch64-rhivos2-linux-gnu
+      TEST_DEVICE_ADDR: localhost:12345
+      SCRIPT: |
+        # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
+        env | grep TEST_DEVICE_ADDR
+        ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
+    steps:
+      - ferrocene-job-test-container:
+          restore-from-job: aarch64-linux-build
+
   # aarch64-apple-darwin jobs
 
   aarch64-darwin-llvm:
@@ -1231,6 +1279,27 @@ workflows:
       - build-docker-rhivos2-test-server-aarch64:
           requires:
             - aarch64-linux-build
+      - aarch64-linux-rhivos2-test-container:
+          name: aarch64-linux-rhivos2-test-library
+          job: test:library
+          resource-class: ferrocene/k8s-arm64-medium # 4-core
+          test-variant: "2021"
+          requires:
+            - aarch64-linux-build
+            - build-docker-rhivos2-test-server-aarch64
+      - aarch64-linux-rhivos2-test-container:
+          name: aarch64-linux-rhivos2-compiletest
+          job: test:compiletest
+          resource-class: ferrocene/k8s-arm64-large # 8-core
+          test-variant: "2021"
+          requires:
+            - aarch64-linux-build
+            - build-docker-rhivos2-test-server-aarch64
+      - aarch64-linux-rhivos2-test-library-std:
+          test-variant: "2021"
+          requires:
+            - aarch64-linux-build
+            - build-docker-rhivos2-test-server-aarch64
 
       - aarch64-darwin-llvm: {}
       - aarch64-darwin-build:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -365,7 +365,7 @@ jobs:
 
   aarch64-linux-llvm:
     executor: docker-aarch64-ubuntu-20
-    resource_class: arm.xlarge # 8-core
+    resource_class: ferrocene/k8s-arm64-large
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
       SCRIPT: ferrocene/ci/scripts/llvm_cache.py prepare
@@ -386,7 +386,7 @@ jobs:
 
   aarch64-linux-build:
     executor: docker-aarch64-ubuntu-20
-    resource_class: arm.xlarge # 8-core
+    resource_class: ferrocene/k8s-arm64-large
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
       FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-unknown-linux-gnu--build >>
@@ -399,7 +399,7 @@ jobs:
 
   aarch64-linux-dist:
     executor: docker-aarch64-ubuntu-20
-    resource_class: arm.xlarge # 8-core
+    resource_class: ferrocene/k8s-arm64-large
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
       SCRIPT: |
@@ -411,7 +411,7 @@ jobs:
 
   aarch64-linux-dist-tools:
     executor: docker-aarch64-ubuntu-20
-    resource_class: arm.xlarge # 8-core
+    resource_class: ferrocene/k8s-arm64-large
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
       SCRIPT: |

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -87,8 +87,15 @@ parameters:
     default: ""
   # This is a stable workflow id that doesn't change on rerun
   #
-  # In practice, we take the setup workflow id, because its convenient, but any random id would work
-  # The stable workflow id is used to identify intermediary container used by this workflow.
+  # The stable workflow id is used to identify intermediary containers used by this workflow.
+  #
+  # We can't key off the commit because we want to rebuild the test-runner image if the underlying
+  # base image is updated.
+  #
+  # We can't key off CirlceCIs workflow ID because it will change if someone uses any of the rerun
+  # options, for example "rerun with SSH", causing any step that uses an intermediary image to fail.
+  #
+  # Instead we take the setup workflow id because it's convenient, but any random id would work.
   stable-workflow-id:
     type: string
     default: ""

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1293,10 +1293,11 @@ workflows:
           requires:
             - aarch64-linux-build
             - build-docker-rhivos2-test-server-aarch64
+      # notably, this job needs significantly more memory.
       - aarch64-linux-rhivos2-test-container:
           name: aarch64-linux-rhivos2-compiletest
           job: qnx:compiletest-no-only-hosts
-          resource-class: ferrocene/k8s-rhel-10-arm64-medium
+          resource-class: ferrocene/k8s-rhel-10-arm64-large
           test-variant: "2021"
           requires:
             - aarch64-linux-build

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -387,8 +387,7 @@ jobs:
         ferrocene/ci/scripts/llvm_cache.py download
         ./x.py --stage 2 build library src/tools/rustdoc
         ./x.py --stage 1 build src/tools/rustdoc
-        ./x build src/tools/remote-test-server --target "aarch64-unknown-linux-gnu" --stage "2"
-        ./x build src/tools/remote-test-server --target "aarch64-rhivos2-linux-gnu" --stage "2"
+        ./x build src/tools/remote-test-server --target "aarch64-unknown-linux-gnu,aarch64-rhivos2-linux-gnu" --stage "2"
     steps: [ferrocene-job-build]
 
   aarch64-linux-dist:
@@ -828,7 +827,7 @@ jobs:
 
   # The image gets built for every job because it needs to contain build results per job
   build-docker-rhivos2-test-server-aarch64:
-    description: Job that builds and uploads a Docker image for a rhivos2 container with a remote testserver.
+    description: Build and upload a Docker image for a rhivos2 container with a remote testserver.
     docker:
       - image: cimg/base:current
     resource_class: arm.medium # 2-core

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -440,26 +440,6 @@ jobs:
       - ferrocene-job-test-container:
           restore-from-job: aarch64-linux-build
 
-    # aarch64-linux-test-library-std:
-    # executor: docker-aarch64-ubuntu-20
-    # resource_class: ferrocene/k8s-arm64-medium # 4-core
-    # parameters:
-    #   test-variant:
-    #     type: string
-    # environment:
-    #   FERROCENE_HOST: aarch64-unknown-linux-gnu
-    #   SCRIPT: |
-    #     env | grep TEST_DEVICE_ADDR
-    #     ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py test:library-std) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
-    # steps:
-    #   - aws-oidc-auth
-    #   - ferrocene-checkout:
-    #       llvm-subset: true
-    #   - run:
-    #       name: Restore files from the aarch64-linux-build job
-    #       command: ferrocene/ci/scripts/persist-between-jobs.sh restore aarch64-linux-build
-    #   - ferrocene-ci
-
   aarch64-linux-self-test:
     executor: docker-aarch64-ubuntu-20
     resource_class: ferrocene/k8s-arm64-small # 2-core
@@ -486,9 +466,6 @@ jobs:
       - aws-oidc-auth
       - ferrocene-checkout:
           llvm-subset: true
-      # - run:
-      #     name: Restore files from the aarch64-linux-build job
-      #     command: ferrocene/ci/scripts/persist-between-jobs.sh restore aarch64-linux-build
       - ferrocene-ci
 
   aarch64-linux-rhivos2-test-library-std:
@@ -1354,10 +1331,6 @@ workflows:
           test-variant: "2021"
           requires:
             - aarch64-linux-build
-      # - aarch64-linux-test-library-std:
-      #     test-variant: "2021"
-      #     requires:
-      #       - aarch64-linux-build
       - aarch64-linux-generic-test-container:
           name: aarch64-linux-compiletest
           job: test:compiletest

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1396,7 +1396,7 @@ workflows:
       - aarch64-linux-rhivos2-test-container:
           name: aarch64-linux-rhivos2-compiletest
           job: qnx:compiletest-no-only-hosts
-          resource-class: ferrocene/k8s-arm64-large
+          resource-class: ferrocene/k8s-rhel-10-arm64-large
           test-variant: "2021"
           requires:
             - aarch64-linux-build

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -468,32 +468,6 @@ jobs:
           llvm-subset: true
       - ferrocene-ci
 
-  aarch64-linux-rhivos2-test-library-std:
-    executor: docker-aarch64-ubuntu-20-rhivos2-test-server
-    resource_class: ferrocene/k8s-rhel-10-arm64-medium # 4-core
-    parameters:
-      test-variant:
-        type: string
-    environment:
-      FERROCENE_HOST: aarch64-unknown-linux-gnu
-      FERROCENE_TARGETS: aarch64-rhivos2-linux-gnu
-      TEST_DEVICE_ADDR: localhost:12345
-      # Standard library tests need IPv6, which is not available in container
-      # jobs. Because of that we need to run *just* standard library tests in a
-      # virtual machine.
-      # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
-      SCRIPT: |
-        env | grep TEST_DEVICE_ADDR
-        ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py test:library-std) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
-    steps:
-      - aws-oidc-auth
-      - ferrocene-checkout:
-          llvm-subset: true
-      - run:
-          name: Restore files from the aarch64-linux-build job
-          command: ferrocene/ci/scripts/persist-between-jobs.sh restore aarch64-linux-build
-      - ferrocene-ci
-
   aarch64-linux-rhivos2-test-container:
     executor: docker-aarch64-ubuntu-20-rhivos2-test-server
     parameters:
@@ -1365,6 +1339,14 @@ workflows:
           requires:
             - aarch64-linux-build
             - build-docker-rhivos2-test-server-aarch64
+      - aarch64-linux-rhivos2-test-container:
+          name: aarch64-linux-rhivos2-test-library-std
+          job: test:library-std
+          resource-class: ferrocene/k8s-rhel-10-arm64-medium
+          test-variant: "2021"
+          requires:
+            - aarch64-linux-build
+            - build-docker-rhivos2-test-server-aarch64
       # notably, this job needs significantly more memory.
       - aarch64-linux-rhivos2-test-container:
           name: aarch64-linux-rhivos2-compiletest
@@ -1374,12 +1356,6 @@ workflows:
           requires:
             - aarch64-linux-build
             - build-docker-rhivos2-test-server-aarch64
-      - aarch64-linux-rhivos2-test-library-std:
-          test-variant: "2021"
-          requires:
-            - aarch64-linux-build
-            - build-docker-rhivos2-test-server-aarch64
-
       - aarch64-darwin-llvm: {}
       - aarch64-darwin-build:
           requires:

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 !requirements.txt
 !ferrocene/ci/docker-images
 !ferrocene/ci/mirrors
+!**remote-test-server

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu.rs
@@ -1,5 +1,6 @@
 use crate::spec::{
-    Arch, FramePointer, SanitizerSet, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Arch, Cc, FramePointer, LinkerFlavor, Lld, SanitizerSet, StackProbeType, Target,
+    TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -15,6 +16,11 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32".into(),
         arch: Arch::AArch64,
         options: TargetOptions {
+            // Enable the Cortex-A53 errata 843419 mitigation by default
+            pre_link_args: TargetOptions::link_args(
+                LinkerFlavor::Gnu(Cc::Yes, Lld::No),
+                &["-Wl,--fix-cortex-a53-843419"],
+            ),
             features: "+v8a,+outline-atomics".into(),
             // the AAPCS64 expects use of non-leaf frame pointers per
             // https://github.com/ARM-software/abi-aa/blob/4492d1570eb70c8fd146623e0db65b2d241f12e7/aapcs64/aapcs64.rst#the-frame-pointer

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_musl.rs
@@ -1,5 +1,6 @@
 use crate::spec::{
-    Arch, FramePointer, SanitizerSet, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Arch, Cc, FramePointer, LinkerFlavor, Lld, SanitizerSet, StackProbeType, Target,
+    TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -29,6 +30,11 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32".into(),
         arch: Arch::AArch64,
         options: TargetOptions {
+            // Enable the Cortex-A53 errata 843419 mitigation by default
+            pre_link_args: TargetOptions::link_args(
+                LinkerFlavor::Gnu(Cc::Yes, Lld::No),
+                &["-Wl,--fix-cortex-a53-843419"],
+            ),
             // the AAPCS64 expects use of non-leaf frame pointers per
             // https://github.com/ARM-software/abi-aa/blob/4492d1570eb70c8fd146623e0db65b2d241f12e7/aapcs64/aapcs64.rst#the-frame-pointer
             // and we tend to encounter interesting bugs in AArch64 unwinding code if we do not

--- a/ferrocene/ci/docker-images/rhel-10.1-test-server/Dockerfile
+++ b/ferrocene/ci/docker-images/rhel-10.1-test-server/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: The Ferrocene Developers
 
 # From the root of this repository, build with
-# `docker build --tag ubuntu-24 --file ferrocene/ci/docker-images/ubuntu-24/Dockerfile .`
+# `docker build --tag rhel-10.1-test-server --file ferrocene/ci/rhel-10.1-test-server/Dockerfile .`
 
 FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi10:10.1
 

--- a/ferrocene/ci/docker-images/rhel-10.1-test-server/Dockerfile
+++ b/ferrocene/ci/docker-images/rhel-10.1-test-server/Dockerfile
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+# From the root of this repository, build with
+# `docker build --tag ubuntu-24 --file ferrocene/ci/docker-images/ubuntu-24/Dockerfile .`
+
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi10:10.1
+
+# As a multiplatform container we support all these: https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+RUN mkdir -p /bin/test-server/aarch64-unknown-linux-gnu
+RUN mkdir -p /bin/test-server/aarch64-rhivos2-linux-gnu
+COPY build/aarch64-unknown-linux-gnu/stage2-tools/aarch64-unknown-linux-gnu/release/remote-test-server /bin/test-server/aarch64-unknown-linux-gnu/remote-test-server
+COPY build/aarch64-unknown-linux-gnu/stage2-tools/aarch64-rhivos2-linux-gnu/release/remote-test-server /bin/test-server/aarch64-rhivos2-linux-gnu/remote-test-server
+CMD [ "sleep", "5000" ]

--- a/ferrocene/ci/docker-images/rhivos-2.0-test-server/Dockerfile
+++ b/ferrocene/ci/docker-images/rhivos-2.0-test-server/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: The Ferrocene Developers
 
-# `docker build --tag ubuntu-24 --file ferrocene/ci/docker-images/rhivos-2.0-test-server/Dockerfile .`
+# `docker build --tag rhivos-2.0-test-server --file ferrocene/ci/docker-images/rhivos-2.0-test-server/Dockerfile .`
 FROM --platform=$TARGETPLATFORM 886866542769.dkr.ecr.us-east-1.amazonaws.com/ci-docker-images:rhivos-2.0-09-04-2026
 
 # As a multiplatform container we support all these: https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope

--- a/ferrocene/ci/docker-images/rhivos-2.0-test-server/Dockerfile
+++ b/ferrocene/ci/docker-images/rhivos-2.0-test-server/Dockerfile
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+# `docker build --tag ubuntu-24 --file ferrocene/ci/docker-images/rhivos-2.0-test-server/Dockerfile .`
+FROM --platform=$TARGETPLATFORM 886866542769.dkr.ecr.us-east-1.amazonaws.com/ci-docker-images:rhivos-2.0-09-04-2026
+
+# As a multiplatform container we support all these: https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+RUN mkdir -p /bin/test-server/aarch64-rhivos2-linux-gnu
+COPY build/aarch64-unknown-linux-gnu/stage2-tools/aarch64-rhivos2-linux-gnu/release/remote-test-server /bin/test-server/aarch64-rhivos2-linux-gnu/remote-test-server
+CMD [ "sleep", "5000" ]

--- a/ferrocene/ci/docker-images/rhivos-2.0-test-server/Dockerfile
+++ b/ferrocene/ci/docker-images/rhivos-2.0-test-server/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: The Ferrocene Developers
 
 # `docker build --tag rhivos-2.0-test-server --file ferrocene/ci/docker-images/rhivos-2.0-test-server/Dockerfile .`
-FROM --platform=$TARGETPLATFORM 886866542769.dkr.ecr.us-east-1.amazonaws.com/ci-docker-images:rhivos-2.0-09-04-2026
+FROM --platform=$TARGETPLATFORM 886866542769.dkr.ecr.us-east-1.amazonaws.com/ci-docker-images:rhivos-2.0-19-04-2026
 
 # As a multiplatform container we support all these: https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
 ARG TARGETPLATFORM

--- a/ferrocene/ci/scripts/calculate_parameters.py
+++ b/ferrocene/ci/scripts/calculate_parameters.py
@@ -233,9 +233,11 @@ def calculate_targets(host_plus_stage: str):
 
     return ",".join(targets)
 
+
 # We need `*dummy` since below in `prepare_paremeters` calls this with args.
 def workflow_id(*dummy):
     return os.environ.get("CIRCLE_WORKFLOW_ID")
+
 
 def prepare_parameters():
     with open(CIRCLECI_CONFIGURATION) as f:

--- a/ferrocene/ci/scripts/calculate_parameters.py
+++ b/ferrocene/ci/scripts/calculate_parameters.py
@@ -233,6 +233,9 @@ def calculate_targets(host_plus_stage: str):
 
     return ",".join(targets)
 
+# We need `*dummy` since below in `prepare_paremeters` calls this with args.
+def workflow_id(*dummy):
+    return os.environ.get("CIRCLE_WORKFLOW_ID")
 
 def prepare_parameters():
     with open(CIRCLECI_CONFIGURATION) as f:
@@ -244,6 +247,7 @@ def prepare_parameters():
         "docker-repository-url--": calculate_docker_repository_url,
         "llvm-rebuild--": calculate_llvm_rebuild,
         "targets--": calculate_targets,
+        "workflow-id": workflow_id,
     }
 
     parameters: dict[str, str] = {}

--- a/ferrocene/ci/scripts/calculate_parameters.py
+++ b/ferrocene/ci/scripts/calculate_parameters.py
@@ -247,7 +247,7 @@ def prepare_parameters():
         "docker-repository-url--": calculate_docker_repository_url,
         "llvm-rebuild--": calculate_llvm_rebuild,
         "targets--": calculate_targets,
-        "workflow-id": workflow_id,
+        "stable-workflow-id": workflow_id,
     }
 
     parameters: dict[str, str] = {}

--- a/ferrocene/doc/qualification-report/src/index.rst
+++ b/ferrocene/doc/qualification-report/src/index.rst
@@ -22,6 +22,8 @@ qualification, in accordance to the standards above.
    :maxdepth: 2
 
    rustc/index
+   rustc/aarch64-unknown-linux-gnu
+   rustc/aarch64-rhivos2-linux-gnu
    rustc/aarch64-unknown-none
    rustc/aarch64-unknown-nto-qnx710
    rustc/thumbv7em-none-eabi

--- a/ferrocene/doc/qualification-report/src/rustc/aarch64-rhivos2-linux-gnu.rst
+++ b/ferrocene/doc/qualification-report/src/rustc/aarch64-rhivos2-linux-gnu.rst
@@ -1,0 +1,7 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+.. render-outcomes-template:: templates/tests.jinja2
+   :host: aarch64-unknown-linux-gnu
+   :target: aarch64-rhivos2-linux-gnu
+   :remote_testing:

--- a/ferrocene/doc/qualification-report/src/rustc/aarch64-unknown-linux-gnu.rst
+++ b/ferrocene/doc/qualification-report/src/rustc/aarch64-unknown-linux-gnu.rst
@@ -1,0 +1,6 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+.. render-outcomes-template:: templates/tests.jinja2
+   :host: aarch64-unknown-linux-gnu
+   :target: aarch64-unknown-linux-gnu

--- a/ferrocene/doc/user-manual/src/index.rst
+++ b/ferrocene/doc/user-manual/src/index.rst
@@ -35,6 +35,8 @@ Ferrocene User Manual
    targets/index
    targets/thumbv7em-none-eabi
    targets/thumbv7em-none-eabihf
+   targets/aarch64-unknown-linux-gnu
+   targets/aarch64-rhivos2-linux-gnu
    targets/aarch64-unknown-none
    targets/aarch64-unknown-nto-qnx710
    targets/aarch64-apple-darwin

--- a/ferrocene/doc/user-manual/src/targets/aarch64-rhivos2-linux-gnu.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-rhivos2-linux-gnu.rst
@@ -7,9 +7,12 @@
 ===================================
 .. note::
 
-   This is a variant of the generic :target:`aarch64-unknown-linux-gnu` target that specifically targets RHIVOS2 automotive linux. As per the RHIVOS2 guidelines, qualified use requires compilation on the matching host platform RedHat Enterprise Linux 10 using using the :ref:`aarch64-unknown-linux-gnu` host compiler.
-The ``aarch64-rhivos2-linux-gnu`` Ferrocene target provides support for RedHat In Vehicle Operating System 2 (RHIVOS2) on
-aarch64 using glibc 2.31 or higher.
+   This is a variant of the generic :target:`aarch64-unknown-linux-gnu` target that specifically targets
+   RHIVOS2 automotive linux. As per the RHIVOS2 guidelines, qualified use requires compilation on the matching
+   host platform RedHat Enterprise Linux 10 using using the :ref:`aarch64-unknown-linux-gnu` host compiler.
+
+The ``aarch64-rhivos2-linux-gnu`` Ferrocene target provides support for RedHat In Vehicle Operating System 2
+(RHIVOS2) on aarch64 using glibc 2.31 or higher.
 
 Prerequisites
 -------------

--- a/ferrocene/doc/user-manual/src/targets/aarch64-rhivos2-linux-gnu.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-rhivos2-linux-gnu.rst
@@ -1,0 +1,63 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+.. _aarch64-rhivos2-linux-gnu:
+
+:target:`aarch64-rhivos2-linux-gnu`
+===================================
+
+The ``aarch64-rhivos2-linux-gnu`` Ferrocene target provides support for RedHat In Vehicle Operating System 2 (RHIVOS2) on
+aarch64 using glibc 2.31 or higher.
+
+Prerequisites
+-------------
+
+While this target is technically a full linux and capable of hosting a compiler,
+the target is only qualified if cross-compiled from RHEL 10 on aarch64 in the
+version specified by the RHIVOS2 documentation. This requirement stems from the
+RHIVOS assumptions of use. The host compiler is :target:`aarch64-unknown-linux-gnu`.
+
+This target uses the LLVM ``ld.lld`` linker. To locate the system C libraries
+required to create a functional Linux binary, this target drives the ``ld.lld``
+linker using your system's C compiler as a linker driver.
+
+You must have a C compiler which:
+
+- Supports ``-fuse-ld=ld.lld`` option to select ``ld.lld`` as the linker
+
+- Supports ``-B`` option to modify the tool search path so it can find Ferrocene's
+  copy of ``ld.lld``
+
+- Does not load plugins into the linker (e.g. the GCC LTO plugin)
+
+- Supplies to ``ld.lld`` only those linker arguments specified in the
+  :doc:`Safety Manual <safety-manual:rustc/options>`
+
+Please refer to the RedHat Enterprise Linux 10 documentation for installation instructions.
+
+Archives to install
+-------------------
+
+The following archives are needed when :doc:`installing </rustc/install>` this
+target as a cross-compilation target:
+
+* ``rust-std-aarch64-rhivos2-linux-gnu``
+
+Required compiler flags
+-----------------------
+
+To use the target, the following additional flags must be provided to
+``rustc``:
+
+- ``--target=aarch64-rhivos2-linux-gnu``
+
+- ``-C linker=<your-c-compiler>``
+
+  - e.g. ``-C linker=/usr/bin/gcc``
+
+If your C compiler loads the GCC LTO plugins by default, you will also need to
+switch off GCC LTO with:
+
+- ``-Clink-arg=-fno-lto``
+
+.. _aarch64-ferrocene-linux-gnu:

--- a/ferrocene/doc/user-manual/src/targets/aarch64-rhivos2-linux-gnu.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-rhivos2-linux-gnu.rst
@@ -5,7 +5,9 @@
 
 :target:`aarch64-rhivos2-linux-gnu`
 ===================================
+.. note::
 
+   This is a variant of the generic :target:`aarch64-unknown-linux-gnu` target that specifically targets RHIVOS2 automotive linux. As per the RHIVOS2 guidelines, qualified use requires compilation on the matching host platform RedHat Enterprise Linux 10 using using the :ref:`aarch64-unknown-linux-gnu` host compiler.
 The ``aarch64-rhivos2-linux-gnu`` Ferrocene target provides support for RedHat In Vehicle Operating System 2 (RHIVOS2) on
 aarch64 using glibc 2.31 or higher.
 

--- a/ferrocene/doc/user-manual/src/targets/aarch64-unknown-linux-gnu.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-unknown-linux-gnu.rst
@@ -1,0 +1,69 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+.. _aarch64-unknown-linux-gnu:
+
+:target:`aarch64-unknown-linux-gnu`
+===================================
+
+The ``aarch64-unknown-linux-gnu`` Ferrocene target provides support for Linux on
+aarch64 using glibc 2.31 or higher.
+
+Prerequisites
+-------------
+
+This target uses the LLVM ``ld.lld`` linker. To locate the system C libraries
+required to create a functional Linux binary, this target drives the ``ld.lld``
+linker using your system's C compiler as a linker driver.
+
+You must have a C compiler which:
+
+- Supports ``-fuse-ld=ld.lld`` option to select ``ld.lld`` as the linker
+
+- Supports ``-B`` option to modify the tool search path so it can find Ferrocene's
+  copy of ``ld.lld``
+
+- Does not load plugins into the linker (e.g. the GCC LTO plugin)
+
+- Supplies to ``ld.lld`` only those linker arguments specified in the
+  :doc:`Safety Manual <safety-manual:rustc/options>`
+
+On Ubuntu 20.04 LTS you can install a suitable C compiler with:
+
+.. code-block::
+
+   $ sudo apt install gcc
+
+Archives to install
+-------------------
+
+The following archives are needed when :doc:`installing </rustc/install>` this
+target as a host platform:
+
+* ``rustc-aarch64-unknown-linux-gnu``
+* ``rust-std-aarch64-unknown-linux-gnu``
+* ``ferrocene-self-test-aarch64-unknown-linux-gnu``
+
+The following archives are needed when :doc:`installing </rustc/install>` this
+target as a cross-compilation target:
+
+* ``rust-std-aarch64-unknown-linux-gnu``
+
+Required compiler flags
+-----------------------
+
+To use the target, the following additional flags must be provided to
+``rustc``:
+
+- ``--target=aarch64-unknown-linux-gnu``
+
+- ``-C linker=<your-c-compiler>``
+
+  - e.g. ``-C linker=/usr/bin/gcc``
+
+If your C compiler loads the GCC LTO plugins by default, you will also need to
+switch off GCC LTO with:
+
+- ``-Clink-arg=-fno-lto``
+
+.. _aarch64-ferrocene-linux-gnu:

--- a/ferrocene/doc/user-manual/src/targets/aarch64-unknown-linux-gnu.rst
+++ b/ferrocene/doc/user-manual/src/targets/aarch64-unknown-linux-gnu.rst
@@ -5,6 +5,9 @@
 
 :target:`aarch64-unknown-linux-gnu`
 ===================================
+.. note::
+
+   Only qualified when cross-compiling to :ref:`aarch64-rhivos2-linux-gnu`.
 
 The ``aarch64-unknown-linux-gnu`` Ferrocene target provides support for Linux on
 aarch64 using glibc 2.31 or higher.

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -90,17 +90,17 @@ qualified upon request.
      - Bare-metal
      - Only qualified when cross-compiled from :ref:`x86_64-unknown-linux-gnu`.
 
-   * - :target:`aarch64-unknown-linux-gnu`
+   * - :ref:`aarch64-unknown-linux-gnu`
      - ``aarch64-unknown-linux-gnu``
      - Host platform
      - Full
      - \-
 
-   * - :target:`aarch64-rhivos2-linux-gnu`
+   * - :ref:`aarch64-rhivos2-linux-gnu`
      - ``aarch64-rhivos2-linux-gnu``
      - Cross-compilation
      - Full
-     - This is a variant of the generic :target:`aarch64-unknown-linux-gnu` target that specifically targets RHIVOS2 automotive linux. As per the RHIVOS2 guidelines, qualified use requires compilation on the matching host platform RedHat Enterprise Linux 10 using using the :ref:`x86_64-unknown-linux-gnu` host compiler.
+     - This is a variant of the generic :target:`aarch64-unknown-linux-gnu` target that specifically targets RHIVOS2 automotive linux. As per the RHIVOS2 guidelines, qualified use requires compilation on the matching host platform RedHat Enterprise Linux 10 using using the :ref:`aarch64-unknown-linux-gnu` host compiler.
 
    * - :ref:`aarch64-unknown-nto-qnx710`
      - ``aarch64-unknown-nto-qnx710``

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -94,7 +94,7 @@ qualified upon request.
      - ``aarch64-unknown-linux-gnu``
      - Host platform
      - Full
-     - \-
+     - Only qualified when cross-compiling to :ref:`aarch64-rhivos2-linux-gnu`.
 
    * - :ref:`aarch64-rhivos2-linux-gnu`
      - ``aarch64-rhivos2-linux-gnu``

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -90,6 +90,18 @@ qualified upon request.
      - Bare-metal
      - Only qualified when cross-compiled from :ref:`x86_64-unknown-linux-gnu`.
 
+   * - :target:`aarch64-unknown-linux-gnu`
+     - ``aarch64-unknown-linux-gnu``
+     - Host platform
+     - Full
+     - \-
+
+   * - :target:`aarch64-rhivos2-linux-gnu`
+     - ``aarch64-rhivos2-linux-gnu``
+     - Cross-compilation
+     - Full
+     - This is a variant of the generic :target:`aarch64-unknown-linux-gnu` target that specifically targets RHIVOS2 automotive linux. As per the RHIVOS2 guidelines, qualified use requires compilation on the matching host platform RedHat Enterprise Linux 10 using using the :ref:`x86_64-unknown-linux-gnu` host compiler.
+
    * - :ref:`aarch64-unknown-nto-qnx710`
      - ``aarch64-unknown-nto-qnx710``
      - Cross-compilation
@@ -180,18 +192,6 @@ Supported targets can often be qualified or quality managed upon request.
      - Kind
      - Standard library
      - Notes
-
-   * - :target:`aarch64-unknown-linux-gnu`
-     - ``aarch64-unknown-linux-gnu``
-     - Host platform
-     - Full
-     - \-
-
-   * - :target:`aarch64-rhivos2-linux-gnu`
-     - ``aarch64-rhivos2-linux-gnu``
-     - Host platform
-     - Full
-     - This is a variant of the generic :target:`aarch64-unknown-linux-gnu` target that specifically targets RHIVOS2 automotive linux.
 
    * - :target:`aarch64r82-unknown-none`
      - ``aarch64r82-unknown-none``

--- a/ferrocene/ignored-tests.toml
+++ b/ferrocene/ignored-tests.toml
@@ -168,7 +168,13 @@ reason = "No ps utility in test environment."
 
 [["tests/run-make"]]
 tests = [
-    "tests/run-make/pointer-auth-link-with-c",
+    "tests/run-make/pointer-auth-link-with-c"
+]
+targets = ["aarch64-rhivos2-linux-gnu", "aarch64-unknown-linux-gnu"]
+reason = "This tests the interoperabilty an unstable feature of the rust compiler (enabling PAC) with newer C compilers (‘-mbranch-protection=’)."
+
+[["tests/run-make"]]
+tests = [
     "tests/run-make/used-proc-macro"
 ]
 targets = ["aarch64-rhivos2-linux-gnu", "aarch64-unknown-linux-gnu"]

--- a/ferrocene/ignored-tests.toml
+++ b/ferrocene/ignored-tests.toml
@@ -21,7 +21,7 @@ tests = [
     "tests/run-coverage",
     "tests/run-coverage-rustdoc",
 ]
-targets = ["aarch64-unknown-linux-gnu"]
+targets = ["aarch64-unknown-linux-gnu", "aarch64-rhivos2-linux-gnu"]
 reason = "The tests generates profraw files to analyze, but remote-test is not capable of pushing those files back to the client yet"
 
 [["tests/run-make"]]
@@ -30,7 +30,7 @@ tests = [
     "tests/run-make/sanitizer-dylib-link",
     "tests/run-make/sanitizer-staticlib-link"
 ]
-targets = ["aarch64-unknown-linux-gnu"]
+targets = ["aarch64-unknown-linux-gnu", "aarch64-rhivos2-linux-gnu"]
 reason = "QEMU user space emulation doesn't support most sanitizers"
 
 [["tests/run-make"]]

--- a/ferrocene/ignored-tests.toml
+++ b/ferrocene/ignored-tests.toml
@@ -137,6 +137,30 @@ reason = "This errata does not affect Armv8-R AArch64 processors"
 
 [["tests/run-make"]]
 tests = [
+    "tests/run-make/sanitizer-cdylib-link",
+    "tests/run-make/sanitizer-dylib-link",
+    "tests/run-make/sanitizer-staticlib-link"
+]
+targets = ["aarch64-rhivos2-linux-gnu"]
+reason = "Sanitizers are not a qualified compiler feature. Support on RHIVOS2 needs investigation."
+
+[["tests/ui"]]
+tests = [
+    "tests/ui/sanitizer/hwaddress.rs",
+    "tests/ui/sanitizer/leak.rs",
+    "tests/ui/sanitizer/memory-eager.rs",
+    "tests/ui/sanitizer/memory-passing.rs",
+    "tests/ui/sanitizer/memory.rs",
+    "tests/ui/sanitizer/realtime-alloc.rs",
+    "tests/ui/sanitizer/realtime-blocking.rs",
+    "tests/ui/sanitizer/realtime-caller.rs",
+    "tests/ui/sanitizer/thread.rs"
+]
+targets = ["aarch64-rhivos2-linux-gnu"]
+reason = "Sanitizers are not a qualified compiler feature. Support on RHIVOS2 needs investigation."
+
+[["tests/run-make"]]
+tests = [
     "tests/run-make/pointer-auth-link-with-c"
 ]
 targets = ["aarch64-rhivos2-linux-gnu", "aarch64-unknown-linux-gnu"]

--- a/ferrocene/ignored-tests.toml
+++ b/ferrocene/ignored-tests.toml
@@ -134,10 +134,3 @@ tests = [
 ]
 targets = ["aarch64r82-unknown-ferrocene.facade", "aarch64v8r-unknown-ferrocene.facade"]
 reason = "This errata does not affect Armv8-R AArch64 processors"
-
-[["tests/run-make"]]
-tests = [
-    "tests/run-make/fix-cortex-a53-843419"
-]
-targets = ["aarch64-rhivos2-linux-gnu"]
-reason = "This test does not work on Linux targets and is under investigation."

--- a/ferrocene/ignored-tests.toml
+++ b/ferrocene/ignored-tests.toml
@@ -165,3 +165,11 @@ tests = [
 ]
 targets = ["aarch64-rhivos2-linux-gnu"]
 reason = "No ps utility in test environment."
+
+[["tests/run-make"]]
+tests = [
+    "tests/run-make/pointer-auth-link-with-c",
+    "tests/run-make/used-proc-macro"
+]
+targets = ["aarch64-rhivos2-linux-gnu", "aarch64-unknown-linux-gnu"]
+reason = "This test does not work on Linux targets and is under investigation."

--- a/ferrocene/ignored-tests.toml
+++ b/ferrocene/ignored-tests.toml
@@ -132,7 +132,7 @@ reason = "libstd test that segfaults on QEMU 8.2.2 but works on newer QEMU versi
 tests = [
     "tests/run-make/fix-cortex-a53-843419"
 ]
-targets = ["aarch64r82-unknown-ferrocene.facade", "aarch64v8r-unknown-ferrocene.facade"]
+targets = ["aarch64r82-unknown-ferrocene.facade", "aarch64v8r-unknown-ferrocene.facade", "aarch64-rhivos2-linux-gnu", "aarch64-unknown-linux-gnu"]
 reason = "This errata does not affect Armv8-R AArch64 processors"
 
 [["tests/run-make"]]

--- a/ferrocene/ignored-tests.toml
+++ b/ferrocene/ignored-tests.toml
@@ -30,7 +30,7 @@ tests = [
     "tests/run-make/sanitizer-dylib-link",
     "tests/run-make/sanitizer-staticlib-link"
 ]
-targets = ["aarch64-unknown-linux-gnu", "aarch64-rhivos2-linux-gnu"]
+targets = ["aarch64-unknown-linux-gnu"]
 reason = "QEMU user space emulation doesn't support most sanitizers"
 
 [["tests/run-make"]]
@@ -134,3 +134,34 @@ tests = [
 ]
 targets = ["aarch64r82-unknown-ferrocene.facade", "aarch64v8r-unknown-ferrocene.facade"]
 reason = "This errata does not affect Armv8-R AArch64 processors"
+
+[["tests/run-make"]]
+tests = [
+    "tests/run-make/sanitizer-cdylib-link",
+    "tests/run-make/sanitizer-dylib-link",
+    "tests/run-make/sanitizer-staticlib-link"
+]
+targets = ["aarch64-rhivos2-linux-gnu"]
+reason = "Sanitizers are not a qualified compiler feature. Support on RHIVOS2 needs investigation."
+
+[["tests/ui"]]
+tests = [
+    "tests/ui/sanitizer/hwaddress.rs",
+    "tests/ui/sanitizer/leak.rs",
+    "tests/ui/sanitizer/memory-eager.rs",
+    "tests/ui/sanitizer/memory-passing.rs",
+    "tests/ui/sanitizer/memory.rs",
+    "tests/ui/sanitizer/realtime-alloc.rs",
+    "tests/ui/sanitizer/realtime-blocking.rs",
+    "tests/ui/sanitizer/realtime-caller.rs",
+    "tests/ui/sanitizer/thread.rs"
+]
+targets = ["aarch64-rhivos2-linux-gnu"]
+reason = "Sanitizers are not a qualified compiler feature. Support on RHIVOS2 needs investigation."
+
+[["tests/ui"]]
+tests = [
+    "tests/ui/process/process-spawn-failure.rs"
+]
+targets = ["aarch64-rhivos2-linux-gnu"]
+reason = "No ps utility in test environment."

--- a/ferrocene/ignored-tests.toml
+++ b/ferrocene/ignored-tests.toml
@@ -159,13 +159,6 @@ tests = [
 targets = ["aarch64-rhivos2-linux-gnu"]
 reason = "Sanitizers are not a qualified compiler feature. Support on RHIVOS2 needs investigation."
 
-[["tests/ui"]]
-tests = [
-    "tests/ui/process/process-spawn-failure.rs"
-]
-targets = ["aarch64-rhivos2-linux-gnu"]
-reason = "No ps utility in test environment."
-
 [["tests/run-make"]]
 tests = [
     "tests/run-make/pointer-auth-link-with-c"

--- a/ferrocene/ignored-tests.toml
+++ b/ferrocene/ignored-tests.toml
@@ -134,3 +134,10 @@ tests = [
 ]
 targets = ["aarch64r82-unknown-ferrocene.facade", "aarch64v8r-unknown-ferrocene.facade"]
 reason = "This errata does not affect Armv8-R AArch64 processors"
+
+[["tests/run-make"]]
+tests = [
+    "tests/run-make/fix-cortex-a53-843419"
+]
+targets = ["aarch64r82-rhivos2-linux-gnu"]
+reason = "This test does not work on Linux targets and is under investigation."

--- a/ferrocene/ignored-tests.toml
+++ b/ferrocene/ignored-tests.toml
@@ -172,10 +172,3 @@ tests = [
 ]
 targets = ["aarch64-rhivos2-linux-gnu", "aarch64-unknown-linux-gnu"]
 reason = "This tests the interoperabilty an unstable feature of the rust compiler (enabling PAC) with newer C compilers (‘-mbranch-protection=’)."
-
-[["tests/run-make"]]
-tests = [
-    "tests/run-make/used-proc-macro"
-]
-targets = ["aarch64-rhivos2-linux-gnu", "aarch64-unknown-linux-gnu"]
-reason = "This test does not work on Linux targets and is under investigation."

--- a/ferrocene/ignored-tests.toml
+++ b/ferrocene/ignored-tests.toml
@@ -132,7 +132,7 @@ reason = "libstd test that segfaults on QEMU 8.2.2 but works on newer QEMU versi
 tests = [
     "tests/run-make/fix-cortex-a53-843419"
 ]
-targets = ["aarch64r82-unknown-ferrocene.facade", "aarch64v8r-unknown-ferrocene.facade", "aarch64-rhivos2-linux-gnu", "aarch64-unknown-linux-gnu"]
+targets = ["aarch64r82-unknown-ferrocene.facade", "aarch64v8r-unknown-ferrocene.facade"]
 reason = "This errata does not affect Armv8-R AArch64 processors"
 
 [["tests/run-make"]]

--- a/ferrocene/ignored-tests.toml
+++ b/ferrocene/ignored-tests.toml
@@ -139,5 +139,5 @@ reason = "This errata does not affect Armv8-R AArch64 processors"
 tests = [
     "tests/run-make/fix-cortex-a53-843419"
 ]
-targets = ["aarch64r82-rhivos2-linux-gnu"]
+targets = ["aarch64-rhivos2-linux-gnu"]
 reason = "This test does not work on Linux targets and is under investigation."

--- a/ferrocene/ignored-tests.toml
+++ b/ferrocene/ignored-tests.toml
@@ -137,30 +137,6 @@ reason = "This errata does not affect Armv8-R AArch64 processors"
 
 [["tests/run-make"]]
 tests = [
-    "tests/run-make/sanitizer-cdylib-link",
-    "tests/run-make/sanitizer-dylib-link",
-    "tests/run-make/sanitizer-staticlib-link"
-]
-targets = ["aarch64-rhivos2-linux-gnu"]
-reason = "Sanitizers are not a qualified compiler feature. Support on RHIVOS2 needs investigation."
-
-[["tests/ui"]]
-tests = [
-    "tests/ui/sanitizer/hwaddress.rs",
-    "tests/ui/sanitizer/leak.rs",
-    "tests/ui/sanitizer/memory-eager.rs",
-    "tests/ui/sanitizer/memory-passing.rs",
-    "tests/ui/sanitizer/memory.rs",
-    "tests/ui/sanitizer/realtime-alloc.rs",
-    "tests/ui/sanitizer/realtime-blocking.rs",
-    "tests/ui/sanitizer/realtime-caller.rs",
-    "tests/ui/sanitizer/thread.rs"
-]
-targets = ["aarch64-rhivos2-linux-gnu"]
-reason = "Sanitizers are not a qualified compiler feature. Support on RHIVOS2 needs investigation."
-
-[["tests/run-make"]]
-tests = [
     "tests/run-make/pointer-auth-link-with-c"
 ]
 targets = ["aarch64-rhivos2-linux-gnu", "aarch64-unknown-linux-gnu"]

--- a/src/bootstrap/defaults/bootstrap.ferrocene-dist.toml
+++ b/src/bootstrap/defaults/bootstrap.ferrocene-dist.toml
@@ -172,8 +172,8 @@ channel = "auto-detect"
 [target]
 # We default to the self-contained lld linker on Linux GNU targets.
 x86_64-unknown-linux-gnu.default-linker-linux-override = 'self-contained-lld-cc'
-aarch-unknown-linux-gnu.default-linker-linux-override = 'self-contained-lld-cc'
-aarch-rhivos2-linux-gnu.default-linker-linux-override = 'self-contained-lld-cc'
+aarch64-unknown-linux-gnu.default-linker-linux-override = 'self-contained-lld-cc'
+aarch64-rhivos2-linux-gnu.default-linker-linux-override = 'self-contained-lld-cc'
 
 # Disable the profiler runtime for WASM. The profiler runtime depends on libc, which is not
 # available on WASM bare metal.

--- a/src/bootstrap/defaults/bootstrap.ferrocene-dist.toml
+++ b/src/bootstrap/defaults/bootstrap.ferrocene-dist.toml
@@ -173,6 +173,7 @@ channel = "auto-detect"
 # We default to the self-contained lld linker on Linux GNU targets.
 x86_64-unknown-linux-gnu.default-linker-linux-override = 'self-contained-lld-cc'
 aarch-unknown-linux-gnu.default-linker-linux-override = 'self-contained-lld-cc'
+aarch-rhivos2-linux-gnu.default-linker-linux-override = 'self-contained-lld-cc'
 
 # Disable the profiler runtime for WASM. The profiler runtime depends on libc, which is not
 # available on WASM bare metal.

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -1533,7 +1533,7 @@ fn supported_sanitizers(
         "aarch64-apple-ios-sim" => darwin_libs("iossim", &["asan", "tsan", "rtsan"]),
         "aarch64-apple-ios-macabi" => darwin_libs("osx", &["asan", "lsan", "tsan"]),
         "aarch64-unknown-fuchsia" => common_libs("fuchsia", "aarch64", &["asan"]),
-        "aarch64-unknown-linux-gnu" | "aarch64-rhivos2-linux-gnu" => {
+        "aarch64-unknown-linux-gnu" => {
             common_libs("linux", "aarch64", &["asan", "lsan", "msan", "tsan", "hwasan", "rtsan"])
         }
         "aarch64-unknown-linux-ohos" => {

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -1533,7 +1533,7 @@ fn supported_sanitizers(
         "aarch64-apple-ios-sim" => darwin_libs("iossim", &["asan", "tsan", "rtsan"]),
         "aarch64-apple-ios-macabi" => darwin_libs("osx", &["asan", "lsan", "tsan"]),
         "aarch64-unknown-fuchsia" => common_libs("fuchsia", "aarch64", &["asan"]),
-        "aarch64-unknown-linux-gnu" => {
+        "aarch64-unknown-linux-gnu" | "aarch64-rhivos2-linux-gnu" => {
             common_libs("linux", "aarch64", &["asan", "lsan", "msan", "tsan", "hwasan", "rtsan"])
         }
         "aarch64-unknown-linux-ohos" => {

--- a/src/tools/compiletest/src/directives/directive_names.rs
+++ b/src/tools/compiletest/src/directives/directive_names.rs
@@ -48,6 +48,7 @@ pub(crate) const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "ignore-64bit",
     "ignore-aarch64",
     "ignore-aarch64-pc-windows-msvc",
+    "ignore-aarch64-rhivos2-linux-gnu",
     "ignore-aarch64-unknown-linux-gnu",
     "ignore-aix",
     "ignore-android",

--- a/tests/debuginfo/by-value-non-immediate-argument.rs
+++ b/tests/debuginfo/by-value-non-immediate-argument.rs
@@ -5,6 +5,7 @@
 //@ disable-gdb-pretty-printers
 //@ ignore-windows-gnu: #128973
 //@ ignore-aarch64-unknown-linux-gnu (gdb tries to read from 0x0; FIXME: #128973)
+//@ ignore-aarch64-rhivos2-linux-gnu (gdb tries to read from 0x0; FIXME: #128973)
 //@ ignore-powerpc64: #128973 on both -gnu and -musl
 
 // === GDB TESTS ===================================================================================

--- a/tests/run-make/fix-cortex-a53-843419/link.x
+++ b/tests/run-make/fix-cortex-a53-843419/link.x
@@ -10,9 +10,4 @@ SECTIONS {
     . = ALIGN(8);
     .bss : { *(.bss .bss*) } > RAM
     . = ALIGN(8);
-    /* this section is produced on AArch64 Linux ELFs and cannot be discarded */
-    /* because it's referred to from other section. it instead needs to be */
-    /* placed in the output ELF to avoid linker errors so we place it RAM */
-    /* even though it won't be inspected as part of the test */
-    .interp : { *(.interp .interp*) } > RAM
 }

--- a/tests/run-make/fix-cortex-a53-843419/link.x
+++ b/tests/run-make/fix-cortex-a53-843419/link.x
@@ -10,4 +10,9 @@ SECTIONS {
     . = ALIGN(8);
     .bss : { *(.bss .bss*) } > RAM
     . = ALIGN(8);
+    /* this section is produced on AArch64 Linux ELFs and cannot be discarded */
+    /* because it's referred to from other section. it instead needs to be */
+    /* placed in the output ELF to avoid linker errors so we place it RAM */
+    /* even though it won't be inspected as part of the test */
+    .interp : { *(.interp .interp*) } > RAM
 }

--- a/tests/run-make/fix-cortex-a53-843419/main.rs
+++ b/tests/run-make/fix-cortex-a53-843419/main.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use core::arch::asm;
+use core::arch::{asm, naked_asm};
 use core::panic::PanicInfo;
 use core::sync::atomic::AtomicU64;
 
@@ -10,21 +10,23 @@ use core::sync::atomic::AtomicU64;
 static SOME_VALUE: AtomicU64 = AtomicU64::new(0);
 
 #[no_mangle]
+// some targets may codegen a prologue for the frame pointer setup; `#[naked]`
+// ensures the instructions appear at the expected addresses regardless of
+// differences in codegen settings
+#[unsafe(naked)]
 extern "C" fn _start() {
     // 1. An ADRP instruction, which writes to a register Rn.
     // 2. A load or store instruction which does not write to Rn
     // 3. <an optional additional instruction>
     // 4. A load or store (unsigned immediate) using Rn
-    unsafe {
-        asm!(
-            "nop",
-            "nop",
-            "adrp x0, {global}",
-            "ldr x1, [x1, #0]",
-            "ldr x0, [x0, :lo12:{global}]",
-            global = sym SOME_VALUE,
-        );
-    }
+    naked_asm!(
+        "nop",
+        "nop",
+        "adrp x0, {global}",
+        "ldr x1, [x1, #0]",
+        "ldr x0, [x0, :lo12:{global}]",
+        global = sym SOME_VALUE,
+    );
 }
 
 #[panic_handler]

--- a/tests/run-make/fix-cortex-a53-843419/rmake.rs
+++ b/tests/run-make/fix-cortex-a53-843419/rmake.rs
@@ -10,10 +10,14 @@ fn main() {
     let mut compile = rustc();
     compile.input("main.rs").target(target()).print("link-args").panic("abort");
 
-    // we're on aarch64 in any case and we want to catch all facade and all linux-gnu targets here
-    let linker_type = if target().contains("ferrocene.facade") || target().contains("-linux-gnu") {
+    let linker_type = if target().contains("ferrocene.facade") {
         // This target directly uses LLD as the linker
         compile.link_arg("link.x").arg("-Clink-self-contained=no");
+        LinkerType::Lld
+    // we're on aarch64 in any case and we want to catch all linux-gnu targets here
+    } else if target().contains("-linux-gnu") {
+        // This target directly uses LLD as the linker
+        compile.link_arg("-Tlink.x").link_arg("-nostartfiles");
         LinkerType::Lld
     } else if target().contains("qnx") {
         // This target uses GCC as the linker, and needs -nostartup since our program is basically a

--- a/tests/run-make/fix-cortex-a53-843419/rmake.rs
+++ b/tests/run-make/fix-cortex-a53-843419/rmake.rs
@@ -12,12 +12,12 @@ fn main() {
 
     let linker_type = if target().contains("ferrocene.facade") {
         // This target directly uses LLD as the linker
-        compile.link_arg("link.x").arg("-Clink-self-contained=no");
+        compile.link_arg("-Tlink.x").arg("-Clink-self-contained=no");
         LinkerType::Lld
     // we're on aarch64 in any case and we want to catch all linux-gnu targets here
     } else if target().contains("-linux-gnu") {
         // This target directly uses LLD as the linker
-        compile.link_arg("-Tlink.x").link_arg("-nostartfiles");
+        compile.link_arg("-Wl,-Tlink.x").link_arg("-nostartfiles");
         LinkerType::Lld
     } else if target().contains("qnx") {
         // This target uses GCC as the linker, and needs -nostartup since our program is basically a

--- a/tests/run-make/fix-cortex-a53-843419/rmake.rs
+++ b/tests/run-make/fix-cortex-a53-843419/rmake.rs
@@ -16,7 +16,7 @@ fn main() {
         LinkerType::Lld
     // we're on aarch64 in any case and we want to catch all linux-gnu targets here
     } else if target().contains("-linux-gnu") {
-        // This target directly uses LLD as the linker
+        // This target uses LLD through GCC (linker driver)
         compile.link_arg("-Wl,-Tlink.x").link_arg("-nostartfiles");
         LinkerType::Lld
     } else if target().contains("qnx") {

--- a/tests/run-make/fix-cortex-a53-843419/rmake.rs
+++ b/tests/run-make/fix-cortex-a53-843419/rmake.rs
@@ -22,13 +22,17 @@ fn main() {
     } else {
         // This target uses GCC as the linker, and needs -nostartfiles since our program is
         // basically a startup object.
-        compile.link_arg("-Wl,link.x").link_arg("-nostartfiles");
+        compile.link_arg("-Wl,-Tlink.x").link_arg("-nostartfiles");
         LinkerType::Gnu
     };
 
     let outcome = compile.run();
     // Ensure --print=link-args shows the errata fix linker flag.
     assert!(outcome.stdout_utf8().contains("--fix-cortex-a53-843419"));
+
+    // sanity check that no prologue was injected
+    assert!(grep_instruction(0xff0, "nop"));
+    assert!(grep_instruction(0xff4, "nop"));
 
     match linker_type {
         LinkerType::Lld => {

--- a/tests/run-make/fix-cortex-a53-843419/rmake.rs
+++ b/tests/run-make/fix-cortex-a53-843419/rmake.rs
@@ -10,7 +10,8 @@ fn main() {
     let mut compile = rustc();
     compile.input("main.rs").target(target()).print("link-args").panic("abort");
 
-    let linker_type = if target().contains("ferrocene.facade") {
+    // we're on aarch64 in any case and we want to catch all facade and all linux-gnu targets here
+    let linker_type = if target().contains("ferrocene.facade") || target().contains("-linux-gnu") {
         // This target directly uses LLD as the linker
         compile.link_arg("link.x").arg("-Clink-self-contained=no");
         LinkerType::Lld

--- a/tests/ui/consts/large_const_alloc.rs
+++ b/tests/ui/consts/large_const_alloc.rs
@@ -2,6 +2,7 @@
 // on 32bit and 16bit platforms it is plausible that the maximum allocation size will succeed
 // FIXME (#135952) In some cases on AArch64 Linux the diagnostic does not trigger
 //@ ignore-aarch64-unknown-linux-gnu
+//@ ignore-aarch64-rhivos2-linux-gnu
 // AIX will allow the allocation to go through, and get SIGKILL when zero initializing
 // the overcommitted page.
 //@ ignore-aix

--- a/tests/ui/consts/large_const_alloc.stderr
+++ b/tests/ui/consts/large_const_alloc.stderr
@@ -1,11 +1,11 @@
 error[E0080]: tried to allocate more memory than available to compiler
-  --> $DIR/large_const_alloc.rs:11:13
+  --> $DIR/large_const_alloc.rs:12:13
    |
 LL |     let x = [0_u8; (1 << 47) - 1];
    |             ^^^^^^^^^^^^^^^^^^^^^ evaluation of `FOO` failed here
 
 error[E0080]: tried to allocate more memory than available to compiler
-  --> $DIR/large_const_alloc.rs:16:13
+  --> $DIR/large_const_alloc.rs:17:13
    |
 LL |     let x = [0_u8; (1 << 47) - 1];
    |             ^^^^^^^^^^^^^^^^^^^^^ evaluation of `FOO2` failed here

--- a/tests/ui/consts/promoted_running_out_of_memory_issue-130687.rs
+++ b/tests/ui/consts/promoted_running_out_of_memory_issue-130687.rs
@@ -5,6 +5,7 @@
 //@ only-64bit
 // FIXME (#135952) In some cases on AArch64 Linux the diagnostic does not trigger
 //@ ignore-aarch64-unknown-linux-gnu
+//@ ignore-aarch64-rhivos2-linux-gnu
 // AIX will allow the allocation to go through, and get SIGKILL when zero initializing
 // the overcommitted page.
 //@ ignore-aix

--- a/tests/ui/consts/promoted_running_out_of_memory_issue-130687.stderr
+++ b/tests/ui/consts/promoted_running_out_of_memory_issue-130687.stderr
@@ -1,5 +1,5 @@
 error[E0080]: tried to allocate more memory than available to compiler
-  --> $DIR/promoted_running_out_of_memory_issue-130687.rs:13:32
+  --> $DIR/promoted_running_out_of_memory_issue-130687.rs:14:32
    |
 LL | const _: &'static Data = &Data([0; (1 << 47) - 1]);
    |                                ^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here


### PR DESCRIPTION
This expands the work of #2310 to include all host testsuites for the aarch64 host. RHIVOS does not support cross compile and thus we need the aarch64 host/rhivos target combination.

Note: This PR elevates both `aarch64-unknown-linux-gnu` and `aarch64-rhivos2-linux-gnu` to qualified status.

The changeset is based on #2310 and contains all of its changes.

Nominated for backporting into 26.05. after discussion with @Hoverbear