### PR TITLE
[1.95] Add coverage for assert_failed_inner match line

### DIFF
--- a/library/coretests/tests/ferrocene/macros.rs
+++ b/library/coretests/tests/ferrocene/macros.rs
@@ -33,3 +33,10 @@ fn test_assert_matches_failure_none() {
 fn test_assert_failed_inner_ne() {
     assert_ne!(5, 5);
 }
+
+// Covers `core::panicking::assert_failed_inner`
+#[test]
+#[should_panic = "left matches right` failed\n  left: Some(1)\n right: None"]
+fn test_assert_failed_inner_match() {
+    std::assert_matches!(Some(1), None);
+}

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -5,6 +5,7 @@
 #![feature(array_try_map)]
 #![feature(ascii_char)]
 #![feature(ascii_char_variants)]
+#![feature(assert_matches)] // Ferrocene addition for `ferrocene/macros.rs test_assert_failed_inner_match`
 #![feature(async_iter_from_iter)]
 #![feature(async_iterator)]
 #![feature(bool_to_result)]


### PR DESCRIPTION
We were missing a line of coverage here, so this covers (ha!) that.