### PR TITLE
Set name of 26.05 Ferrocene release page

### DIFF
--- a/ferrocene/doc/release-notes/src/26.05.0.rst
+++ b/ferrocene/doc/release-notes/src/26.05.0.rst
@@ -3,8 +3,8 @@
 
 :upcoming-release:
 
-Next Ferrocene release
-======================
+Ferrocene 26.05.0
+=================
 
 This page contains the changes to be introduced in the upcoming Ferrocene
 release.


### PR DESCRIPTION
Part of https://public-docs.ferrocene.dev/main/qualification/internal-procedures/release/stable.html#version-bump-release-notes, related to #2327