### PR TITLE
Add specific target-cpu tests for cortex-a53

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -947,10 +947,31 @@ workflows:
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build
+
+      - facade-generic-test:
+          name: aarch64-none-test-target-cpu-compiletest
+          target: aarch64-unknown-ferrocene.facade
+          test-variant: 2021-specific-cortex-a53
+          qemu-arch: qemu-aarch64
+          job: qnx:compiletest-no-only-hosts
+          resource-class: large # 4-core
+          requires:
+            - x86_64-linux-build
+
       - facade-generic-test:
           name: aarch64-none-test-library
           target: aarch64-unknown-ferrocene.facade
           test-variant: 2021-cortex-a53
+          qemu-arch: qemu-aarch64
+          job: test:library
+          resource-class: large # 4-core
+          requires:
+            - x86_64-linux-build
+
+      - facade-generic-test:
+          name: aarch64-none-test-target-cpu-library
+          target: aarch64-unknown-ferrocene.facade
+          test-variant: 2021-specific-cortex-a53
           qemu-arch: qemu-aarch64
           job: test:library
           resource-class: large # 4-core


### PR DESCRIPTION
We missed this in #2225, see https://public-docs.ferrocene.dev/main/qualification/report/rustc/aarch64-unknown-none.html