### PR TITLE
ferrocene::unvalidated: Recurse into impl items in THIR pass

### DIFF
--- a/compiler/rustc_lint/src/ferrocene/mod.rs
+++ b/compiler/rustc_lint/src/ferrocene/mod.rs
@@ -205,6 +205,14 @@ impl<'tcx> LateLintPass<'tcx> for LintUnvalidated {
     fn check_item_post(&mut self, cx: &LateContext<'tcx>, item: &Item<'tcx>) {
         LintThir::check_item(cx.tcx, item.owner_id, item.owner_id.def_id);
     }
+
+    fn check_impl_item_post(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        item: &'tcx rustc_hir::ImplItem<'tcx>,
+    ) {
+        LintThir::check_item(cx.tcx, item.owner_id, item.owner_id.def_id);
+    }
 }
 
 struct LintState<'tcx> {

--- a/compiler/rustc_lint/src/ferrocene/thir.rs
+++ b/compiler/rustc_lint/src/ferrocene/thir.rs
@@ -52,6 +52,8 @@ impl<'thir, 'tcx: 'thir> LintThir<'thir, 'tcx> {
     /// We need a separate `owner` to be able to synthesize `HirId`s from expression IDs.
     /// `item` might not be an owner if it's a closure.
     pub(super) fn check_item(tcx: TyCtxt<'tcx>, owner: OwnerId, item: LocalDefId) -> Option<()> {
+        tracing::trace!("checking {item:?}");
+
         if tcx.sess.opts.test
             && tcx.entry_fn(()).and_then(|(id, _)| id.as_local()) == Some(owner.def_id)
         {
@@ -62,8 +64,11 @@ impl<'thir, 'tcx: 'thir> LintThir<'thir, 'tcx> {
 
         let linter = LintState::new(tcx, item)?;
         // thir_body can return ErrorGuaranteed if this is a const block that failed evaluation.
-        let body = tcx.thir_body(item).ok()?;
-        let thir = &body.0.borrow();
+        let body = tcx.thir_body(item).ok();
+        if body.is_none() {
+            info!("skipping item {item:?} without body");
+        }
+        let thir = &body?.0.borrow();
         let mut visitor = LintThir { linter, thir, owner };
         for expr in &*thir.exprs {
             visitor.visit_expr(expr);

--- a/tests/ui/ferrocene/lint-prevalidated/thir-impl-item.rs
+++ b/tests/ui/ferrocene/lint-prevalidated/thir-impl-item.rs
@@ -1,0 +1,18 @@
+// Make sure our THIR visitor recurses into functions in impl blocks.
+
+//@ check-fail
+#![crate_type = "lib"]
+#![deny(ferrocene::unvalidated)]
+
+pub struct A(u32);
+
+const fn unvalidated() {}
+
+impl A {
+    #[ferrocene::prevalidated]
+    #[inline]
+    pub const fn b(&self) -> u32 {
+        unvalidated(); //~ ERROR: unvalidated
+        0
+    }
+}

--- a/tests/ui/ferrocene/lint-prevalidated/thir-impl-item.stderr
+++ b/tests/ui/ferrocene/lint-prevalidated/thir-impl-item.stderr
@@ -1,0 +1,25 @@
+error: validated method calls an unvalidated function
+  --> $DIR/thir-impl-item.rs:13:9
+   |
+LL | const fn unvalidated() {}
+   |          ----------- `unvalidated` is unvalidated
+...
+LL |         unvalidated();
+   |         ^^^^^^^^^^^
+   |
+note: `A::b` is validated
+  --> $DIR/thir-impl-item.rs:12:18
+   |
+LL |     #[ferrocene::prevalidated]
+   |     -------------------------- marked as validated here
+LL |     #[inline]
+LL |     pub const fn b(&self) -> u32 {
+   |                  ^
+note: the lint level is defined here
+  --> $DIR/thir-impl-item.rs:3:9
+   |
+LL | #![deny(ferrocene::unvalidated)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Previously this wouldn't get caught until the post-mono pass, which made it annoying to check whether generic inline functions were validated.