### PR TITLE
download-rustc: Invalidate the cache less often

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -78,6 +78,7 @@ pub const RUSTC_IF_UNCHANGED_ALLOWED_PATHS: &[&str] = &[
     ":!src/rustdoc-json-types",
     ":!tests",
     // ":!triagebot.toml", // ferrocene deletion: We don't have triagebot.toml
+    ":!ferrocene", // ferrocene addition: can't affect compiler builds
     ":!src/bootstrap/defaults",
 ];
 


### PR DESCRIPTION
This avoids having to rebuild the compiler from source if you've only modified, e.g., `ferrocene/doc`.