### PR TITLE
the compiletest doesn't need a large runner

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1372,7 +1372,7 @@ workflows:
       - aarch64-linux-rhivos2-test-container:
           name: aarch64-linux-rhivos2-compiletest
           job: qnx:compiletest-no-only-hosts
-          resource-class: ferrocene/k8s-rhel-10-arm64-large
+          resource-class: ferrocene/k8s-rhel-10-arm64-medium
           test-variant: "2021"
           requires:
             - aarch64-linux-build


### PR DESCRIPTION
we're still well within the memory allocation for a medium runner