### PR TITLE
Refactor std test ci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,18 @@
 version: 2.1
 setup: true
 
+parameters:
+  # use this parameter to disable building the windows host. This is useful to cut down build times and
+  # cost in cases where you want to experiment with linux builds and are not interested in windows results
+  full-build-x86_64-pc-windows-msvc-host:
+    type: boolean
+    default: true
+  # use this parameter to disable building the darwin host. This is useful to cut down build times and
+  # cost in cases where you want to experiment with linux builds and are not interested in darwin results
+  full-build-aarch64-darwin-host:
+    type: boolean
+    default: true
+
 orbs:
   aws-cli: circleci/aws-cli@4.0
   continuation: circleci/continuation@0.2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
   setup:
     docker:
       - image: cimg/python:3.12
-    resource_class: small # 1-core
+    resource_class: ferrocene/k8s-arm64-small # 1-core
     steps:
       - aws-cli/install
 

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1141,7 +1141,7 @@ workflows:
           target: aarch64-unknown-ferrocene.facade
           test-variant: 2021-cortex-a53
           qemu-arch: qemu-aarch64
-          job: test:library
+          job: test:library-nostd
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build
@@ -1151,7 +1151,7 @@ workflows:
           target: aarch64-unknown-ferrocene.facade
           test-variant: 2021-specific-cortex-a53
           qemu-arch: qemu-aarch64
-          job: test:library
+          job: test:library-nostd
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build
@@ -1170,7 +1170,7 @@ workflows:
           target: aarch64r82-unknown-ferrocene.facade
           test-variant: 2021-neoverse-v1
           qemu-arch: qemu-aarch64
-          job: test:library
+          job: test:library-nostd
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build
@@ -1189,7 +1189,7 @@ workflows:
           target: aarch64v8r-unknown-ferrocene.facade
           test-variant: 2021-neoverse-v1
           qemu-arch: qemu-aarch64
-          job: test:library
+          job: test:library-nostd
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build
@@ -1229,7 +1229,7 @@ workflows:
           target: thumbv7em-ferrocene.facade-eabihf
           test-variant: 2021-cortex-m4
           qemu-arch: qemu-arm
-          job: test:library
+          job: test:library-nostd
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build
@@ -1239,7 +1239,7 @@ workflows:
           target: thumbv7em-ferrocene.facade-eabi
           test-variant: 2021-cortex-m4
           qemu-arch: qemu-arm
-          job: test:library
+          job: test:library-nostd
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build
@@ -1249,7 +1249,7 @@ workflows:
           target: thumbv7em-ferrocene.facade-eabihf
           test-variant: 2021-specific-cortex-m4
           qemu-arch: qemu-arm
-          job: test:library
+          job: test:library-nostd
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build
@@ -1259,7 +1259,7 @@ workflows:
           target: thumbv7em-ferrocene.facade-eabi
           test-variant: 2021-specific-cortex-m4
           qemu-arch: qemu-arm
-          job: test:library
+          job: test:library-nostd
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1124,10 +1124,6 @@ workflows:
           test-variant: "2021"
           requires:
             - x86_64-linux-build
-      # - x86_64-linux-test-library-std:
-      #     test-variant: "2021"
-      #     requires:
-      #       - x86_64-linux-build
       - x86_64-linux-library-coverage:
           requires:
             - x86_64-linux-build

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -267,28 +267,6 @@ jobs:
           path: build/x86_64-unknown-linux-gnu/ferrocene/traceability-matrix.html
           destination: reports
 
-  # x86_64-linux-test-library-std:
-  #   executor:  docker-x86_64-ubuntu-20
-  #   resource_class: ferrocene/k8s-amd64-medium # 4-core
-  #   parameters:
-  #     test-variant:
-  #       type: string
-  #   environment:
-  #     FERROCENE_HOST: x86_64-unknown-linux-gnu
-  #     # Standard library tests need IPv6, which is not available in container
-  #     # jobs. Because of that we need to run *just* standard library tests in a
-  #     # virtual machine.
-  #     # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
-  #     SCRIPT: ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py test:library-std) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
-  #   steps:
-  #     - aws-oidc-auth
-  #     - ferrocene-checkout:
-  #         llvm-subset: true
-  #     - run:
-  #         name: Restore files from the x86_64-linux-build job
-  #         command: ferrocene/ci/scripts/persist-between-jobs.sh restore x86_64-linux-build
-  #     - ferrocene-ci
-
   x86_64-linux-library-coverage:
     executor: docker-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-large

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1140,7 +1140,7 @@ workflows:
           requires:
             - x86_64-linux-build
       - x86_64-linux-generic-test-container:
-          name: x86_64-linux-test-library
+          name: x86_64-linux-test-library-std
           job: test:library-std
           resource-class: ferrocene/k8s-amd64-medium
           test-variant: "2021"

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1055,14 +1055,11 @@ workflows:
             - misc-checks
             - x86_64-linux-test
             - x86_64-linux-test-library
-            - x86_64-linux-test-library-std
             - x86_64-linux-compiletest
             - x86_64-linux-library-coverage
             - x86_64-qnx-test-library
-            - x86_64-qnx-test-library-std
             - x86_64-qnx-test-compiletest
             - aarch64-qnx-test-library
-            - aarch64-qnx-test-library-std
             - aarch64-qnx-test-compiletest
             - aarch64-none-test-library
             - aarch64-none-test-compiletest
@@ -1076,11 +1073,9 @@ workflows:
             - thumbv7em-eabi-test-compiletest
             - aarch64-linux-test
             - aarch64-linux-test-library
-            - aarch64-linux-test-library-std
             - aarch64-linux-compiletest
             - aarch64-linux-library-coverage
             - aarch64-linux-rhivos2-test-library
-            - aarch64-linux-rhivos2-test-library-std
             - aarch64-linux-rhivos2-compiletest
       - x86_64-linux-traceability-matrix:
           requires: *test-outcomes-dependencies
@@ -1114,13 +1109,6 @@ workflows:
           name: x86_64-linux-compiletest
           job: test:compiletest
           resource-class: ferrocene/k8s-amd64-large
-          test-variant: "2021"
-          requires:
-            - x86_64-linux-build
-      - x86_64-linux-generic-test-container:
-          name: x86_64-linux-test-library-std
-          job: test:library-std
-          resource-class: ferrocene/k8s-amd64-medium
           test-variant: "2021"
           requires:
             - x86_64-linux-build
@@ -1228,15 +1216,6 @@ workflows:
             - build-docker--ubuntu-24--x86_64
 
       - x86_64-qnx-generic-test-vm:
-          name: x86_64-qnx-test-library-std
-          job: test:library-std
-          test-variant: "2021"
-          resource-class: large # 4-core
-          requires:
-            - x86_64-linux-build
-            - build-docker--ubuntu-24--x86_64
-
-      - x86_64-qnx-generic-test-vm:
           name: x86_64-qnx-test-compiletest
           job: qnx:compiletest-no-only-hosts
           test-variant: "2021"
@@ -1336,15 +1315,6 @@ workflows:
             - build-docker--ubuntu-24--x86_64
 
       - aarch64-qnx-generic-test-vm:
-          name: aarch64-qnx-test-library-std
-          job: test:library-std
-          test-variant: "2021"
-          resource-class: large # 4-core
-          requires:
-            - x86_64-linux-build
-            - build-docker--ubuntu-24--x86_64
-
-      - aarch64-qnx-generic-test-vm:
           name: aarch64-qnx-test-compiletest
           job: qnx:compiletest-no-only-hosts
           test-variant: "2021"
@@ -1380,13 +1350,6 @@ workflows:
           requires:
             - aarch64-linux-build
       - aarch64-linux-generic-test-container:
-          name: aarch64-linux-test-library-std
-          job: test:library-std
-          resource-class: ferrocene/k8s-arm64-medium
-          test-variant: "2021"
-          requires:
-            - aarch64-linux-build
-      - aarch64-linux-generic-test-container:
           name: aarch64-linux-compiletest
           job: test:compiletest
           resource-class: ferrocene/k8s-arm64-large
@@ -1415,14 +1378,6 @@ workflows:
       - aarch64-linux-rhivos2-test-container:
           name: aarch64-linux-rhivos2-test-library
           job: test:library
-          resource-class: ferrocene/k8s-rhel-10-arm64-medium
-          test-variant: "2021"
-          requires:
-            - aarch64-linux-build
-            - build-docker-rhivos2-test-server-aarch64
-      - aarch64-linux-rhivos2-test-container:
-          name: aarch64-linux-rhivos2-test-library-std
-          job: test:library-std
           resource-class: ferrocene/k8s-rhel-10-arm64-medium
           test-variant: "2021"
           requires:
@@ -1465,12 +1420,6 @@ workflows:
           resource-class: m4pro.medium # 6 cores
           requires:
             - aarch64-darwin-build
-      - aarch64-darwin-generic-test-runner:
-          name: aarch64-darwin-test-library-std
-          job: test:library-std
-          resource-class: m4pro.medium # 6 cores
-          requires:
-            - aarch64-darwin-build
       - aarch64-darwin-self-test:
           requires:
             - aarch64-darwin-dist
@@ -1502,7 +1451,6 @@ workflows:
             - aarch64-darwin-self-test
             - aarch64-darwin-test
             - aarch64-darwin-test-library
-            - aarch64-darwin-test-library-std
             - aarch64-darwin-compiletest
             - sbom-gen
 

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -267,27 +267,27 @@ jobs:
           path: build/x86_64-unknown-linux-gnu/ferrocene/traceability-matrix.html
           destination: reports
 
-  x86_64-linux-test-library-std:
-    executor:  docker-x86_64-ubuntu-20
-    resource_class: ferrocene/k8s-amd64-medium # 4-core
-    parameters:
-      test-variant:
-        type: string
-    environment:
-      FERROCENE_HOST: x86_64-unknown-linux-gnu
-      # Standard library tests need IPv6, which is not available in container
-      # jobs. Because of that we need to run *just* standard library tests in a
-      # virtual machine.
-      # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
-      SCRIPT: ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py test:library-std) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
-    steps:
-      - aws-oidc-auth
-      - ferrocene-checkout:
-          llvm-subset: true
-      - run:
-          name: Restore files from the x86_64-linux-build job
-          command: ferrocene/ci/scripts/persist-between-jobs.sh restore x86_64-linux-build
-      - ferrocene-ci
+  # x86_64-linux-test-library-std:
+  #   executor:  docker-x86_64-ubuntu-20
+  #   resource_class: ferrocene/k8s-amd64-medium # 4-core
+  #   parameters:
+  #     test-variant:
+  #       type: string
+  #   environment:
+  #     FERROCENE_HOST: x86_64-unknown-linux-gnu
+  #     # Standard library tests need IPv6, which is not available in container
+  #     # jobs. Because of that we need to run *just* standard library tests in a
+  #     # virtual machine.
+  #     # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
+  #     SCRIPT: ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py test:library-std) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
+  #   steps:
+  #     - aws-oidc-auth
+  #     - ferrocene-checkout:
+  #         llvm-subset: true
+  #     - run:
+  #         name: Restore files from the x86_64-linux-build job
+  #         command: ferrocene/ci/scripts/persist-between-jobs.sh restore x86_64-linux-build
+  #     - ferrocene-ci
 
   x86_64-linux-library-coverage:
     executor: docker-x86_64-ubuntu-20
@@ -1121,28 +1121,35 @@ workflows:
       - x86_64-linux-generic-test-container:
           name: x86_64-linux-test
           job: test
-          resource-class: large # 4-core
+          resource-class: ferrocene/k8s-amd64-medium
           test-variant: "2021"
           requires:
             - x86_64-linux-build
       - x86_64-linux-generic-test-container:
           name: x86_64-linux-test-library
           job: test:library
-          resource-class: large # 4-core
+          resource-class: ferrocene/k8s-amd64-medium
           test-variant: "2021"
           requires:
             - x86_64-linux-build
       - x86_64-linux-generic-test-container:
           name: x86_64-linux-compiletest
           job: test:compiletest
-          resource-class: xlarge # 8-core
+          resource-class: ferrocene/k8s-amd64-large
           test-variant: "2021"
           requires:
             - x86_64-linux-build
-      - x86_64-linux-test-library-std:
+      - x86_64-linux-generic-test-container:
+          name: x86_64-linux-test-library
+          job: test:library-std
+          resource-class: ferrocene/k8s-amd64-medium
           test-variant: "2021"
           requires:
             - x86_64-linux-build
+      # - x86_64-linux-test-library-std:
+      #     test-variant: "2021"
+      #     requires:
+      #       - x86_64-linux-build
       - x86_64-linux-library-coverage:
           requires:
             - x86_64-linux-build

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -968,34 +968,53 @@ jobs:
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
     steps:
-      - aws-oidc-auth
-      - ferrocene-git-shallow-clone:
-          depth: 1
-      - run:
-          name: Restore files from the x86_64-linux-build
-          command: ferrocene/ci/scripts/persist-between-jobs.sh restore x86_64-linux-build
-      - run:
-          name: Configure
-          command: ferrocene/ci/configure.sh
-      - run:
-          name: Checkout the submodules
-          command: ferrocene/ci/scripts/checkout-submodules.sh
-      - run:
-          name: Generate build metadata
-          command: ./x.py dist ferrocene-build-metadata
-      # From this point onwards, the commit can be released by the release process.
-      - run:
-          name: Upload metadata files to S3
-          command: ferrocene/ci/scripts/upload-dist-artifacts.sh
-      # Unfortunately the validation script for packages.toml has to be executed after the build
-      # metadata has been uploaded, as it needs to retrieve some of it from S3.
-      #
-      # In theory this means a release could be published even when this step failed to execute. In
-      # practice it's not a problem, as the failures detected by this script also result in errors
-      # during the release process.
-      - run:
-          name: Verify that all of the expected artifacts were uploaded
-          command: ferrocene/ci/scripts/validate-packages-toml.py ${CIRCLE_SHA1}
+      # if at least one of the conditions is set to false, we're not building the
+      # whole set and we want to fail the build
+      - when:
+          condition:
+            or:
+              - not: << pipeline.parameters.full-build-x86_64-pc-windows-msvc-host >>
+              - not: << pipeline.parameters.full-build-aarch64-darwin-host >>
+          steps:
+            - run:
+                name: Fail build as incomplete
+                command: "false"
+      # only if both windows and darwin builds are enabled we want to continue the build and
+      # do the final checks
+      - when:
+          condition:
+            and:
+              - << pipeline.parameters.full-build-x86_64-pc-windows-msvc-host >>
+              - << pipeline.parameters.full-build-aarch64-darwin-host >>
+          steps:
+            - aws-oidc-auth
+            - ferrocene-git-shallow-clone:
+                depth: 1
+            - run:
+                name: Restore files from the x86_64-linux-build
+                command: ferrocene/ci/scripts/persist-between-jobs.sh restore x86_64-linux-build
+            - run:
+                name: Configure
+                command: ferrocene/ci/configure.sh
+            - run:
+                name: Checkout the submodules
+                command: ferrocene/ci/scripts/checkout-submodules.sh
+            - run:
+                name: Generate build metadata
+                command: ./x.py dist ferrocene-build-metadata
+            # From this point onwards, the commit can be released by the release process.
+            - run:
+                name: Upload metadata files to S3
+                command: ferrocene/ci/scripts/upload-dist-artifacts.sh
+            # Unfortunately the validation script for packages.toml has to be executed after the build
+            # metadata has been uploaded, as it needs to retrieve some of it from S3.
+            #
+            # In theory this means a release could be published even when this step failed to execute. In
+            # practice it's not a problem, as the failures detected by this script also result in errors
+            # during the release process.
+            - run:
+                name: Verify that all of the expected artifacts were uploaded
+                command: ferrocene/ci/scripts/validate-packages-toml.py ${CIRCLE_SHA1}
 
   # Simple job used to run "something" when no other jobs are supposed to be
   # run. See the `skip` workflow for more information.

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1993,12 +1993,14 @@ executors:
     docker:
       - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--x86_64--ubuntu-24 >>
         aws_auth:
+          # Self-Hosted Runners can't do OIDC auth at the moment
           aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
           aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
   docker-aarch64-ubuntu-24:
     docker:
       - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--aarch64--ubuntu-24 >>
         aws_auth:
+          # Self-Hosted Runners can't do OIDC auth at the moment
           aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
           aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
   linux-vm:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -120,7 +120,7 @@ jobs:
   # is the place for it.
   misc-checks:
     executor: docker-x86_64-ubuntu-20
-    resource_class: medium # 2-core
+    resource_class: ferrocene/k8s-amd64-small
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       SCRIPT: |
@@ -138,7 +138,7 @@ jobs:
   # Generate a SBOM for the Ferrocene repository
   sbom-gen:
     executor: docker-x86_64-ubuntu-20
-    resource_class: medium
+    resource_class: ferrocene/k8s-amd64-small
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       SCRIPT: |
@@ -151,7 +151,7 @@ jobs:
 
   x86_64-linux-build:
     executor: docker-x86_64-ubuntu-20
-    resource_class: xlarge # 8-core
+    resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       FERROCENE_TARGETS: aarch64-unknown-linux-gnu
@@ -162,7 +162,7 @@ jobs:
 
   x86_64-linux-docs:
     executor: docker-x86_64-ubuntu-20
-    resource_class: large # 4-core
+    resource_class: ferrocene/k8s-amd64-medium
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       FERROCENE_TEST_OUTCOMES_DIR: /tmp/test-outcomes
@@ -181,7 +181,7 @@ jobs:
 
   x86_64-linux-dist:
     executor: docker-x86_64-ubuntu-20
-    resource_class: xlarge # 8-core
+    resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       SCRIPT: |
@@ -193,7 +193,7 @@ jobs:
 
   x86_64-linux-dist-tools:
     executor: docker-x86_64-ubuntu-20
-    resource_class: xlarge # 8-core
+    resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       SCRIPT: |
@@ -205,7 +205,7 @@ jobs:
 
   x86_64-linux-dist-targets:
     executor: docker-x86_64-ubuntu-20
-    resource_class: large # 4-core
+    resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       FERROCENE_TARGETS: << pipeline.parameters.targets--x86_64-unknown-linux-gnu--std >>
@@ -218,7 +218,7 @@ jobs:
 
   x86_64-linux-dist-src:
     executor: docker-x86_64-ubuntu-20
-    resource_class: medium # 2-core
+    resource_class: ferrocene/k8s-amd64-medium
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       SCRIPT: |
@@ -251,7 +251,7 @@ jobs:
 
   x86_64-linux-traceability-matrix:
     executor: docker-x86_64-ubuntu-20
-    resource_class: medium # 2-core
+    resource_class: ferrocene/k8s-amd64-small
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       FERROCENE_TEST_OUTCOMES_DIR: /tmp/test-outcomes
@@ -268,8 +268,8 @@ jobs:
           destination: reports
 
   x86_64-linux-test-library-std:
-    executor: linux-vm
-    resource_class: large # 4-core
+    executor:  docker-x86_64-ubuntu-20
+    resource_class: ferrocene/k8s-amd64-medium # 4-core
     parameters:
       test-variant:
         type: string
@@ -282,14 +282,16 @@ jobs:
       SCRIPT: ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py test:library-std) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
     steps:
       - aws-oidc-auth
-      - ferrocene-job-test-vm:
-          docker-image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-          run-emulator-docker-image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-          restore-from-job: x86_64-linux-build
+      - ferrocene-checkout:
+          llvm-subset: true
+      - run:
+          name: Restore files from the x86_64-linux-build job
+          command: ferrocene/ci/scripts/persist-between-jobs.sh restore x86_64-linux-build
+      - ferrocene-ci
 
   x86_64-linux-library-coverage:
     executor: docker-x86_64-ubuntu-20
-    resource_class: xlarge # 8-core
+    resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       SCRIPT: |
@@ -306,7 +308,7 @@ jobs:
 
   x86_64-linux-llvm:
     executor: docker-x86_64-ubuntu-20
-    resource_class: xlarge # 8-core
+    resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       SCRIPT: ferrocene/ci/scripts/llvm_cache.py prepare
@@ -327,7 +329,7 @@ jobs:
 
   x86_64-linux-self-test:
     executor: docker-x86_64-ubuntu-20
-    resource_class: small # 1-core
+    resource_class: ferrocene/k8s-amd64-tiny
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       FERROCENE_TARGETS: << pipeline.parameters.targets--x86_64-unknown-linux-gnu--self-test >>
@@ -452,7 +454,7 @@ jobs:
 
   aarch64-linux-self-test:
     executor: docker-aarch64-ubuntu-20
-    resource_class: ferrocene/k8s-arm64-small # 2-core
+    resource_class: ferrocene/k8s-arm64-small
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
       FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-unknown-linux-gnu--self-test >>

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -85,6 +85,16 @@ parameters:
   targets--x86_64-pc-windows-msvc--self-test:
     type: string
     default: ""
+  # use this parameter to disable building the windows host. This is useful to cut down build times and
+  # cost in cases where you want to experiment with linux builds and are not interested in windows results
+  full-build-x86_64-pc-windows-msvc-host:
+    type: boolean
+    default: true
+  # use this parameter to disable building the darwin host. This is useful to cut down build times and
+  # cost in cases where you want to experiment with linux builds and are not interested in darwin results
+  full-build-aarch64-darwin-host:
+    type: boolean
+    default: true
   # This is a stable workflow id that doesn't change on rerun
   #
   # The stable workflow id is used to identify intermediary containers used by this workflow.
@@ -506,7 +516,10 @@ jobs:
       LLVM_BUILD_PARALLELISM: 12
     steps:
       - when:
-          condition: << pipeline.parameters.llvm-rebuild--aarch64-apple-darwin >>
+          condition:
+            and:
+              - << pipeline.parameters.llvm-rebuild--aarch64-apple-darwin >>
+              - << pipeline.parameters.full-build-aarch64-darwin-host >>
           steps:
             - ferrocene-checkout
             # Darwin does not come with awscli, setup it before aws steps
@@ -533,8 +546,14 @@ jobs:
         ./x.py --stage 2 build library src/tools/rustdoc
         ./x.py --stage 1 build src/tools/rustdoc
     steps:
-      - ferrocene-job-build:
-          os: darwin
+      - when:
+          condition: << pipeline.parameters.full-build-aarch64-darwin-host >>
+          steps:
+            - ferrocene-job-build:
+                os: darwin
+      - run:
+          name: Empty step to make sure the job always has steps
+          command: echo
 
   aarch64-darwin-dist:
     macos:
@@ -548,9 +567,15 @@ jobs:
         ./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist)
         ./x.py --stage 2 dist rust-std
     steps:
-      - ferrocene-job-dist:
-          os: darwin
-          restore-from-job: aarch64-darwin-build
+      - when:
+          condition: << pipeline.parameters.full-build-aarch64-darwin-host >>
+          steps:
+            - ferrocene-job-dist:
+                os: darwin
+                restore-from-job: aarch64-darwin-build
+      - run:
+          name: Empty step to make sure the job always has steps
+          command: echo
 
   aarch64-darwin-dist-tools:
     macos:
@@ -563,9 +588,15 @@ jobs:
         # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
         ./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist:tools)
     steps:
-      - ferrocene-job-dist:
-          os: darwin
-          restore-from-job: aarch64-darwin-build
+      - when:
+          condition: << pipeline.parameters.full-build-aarch64-darwin-host >>
+          steps:
+            - ferrocene-job-dist:
+                os: darwin
+                restore-from-job: aarch64-darwin-build
+      - run:
+          name: Empty step to make sure the job always has steps
+          command: echo
 
   aarch64-darwin-self-test:
     macos:
@@ -575,18 +606,24 @@ jobs:
       FERROCENE_HOST: aarch64-apple-darwin
       FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-apple-darwin--self-test >>
     steps:
-      - ferrocene-git-shallow-clone:
-          depth: 1
-      # Darwin does not come with awscli, setup it before aws steps
+      - when:
+          condition: << pipeline.parameters.full-build-aarch64-darwin-host >>
+          steps:
+            - ferrocene-git-shallow-clone:
+                depth: 1
+            # Darwin does not come with awscli, setup it before aws steps
+            - run:
+                name: Install AWSCLIv2
+                command: brew install awscli
+            - aws-oidc-auth
+            - ferrocene-setup-darwin
+            - setup-uv
+            - run:
+                name: Download dist artifacts and run the self-test tool
+                command: ferrocene/ci/scripts/run-self-test.sh
       - run:
-          name: Install AWSCLIv2
-          command: brew install awscli
-      - aws-oidc-auth
-      - ferrocene-setup-darwin
-      - setup-uv
-      - run:
-          name: Download dist artifacts and run the self-test tool
-          command: ferrocene/ci/scripts/run-self-test.sh
+          name: Empty step to make sure the job always has steps
+          command: echo
 
   aarch64-darwin-generic-test-runner:
     macos:
@@ -603,9 +640,15 @@ jobs:
         # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
         ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call
     steps:
-      - ferrocene-job-test-container:
-          os: darwin
-          restore-from-job: aarch64-darwin-build
+      - when:
+          condition: << pipeline.parameters.full-build-aarch64-darwin-host >>
+          steps:
+            - ferrocene-job-test-container:
+                os: darwin
+                restore-from-job: aarch64-darwin-build
+      - run:
+          name: Empty step to make sure the job always has steps
+          command: echo
 
   # x86_64-pc-windows-msvc jobs
 
@@ -632,7 +675,10 @@ jobs:
           name: Make sure git autocrlf is false
           command: git config --global core.autocrlf false
       - when:
-          condition: << pipeline.parameters.llvm-rebuild--x86_64-pc-windows-msvc >>
+          condition:
+            and:
+              - << pipeline.parameters.llvm-rebuild--x86_64-pc-windows-msvc >>
+              - << pipeline.parameters.full-build-x86_64-pc-windows-msvc-host >>
           steps:
             - aws-oidc-auth
             - ferrocene-checkout
@@ -661,8 +707,14 @@ jobs:
         ./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist:tools)
         ./x.py --stage 2 dist rust-std
     steps:
-      - ferrocene-job-dist:
-          os: windows
+      - when:
+          condition: << pipeline.parameters.full-build-x86_64-pc-windows-msvc-host >>
+          steps:
+            - ferrocene-job-dist:
+                os: windows
+      - run:
+          name: Empty step to make sure the job always has steps
+          command: echo
 
   x86_64-windows-self-test:
     executor:
@@ -674,15 +726,21 @@ jobs:
       FERROCENE_HOST: x86_64-pc-windows-msvc
       FERROCENE_TARGETS: << pipeline.parameters.targets--x86_64-pc-windows-msvc--self-test >>
     steps:
-      - ferrocene-git-shallow-clone:
-          depth: 1
-      - aws-oidc-auth
-      - ferrocene-setup-windows
-      - setup-uv
-      - setup-qnx-toolchain: {}
+      - when:
+          condition: << pipeline.parameters.full-build-x86_64-pc-windows-msvc-host >>
+          steps:
+            - ferrocene-git-shallow-clone:
+                depth: 1
+            - aws-oidc-auth
+            - ferrocene-setup-windows
+            - setup-uv
+            - setup-qnx-toolchain: {}
+            - run:
+                name: Download dist artifacts and run the self-test tool
+                command: ferrocene/ci/scripts/run-self-test.sh
       - run:
-          name: Download dist artifacts and run the self-test tool
-          command: ferrocene/ci/scripts/run-self-test.sh
+          name: Empty step to make sure the job always has steps
+          command: echo
 
   # Test VMs
 

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -954,7 +954,7 @@ jobs:
   # Misc jobs
   wasm-dist-oxidos:
     executor: docker-x86_64-ubuntu-20
-    resource_class: large # 4-core
+    resource_class: ferrocene/k8s-amd64-medium
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       FERROCENE_TARGETS: wasm32-unknown-unknown
@@ -966,7 +966,7 @@ jobs:
 
   finish-build:
     executor: docker-x86_64-ubuntu-20
-    resource_class: small # 1-core
+    resource_class: ferrocene/k8s-amd64-tiny
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
     steps:
@@ -1022,7 +1022,7 @@ jobs:
   # run. See the `skip` workflow for more information.
   skip:
     executor: docker-x86_64-ubuntu-20
-    resource_class: small # 1-core
+    resource_class: ferrocene/k8s-amd64-tiny
     steps:
       - run:
           name: This is a workaround for CircleCI always wanting at least a job per commit.

--- a/ferrocene/ci/scripts/calculate_parameters.py
+++ b/ferrocene/ci/scripts/calculate_parameters.py
@@ -259,7 +259,7 @@ def prepare_parameters():
                 # Anything after the prefix gets passed as a parameter
                 parameters[parameter] = func(parameter[len(prefix) :])
                 break
-            if parameter.startswith('full-build-'):
+            if parameter.startswith("full-build-"):
                 # ignore these parameters, they'll be passed straight on.
                 break
         # In Python, the `else` is executed when the for loop finished

--- a/ferrocene/ci/scripts/calculate_parameters.py
+++ b/ferrocene/ci/scripts/calculate_parameters.py
@@ -259,6 +259,9 @@ def prepare_parameters():
                 # Anything after the prefix gets passed as a parameter
                 parameters[parameter] = func(parameter[len(prefix) :])
                 break
+            if parameter.startswith('full-build-'):
+                # ignore these parameters, they'll be passed straight on.
+                break
         # In Python, the `else` is executed when the for loop finished
         # normally, without any `break` being executed. In this case, it's
         # executed whenever we don't do any replacement.

--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -135,14 +135,8 @@ JOBS_DEFINITION: JobsDefinition = {
         ),
 
         # Library tests are the second slowest part of a test run, so we run
-        # them in a separate job to reduce the CI wall clock time. Note that
-        # stdlib tests are run in a separate job, as those require IPv6 and
-        # thus can't be executed in containers due to CircleCI limitations.
-        "library": ["library/core", "library/alloc", "library/test"],
-
-        # The standard library tests require IPv6, which is not available in
-        # containers. Run them separately in a VM.
-        "library-std": ["library/std"],
+        # them in a separate job to reduce the CI wall clock time.
+        "library": ["library/core", "library/alloc", "library/test", "library/std"],
     },
 
     "qnx": {

--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -137,6 +137,9 @@ JOBS_DEFINITION: JobsDefinition = {
         # Library tests are the second slowest part of a test run, so we run
         # them in a separate job to reduce the CI wall clock time.
         "library": ["library/core", "library/alloc", "library/test", "library/std"],
+
+        # This is the library without std, for all targets that have no std.
+        "library-nostd": ["library/core", "library/alloc", "library/test"],
     },
 
     "qnx": {


### PR DESCRIPTION
This refactors the build jobs around the standard library.

We used to split the std build into its own build step with a different executor because the circleci docker executor is limited when it comes to ipv6. After moving these jobs to self-hosted, this limitation no longer exists and we can refactor the library tests into cleaner sets, one for the full set including std and one for no-std targets

This also reduces the number of jobs we need to run and cuts down on the overhead of starting a new build step.

This changeset is based on the changes of #2312, but split out for easier review.