### PR TITLE
gate the expensive builds on x86_64 linux tests

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1224,6 +1224,7 @@ workflows:
           test-variant: "2021"
           resource-class: xlarge # 8-core
           requires:
+            - misc-checks
             - x86_64-linux-build
             - x86_64-linux-test
             - x86_64-linux-test-library
@@ -1317,6 +1318,7 @@ workflows:
           extra-args: --tests # We do not run cross compiled doctests for this job on this platform, there are segfaults
           resource-class: large # 4-core
           requires:
+            - misc-checks
             - x86_64-linux-build
             - x86_64-linux-test
             - x86_64-linux-test-library
@@ -1329,6 +1331,7 @@ workflows:
           test-variant: "2021"
           resource-class: xlarge # 8-core
           requires:
+            - misc-checks
             - x86_64-linux-build
             - x86_64-linux-test
             - x86_64-linux-test-library
@@ -1407,6 +1410,7 @@ workflows:
       - aarch64-darwin-llvm: {}
       - aarch64-darwin-build:
           requires:
+            - misc-checks
             - aarch64-darwin-llvm
             - x86_64-linux-test
             - x86_64-linux-test-library
@@ -1444,6 +1448,7 @@ workflows:
       - x86_64-windows-llvm: {}
       - x86_64-windows-dist:
           requires:
+            - misc-checks
             - x86_64-windows-llvm
             - x86_64-linux-test
             - x86_64-linux-test-library

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1404,11 +1404,7 @@ workflows:
           requires:
             - aarch64-linux-build
             - build-docker-rhivos2-test-server-aarch64
-      - aarch64-darwin-llvm:
-          requires:
-            - x86_64-linux-test
-            - x86_64-linux-test-library
-            - x86_64-linux-compiletest
+      - aarch64-darwin-llvm: {}
       - aarch64-darwin-build:
           requires:
             - aarch64-darwin-llvm
@@ -1445,11 +1441,7 @@ workflows:
             - aarch64-darwin-dist-tools
             - x86_64-linux-dist-targets
 
-      - x86_64-windows-llvm:
-          requires:
-            - x86_64-linux-test
-            - x86_64-linux-test-library
-            - x86_64-linux-compiletest
+      - x86_64-windows-llvm: {}
       - x86_64-windows-dist:
           requires:
             - x86_64-windows-llvm

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1213,6 +1213,9 @@ workflows:
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build
+            - x86_64-linux-test
+            - x86_64-linux-test-library
+            - x86_64-linux-compiletest
             - build-docker--ubuntu-24--x86_64
 
       - x86_64-qnx-generic-test-vm:
@@ -1222,6 +1225,9 @@ workflows:
           resource-class: xlarge # 8-core
           requires:
             - x86_64-linux-build
+            - x86_64-linux-test
+            - x86_64-linux-test-library
+            - x86_64-linux-compiletest
             - build-docker--ubuntu-24--x86_64
 
       - facade-generic-test:
@@ -1312,6 +1318,9 @@ workflows:
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build
+            - x86_64-linux-test
+            - x86_64-linux-test-library
+            - x86_64-linux-compiletest
             - build-docker--ubuntu-24--x86_64
 
       - aarch64-qnx-generic-test-vm:
@@ -1321,6 +1330,9 @@ workflows:
           resource-class: xlarge # 8-core
           requires:
             - x86_64-linux-build
+            - x86_64-linux-test
+            - x86_64-linux-test-library
+            - x86_64-linux-compiletest
             - build-docker--ubuntu-24--x86_64
 
       - aarch64-linux-llvm:
@@ -1392,10 +1404,17 @@ workflows:
           requires:
             - aarch64-linux-build
             - build-docker-rhivos2-test-server-aarch64
-      - aarch64-darwin-llvm: {}
+      - aarch64-darwin-llvm:
+          requires:
+            - x86_64-linux-test
+            - x86_64-linux-test-library
+            - x86_64-linux-compiletest
       - aarch64-darwin-build:
           requires:
             - aarch64-darwin-llvm
+            - x86_64-linux-test
+            - x86_64-linux-test-library
+            - x86_64-linux-compiletest
       - aarch64-darwin-dist:
           requires:
             - aarch64-darwin-build
@@ -1426,10 +1445,17 @@ workflows:
             - aarch64-darwin-dist-tools
             - x86_64-linux-dist-targets
 
-      - x86_64-windows-llvm: {}
+      - x86_64-windows-llvm:
+          requires:
+            - x86_64-linux-test
+            - x86_64-linux-test-library
+            - x86_64-linux-compiletest
       - x86_64-windows-dist:
           requires:
             - x86_64-windows-llvm
+            - x86_64-linux-test
+            - x86_64-linux-test-library
+            - x86_64-linux-compiletest
       - x86_64-windows-self-test:
           requires:
             - x86_64-windows-dist


### PR DESCRIPTION
this will increase the total wallclock time in the success case, but lead to a faster fail