### PR TITLE
simplify QNX emulator scripts

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -337,7 +337,7 @@ jobs:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       FERROCENE_TARGETS: x86_64-pc-nto-qnx710
       SCRIPT: |
-        set +u; source ./qnx710-472/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.11:12345 ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >> << parameters.extra-args >>
+        set +u; source ./qnx710-472/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.105:12345 ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >> << parameters.extra-args >>
     steps:
       - aws-oidc-auth
       - ferrocene-checkout

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1657,7 +1657,6 @@ commands:
                     --rm \
                     $(uv run python3 -c "import os; print(' '.join('--env ' + var for var in os.environ if var not in ['HOME', 'LANG', 'SUDO_USER']))") \
                     -e SCRIPT="<< parameters.emulator-script >> prepare" \
-                    -e REMOTE_TEST_SERVER_STAGE=2 \
                     --workdir /home/ci/project \
                     --volume $(pwd):/home/ci/project \
                     --volume /tmp/emulator:/tmp/emulator \

--- a/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
@@ -55,6 +55,7 @@ RUN <<-EOF
         bridge-utils \
         dnsmasq \
         net-tools \
+        iputils-ping \
         sudo
 
     # let regular users run sudo without password

--- a/ferrocene/ci/scripts/emulated-aarch64-qnx-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-aarch64-qnx-test-runner.sh
@@ -16,31 +16,6 @@ panic() {
     exit 1
 }
 
-on_vm() {
-    echo >"${emulatordir}"/pipe.in
-    echo "${@}" >"${emulatordir}"/pipe.in
-    echo 'echo "===$?==="' >"${emulatordir}"/pipe.in
-
-    while read -r line; do
-        if [[ "$line" = "==="*"==="* ]]; then
-            ret=$(echo "$line" | cut -d'=' -f4)
-
-            if [ "$ret" -eq 0  ]; then
-                break
-            else
-                panic failed to run "${@}" on VM. exit code: "$ret"
-            fi
-        fi
-
-        echo "QEMU: $line"
-    done <"${emulatordir}"/pipe.out
-}
-
-on_vm_nowait() {
-    echo >"${emulatordir}"/pipe.in
-    echo "${@}" >"${emulatordir}"/pipe.in
-}
-
 start_vm() {
     echo
     echo "===> setting up QEMU bridge network"
@@ -63,8 +38,6 @@ start_vm() {
     if [ -f "${emulatordir}"/qemu.pid ]; then
         panic a previous instance of the emulator may already be running
     fi
-    rm -f "${emulatordir}"/pipe.*
-    mkfifo "${emulatordir}"/pipe.in "${emulatordir}"/pipe.out
 
     # NOTE(-net nic): the (real) ZCU102 has 4 NICs; only the 4th one can be used in QEMU
     # the unused NICs need to be listed in the command line invocation
@@ -81,16 +54,7 @@ start_vm() {
         -no-reboot \
         -nographic \
         -pidfile "${emulatordir}"/qemu.pid \
-        -serial pipe:"${emulatordir}"/pipe &
-
-    while read -r line; do
-        # last boot message
-        if [[ "$line" = "Boot complete"* ]]; then
-            break
-        fi
-
-        echo "QEMU: ${line}"
-    done <"${emulatordir}"/pipe.out
+        -serial mon:stdio
 }
 
 cmd_prepare() {
@@ -113,9 +77,8 @@ cmd_prepare() {
 
     echo
     echo "===> building remote-test-server"
-    stage="${REMOTE_TEST_SERVER_STAGE-1}"
-    ./x build src/tools/remote-test-server --target "${nto_target}" --stage "${stage}"
-    cp build/host/"stage${stage}-tools"/"${nto_target}"/release/remote-test-server "${emulatordir}"/src/install/aarch64le/sbin
+    ./x build src/tools/remote-test-server --target "${nto_target}"
+    cp build/host/"stage2-tools"/"${nto_target}"/release/remote-test-server "${emulatordir}"/src/install/aarch64le/sbin
 
     echo
     echo "===> building IFS"
@@ -151,8 +114,8 @@ cmd_prepare() {
 /bin/sh=sh\
 /bin/echo=echo' "${buildscript}"
 
-    # signal that boot is complete
-    sed -i '326i echo "Boot complete"' "${buildscript}"
+    # run remote-test-server instead of console
+    sed -i '326i RUST_TEST_THREADS=1 remote-test-server -v --bind 0.0.0.0:12345 --sequential' "${buildscript}"
 
     # use virtual SD card as TMPDIR
     sed -i '268i export TMPDIR=/mnt/tmp' "${buildscript}"
@@ -183,14 +146,6 @@ cmd_run() {
     fi
 
     start_vm
-
-    echo
-    echo "===> starting remote-test-server"
-    on_vm_nowait RUST_TEST_THREADS=1 remote-test-server -v --bind 0.0.0.0:12345 --sequential
-
-    while read -r line; do
-        echo "QEMU: $line"
-    done <"${emulatordir}"/pipe.out
 }
 
 if [[ $# -eq 1 ]] && [[ "$1" = "prepare" ]]; then

--- a/ferrocene/ci/scripts/emulated-aarch64-qnx-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-aarch64-qnx-test-runner.sh
@@ -5,21 +5,12 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-# this file resides in `/ferrocene/ci/scripts/(here)`
-basedir="$(realpath $(dirname $0)/../../..)"
-qnxdir="$(realpath $(dirname $(which qcc))/../../../../..)"
-emulatordir=/tmp/emulator
+. "$(dirname $0)"/qnx-common.sh
+
 nto_target=aarch64-unknown-nto-qnx710
 
-panic() {
-    echo "error:" "${@}" >&2
-    exit 1
-}
-
 start_vm() {
-    echo
-    echo "===> setting up QEMU bridge network"
-    sudo "${qnxdir}"/host/common/mkqnximage/qemu/net.sh /usr/lib/qemu/qemu-bridge-helper /etc/qemu/bridge.conf
+    qnx7_set_up_bridge_network
 
     echo
     echo "===> creating virtual SD card"
@@ -35,9 +26,8 @@ start_vm() {
 
     echo
     echo "===> starting QEMU"
-    if [ -f "${emulatordir}"/qemu.pid ]; then
-        panic a previous instance of the emulator may already be running
-    fi
+    check_no_other_emulator_is_running
+    check_ip_address_is_free
 
     # NOTE(-net nic): the (real) ZCU102 has 4 NICs; only the 4th one can be used in QEMU
     # the unused NICs need to be listed in the command line invocation
@@ -58,11 +48,7 @@ start_vm() {
 }
 
 cmd_prepare() {
-    if ! [[ -d "${emulatordir}" ]]; then
-        echo "error: directory ${emulatordir} does not exist"
-        echo
-        exit 1
-    fi
+    check_emulatordir_exists
 
     echo
     echo "===> building BSP"

--- a/ferrocene/ci/scripts/emulated-aarch64-qnx-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-aarch64-qnx-test-runner.sh
@@ -63,6 +63,7 @@ cmd_prepare() {
 
     echo
     echo "===> building remote-test-server"
+    # for rationale on chosen stage; see `emulated-x86_64-qnx-test-runner.sh` script
     ./x build src/tools/remote-test-server --stage 2 --target "${nto_target}"
     cp build/host/"stage2-tools"/"${nto_target}"/release/remote-test-server "${emulatordir}"/src/install/aarch64le/sbin
 
@@ -72,6 +73,17 @@ cmd_prepare() {
 
     buildscript="${emulatordir}"/src/images/zcu102.build
 
+    # the chosen BSP can be run on a QEMU emulator; that's the reason it was chosen over
+    # other options. however, the build scripts for the QNX images ("IFS" files) are set
+    # up to run on actual hardware, not an emulator
+    #
+    # because the QEMU machine model does not, or not faithfully enough, emulate the hardware
+    # some services that rely on hardware features need to be disabled in the .build scripts or
+    # they'll hang the startup process
+    #
+    # if the .build script changes then the new version needs to be re-reviewed for
+    # QEMU compatibility and all the patches below adjusted. this command checks for
+    # such build script changes
     sha256sum "${buildscript}" | grep -q '^5cb44fba650dfd69d8ad00e4f2d684a8f7bb97bdbad5cd246e17097c05d99e3b ' || \
         panic "upstream file zcu102.build appears to have changed; this cmd_prepare function may need to be updated"
 

--- a/ferrocene/ci/scripts/emulated-aarch64-qnx-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-aarch64-qnx-test-runner.sh
@@ -63,7 +63,7 @@ cmd_prepare() {
 
     echo
     echo "===> building remote-test-server"
-    ./x build src/tools/remote-test-server --target "${nto_target}"
+    ./x build src/tools/remote-test-server --stage 2 --target "${nto_target}"
     cp build/host/"stage2-tools"/"${nto_target}"/release/remote-test-server "${emulatordir}"/src/install/aarch64le/sbin
 
     echo

--- a/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
@@ -10,6 +10,7 @@ qnxdir="$(realpath $(dirname $(which qcc))/../../../../..)"
 emulatordir=/tmp/emulator
 nto_target=x86_64-pc-nto-qnx710
 vm_hostname=x86_64-qnx-vm
+ssh_id=id_ed25519
 
 # QNX network stack needs these to be hardcoded in the image
 vm_mac_addr=52:54:00:83:26:e0
@@ -19,31 +20,6 @@ vm_ipv4_addr=172.31.1.11
 panic() {
     echo "error:" "${@}" >&2
     exit 1
-}
-
-on_vm() {
-    echo >"${emulatordir}"/pipe.in
-    echo "${@}" >"${emulatordir}"/pipe.in
-    echo 'echo "===$?==="' >"${emulatordir}"/pipe.in
-
-    while read -r line; do
-        if [[ "$line" = "==="*"==="* ]]; then
-            ret=$(echo "$line" | cut -d'=' -f4)
-
-            if [ "$ret" -eq 0  ]; then
-                break
-            else
-                panic failed to run "${@}" on VM. exit code: "$ret"
-            fi
-        fi
-
-        echo "QEMU: $line"
-    done <"${emulatordir}"/pipe.out
-}
-
-on_vm_nowait() {
-    echo >"${emulatordir}"/pipe.in
-    echo "${@}" >"${emulatordir}"/pipe.in
 }
 
 start_vm() {
@@ -56,8 +32,7 @@ start_vm() {
     if [ -f "${emulatordir}"/qemu.pid ]; then
         panic a previous instance of the emulator may already be running
     fi
-    rm -f "${emulatordir}"/pipe.*
-    mkfifo "${emulatordir}"/pipe.in "${emulatordir}"/pipe.out
+
     qemu-system-x86_64 \
         -smp 2 \
         -m 1G \
@@ -68,18 +43,14 @@ start_vm() {
         -kernel "${emulatordir}"/ifs.bin \
         -object rng-random,filename=/dev/urandom,id=rng0 \
         -device virtio-rng-pci,rng=rng0 \
-        -serial pipe:"${emulatordir}"/pipe \
-        -hdb fat:rw:"${emulatordir}"/shared &
+        -serial mon:stdio \
+        -hdb fat:rw:"${emulatordir}"/shared \
+        &> "${emulatordir}"/qemu.out &
+    echo "QEMU running in background. logs at ${emulatordir}/qemu.out"
 
-    # wait until boot process completes
-    while read -r line; do
-        echo "QEMU: $line"
-
-        # last boot message
-        if [[ "$line" = "QNX ${vm_hostname} "*"x86pc x86_64"*  ]]; then
-          break
-        fi
-    done <"${emulatordir}"/pipe.out
+    echo
+    echo "===> wait for VM's network to go online"
+    ping -i3 -c4 ${vm_ipv4_addr}
 }
 
 cmd_prepare() {
@@ -90,6 +61,10 @@ cmd_prepare() {
     fi
 
     echo
+    echo "===> creating SSH key pair"
+    ssh-keygen -q -t ed25519 -N '' -f "${emulatordir}"/$ssh_id
+
+    echo
     echo "===> creating rootfs"
     tmpdir="$(mktemp -d)"
     pushd "$tmpdir"
@@ -97,7 +72,7 @@ cmd_prepare() {
     QNX_TARGET="${qnxdir}/target/qnx7" mkqnximage \
         --data-size=5000 --data-inodes=40000 --noprompt \
         --hostname="${vm_hostname}" --type=qemu --arch=x86_64 \
-        --ip="${vm_ipv4_addr}" --ssh-ident=none
+        --ip="${vm_ipv4_addr}" --ssh-ident="${emulatordir}"/$ssh_id.pub
 
     # as per https://www.qnx.com/support/knowledgebase.html?id=5015Y000001gM7T
     # the ifs.build script needs to include the libpci.so.2.3 file in the IFS
@@ -120,6 +95,16 @@ lib/libpci.so.2.3|' "${ifsbuild}"
     cp build/host/"stage${stage}-tools"/"${nto_target}"/release/remote-test-server "${emulatordir}"/shared/
 }
 
+on_vm() {
+    # disable user prompts around host key checking
+    # suppress warnings about adding $vm_ipv4_addr to list of known hosts
+    ssh \
+        -i "${emulatordir}"/$ssh_id \
+        -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+        -o LogLevel=ERROR \
+        root@$vm_ipv4_addr "${@}"
+}
+
 cmd_run() {
     if ! [[ -f "${emulatordir}/shared/remote-test-server" ]]; then
         echo "error: preparation is needed before running the emulator; run:"
@@ -140,11 +125,7 @@ cmd_run() {
     on_vm cp /mnt/remote-test-server /tmp/
     on_vm chmod +x /tmp/remote-test-server
 
-    on_vm_nowait RUST_TEST_THREADS=1 /tmp/remote-test-server -v --bind 0.0.0.0:12345 --sequential
-
-    while read -r line; do
-        echo "QEMU: $line"
-    done <"${emulatordir}"/pipe.out
+    on_vm env RUST_TEST_THREADS=1 /tmp/remote-test-server -v --bind 0.0.0.0:12345 --sequential
 }
 
 if [[ $# -eq 1 ]] && [[ "$1" = "prepare" ]]; then

--- a/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
@@ -12,9 +12,7 @@ nto_target=x86_64-pc-nto-qnx710
 vm_hostname=x86_64-qnx-vm
 ssh_id=id_ed25519
 
-# QNX network stack needs these to be hardcoded in the image
-vm_mac_addr=52:54:00:83:26:e0
-# br0 has netmask 172.31.1.1/24
+# static IP configuration relied on by circle CI workflow
 vm_ipv4_addr=172.31.1.11
 
 panic() {
@@ -37,7 +35,7 @@ start_vm() {
         -smp 2 \
         -m 1G \
         -drive file="${emulatordir}"/disk-qemu.vmdk,if=ide,id=drv0 \
-        -netdev bridge,br=br0,id=net0 -device e1000,netdev=net0,mac="${vm_mac_addr}" \
+        -netdev bridge,br=br0,id=net0 -device e1000,netdev=net0 \
         -pidfile "${emulatordir}"/qemu.pid \
         -nographic \
         -kernel "${emulatordir}"/ifs.bin \

--- a/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
@@ -5,31 +5,19 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-# qcc resides in `somewhere/qnx710/host/linux/x86_64/usr/bin`
-qnxdir="$(realpath $(dirname $(which qcc))/../../../../..)"
-emulatordir=/tmp/emulator
+. "$(dirname $0)"/qnx-common.sh
+
 nto_target=x86_64-pc-nto-qnx710
 vm_hostname=x86_64-qnx-vm
 ssh_id=id_ed25519
 
-# static IP configuration relied on by circle CI workflow
-vm_ipv4_addr=172.31.1.11
-
-panic() {
-    echo "error:" "${@}" >&2
-    exit 1
-}
-
 start_vm() {
-    echo
-    echo "===> setting up QEMU bridge network"
-    sudo "${qnxdir}"/host/common/mkqnximage/qemu/net.sh /usr/lib/qemu/qemu-bridge-helper /etc/qemu/bridge.conf
+    qnx7_set_up_bridge_network
 
     echo
     echo "===> starting QEMU"
-    if [ -f "${emulatordir}"/qemu.pid ]; then
-        panic a previous instance of the emulator may already be running
-    fi
+    check_no_other_emulator_is_running
+    check_ip_address_is_free
 
     qemu-system-x86_64 \
         -smp 2 \
@@ -51,11 +39,7 @@ start_vm() {
 }
 
 cmd_prepare() {
-    if ! [[ -d "${emulatordir}" ]]; then
-        echo "error: directory ${emulatordir} does not exist"
-        echo
-        exit 1
-    fi
+    check_emulatordir_exists
 
     echo
     echo "===> creating SSH key pair"

--- a/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
@@ -44,7 +44,6 @@ start_vm() {
         -object rng-random,filename=/dev/urandom,id=rng0 \
         -device virtio-rng-pci,rng=rng0 \
         -serial mon:stdio \
-        -hdb fat:rw:"${emulatordir}"/shared \
         &> "${emulatordir}"/qemu.out &
     echo "QEMU running in background. logs at ${emulatordir}/qemu.out"
 
@@ -89,10 +88,8 @@ lib/libpci.so.2.3|' "${ifsbuild}"
 
     echo
     echo "===> building and copying remote-test-server into rootfs"
-    stage="${REMOTE_TEST_SERVER_STAGE-1}"
-    ./x build src/tools/remote-test-server --target "${nto_target}" --stage "${stage}"
-    mkdir -p "${emulatordir}"/shared/
-    cp build/host/"stage${stage}-tools"/"${nto_target}"/release/remote-test-server "${emulatordir}"/shared/
+    ./x build src/tools/remote-test-server --target "${nto_target}"
+    cp build/host/"stage2-tools"/"${nto_target}"/release/remote-test-server "${emulatordir}"/
 }
 
 on_vm() {
@@ -105,8 +102,17 @@ on_vm() {
         root@$vm_ipv4_addr "${@}"
 }
 
+copy_to_vm() {
+    # same flags as `on_vm`
+    scp \
+        -i "${emulatordir}"/$ssh_id \
+        -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+        -o LogLevel=ERROR \
+        "$1" root@$vm_ipv4_addr:"$2"
+}
+
 cmd_run() {
-    if ! [[ -f "${emulatordir}/shared/remote-test-server" ]]; then
+    if ! [[ -f "${emulatordir}/remote-test-server" ]]; then
         echo "error: preparation is needed before running the emulator; run:"
         echo
         echo "    $0 prepare"
@@ -118,12 +124,9 @@ cmd_run() {
 
     echo
     echo "===> starting remote-test-server"
+    copy_to_vm "${emulatordir}"/remote-test-server /tmp/
     # `std::net` tests need this
     on_vm 'grep -q localhost /etc/hosts || echo "127.0.0.1 localhost" >> /etc/hosts'
-
-    on_vm mount -t dos /dev/hd1t6 /mnt
-    on_vm cp /mnt/remote-test-server /tmp/
-    on_vm chmod +x /tmp/remote-test-server
 
     on_vm env RUST_TEST_THREADS=1 /tmp/remote-test-server -v --bind 0.0.0.0:12345 --sequential
 }

--- a/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
@@ -9,7 +9,6 @@ IFS=$'\n\t'
 
 nto_target=x86_64-pc-nto-qnx710
 vm_hostname=x86_64-qnx-vm
-ssh_id=id_ed25519
 
 start_vm() {
     qnx7_set_up_bridge_network
@@ -29,72 +28,55 @@ start_vm() {
         -kernel "${emulatordir}"/ifs.bin \
         -object rng-random,filename=/dev/urandom,id=rng0 \
         -device virtio-rng-pci,rng=rng0 \
-        -serial mon:stdio \
-        &> "${emulatordir}"/qemu.out &
-    echo "QEMU running in background. logs at ${emulatordir}/qemu.out"
-
-    echo
-    echo "===> wait for VM's network to go online"
-    ping -i3 -c4 ${vm_ipv4_addr}
+        -serial mon:stdio
 }
 
 cmd_prepare() {
     check_emulatordir_exists
 
     echo
-    echo "===> creating SSH key pair"
-    ssh-keygen -q -t ed25519 -N '' -f "${emulatordir}"/$ssh_id
+    echo "===> building remote-test-server"
+    ./x build src/tools/remote-test-server --target "${nto_target}"
 
     echo
-    echo "===> creating rootfs"
+    echo "===> creating initial IFS"
     tmpdir="$(mktemp -d)"
     pushd "$tmpdir"
     # NOTE `--data-size=5000 --data-inodes=40000` are required to make the test `std::fs::tests::read_large_dir` pass
     QNX_TARGET="${qnxdir}/target/qnx7" mkqnximage \
         --data-size=5000 --data-inodes=40000 --noprompt \
         --hostname="${vm_hostname}" --type=qemu --arch=x86_64 \
-        --ip="${vm_ipv4_addr}" --ssh-ident="${emulatordir}"/$ssh_id.pub
+        --ip="${vm_ipv4_addr}" --ssh-ident=none
 
+    echo
+    echo "===> re-building a custom IFS that includes remote-test-server"
     # as per https://www.qnx.com/support/knowledgebase.html?id=5015Y000001gM7T
     # the ifs.build script needs to include the libpci.so.2.3 file in the IFS
     # but the stock version does not so patch it and then re-generate ifs.bin
     local ifsbuild=output/build/ifs.build
     grep 'lib/libpci.so.2.3' "${ifsbuild}" || sed -i 's|lib/libpci.so|lib/libpci.so\
 lib/libpci.so.2.3|' "${ifsbuild}"
+
+    # add remote-test-servere binary to IFS
+    cp "$basedir"/build/host/"stage2-tools"/"${nto_target}"/release/remote-test-server "${tmpdir}"/output/build/
+    echo 'remote-test-server=output/build/remote-test-server' >> "${ifsbuild}"
+
+    # run remote-test-server once startup is complete
+    local startup=output/build/startup.sh
+    # UI tests and libstd tests will try to resolve 'localhost'
+    echo 'grep -q localhost /etc/hosts || echo "127.0.0.1 localhost" >> /etc/hosts' >> "${startup}"
+    echo 'RUST_TEST_THREADS=1 remote-test-server -v --bind 0.0.0.0:12345 --sequential' >> "${startup}"
+
     rm output/ifs.bin
     mkifs "${ifsbuild}" output/ifs.bin
 
     cp output/{disk-qemu{,.vmdk},ifs.bin} "${emulatordir}/"
     popd
     rm -rf "${tmpdir}"
-
-    echo
-    echo "===> building and copying remote-test-server into rootfs"
-    ./x build src/tools/remote-test-server --target "${nto_target}"
-    cp build/host/"stage2-tools"/"${nto_target}"/release/remote-test-server "${emulatordir}"/
-}
-
-on_vm() {
-    # disable user prompts around host key checking
-    # suppress warnings about adding $vm_ipv4_addr to list of known hosts
-    ssh \
-        -i "${emulatordir}"/$ssh_id \
-        -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-        -o LogLevel=ERROR \
-        root@$vm_ipv4_addr "${@}"
-}
-
-copy_to_vm() {
-    # same flags as `on_vm`
-    scp \
-        -i "${emulatordir}"/$ssh_id \
-        -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-        -o LogLevel=ERROR \
-        "$1" root@$vm_ipv4_addr:"$2"
 }
 
 cmd_run() {
-    if ! [[ -f "${emulatordir}/remote-test-server" ]]; then
+    if ! [[ -f "${emulatordir}/ifs.bin" ]]; then
         echo "error: preparation is needed before running the emulator; run:"
         echo
         echo "    $0 prepare"
@@ -103,14 +85,6 @@ cmd_run() {
     fi
 
     start_vm
-
-    echo
-    echo "===> starting remote-test-server"
-    copy_to_vm "${emulatordir}"/remote-test-server /tmp/
-    # `std::net` tests need this
-    on_vm 'grep -q localhost /etc/hosts || echo "127.0.0.1 localhost" >> /etc/hosts'
-
-    on_vm env RUST_TEST_THREADS=1 /tmp/remote-test-server -v --bind 0.0.0.0:12345 --sequential
 }
 
 if [[ $# -eq 1 ]] && [[ "$1" = "prepare" ]]; then

--- a/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
@@ -36,6 +36,16 @@ cmd_prepare() {
 
     echo
     echo "===> building remote-test-server"
+    # a stage $N tool is built using a stage $(N-1) compiler
+    # when cross compiling a stage0 compiler cannot be used as it does not
+    # include cross-compiled stage0 libraries
+    # in that case, bootstrap bumps the stage by one so that the minimum is stage1
+    # what that means for this command is that both `--stage 1` and `--stage 2` produce the same
+    # outcome; remote-test-server will be built using a stage1 compiler
+    # see https://github.com/ferrocene/ferrocene/blob/2118a6927233a45998e02c1fc341beb21a15c1b6/src/bootstrap/src/core/build_steps/tool.rs#L332
+    #
+    # also this is a testing tool, not the code under test so the stage used is not critical so long
+    # the tool adheres to the remote-test protocol
     ./x build src/tools/remote-test-server --stage 2 --target "${nto_target}"
 
     echo

--- a/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
@@ -36,7 +36,7 @@ cmd_prepare() {
 
     echo
     echo "===> building remote-test-server"
-    ./x build src/tools/remote-test-server --target "${nto_target}"
+    ./x build src/tools/remote-test-server --stage 2 --target "${nto_target}"
 
     echo
     echo "===> creating initial IFS"

--- a/ferrocene/ci/scripts/qnx-common.sh
+++ b/ferrocene/ci/scripts/qnx-common.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+
+# this file resides in `/ferrocene/ci/scripts/(here)`
+basedir="$(realpath $(dirname $0)/../../..)"
+qnxdir="$(realpath $(dirname $(which qcc))/../../../../..)"
+emulatordir=/tmp/emulator
+# aarch64-qnx71 will get assigned an IP address at boot time, this one, if not already taken
+# we'll statically assign this IP address to the other QNX VMs
+vm_ipv4_addr=172.31.1.105
+
+panic() {
+    echo "error:" "${@}" >&2
+    exit 1
+}
+
+qnx7_set_up_bridge_network() {
+    echo
+    echo "===> setting up QEMU bridge network"
+    sudo "${qnxdir}"/host/common/mkqnximage/qemu/net.sh /usr/lib/qemu/qemu-bridge-helper /etc/qemu/bridge.conf
+}
+
+check_no_other_emulator_is_running() {
+    if [ -f "${emulatordir}"/qemu.pid ]; then
+        panic a previous instance of the emulator may already be running
+    fi
+}
+
+check_ip_address_is_free() {
+     ping -w1 -c1 "${vm_ipv4_addr}" && panic "there's a node already active at the IP address (${vm_ipv4_addr}) we want to use" || true
+}
+
+check_emulatordir_exists() {
+    if ! [[ -d "${emulatordir}" ]]; then
+        panic "error: directory ${emulatordir} does not exist"
+    fi
+}

--- a/ferrocene/ci/scripts/qnx-common.sh
+++ b/ferrocene/ci/scripts/qnx-common.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 # this file resides in `/ferrocene/ci/scripts/(here)`
 basedir="$(realpath $(dirname $0)/../../..)"


### PR DESCRIPTION
This PR moves both the aarch64 and x86_64 emulators away from using pipe files to drive a serial port console. 

In the case of the x86_64 VM a SSH connection is used for remote command execution as this the easiest to set up using the existing `mkqnximage` workflow. also, instead of sharing a folder from the host to the guest using a virtual drive the remote-test-server binary is now copied over via SSH.

In the case of the aarch64 VM, as we were already patching the IFS build script we tweak further the startup script to run the remote-test-server on boot; this avoids having to remotely run commands after boot. Hence no need for SSH or a serial port console in this case.

Other changes include: removing unnecessary variables; making the IP addresses of both emulators the same; and refactoring duplicated logic into a separate shared file.

This PR is best reviewed on a commit by commit basis