### PR TITLE
Expand coverage to include recent changes

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2062,9 +2062,12 @@ impl<'a> Formatter<'a> {
             } else {
                 // Padding widths are capped at `u16`, so reaching this branch means
                 // the formatted output is also shorter than `u16::MAX`.
+                #[ferrocene::annotation("The `Err(_)` branch is explicitly marked unreachable, causing it be reached would be a bug")]
                 let len = match u16::try_from(len) {
                     Ok(len) => len,
-                    Err(_) => unreachable!(),
+                    Err(_) => {
+                        unreachable!()
+                    },
                 };
                 let post_padding = self.padding(width - len, Alignment::Right)?;
                 // SAFETY: Per the precondition.

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2065,11 +2065,9 @@ impl<'a> Formatter<'a> {
                 let len = match u16::try_from(len) {
                     Ok(len) => len,
                     #[ferrocene::annotation(
-                        "The `Err(_)` branch is explicitly marked unreachable, causing it be reached would be a bug"
+                        "The `Err(_)` branch is explicitly marked unreachable, causing it to be reached would be a bug"
                     )]
-                    Err(_) => {
-                        unreachable!()
-                    }
+                    Err(_) => unreachable!(),
                 };
                 let post_padding = self.padding(width - len, Alignment::Right)?;
                 // SAFETY: Per the precondition.

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2064,10 +2064,12 @@ impl<'a> Formatter<'a> {
                 // the formatted output is also shorter than `u16::MAX`.
                 let len = match u16::try_from(len) {
                     Ok(len) => len,
-                    #[ferrocene::annotation("The `Err(_)` branch is explicitly marked unreachable, causing it be reached would be a bug")]
+                    #[ferrocene::annotation(
+                        "The `Err(_)` branch is explicitly marked unreachable, causing it be reached would be a bug"
+                    )]
                     Err(_) => {
                         unreachable!()
-                    },
+                    }
                 };
                 let post_padding = self.padding(width - len, Alignment::Right)?;
                 // SAFETY: Per the precondition.

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2062,9 +2062,9 @@ impl<'a> Formatter<'a> {
             } else {
                 // Padding widths are capped at `u16`, so reaching this branch means
                 // the formatted output is also shorter than `u16::MAX`.
-                #[ferrocene::annotation("The `Err(_)` branch is explicitly marked unreachable, causing it be reached would be a bug")]
                 let len = match u16::try_from(len) {
                     Ok(len) => len,
+                    #[ferrocene::annotation("The `Err(_)` branch is explicitly marked unreachable, causing it be reached would be a bug")]
                     Err(_) => {
                         unreachable!()
                     },

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3164,6 +3164,12 @@ pub const fn minimum_number_nsz_f16(x: f16, y: f16) -> f16 {
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
 #[ferrocene::prevalidated]
+#[ferrocene::annotation(
+    "This function is replaced by an LLVM instrinsic in LLVM 22 or later (which Ferrocene uses). \
+    See `codegen_intrinsic_call` in `compiler/rustc_codegen_llvm/src/intrinsic.rs. \
+    A manual test was done with this functions forcibly included and it was fully covered,
+    see `test_minimum_number_nsz_f32` in `library/coretests/tests/ferrocene/intrinsics.rs`."
+)]
 pub const fn minimum_number_nsz_f32(x: f32, y: f32) -> f32 {
     if x.is_nan() || y <= x {
         y
@@ -3367,6 +3373,12 @@ pub const fn maximum_number_nsz_f16(x: f16, y: f16) -> f16 {
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
 #[ferrocene::prevalidated]
+#[ferrocene::annotation(
+    "This function is replaced by an LLVM instrinsic in LLVM 22 or later (which Ferrocene uses). \
+    See `codegen_intrinsic_call` in `compiler/rustc_codegen_llvm/src/intrinsic.rs. \
+    A manual test was done with this functions forcibly included and it was fully covered,
+    see `test_maximum_number_nsz_f32` in `library/coretests/tests/ferrocene/intrinsics.rs`."
+)]
 pub const fn maximum_number_nsz_f32(x: f32, y: f32) -> f32 {
     if x.is_nan() || y >= x {
         y

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3093,6 +3093,12 @@ pub const fn minimum_number_nsz_f16(x: f16, y: f16) -> f16 {
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
 #[ferrocene::prevalidated]
+#[ferrocene::annotation(
+    "This function is replaced by an LLVM instrinsic in LLVM 22 or later (which Ferrocene uses). \
+    See `codegen_intrinsic_call` in `compiler/rustc_codegen_llvm/src/intrinsic.rs. \
+    A manual test was done with this functions forcibly included and it was fully covered,
+    see `test_minimum_number_nsz_f32` in `library/coretests/tests/ferrocene/intrinsics.rs`."
+)]
 pub const fn minimum_number_nsz_f32(x: f32, y: f32) -> f32 {
     if x.is_nan() || y <= x {
         y
@@ -3296,6 +3302,12 @@ pub const fn maximum_number_nsz_f16(x: f16, y: f16) -> f16 {
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
 #[ferrocene::prevalidated]
+#[ferrocene::annotation(
+    "This function is replaced by an LLVM instrinsic in LLVM 22 or later (which Ferrocene uses). \
+    See `codegen_intrinsic_call` in `compiler/rustc_codegen_llvm/src/intrinsic.rs. \
+    A manual test was done with this functions forcibly included and it was fully covered,
+    see `test_maximum_number_nsz_f32` in `library/coretests/tests/ferrocene/intrinsics.rs`."
+)]
 pub const fn maximum_number_nsz_f32(x: f32, y: f32) -> f32 {
     if x.is_nan() || y >= x {
         y

--- a/library/core/src/num/error.rs
+++ b/library/core/src/num/error.rs
@@ -155,7 +155,16 @@ impl fmt::Display for ParseIntError {
             IntErrorKind::PosOverflow => "number too large to fit in target type",
             IntErrorKind::NegOverflow => "number too small to fit in target type",
             IntErrorKind::Zero => "number would be zero for non-zero type",
-            IntErrorKind::NotAPowerOfTwo => "number is not a power of two",
+            IntErrorKind::NotAPowerOfTwo => {
+                #[cfg(feature = "ferrocene_test")]
+                unreachable!();
+                #[ferrocene::annotation(
+                    "This variant can't be constructed anywhere in the API surface. \
+                     Testing would require transmuting from a fake struct, the unreachable!() \
+                     above will indicate to us if this ever does become a live codepath."
+                )]
+                "number is not a power of two"
+            }
         }
         .fmt(f)
     }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1858,6 +1858,9 @@ macro_rules! uint_impl {
             // Note: Like all optimizations, this is not guaranteed to be
             // applied by the compiler. If you want those specific bases,
             // use `.checked_ilog2()` or `.checked_ilog10()` directly.
+            #[ferrocene::annotation(
+                "The uncovered } at the end of this statement is a tooling bug, since the lines after are covered, the else case here is also covered."
+            )]
             if core::intrinsics::is_val_statically_known(base) {
                 if base == 2 {
                     return self.checked_ilog2();

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1858,9 +1858,6 @@ macro_rules! uint_impl {
             // Note: Like all optimizations, this is not guaranteed to be
             // applied by the compiler. If you want those specific bases,
             // use `.checked_ilog2()` or `.checked_ilog10()` directly.
-            #[ferrocene::annotation(
-                "The uncovered } at the end of this statement is a tooling bug, since the lines after are covered, the else case here is also covered."
-            )]
             if core::intrinsics::is_val_statically_known(base) {
                 if base == 2 {
                     return self.checked_ilog2();

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1850,6 +1850,9 @@ macro_rules! uint_impl {
             // Note: Like all optimizations, this is not guaranteed to be
             // applied by the compiler. If you want those specific bases,
             // use `.checked_ilog2()` or `.checked_ilog10()` directly.
+            #[ferrocene::annotation(
+                "The uncovered } at the end of this statement is a tooling bug, since the lines after are covered, the else case here is also covered."
+            )]
             if core::intrinsics::is_val_statically_known(base) {
                 // change of base:
                 // if base == 2 ** k, then

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1850,9 +1850,6 @@ macro_rules! uint_impl {
             // Note: Like all optimizations, this is not guaranteed to be
             // applied by the compiler. If you want those specific bases,
             // use `.checked_ilog2()` or `.checked_ilog10()` directly.
-            #[ferrocene::annotation(
-                "The uncovered } at the end of this statement is a tooling bug, since the lines after are covered, the else case here is also covered."
-            )]
             if core::intrinsics::is_val_statically_known(base) {
                 // change of base:
                 // if base == 2 ** k, then

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -164,7 +164,7 @@ impl [u8] {
                 }
             } else {
                 #[ferrocene::annotation("
-                    This branch of is not coverable from public API. \
+                    This branch is not coverable from public API. \
                     The only caller (`eq_ignore_ascii_case`) only calls this function if both values \
                     are the same length, and that shared length is greater than the `N` chunk size.
                     The `if` statement above is currently acting to destructure the returned values.

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -157,14 +157,19 @@ impl [u8] {
 
         // If there are remaining tails, load the last N bytes in the slices to
         // avoid falling back to per-byte checking.
-        #[ferrocene::annotation("
-            A tooling bug marks the trailing `}` as uncovered, but since the `true` below is covered, we know we test the fall-through. See `test_eq_ignore_ascii_case_chunks`.
-        ")]
         if !self_rem.is_empty() {
             if let (Some(a_rem), Some(b_rem)) = (self.last_chunk::<N>(), other.last_chunk::<N>()) {
                 if !eq_ignore_ascii_inner(a_rem, b_rem) {
                     return false;
                 }
+            } else {
+                #[ferrocene::annotation("
+                    This branch of is not coverable from public API. \
+                    The only caller (`eq_ignore_ascii_case`) only calls this function if both values \
+                    are the same length, and that shared length is greater than the `N` chunk size.
+                    The `if` statement above is currently acting to destructure the returned values.
+                ")]
+                {}
             }
         }
 

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -157,6 +157,9 @@ impl [u8] {
 
         // If there are remaining tails, load the last N bytes in the slices to
         // avoid falling back to per-byte checking.
+        #[ferrocene::annotation("
+            A tooling bug marks the trailing `}` as uncovered, but since the `true` below is covered, we know we test the fall-through. See `test_eq_ignore_ascii_case_chunks`.
+        ")]
         if !self_rem.is_empty() {
             if let (Some(a_rem), Some(b_rem)) = (self.last_chunk::<N>(), other.last_chunk::<N>()) {
                 if !eq_ignore_ascii_inner(a_rem, b_rem) {

--- a/library/coretests/tests/ferrocene/fmt.rs
+++ b/library/coretests/tests/ferrocene/fmt.rs
@@ -526,9 +526,9 @@ fn test_formatter_align() {
         fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
             let s = if let Some(s) = formatter.align() {
                 match s {
-                    Alignment::Left    => "left",
-                    Alignment::Right   => "right",
-                    Alignment::Center  => "center",
+                    Alignment::Left => "left",
+                    Alignment::Right => "right",
+                    Alignment::Center => "center",
                 }
             } else {
                 "into the void"

--- a/library/coretests/tests/ferrocene/fmt.rs
+++ b/library/coretests/tests/ferrocene/fmt.rs
@@ -542,20 +542,3 @@ fn test_formatter_align() {
     assert_eq!(format!("{Foo:^}"), "center");
     assert_eq!(format!("{Foo}"), "into the void");
 }
-
-#[test]
-fn test_fmt_parse_int_error_not_a_power_of_two() {
-    use core::num::IntErrorKind;
-    pub struct FakeParseIntError {
-        #[allow(dead_code)] // This is used for transmuting.
-        pub kind: IntErrorKind,
-    }
-
-    let val = FakeParseIntError { kind: IntErrorKind::NotAPowerOfTwo };
-    // We need to do a truly cursed thing here since there are no situations in public API where
-    // we can conjure ourselves a `ParseIntError` with a `NotAPowerOfTwo` in it.
-    let cursed =
-        unsafe { core::mem::transmute::<FakeParseIntError, core::num::ParseIntError>(val) };
-    let formatted = format!("{}", cursed);
-    assert_eq!(formatted, "number is not a power of two")
-}

--- a/library/coretests/tests/ferrocene/fmt.rs
+++ b/library/coretests/tests/ferrocene/fmt.rs
@@ -542,3 +542,23 @@ fn test_formatter_align() {
     assert_eq!(format!("{Foo:^}"), "center");
     assert_eq!(format!("{Foo}"), "into the void");
 }
+
+#[test]
+fn test_fmt_parse_int_error_not_a_power_of_two() {
+    use core::num::IntErrorKind;
+    pub struct FakeParseIntError {
+        #[allow(dead_code)] // This is used for transmuting.
+        pub kind: IntErrorKind,
+    }
+
+    let val = FakeParseIntError {
+        kind: IntErrorKind::NotAPowerOfTwo,
+    };
+    // We need to do a truly cursed thing here since there are no situations in public API where
+    // we can conjure ourselves a `ParseIntError` with a `NotAPowerOfTwo` in it.
+    let cursed = unsafe {
+        core::mem::transmute::<FakeParseIntError, core::num::ParseIntError>(val)
+    };
+    let formatted = format!("{}", cursed);
+    assert_eq!(formatted, "number is not a power of two")
+}

--- a/library/coretests/tests/ferrocene/fmt.rs
+++ b/library/coretests/tests/ferrocene/fmt.rs
@@ -551,14 +551,11 @@ fn test_fmt_parse_int_error_not_a_power_of_two() {
         pub kind: IntErrorKind,
     }
 
-    let val = FakeParseIntError {
-        kind: IntErrorKind::NotAPowerOfTwo,
-    };
+    let val = FakeParseIntError { kind: IntErrorKind::NotAPowerOfTwo };
     // We need to do a truly cursed thing here since there are no situations in public API where
     // we can conjure ourselves a `ParseIntError` with a `NotAPowerOfTwo` in it.
-    let cursed = unsafe {
-        core::mem::transmute::<FakeParseIntError, core::num::ParseIntError>(val)
-    };
+    let cursed =
+        unsafe { core::mem::transmute::<FakeParseIntError, core::num::ParseIntError>(val) };
     let formatted = format!("{}", cursed);
     assert_eq!(formatted, "number is not a power of two")
 }

--- a/library/coretests/tests/ferrocene/fmt.rs
+++ b/library/coretests/tests/ferrocene/fmt.rs
@@ -488,3 +488,28 @@ fn from_fn_debug_fmt() {
     let val = core::fmt::from_fn(|f| write!(f, "{msg}"));
     assert_eq!(format!("{val:?}"), msg);
 }
+
+// Covers `core::fmt::Formatter::<'a>::fill`
+// Copied from `core::fmt::Formatter::<'a>::fill` doc test
+#[test]
+fn test_formatter_fill() {
+    struct Foo;
+
+    impl fmt::Display for Foo {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let c = formatter.fill();
+            if let Some(width) = formatter.width() {
+                for _ in 0..width {
+                    write!(formatter, "{c}")?;
+                }
+                Ok(())
+            } else {
+                write!(formatter, "{c}")
+            }
+        }
+    }
+
+    // We set alignment to the right with ">".
+    assert_eq!(format!("{Foo:G>3}"), "GGG");
+    assert_eq!(format!("{Foo:t>6}"), "tttttt");
+}

--- a/library/coretests/tests/ferrocene/fmt.rs
+++ b/library/coretests/tests/ferrocene/fmt.rs
@@ -513,3 +513,32 @@ fn test_formatter_fill() {
     assert_eq!(format!("{Foo:G>3}"), "GGG");
     assert_eq!(format!("{Foo:t>6}"), "tttttt");
 }
+
+// Covers `core::fmt::Formatter::<'a>::align`
+// Copied from `core::fmt::Formatter::<'a>::align` doc test
+#[test]
+fn test_formatter_align() {
+    use std::fmt::{self, Alignment};
+
+    struct Foo;
+
+    impl fmt::Display for Foo {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let s = if let Some(s) = formatter.align() {
+                match s {
+                    Alignment::Left    => "left",
+                    Alignment::Right   => "right",
+                    Alignment::Center  => "center",
+                }
+            } else {
+                "into the void"
+            };
+            write!(formatter, "{s}")
+        }
+    }
+
+    assert_eq!(format!("{Foo:<}"), "left");
+    assert_eq!(format!("{Foo:>}"), "right");
+    assert_eq!(format!("{Foo:^}"), "center");
+    assert_eq!(format!("{Foo}"), "into the void");
+}

--- a/library/coretests/tests/ferrocene/intrinsics.rs
+++ b/library/coretests/tests/ferrocene/intrinsics.rs
@@ -91,3 +91,43 @@ test_int_carryless_mul! {
     u128 => test_u128_carryless_mul,
     usize => test_usize_carryless_mul,
 }
+
+// Covers:
+// <T as core::intrinsics::fallback::FunnelShift>::unchecked_funnel_shl
+// <T as core::intrinsics::fallback::FunnelShift>::unchecked_funnel_shr
+macro_rules! test_intrinsic_unchecked_funnel {
+    ($($T:ty => $fn:ident,)*) => {
+        $(
+        #[test]
+        fn $fn() {
+            unsafe {
+                assert_eq!(
+                    core::intrinsics::fallback::FunnelShift::unchecked_funnel_shl(12 as $T, 12 as $T, 0),
+                    12,
+                );
+                assert_eq!(
+                    core::intrinsics::fallback::FunnelShift::unchecked_funnel_shr(12 as $T, 12 as $T, 0),
+                    12,
+                );
+                assert_eq!(
+                    core::intrinsics::fallback::FunnelShift::unchecked_funnel_shl(12 as $T, 12 as $T, 2),
+                    48,
+                );
+                assert_eq!(
+                    core::intrinsics::fallback::FunnelShift::unchecked_funnel_shr(12 as $T, 12 as $T, 2),
+                    3,
+                );
+            }
+        }
+        )*
+    };
+}
+
+test_intrinsic_unchecked_funnel! {
+    u8 => test_intrinsic_unchecked_funnel_u8,
+    u16 => test_intrinsic_unchecked_funnel_u16,
+    u32 => test_intrinsic_unchecked_funnel_u32,
+    u64 => test_intrinsic_unchecked_funnel_u64,
+    u128 => test_intrinsic_unchecked_funnel_u128,
+    usize => test_intrinsic_unchecked_funnel_usize,
+}

--- a/library/coretests/tests/ferrocene/intrinsics.rs
+++ b/library/coretests/tests/ferrocene/intrinsics.rs
@@ -131,3 +131,23 @@ test_intrinsic_unchecked_funnel! {
     u128 => test_intrinsic_unchecked_funnel_u128,
     usize => test_intrinsic_unchecked_funnel_usize,
 }
+
+#[test]
+fn test_minimum_number_nsz_f32() {
+    // x.is_nan() == true
+    assert_eq!(0.0_f32, core::intrinsics::minimum_number_nsz_f32(f32::NAN, 0.0_f32));
+    // y <= x
+    assert_eq!(0.0_f32, core::intrinsics::minimum_number_nsz_f32(1.0_32, 0.0_f32));
+    // else
+    assert_eq!(0.0_f32, core::intrinsics::minimum_number_nsz_f32(0.0_f32, 1.0_32));
+}
+
+#[test]
+fn test_maximum_number_nsz_f32() {
+    // x.is_nan() == true
+    assert_eq!(0.0_f32, core::intrinsics::maximum_number_nsz_f32(f32::NAN, 0.0_f32));
+    // y >= x
+    assert_eq!(1.0_f32, core::intrinsics::maximum_number_nsz_f32(1.0_f32, 0.0_f32));
+    // else
+    assert_eq!(1.0_f32, core::intrinsics::maximum_number_nsz_f32(0.0_f32, 1.0_f32));
+}

--- a/library/coretests/tests/ferrocene/iter.rs
+++ b/library/coretests/tests/ferrocene/iter.rs
@@ -1131,3 +1131,14 @@ fn test_ref_spec_try_rfold() {
     let folded: Result<_, core::str::Utf8Error> = <&mut core::slice::IterMut<'_, _> as DoubleEndedIterator>::try_rfold(&mut &mut abstracted, 0, |acc, &mut x| Ok(acc + x));
     assert_eq!(folded, Ok(15));
 }
+
+// Covers `<core::iter::adapters::scan::Scan<I, St, F> as core::iter::traits::iterator::Iterator>::try_fold`
+#[test]
+fn test_scan_iterator_try_fold() {
+    let mut iter: core::iter::Scan<_, _, _> = [1, 2, 3, 4, 5].iter().scan(0, |acc: &mut usize, x: &usize| {
+        *acc += *x;
+        None
+    });
+    let folded = iter.try_fold(0, |_acc, _x: usize| None);
+    assert_eq!(folded, Some(0));
+}

--- a/library/coretests/tests/ferrocene/iter.rs
+++ b/library/coretests/tests/ferrocene/iter.rs
@@ -1100,3 +1100,17 @@ fn test_char_indices_count() {
     let suspect = "Hello there, I'm a code coverage test";
     assert_eq!(suspect.char_indices().count(), 37);
 }
+
+// Covers `<core::iter::adapters::map_while::MapWhile<I, P> as core::iter::traits::iterator::Iterator>::try_fold`
+#[test]
+fn test_map_while_try_fold() {
+    let mut iter = [1, 2, 3, 4, 5].iter().map_while(|x| {
+        if *x % 2 == 0 {
+            Some(*x)
+        } else {
+            None
+        }
+    });
+    let folded = iter.try_fold(0, |_acc, _x| None);
+    assert_eq!(folded, Some(0));
+}

--- a/library/coretests/tests/ferrocene/iter.rs
+++ b/library/coretests/tests/ferrocene/iter.rs
@@ -1114,3 +1114,11 @@ fn test_map_while_try_fold() {
     let folded = iter.try_fold(0, |_acc, _x| None);
     assert_eq!(folded, Some(0));
 }
+
+// Covers `core::array::<impl core::cmp::PartialOrd for [T; N]>::partial_cmp`
+#[test]
+fn test_partialord_slice_partialcmp() {
+    let x = [1, 2, 3];
+    let y = [4, 5, 6];
+    assert!(x.partial_cmp(&y).is_some());
+}

--- a/library/coretests/tests/ferrocene/iter.rs
+++ b/library/coretests/tests/ferrocene/iter.rs
@@ -1093,7 +1093,6 @@ fn test_filter_spec_assume_count_default() {
     assert_eq!(no_trusted_len.filter(|a| *a % 2 == 0).count(), 2);
 }
 
-
 // Covers `<core::str::iter::CharIndices<'a> as core::iter::traits::iterator::Iterator>::count`
 #[test]
 fn test_char_indices_count() {
@@ -1104,13 +1103,7 @@ fn test_char_indices_count() {
 // Covers `<core::iter::adapters::map_while::MapWhile<I, P> as core::iter::traits::iterator::Iterator>::try_fold`
 #[test]
 fn test_map_while_try_fold() {
-    let mut iter = [1, 2, 3, 4, 5].iter().map_while(|x| {
-        if *x % 2 == 0 {
-            Some(*x)
-        } else {
-            None
-        }
-    });
+    let mut iter = [1, 2, 3, 4, 5].iter().map_while(|x| if *x % 2 == 0 { Some(*x) } else { None });
     let folded = iter.try_fold(0, |_acc, _x| None);
     assert_eq!(folded, Some(0));
 }
@@ -1128,17 +1121,23 @@ fn test_partialord_slice_partialcmp() {
 fn test_ref_spec_try_rfold() {
     let mut suspect = [1, 2, 3, 4, 5];
     let mut abstracted = suspect.iter_mut();
-    let folded: Result<_, core::str::Utf8Error> = <&mut core::slice::IterMut<'_, _> as DoubleEndedIterator>::try_rfold(&mut &mut abstracted, 0, |acc, &mut x| Ok(acc + x));
+    let folded: Result<_, core::str::Utf8Error> =
+        <&mut core::slice::IterMut<'_, _> as DoubleEndedIterator>::try_rfold(
+            &mut &mut abstracted,
+            0,
+            |acc, &mut x| Ok(acc + x),
+        );
     assert_eq!(folded, Ok(15));
 }
 
 // Covers `<core::iter::adapters::scan::Scan<I, St, F> as core::iter::traits::iterator::Iterator>::try_fold`
 #[test]
 fn test_scan_iterator_try_fold() {
-    let mut iter: core::iter::Scan<_, _, _> = [1, 2, 3, 4, 5].iter().scan(0, |acc: &mut usize, x: &usize| {
-        *acc += *x;
-        None
-    });
+    let mut iter: core::iter::Scan<_, _, _> =
+        [1, 2, 3, 4, 5].iter().scan(0, |acc: &mut usize, x: &usize| {
+            *acc += *x;
+            None
+        });
     let folded = iter.try_fold(0, |_acc, _x: usize| None);
     assert_eq!(folded, Some(0));
 }

--- a/library/coretests/tests/ferrocene/iter.rs
+++ b/library/coretests/tests/ferrocene/iter.rs
@@ -1092,3 +1092,11 @@ fn test_filter_spec_assume_count_default() {
     let no_trusted_len: &mut dyn Iterator<Item = &i32> = &mut yes_trusted_len;
     assert_eq!(no_trusted_len.filter(|a| *a % 2 == 0).count(), 2);
 }
+
+
+// Covers `<core::str::iter::CharIndices<'a> as core::iter::traits::iterator::Iterator>::count`
+#[test]
+fn test_char_indices_count() {
+    let suspect = "Hello there, I'm a code coverage test";
+    assert_eq!(suspect.char_indices().count(), 37);
+}

--- a/library/coretests/tests/ferrocene/iter.rs
+++ b/library/coretests/tests/ferrocene/iter.rs
@@ -1122,3 +1122,12 @@ fn test_partialord_slice_partialcmp() {
     let y = [4, 5, 6];
     assert!(x.partial_cmp(&y).is_some());
 }
+
+// Covers `<&mut I as core::iter::traits::double_ended::DoubleEndedIteratorRefSpec>::spec_try_rfold`
+#[test]
+fn test_ref_spec_try_rfold() {
+    let mut suspect = [1, 2, 3, 4, 5];
+    let mut abstracted = suspect.iter_mut();
+    let folded: Result<_, core::str::Utf8Error> = <&mut core::slice::IterMut<'_, _> as DoubleEndedIterator>::try_rfold(&mut &mut abstracted, 0, |acc, &mut x| Ok(acc + x));
+    assert_eq!(folded, Ok(15));
+}

--- a/library/coretests/tests/ferrocene/num.rs
+++ b/library/coretests/tests/ferrocene/num.rs
@@ -883,3 +883,49 @@ fn test_saturating_div() {
         "i8",
     );
 }
+
+// Cover `core::num::<T>::saturating_mul`.
+#[test]
+fn test_saturating_mul() {
+    assert_eq!(
+        i128::saturating_mul(i128::MIN, 10),
+        i128::MIN,
+        "i128",
+    );
+    assert_eq!(
+        i64::saturating_mul(i64::MIN, 10),
+        i64::MIN,
+        "i64",
+    );
+    assert_eq!(
+        i32::saturating_mul(i32::MIN, 10),
+        i32::MIN,
+        "i32",
+    );
+    assert_eq!(
+        i8::saturating_mul(i8::MIN, 10),
+        i8::MIN,
+        "i8",
+    );
+
+    assert_eq!(
+        i128::saturating_mul(2 as i128, 4),
+        8 as i128,
+        "i128",
+    );
+    assert_eq!(
+        i64::saturating_mul(2 as i64, 4),
+        8 as i64,
+        "i64",
+    );
+    assert_eq!(
+        i32::saturating_mul(2 as i32, 4),
+        8 as i32,
+        "i32",
+    );
+    assert_eq!(
+        i8::saturating_mul(2 as i8, 4),
+        8 as i8,
+        "i8",
+    );
+}

--- a/library/coretests/tests/ferrocene/num.rs
+++ b/library/coretests/tests/ferrocene/num.rs
@@ -450,3 +450,411 @@ fn non_zero_ne() {
     assert!(lhs != rhs);
     assert!(!(lhs != lhs));
 }
+
+// covers
+// - <core::num::saturating::Saturating<T> as core::ops::arith::AddAssign>::add_assign
+// - <core::num::saturating::Saturating<T> as core::ops::arith::DivAssign>::div_assign
+// - <core::num::saturating::Saturating<T> as core::ops::arith::MulAssign>::mul_assign
+// - <core::num::saturating::Saturating<T> as core::ops::arith::Neg>::neg
+// - <core::num::saturating::Saturating<T> as core::ops::arith::Rem>::rem
+// - <core::num::saturating::Saturating<T> as core::ops::arith::RemAssign<T>>::rem_assign
+// - <core::num::saturating::Saturating<T> as core::ops::arith::RemAssign>::rem_assign
+// - <core::num::saturating::Saturating<T> as core::ops::arith::SubAssign>::sub_assign
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitAnd>::bitand
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitAndAssign<T>>::bitand_assign
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitAndAssign>::bitand_assign
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitOr>::bitor
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitOrAssign<T>>::bitor_assign
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitOrAssign>::bitor_assign
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitXor>::bitxor
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitXorAssign<T>>::bitxor_assign
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitXorAssign>::bitxor_assign
+// - <core::num::saturating::Saturating<T> as core::ops::bit::Not>::not
+macro_rules! test_saturating_ops {
+    ($($T:ty => $fn:ident,)*) => {
+        $(
+            #[test]
+            fn $fn() {
+                use core::num::Saturating;
+
+
+                // add_assign (Saturating)
+                {
+                    let mut max = Saturating(<$T>::MAX);
+                    max += Saturating(1 as $T);
+                    assert_eq!(max, Saturating(<$T>::MAX), "add_assign (Saturating)");
+                }
+
+                // add_assign
+                {
+                    let mut max = Saturating(<$T>::MAX);
+                    max += 1 as $T;
+                    assert_eq!(max, Saturating(<$T>::MAX), "add_assign");
+                }
+
+                // add (Saturating)
+                {
+                    let added_max = Saturating(<$T>::MAX) + Saturating(1 as $T);
+                    assert_eq!(added_max, Saturating(<$T>::MAX), "add (Saturating)");
+                }
+
+                // sub_assign (Saturating)
+                {
+                    let mut min = Saturating(<$T>::MIN);
+                    min -= Saturating(1 as $T);
+                    assert_eq!(min, Saturating(<$T>::MIN), "sub_assign (Saturating)");
+                }
+
+                // sub_assign
+                {
+                    let mut min = Saturating(<$T>::MIN);
+                    min -= 1 as $T;
+                    assert_eq!(min, Saturating(<$T>::MIN), "sub_assign");
+                }
+
+                // sub (Saturating)
+                {
+                    let subbed_min = Saturating(<$T>::MIN) - Saturating(1 as $T);
+                    assert_eq!(subbed_min, Saturating(<$T>::MIN), "sub (Saturating)");
+                }
+
+                // mul_assign (Saturating)
+                {
+                    let mut max = Saturating(<$T>::MAX);
+                    max *= Saturating(2);
+                    assert_eq!(max, Saturating(<$T>::MAX), "mul_assign (Saturating)");
+                }
+
+                // mul_assign
+                {
+                    let mut max = Saturating(<$T>::MAX);
+                    max *= 2;
+                    assert_eq!(max, Saturating(<$T>::MAX), "mul_assign");
+                }
+
+                // div_assign (Saturating)
+                {
+                    let mut max = Saturating(<$T>::MAX);
+                    max /= Saturating(2);
+                    assert_eq!(max, Saturating(<$T>::MAX / 2), "div_assign (Saturating)");
+                }
+
+                // div_assign
+                {
+                    let mut max = Saturating(<$T>::MAX);
+                    max /= 2;
+                    assert_eq!(max, Saturating(<$T>::MAX / 2), "div_assign");
+                }
+
+                // rem_assign (Saturating)
+                {
+                    let mut suspect = Saturating(15 as $T);
+                    suspect %= Saturating(2);
+                    assert_eq!(suspect, Saturating(1), "rem_assign (Saturating)");
+                }
+
+                // rem_assign
+                {
+                    let mut suspect = Saturating(15 as $T);
+                    suspect %= 2;
+                    assert_eq!(suspect, Saturating(1), "rem_assign");
+                }
+
+                // rem (Saturating)
+                {
+                    let suspect = Saturating(15 as $T) % Saturating(2 as $T);
+                    assert_eq!(suspect, Saturating(1), "rem (Saturating)");
+                }
+
+                // bit_or (Saturating)
+                {
+                    let suspect = Saturating(5 as $T) | Saturating(2 as $T);
+                    assert_eq!(suspect, Saturating(7), "bit_or (Saturating)");
+                }
+
+                // bit_or_assign (Saturating)
+                {
+                    let mut suspect = Saturating(5 as $T);
+                    suspect |= Saturating(2 as $T);
+                    assert_eq!(suspect, Saturating(7), "bit_or_assign (Saturating)");
+                }
+
+                // bit_or_assign
+                {
+                    let mut suspect = Saturating(5 as $T);
+                    suspect |= 2 as $T;
+                    assert_eq!(suspect, Saturating(7), "bit_or_assign");
+                }
+
+                // bit_and (Saturating)
+                {
+                    let suspect = Saturating(5 as $T) & Saturating(2 as $T);
+                    assert_eq!(suspect, Saturating(0), "bit_and (Saturating)");
+                }
+
+                // bit_and_assign (Saturating)
+                {
+                    let mut suspect = Saturating(5 as $T);
+                    suspect &= Saturating(2 as $T);
+                    assert_eq!(suspect, Saturating(0), "bit_and_assign (Saturating)");
+                }
+
+                // bit_and_assign
+                {
+                    let mut suspect = Saturating(5 as $T);
+                    suspect &= 2 as $T;
+                    assert_eq!(suspect, Saturating(0), "bit_and_assign");
+                }
+
+                // bit_xor (Saturating)
+                {
+                    let suspect = Saturating(5 as $T) ^ Saturating(1 as $T);
+                    assert_eq!(suspect, Saturating(4), "bit_xor");
+                }
+
+                // bit_xor_assign (Saturating)
+                {
+                    let mut suspect = Saturating(5 as $T);
+                    suspect ^= Saturating(1 as $T);
+                    assert_eq!(suspect, Saturating(4), "bit_xor_assign (Saturating)");
+                }
+
+                // bit_xor_assign
+                {
+                    let mut suspect = Saturating(5 as $T);
+                    suspect ^= 1 as $T;
+                    assert_eq!(suspect, Saturating(4), "bit_xor_assign");
+                }
+
+                // not
+                {
+                    let suspect = Saturating(<$T>::MAX);
+                    assert_eq!(!suspect, Saturating(<$T>::MIN), "not");
+                }
+            }
+
+        )*
+    };
+}
+test_saturating_ops! {
+    i128 => saturating_i128_ops,
+    i64 => saturating_i64_ops,
+    i32 => saturating_i32_ops,
+    i8 => saturating_i8_ops,
+    isize => saturating_isize_ops,
+    u128 => saturating_u128_ops,
+    u64 => saturating_u64_ops,
+    u32 => saturating_u32_ops,
+    u8 => saturating_u8_ops,
+    usize => saturating_usize_ops,
+}
+
+// covers
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::AddAssign>::add_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::DivAssign>::div_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::MulAssign>::mul_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::Neg>::neg
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::Rem>::rem
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::RemAssign<T>>::rem_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::RemAssign>::rem_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::SubAssign>::sub_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitAnd>::bitand
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitAndAssign<T>>::bitand_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitAndAssign>::bitand_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitOr>::bitor
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitOrAssign<T>>::bitor_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitOrAssign>::bitor_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitXor>::bitxor
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitXorAssign<T>>::bitxor_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitXorAssign>::bitxor_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::Not>::not
+// - <core::num::saturating::Saturating<T> as core::ops::arith::Neg>::neg
+macro_rules! test_wrapping_ops {
+    ($($T:ty => $fn:ident,)*) => {
+        $(
+            #[test]
+            fn $fn() {
+                use core::num::Wrapping;
+
+
+                // add_assign (Wrapping)
+                {
+                    let mut max = Wrapping(<$T>::MAX);
+                    max += Wrapping(1 as $T);
+                    assert_eq!(max, Wrapping(<$T>::MIN), "add_assign (Wrapping)");
+                }
+
+                // add_assign
+                {
+                    let mut max = Wrapping(<$T>::MAX);
+                    max += 1 as $T;
+                    assert_eq!(max, Wrapping(<$T>::MIN), "add_assign");
+                }
+
+                // add (Wrapping)
+                {
+                    let added_max = Wrapping(<$T>::MAX) + Wrapping(1 as $T);
+                    assert_eq!(added_max, Wrapping(<$T>::MIN), "add (Wrapping)");
+                }
+
+                // sub_assign (Wrapping)
+                {
+                    let mut min = Wrapping(<$T>::MIN);
+                    min -= Wrapping(1 as $T);
+                    assert_eq!(min, Wrapping(<$T>::MAX), "sub_assign (Wrapping)");
+                }
+
+                // sub_assign (Wrapping)
+                {
+                    let mut min = Wrapping(<$T>::MIN);
+                    min -= 1 as $T;
+                    assert_eq!(min, Wrapping(<$T>::MAX), "sub_assign (Wrapping)");
+                }
+
+                // sub (Wrapping)
+                {
+                    let subbed_min = Wrapping(<$T>::MIN) - Wrapping(1 as $T);
+                    assert_eq!(subbed_min, Wrapping(<$T>::MAX), "sub (Wrapping)");
+                }
+
+                // mul_assign (Wrapping)
+                {
+                    let mut max = Wrapping(24 as $T);
+                    max *= Wrapping(2); // Other functions test the correctness of mul in general, just worry about covering this convienence wrapper
+                    assert_eq!(max, Wrapping(48), "mul_assign (Wrapping)");
+                }
+
+                // mul_assign
+                {
+                    let mut max = Wrapping(24 as $T);
+                    max *= 2; // Other functions test the correctness of mul in general, just worry about covering this convienence wrapper
+                    assert_eq!(max, Wrapping(48), "mul_assign");
+                }
+
+                // div_assign (Wrapping)
+                {
+                    let mut max = Wrapping(<$T>::MAX);
+                    max /= Wrapping(2);
+                    assert_eq!(max, Wrapping(<$T>::MAX / 2), "div_assign (Wrapping)");
+                }
+
+                // div_assign
+                {
+                    let mut max = Wrapping(<$T>::MAX);
+                    max /= 2;
+                    assert_eq!(max, Wrapping(<$T>::MAX / 2), "div_assign");
+                }
+
+                // rem_assign (Wrapping)
+                {
+                    let mut suspect = Wrapping(15 as $T);
+                    suspect %= Wrapping(2);
+                    assert_eq!(suspect, Wrapping(1), "rem_assign (Wrapping)");
+                }
+
+                // rem_assign
+                {
+                    let mut suspect = Wrapping(15 as $T);
+                    suspect %= 2;
+                    assert_eq!(suspect, Wrapping(1), "rem_assign");
+                }
+
+                // rem (Wrapping)
+                {
+                    let suspect = Wrapping(15 as $T) % Wrapping(2 as $T);
+                    assert_eq!(suspect, Wrapping(1), "rem (Wrapping)");
+                }
+
+                // bit_or (Wrapping)
+                {
+                    let suspect = Wrapping(5 as $T) | Wrapping(2 as $T);
+                    assert_eq!(suspect, Wrapping(7), "bit_or (Wrapping)");
+                }
+
+                // bit_or_assign (Wrapping)
+                {
+                    let mut suspect = Wrapping(5 as $T);
+                    suspect |= Wrapping(2 as $T);
+                    assert_eq!(suspect, Wrapping(7), "bit_or_assign (Wrapping)");
+                }
+
+
+                // bit_or_assign
+                {
+                    let mut suspect = Wrapping(5 as $T);
+                    suspect |= 2 as $T;
+                    assert_eq!(suspect, Wrapping(7), "bit_or_assign");
+                }
+
+                // bit_and (Wrapping)
+                {
+                    let suspect = Wrapping(5 as $T) & Wrapping(2 as $T);
+                    assert_eq!(suspect, Wrapping(0), "bit_and (Wrapping)");
+                }
+
+                // bit_and_assign (Wrapping)
+                {
+                    let mut suspect = Wrapping(5 as $T);
+                    suspect &= Wrapping(2 as $T);
+                    assert_eq!(suspect, Wrapping(0), "bit_and_assign (Wrapping)");
+                }
+
+                // bit_and_assign (Wrapping)
+                {
+                    let mut suspect = Wrapping(5 as $T);
+                    suspect &= 2 as $T;
+                    assert_eq!(suspect, Wrapping(0), "bit_and_assign");
+                }
+
+                // bit_xor (Wrapping)
+                {
+                    let suspect = Wrapping(5 as $T) ^ Wrapping(1 as $T);
+                    assert_eq!(suspect, Wrapping(4), "bit_xor (Wrapping)");
+                }
+
+                // bit_xor_assign (Wrapping)
+                {
+                    let mut suspect = Wrapping(5 as $T);
+                    suspect ^= Wrapping(1 as $T);
+                    assert_eq!(suspect, Wrapping(4), "bit_xor_assign (Wrapping)");
+                }
+
+                // bit_xor_assign
+                {
+                    let mut suspect = Wrapping(5 as $T);
+                    suspect ^= 1 as $T;
+                    assert_eq!(suspect, Wrapping(4), "bit_xor_assign");
+                }
+
+                // not
+                {
+                    let suspect = Wrapping(<$T>::MAX);
+                    assert_eq!(!suspect, Wrapping(<$T>::MIN), "not");
+                }
+            }
+
+        )*
+    };
+}
+test_wrapping_ops! {
+    i128 => wrapping_i128_ops,
+    i64 => wrapping_i64_ops,
+    i32 => wrapping_i32_ops,
+    i8 => wrapping_i8_ops,
+    isize => wrapping_isize_ops,
+    u128 => wrapping_u128_ops,
+    u64 => wrapping_u64_ops,
+    u32 => wrapping_u32_ops,
+    u8 => wrapping_u8_ops,
+    usize => wrapping_usize_ops,
+}
+
+// Covers `<core::num::saturating::Saturating<T> as core::ops::arith::Neg>::neg`
+#[test]
+fn test_saturating_neg() {
+    use core::num::Saturating;
+    assert_eq!(-Saturating(42 as i128), Saturating(-42 as i128));
+    assert_eq!(-Saturating(42 as i64), Saturating(-42 as i64));
+    assert_eq!(-Saturating(42 as i32), Saturating(-42 as i32));
+    assert_eq!(-Saturating(42 as i8), Saturating(-42 as i8));
+}

--- a/library/coretests/tests/ferrocene/num.rs
+++ b/library/coretests/tests/ferrocene/num.rs
@@ -858,3 +858,28 @@ fn test_saturating_neg() {
     assert_eq!(-Saturating(42 as i32), Saturating(-42 as i32));
     assert_eq!(-Saturating(42 as i8), Saturating(-42 as i8));
 }
+
+// Cover `core::num::<T>::saturating_div`.
+#[test]
+fn test_saturating_div() {
+    assert_eq!(
+        i128::saturating_div(i128::MIN, -1 as i128),
+        i128::MAX,
+        "i128",
+    );
+    assert_eq!(
+        i64::saturating_div(i64::MIN, -1 as i64),
+        i64::MAX,
+        "i64",
+    );
+    assert_eq!(
+        i32::saturating_div(i32::MIN, -1 as i32),
+        i32::MAX,
+        "i32",
+    );
+    assert_eq!(
+        i8::saturating_div(i8::MIN, -1 as i8),
+        i8::MAX,
+        "i8",
+    );
+}

--- a/library/coretests/tests/ferrocene/num.rs
+++ b/library/coretests/tests/ferrocene/num.rs
@@ -862,70 +862,22 @@ fn test_saturating_neg() {
 // Cover `core::num::<T>::saturating_div`.
 #[test]
 fn test_saturating_div() {
-    assert_eq!(
-        i128::saturating_div(i128::MIN, -1 as i128),
-        i128::MAX,
-        "i128",
-    );
-    assert_eq!(
-        i64::saturating_div(i64::MIN, -1 as i64),
-        i64::MAX,
-        "i64",
-    );
-    assert_eq!(
-        i32::saturating_div(i32::MIN, -1 as i32),
-        i32::MAX,
-        "i32",
-    );
-    assert_eq!(
-        i8::saturating_div(i8::MIN, -1 as i8),
-        i8::MAX,
-        "i8",
-    );
+    assert_eq!(i128::saturating_div(i128::MIN, -1 as i128), i128::MAX, "i128",);
+    assert_eq!(i64::saturating_div(i64::MIN, -1 as i64), i64::MAX, "i64",);
+    assert_eq!(i32::saturating_div(i32::MIN, -1 as i32), i32::MAX, "i32",);
+    assert_eq!(i8::saturating_div(i8::MIN, -1 as i8), i8::MAX, "i8",);
 }
 
 // Cover `core::num::<T>::saturating_mul`.
 #[test]
 fn test_saturating_mul() {
-    assert_eq!(
-        i128::saturating_mul(i128::MIN, 10),
-        i128::MIN,
-        "i128",
-    );
-    assert_eq!(
-        i64::saturating_mul(i64::MIN, 10),
-        i64::MIN,
-        "i64",
-    );
-    assert_eq!(
-        i32::saturating_mul(i32::MIN, 10),
-        i32::MIN,
-        "i32",
-    );
-    assert_eq!(
-        i8::saturating_mul(i8::MIN, 10),
-        i8::MIN,
-        "i8",
-    );
+    assert_eq!(i128::saturating_mul(i128::MIN, 10), i128::MIN, "i128",);
+    assert_eq!(i64::saturating_mul(i64::MIN, 10), i64::MIN, "i64",);
+    assert_eq!(i32::saturating_mul(i32::MIN, 10), i32::MIN, "i32",);
+    assert_eq!(i8::saturating_mul(i8::MIN, 10), i8::MIN, "i8",);
 
-    assert_eq!(
-        i128::saturating_mul(2 as i128, 4),
-        8 as i128,
-        "i128",
-    );
-    assert_eq!(
-        i64::saturating_mul(2 as i64, 4),
-        8 as i64,
-        "i64",
-    );
-    assert_eq!(
-        i32::saturating_mul(2 as i32, 4),
-        8 as i32,
-        "i32",
-    );
-    assert_eq!(
-        i8::saturating_mul(2 as i8, 4),
-        8 as i8,
-        "i8",
-    );
+    assert_eq!(i128::saturating_mul(2 as i128, 4), 8 as i128, "i128",);
+    assert_eq!(i64::saturating_mul(2 as i64, 4), 8 as i64, "i64",);
+    assert_eq!(i32::saturating_mul(2 as i32, 4), 8 as i32, "i32",);
+    assert_eq!(i8::saturating_mul(2 as i8, 4), 8 as i8, "i8",);
 }

--- a/library/coretests/tests/ferrocene/slice.rs
+++ b/library/coretests/tests/ferrocene/slice.rs
@@ -305,3 +305,17 @@ fn slice_split_first_chunk() {
     assert_eq!(slice.split_first_chunk::<3>(), Some((&[1, 2, 3], [4, 5].as_slice())));
     assert_eq!(slice.split_first_chunk::<10>(), None);
 }
+
+// covers `core::slice::ascii::<impl [u8]>::eq_ignore_ascii_case_chunks`
+#[test]
+fn test_eq_ignore_ascii_case_chunks() {
+    // Two equal sized (16 chunked) values with an inequality at the end.
+    let x = b"absentmindednessabsentmindednessabsentmindednessabsentmindedness";
+    let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNES0";
+    assert!(!x.eq_ignore_ascii_case(y));
+
+    // Two inequal sized (16 chunked) values with an inequality at the end.
+    let x = b"absentmindednessabsentmindednessabsentmindednessabsentmindedness00";
+    let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESS01";
+    assert!(!x.eq_ignore_ascii_case(y));
+}

--- a/library/coretests/tests/ferrocene/slice.rs
+++ b/library/coretests/tests/ferrocene/slice.rs
@@ -319,7 +319,7 @@ fn test_eq_ignore_ascii_case_chunks() {
     let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESS";
     assert!(x.eq_ignore_ascii_case(y));
 
-    // Two inequal sized (16 chunked) values with an inequality at the end.
+    // Two equal sized (16 chunked) values with an inequality at the end.
     let x = b"absentmindednessabsentmindednessabsentmindednessabsentmindedness00";
     let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESS01";
     assert!(!x.eq_ignore_ascii_case(y));

--- a/library/coretests/tests/ferrocene/slice.rs
+++ b/library/coretests/tests/ferrocene/slice.rs
@@ -314,6 +314,11 @@ fn test_eq_ignore_ascii_case_chunks() {
     let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNES0";
     assert!(!x.eq_ignore_ascii_case(y));
 
+    // Two equal sized (16 chunked) values that are equal.
+    let x = b"absentmindednessabsentmindednessabsentmindednessabsentmindedness";
+    let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESS";
+    assert!(x.eq_ignore_ascii_case(y));
+
     // Two inequal sized (16 chunked) values with an inequality at the end.
     let x = b"absentmindednessabsentmindednessabsentmindednessabsentmindedness00";
     let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESS01";

--- a/library/coretests/tests/ferrocene/slice.rs
+++ b/library/coretests/tests/ferrocene/slice.rs
@@ -334,7 +334,7 @@ fn test_eq_ignore_ascii_case_chunks() {
     let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESS";
     assert!(x.eq_ignore_ascii_case(y));
 
-    // Two inequal sized (16 chunked) values with an inequality at the end.
+    // Two equal sized (16 chunked) values with an inequality at the end.
     let x = b"absentmindednessabsentmindednessabsentmindednessabsentmindedness00";
     let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESS01";
     assert!(!x.eq_ignore_ascii_case(y));

--- a/library/coretests/tests/ferrocene/slice.rs
+++ b/library/coretests/tests/ferrocene/slice.rs
@@ -320,3 +320,17 @@ fn slice_split_first_chunk() {
     assert_eq!(slice.split_first_chunk::<3>(), Some((&[1, 2, 3], [4, 5].as_slice())));
     assert_eq!(slice.split_first_chunk::<10>(), None);
 }
+
+// covers `core::slice::ascii::<impl [u8]>::eq_ignore_ascii_case_chunks`
+#[test]
+fn test_eq_ignore_ascii_case_chunks() {
+    // Two equal sized (16 chunked) values with an inequality at the end.
+    let x = b"absentmindednessabsentmindednessabsentmindednessabsentmindedness";
+    let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNES0";
+    assert!(!x.eq_ignore_ascii_case(y));
+
+    // Two inequal sized (16 chunked) values with an inequality at the end.
+    let x = b"absentmindednessabsentmindednessabsentmindednessabsentmindedness00";
+    let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESS01";
+    assert!(!x.eq_ignore_ascii_case(y));
+}

--- a/library/coretests/tests/ferrocene/slice.rs
+++ b/library/coretests/tests/ferrocene/slice.rs
@@ -329,6 +329,11 @@ fn test_eq_ignore_ascii_case_chunks() {
     let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNES0";
     assert!(!x.eq_ignore_ascii_case(y));
 
+    // Two equal sized (16 chunked) values that are equal.
+    let x = b"absentmindednessabsentmindednessabsentmindednessabsentmindedness";
+    let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESS";
+    assert!(x.eq_ignore_ascii_case(y));
+
     // Two inequal sized (16 chunked) values with an inequality at the end.
     let x = b"absentmindednessabsentmindednessabsentmindednessabsentmindedness00";
     let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESS01";

--- a/library/coretests/tests/ferrocene/str.rs
+++ b/library/coretests/tests/ferrocene/str.rs
@@ -195,6 +195,11 @@ fn test_utf8_chunks_next() {
     let mut chunks = replacement_character.utf8_chunks();
     assert_eq!("�", chunks.next().unwrap().valid());
     assert!(chunks.next().is_none());
+
+    let two_width_chars = "§ɮʃ ͒ʦ";
+    for two_width_char in two_width_chars.as_bytes().utf8_chunks() {
+        println!("{two_width_char:?}");
+    }
 }
 
 // covers:


### PR DESCRIPTION
#2336 fixed a number of bugs in the `#[ferrocene::prevalidated]` lint, this handles coverage coming from those changes.