### PR TITLE
[1.95] prevalidated fix backport

### DIFF
--- a/compiler/rustc_lint/src/ferrocene/diagnostics.rs
+++ b/compiler/rustc_lint/src/ferrocene/diagnostics.rs
@@ -4,7 +4,6 @@
 use rustc_errors::{Diag, MultiSpan};
 use rustc_hir::def_id::DefId;
 use rustc_hir::{HirId, LangItem};
-use rustc_middle::ty::TraitRef;
 use rustc_span::{STDLIB_STABLE_CRATES, Span};
 use tracing::debug;
 

--- a/compiler/rustc_lint/src/ferrocene/diagnostics.rs
+++ b/compiler/rustc_lint/src/ferrocene/diagnostics.rs
@@ -92,12 +92,8 @@ impl<'tcx> LintState<'tcx> {
                         tcx.def_path_str(assoc_fn)
                     ));
                 }
-                UnvalidatedImplCause::UnresolvedGenericImpl(span, trait_ref) => {
-                    diag.span_note(
-                        span,
-                        format!("Ferrocene does not know if `{trait_ref}` is validated"),
-                    );
-                    diag.note("as a precaution, it must assume it is unvalidated");
+                UnvalidatedImplCause::UnresolvedGenericImpl(..) => {
+                    unreachable!("all generics should be resolved by post-mono")
                 }
             }
         }

--- a/compiler/rustc_lint/src/ferrocene/diagnostics.rs
+++ b/compiler/rustc_lint/src/ferrocene/diagnostics.rs
@@ -4,11 +4,12 @@
 use rustc_errors::{Diag, MultiSpan};
 use rustc_hir::def_id::DefId;
 use rustc_hir::{HirId, LangItem};
+use rustc_middle::ty::TraitRef;
 use rustc_span::{STDLIB_STABLE_CRATES, Span};
 use tracing::debug;
 
 use crate::ferrocene::post_mono::InstantiationSite;
-use crate::ferrocene::{LintState, UNVALIDATED, Use, UseKind};
+use crate::ferrocene::{LintState, UNVALIDATED, UnvalidatedImplCause, Use, UseKind};
 
 /// Diagnostics.
 impl<'tcx> LintState<'tcx> {
@@ -83,12 +84,23 @@ impl<'tcx> LintState<'tcx> {
         if matches!(use_.kind, UseKind::FnPtrCast(..)) {
             diag.note("once a function is cast to a function pointer, Ferrocene can no longer tell whether it is validated");
             diag.note("as a precaution, it must assume you will eventually call the function");
-        } else if let UseKind::TraitObjectCast(assoc_fn, ty) = use_.kind {
+        } else if let UseKind::TraitObjectCast(cause, ty) = use_.kind {
             diag.note(format!("once `{ty}` is cast to a dynamic trait object, Ferrocene can no longer tell whether it is validated"));
-            diag.note(format!(
-                "as a precaution, it must assume you will eventually call `{}`",
-                tcx.def_path_str(assoc_fn)
-            ));
+            match cause {
+                UnvalidatedImplCause::AssocFn(assoc_fn) => {
+                    diag.note(format!(
+                        "as a precaution, it must assume you will eventually call `{}`",
+                        tcx.def_path_str(assoc_fn)
+                    ));
+                }
+                UnvalidatedImplCause::UnresolvedGenericImpl(span, trait_ref) => {
+                    diag.span_note(
+                        span,
+                        format!("Ferrocene does not know if `{trait_ref}` is validated"),
+                    );
+                    diag.note("as a precaution, it must assume it is unvalidated");
+                }
+            }
         }
     }
 

--- a/compiler/rustc_lint/src/ferrocene/dynamic_casts.rs
+++ b/compiler/rustc_lint/src/ferrocene/dynamic_casts.rs
@@ -10,12 +10,12 @@ use rustc_middle::middle::codegen_fn_attrs::ferrocene::item_is_validated;
 use rustc_middle::span_bug;
 use rustc_middle::ty::adjustment::CustomCoerceUnsized;
 use rustc_middle::ty::{
-    self, ExistentialPredicate, GenericArgsRef, Instance, PolyTraitRef, Predicate, Ty, TyCtxt,
+    self, ExistentialPredicate, GenericArgsRef, Instance, PolyTraitRef, Ty, TyCtxt,
     TypeSuperVisitable as _, TypeVisitable as _, TypingEnv,
 };
 use rustc_span::{DUMMY_SP, Span};
 use rustc_trait_selection::traits::{ObligationCtxt, SelectionContext, supertraits};
-use tracing::debug;
+use tracing::{debug, instrument};
 
 use super::UnvalidatedImplCause;
 use crate::ferrocene::{InstantiateResult, LintState, UseKind};
@@ -76,6 +76,7 @@ impl<'tcx> LintState<'tcx> {
     /// 4. For each method in the impl, check whether it's validated. For example, we would check
     ///    `<String as Diplay>::fmt`, see that it's unvalidated, and return its `DefId` in the
     ///    `UseKind`.
+    #[instrument(skip(self, try_instantiate, span), ret)]
     pub(super) fn check_dyn_trait_coercion(
         &self,
         dest_ty: Ty<'tcx>,
@@ -126,14 +127,22 @@ impl<'tcx> LintState<'tcx> {
             };
             let impl_ = self.find_trait_impl(trait_ref, typing_env, span);
 
-            let use_kind = match impl_ {
+            match impl_ {
                 ImplSource::UserDefined(ImplSourceUserDefinedData {
                     impl_def_id,
                     args: _,
                     nested: _,
-                }) => self.find_unvalidated_impl_fn(impl_def_id, span, coerce_src),
+                }) => {
+                    // This function in the impl needs to be marked with `prevalidated`.
+                    if let Some(impl_fn) = self.find_unvalidated_impl_fn(impl_def_id) {
+                        return Some(UseKind::TraitObjectCast(
+                            UnvalidatedImplCause::AssocFn(impl_fn),
+                            coerce_src,
+                        ));
+                    }
+                }
                 // builtin impls are always ok
-                ImplSource::Builtin(..) => return None,
+                ImplSource::Builtin(..) => continue,
                 ImplSource::Param(obligations) => {
                     // This is something like the following:
                     // ```
@@ -152,10 +161,6 @@ impl<'tcx> LintState<'tcx> {
                         coerce_src,
                     ));
                 }
-            };
-
-            if use_kind.is_some() {
-                return use_kind;
             }
         }
         None
@@ -318,7 +323,7 @@ impl<'tcx> LintState<'tcx> {
                 }
                 _ => span_bug!(
                     span,
-                    "mismatched types trying to coerce from {src_inner:?} to {dst_inner:?}"
+                    "mismatched types trying to coerce from {src_ty:?} to {dst_ty:?}"
                 ),
             }
         }
@@ -352,12 +357,7 @@ impl<'tcx> LintState<'tcx> {
     /// Given an `impl`, find the first associated function that isn't validated.
     ///
     /// FIXME: list all unvalidated functions, not just the first.
-    fn find_unvalidated_impl_fn(
-        &self,
-        impl_block: DefId,
-        span: Span,
-        coerce_src: Ty<'tcx>,
-    ) -> Option<UseKind<'tcx>> {
+    fn find_unvalidated_impl_fn(&self, impl_block: DefId) -> Option<DefId> {
         let tcx = self.tcx;
 
         let trait_to_impl_map = tcx.impl_item_implementor_ids(impl_block);
@@ -378,10 +378,7 @@ impl<'tcx> LintState<'tcx> {
 
             debug!("found unvalidated method {impl_fn:?}");
             // This function in the impl needs to be marked with `prevalidated`.
-            return Some(UseKind::TraitObjectCast(
-                UnvalidatedImplCause::AssocFn(impl_fn),
-                coerce_src,
-            ));
+            return Some(impl_fn);
         }
         return None;
     }

--- a/compiler/rustc_lint/src/ferrocene/dynamic_casts.rs
+++ b/compiler/rustc_lint/src/ferrocene/dynamic_casts.rs
@@ -4,20 +4,23 @@ use rustc_abi::{FieldIdx, VariantIdx};
 use rustc_hir::LangItem;
 use rustc_hir::def_id::DefId;
 use rustc_infer::traits::{
-    ImplSource, ImplSourceUserDefinedData, Obligation, ObligationCause, ObligationCauseCode,
+    ImplSourceUserDefinedData, Obligation, ObligationCause, ObligationCauseCode,
 };
 use rustc_middle::middle::codegen_fn_attrs::ferrocene::item_is_validated;
 use rustc_middle::span_bug;
 use rustc_middle::ty::adjustment::CustomCoerceUnsized;
 use rustc_middle::ty::{
-    self, ExistentialPredicate, GenericArgsRef, Instance, PolyTraitRef, Ty, TyCtxt,
+    self, ExistentialPredicate, GenericArgsRef, Instance, PolyTraitRef, Predicate, Ty, TyCtxt,
     TypeSuperVisitable as _, TypeVisitable as _, TypingEnv,
 };
-use rustc_span::Span;
+use rustc_span::{DUMMY_SP, Span};
 use rustc_trait_selection::traits::{ObligationCtxt, SelectionContext, supertraits};
 use tracing::debug;
 
+use super::UnvalidatedImplCause;
 use crate::ferrocene::{InstantiateResult, LintState, UseKind};
+
+type ImplSource<'tcx> = rustc_infer::traits::ImplSource<'tcx, Span>;
 
 impl<'tcx> LintState<'tcx> {
     pub(super) fn check_fn_ptr_coercion(
@@ -122,8 +125,37 @@ impl<'tcx> LintState<'tcx> {
                 continue;
             };
             let impl_ = self.find_trait_impl(trait_ref, typing_env, span);
-            if let Some(unvalidated) = self.find_unvalidated_impl_fn(impl_, span) {
-                return Some(UseKind::TraitObjectCast(unvalidated, coerce_src));
+
+            let use_kind = match impl_ {
+                ImplSource::UserDefined(ImplSourceUserDefinedData {
+                    impl_def_id,
+                    args: _,
+                    nested: _,
+                }) => self.find_unvalidated_impl_fn(impl_def_id, span, coerce_src),
+                // builtin impls are always ok
+                ImplSource::Builtin(..) => return None,
+                ImplSource::Param(obligations) => {
+                    // This is something like the following:
+                    // ```
+                    // fn foo<T: Display + 'static>(x: T) -> Box<dyn Display> {
+                    //     Box::new(x)
+                    // }
+                    // ```
+                    // We can't resolve `x.fmt` until post-mono, so we can't point to the reason
+                    // the cast is disallowed.
+
+                    // NOTE: this can give an empty list of obligations in weird cases like
+                    // `core::mem::DiscriminantKind`, which is automatically implemented for any Sized type.
+                    let span = obligations.first().copied().unwrap_or(DUMMY_SP);
+                    return Some(UseKind::TraitObjectCast(
+                        UnvalidatedImplCause::UnresolvedGenericImpl(span, trait_ref),
+                        coerce_src,
+                    ));
+                }
+            };
+
+            if use_kind.is_some() {
+                return use_kind;
             }
         }
         None
@@ -309,9 +341,10 @@ impl<'tcx> LintState<'tcx> {
         match tcx.codegen_select_candidate(
             ty::TypingEnv::fully_monomorphized().as_query_input(trait_ref),
         ) {
-            Ok(ImplSource::UserDefined(ImplSourceUserDefinedData { impl_def_id, .. })) => {
-                Some(tcx.coerce_unsized_info(*impl_def_id).unwrap().custom_kind.unwrap())
-            }
+            Ok(rustc_infer::traits::ImplSource::UserDefined(ImplSourceUserDefinedData {
+                impl_def_id,
+                ..
+            })) => Some(tcx.coerce_unsized_info(*impl_def_id).unwrap().custom_kind.unwrap()),
             _ => None,
         }
     }
@@ -321,23 +354,11 @@ impl<'tcx> LintState<'tcx> {
     /// FIXME: list all unvalidated functions, not just the first.
     fn find_unvalidated_impl_fn(
         &self,
-        impl_source: ImplSource<'tcx, ()>,
+        impl_block: DefId,
         span: Span,
-    ) -> Option<DefId> {
+        coerce_src: Ty<'tcx>,
+    ) -> Option<UseKind<'tcx>> {
         let tcx = self.tcx;
-
-        let impl_block = match impl_source {
-            ImplSource::UserDefined(ImplSourceUserDefinedData {
-                impl_def_id,
-                args: _,
-                nested: _,
-            }) => impl_def_id,
-            // builtin impls are always ok
-            ImplSource::Builtin(..) => return None,
-            param @ ImplSource::Param(_) => {
-                span_bug!(span, "don't know how to handle nested obligations in {param:?}")
-            }
-        };
 
         let trait_to_impl_map = tcx.impl_item_implementor_ids(impl_block);
         for trait_item in tcx.associated_item_def_ids(tcx.impl_trait_id(impl_block)) {
@@ -357,7 +378,10 @@ impl<'tcx> LintState<'tcx> {
 
             debug!("found unvalidated method {impl_fn:?}");
             // This function in the impl needs to be marked with `prevalidated`.
-            return Some(impl_fn);
+            return Some(UseKind::TraitObjectCast(
+                UnvalidatedImplCause::AssocFn(impl_fn),
+                coerce_src,
+            ));
         }
         return None;
     }
@@ -367,7 +391,7 @@ impl<'tcx> LintState<'tcx> {
         trait_ref: PolyTraitRef<'tcx>,
         typing_env: TypingEnv<'tcx>,
         span: Span,
-    ) -> ImplSource<'tcx, ()> {
+    ) -> ImplSource<'tcx> {
         match self.try_find_trait_impl(trait_ref, typing_env, span) {
             Some(found) => found,
             None => span_bug!(span, "failed to resolve impl: {trait_ref:?}"),
@@ -389,7 +413,7 @@ impl<'tcx> LintState<'tcx> {
         trait_ref: PolyTraitRef<'tcx>,
         typing_env: TypingEnv<'tcx>,
         span: Span,
-    ) -> Option<ImplSource<'tcx, ()>> {
+    ) -> Option<ImplSource<'tcx>> {
         use rustc_infer::infer::TyCtxtInferExt;
 
         let tcx = self.tcx;
@@ -418,7 +442,9 @@ impl<'tcx> LintState<'tcx> {
         let ocx = ObligationCtxt::new(&infcx);
         let impl_source = selection.map(|o| {
             debug!("registering obligation {o:?}");
-            ocx.register_obligation(o)
+            let span = o.cause.span;
+            ocx.register_obligation(o);
+            span
         });
         let errors = ocx.evaluate_obligations_error_on_ambiguity();
         if !errors.is_empty() {

--- a/compiler/rustc_lint/src/ferrocene/dynamic_casts.rs
+++ b/compiler/rustc_lint/src/ferrocene/dynamic_casts.rs
@@ -13,7 +13,7 @@ use rustc_middle::ty::{
     self, ExistentialPredicate, GenericArgsRef, Instance, PolyTraitRef, Ty, TyCtxt,
     TypeSuperVisitable as _, TypeVisitable as _, TypingEnv,
 };
-use rustc_span::{DUMMY_SP, Span};
+use rustc_span::Span;
 use rustc_trait_selection::traits::{ObligationCtxt, SelectionContext, supertraits};
 use tracing::{debug, instrument};
 
@@ -143,7 +143,7 @@ impl<'tcx> LintState<'tcx> {
                 }
                 // builtin impls are always ok
                 ImplSource::Builtin(..) => continue,
-                ImplSource::Param(obligations) => {
+                ImplSource::Param(_obligations) => {
                     // This is something like the following:
                     // ```
                     // fn foo<T: Display + 'static>(x: T) -> Box<dyn Display> {
@@ -155,9 +155,8 @@ impl<'tcx> LintState<'tcx> {
 
                     // NOTE: this can give an empty list of obligations in weird cases like
                     // `core::mem::DiscriminantKind`, which is automatically implemented for any Sized type.
-                    let span = obligations.first().copied().unwrap_or(DUMMY_SP);
                     return Some(UseKind::TraitObjectCast(
-                        UnvalidatedImplCause::UnresolvedGenericImpl(span, trait_ref),
+                        UnvalidatedImplCause::UnresolvedGenericImpl(trait_ref),
                         coerce_src,
                     ));
                 }

--- a/compiler/rustc_lint/src/ferrocene/mod.rs
+++ b/compiler/rustc_lint/src/ferrocene/mod.rs
@@ -182,8 +182,8 @@ use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::def::DefKind;
 use rustc_hir::{HirId, Item};
 use rustc_middle::middle::codegen_fn_attrs::ferrocene::{ValidatedStatus, item_is_validated};
-use rustc_middle::span_bug;
-use rustc_middle::ty::{Instance, Ty, TyCtxt};
+use rustc_middle::ty::{Instance, TraitRef, Ty, TyCtxt};
+use rustc_middle::{bug, span_bug};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::Span;
 use rustc_span::def_id::{DefId, LocalDefId};
@@ -311,10 +311,18 @@ struct Use<'tcx> {
 }
 
 #[derive(Copy, Clone, Debug)]
+enum UnvalidatedImplCause<'tcx> {
+    AssocFn(DefId),
+    UnresolvedGenericImpl(Span, rustc_middle::ty::PolyTraitRef<'tcx>),
+    // UnresolvedGenericImpl(Span, TraitRef<'tcx>),
+    // UnresolvedGenericImpl(Span, DefId),
+}
+
+#[derive(Copy, Clone, Debug)]
 enum UseKind<'tcx> {
     Called(Instance<'tcx>),
     FnPtrCast(Instance<'tcx>),
-    TraitObjectCast(DefId, Ty<'tcx>),
+    TraitObjectCast(UnvalidatedImplCause<'tcx>, Ty<'tcx>),
     /// Only occurs for consts and statics.
     ContainsFnPtr(DefId, Ty<'tcx>),
 }
@@ -324,7 +332,11 @@ impl<'tcx> Use<'tcx> {
         match self.kind {
             UseKind::Called(instance) | UseKind::FnPtrCast(instance) => instance.def_id(),
             UseKind::ContainsFnPtr(id, _) => id,
-            UseKind::TraitObjectCast(assoc_fn, _) => assoc_fn,
+            UseKind::TraitObjectCast(UnvalidatedImplCause::AssocFn(id), _) => id,
+            UseKind::TraitObjectCast(
+                UnvalidatedImplCause::UnresolvedGenericImpl(_, trait_ref),
+                _,
+            ) => trait_ref.def_id(),
         }
     }
 

--- a/compiler/rustc_lint/src/ferrocene/mod.rs
+++ b/compiler/rustc_lint/src/ferrocene/mod.rs
@@ -205,6 +205,14 @@ impl<'tcx> LateLintPass<'tcx> for LintUnvalidated {
     fn check_item_post(&mut self, cx: &LateContext<'tcx>, item: &Item<'tcx>) {
         LintThir::check_item(cx.tcx, item.owner_id, item.owner_id.def_id);
     }
+
+    fn check_impl_item_post(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        item: &'tcx rustc_hir::ImplItem<'tcx>,
+    ) {
+        LintThir::check_item(cx.tcx, item.owner_id, item.owner_id.def_id);
+    }
 }
 
 struct LintState<'tcx> {

--- a/compiler/rustc_lint/src/ferrocene/mod.rs
+++ b/compiler/rustc_lint/src/ferrocene/mod.rs
@@ -182,8 +182,8 @@ use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::def::DefKind;
 use rustc_hir::{HirId, Item};
 use rustc_middle::middle::codegen_fn_attrs::ferrocene::{ValidatedStatus, item_is_validated};
-use rustc_middle::ty::{Instance, TraitRef, Ty, TyCtxt};
-use rustc_middle::{bug, span_bug};
+use rustc_middle::span_bug;
+use rustc_middle::ty::{Instance, Ty, TyCtxt};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::Span;
 use rustc_span::def_id::{DefId, LocalDefId};
@@ -312,16 +312,19 @@ struct Use<'tcx> {
 
 #[derive(Copy, Clone, Debug)]
 enum UnvalidatedImplCause<'tcx> {
+    /// A associated function from the source type's impl of one of the traits we were casting to.
+    ///
+    /// FIXME: this should have all unvalidated items in the impl, not just the first.
     AssocFn(DefId),
+    /// Only occurs pre-mono.
     UnresolvedGenericImpl(Span, rustc_middle::ty::PolyTraitRef<'tcx>),
-    // UnresolvedGenericImpl(Span, TraitRef<'tcx>),
-    // UnresolvedGenericImpl(Span, DefId),
 }
 
 #[derive(Copy, Clone, Debug)]
 enum UseKind<'tcx> {
     Called(Instance<'tcx>),
     FnPtrCast(Instance<'tcx>),
+    /// The `Ty` is the source type of the cast. We don't currently store the destination type.
     TraitObjectCast(UnvalidatedImplCause<'tcx>, Ty<'tcx>),
     /// Only occurs for consts and statics.
     ContainsFnPtr(DefId, Ty<'tcx>),

--- a/compiler/rustc_lint/src/ferrocene/mod.rs
+++ b/compiler/rustc_lint/src/ferrocene/mod.rs
@@ -314,7 +314,7 @@ struct Use<'tcx> {
 enum UnvalidatedImplCause<'tcx> {
     /// An associated function from the source type's impl of one of the traits we were casting to.
     ///
-    /// FIXME: this should have all unvalidated items in the impl, not just the first.
+    /// FIXME(diagnostics): this should have all unvalidated items in the impl, not just the first.
     AssocFn(DefId),
     /// Only occurs pre-mono.
     UnresolvedGenericImpl(rustc_middle::ty::PolyTraitRef<'tcx>),

--- a/compiler/rustc_lint/src/ferrocene/mod.rs
+++ b/compiler/rustc_lint/src/ferrocene/mod.rs
@@ -312,12 +312,12 @@ struct Use<'tcx> {
 
 #[derive(Copy, Clone, Debug)]
 enum UnvalidatedImplCause<'tcx> {
-    /// A associated function from the source type's impl of one of the traits we were casting to.
+    /// An associated function from the source type's impl of one of the traits we were casting to.
     ///
     /// FIXME: this should have all unvalidated items in the impl, not just the first.
     AssocFn(DefId),
     /// Only occurs pre-mono.
-    UnresolvedGenericImpl(Span, rustc_middle::ty::PolyTraitRef<'tcx>),
+    UnresolvedGenericImpl(rustc_middle::ty::PolyTraitRef<'tcx>),
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -336,10 +336,9 @@ impl<'tcx> Use<'tcx> {
             UseKind::Called(instance) | UseKind::FnPtrCast(instance) => instance.def_id(),
             UseKind::ContainsFnPtr(id, _) => id,
             UseKind::TraitObjectCast(UnvalidatedImplCause::AssocFn(id), _) => id,
-            UseKind::TraitObjectCast(
-                UnvalidatedImplCause::UnresolvedGenericImpl(_, trait_ref),
-                _,
-            ) => trait_ref.def_id(),
+            UseKind::TraitObjectCast(UnvalidatedImplCause::UnresolvedGenericImpl(trait_ref), _) => {
+                trait_ref.def_id()
+            }
         }
     }
 

--- a/compiler/rustc_lint/src/ferrocene/post_mono.rs
+++ b/compiler/rustc_lint/src/ferrocene/post_mono.rs
@@ -35,7 +35,7 @@ use rustc_middle::ty::{
 use rustc_span::Span;
 use tracing::{debug, info, trace};
 
-use crate::ferrocene::{LintState, Use, UseKind};
+use crate::ferrocene::{InstantiateResult, LintState, UnvalidatedImplCause, Use, UseKind};
 
 struct LintPostMono<'a, 'tcx> {
     /// The function we are currently traversing.
@@ -131,40 +131,66 @@ impl<'a, 'tcx> mir::visit::Visitor<'tcx> for LintPostMono<'a, 'tcx> {
     }
 
     fn visit_rvalue(&mut self, rval: &Rvalue<'tcx>, location: Location) {
-        let Rvalue::Cast(
-            CastKind::PointerCoercion(PointerCoercion::ReifyFnPointer(_), _),
-            operand,
-            _fn_ptr_ty,
-        ) = rval
-        else {
-            return;
-        };
-        let call_span = operand.span(self.body);
-
-        let Some((pre_mono_callee, generic_args)) = operand.const_fn_def() else {
-            span_bug!(
-                call_span,
-                "don't know how to handle ReifyFnPointer cast of non-constant fn {operand:?}"
-            );
-        };
-
-        let callee_instance = self.monomorphize_instance(pre_mono_callee, generic_args, call_span);
-        // FIXME: want to also check this in THIR pass
-        let use_ = self.use_(UseKind::FnPtrCast(callee_instance), call_span);
+        let Some((call_span, use_kind)) = self.find_dynamic_cast(rval) else { return };
         let source_info = self.body.source_info(location);
-        self.on_edge(use_, source_info, pre_mono_callee);
+        let use_ = self.use_(use_kind, call_span);
+        self.on_edge(use_, source_info, use_.def_id());
     }
 }
 
 impl<'a, 'tcx> LintPostMono<'a, 'tcx> {
+    fn find_dynamic_cast(&self, rval: &Rvalue<'tcx>) -> Option<(Span, UseKind<'tcx>)> {
+        let tcx = self.linter.tcx;
+        match rval {
+            Rvalue::Cast(
+                CastKind::PointerCoercion(PointerCoercion::ReifyFnPointer(_), _),
+                operand,
+                _fn_ptr_ty,
+            ) => {
+                let call_span = operand.span(self.body);
+                let Some((pre_mono_callee, generic_args)) = operand.const_fn_def() else {
+                    span_bug!(
+                        call_span,
+                        "don't know how to handle ReifyFnPointer cast of non-constant fn {operand:?}"
+                    );
+                };
+
+                let callee_instance =
+                    self.monomorphize_instance(pre_mono_callee, generic_args, call_span);
+                // FIXME: want to also check this in THIR pass
+                Some((call_span, UseKind::FnPtrCast(callee_instance)))
+            }
+            Rvalue::Cast(
+                CastKind::PointerCoercion(PointerCoercion::Unsize, _),
+                operand,
+                dest_ty,
+            ) => {
+                let (source_ty, typing_env) = self.monomorphize_args(operand.ty(self.body, tcx));
+                let (dest_ty, _) = self.monomorphize_args(*dest_ty);
+                let call_span = operand.span(self.body);
+
+                let mut try_instantiate = |def_id, args| {
+                    InstantiateResult::Resolved(self.monomorphize_instance(def_id, args, call_span))
+                };
+
+                let use_kind = self.linter.check_dyn_trait_coercion(
+                    dest_ty,
+                    source_ty,
+                    typing_env,
+                    &mut try_instantiate,
+                    call_span,
+                )?;
+                Some((call_span, use_kind))
+            }
+            _ => None,
+        }
+    }
+
     fn use_(&self, kind: UseKind<'tcx>, span: Span) -> Use<'tcx> {
         Use { kind, span, from_instantiation: self.from_instantiation }
     }
 
     fn on_edge(&mut self, use_: Use<'tcx>, source_info: &SourceInfo, pre_mono_callee: DefId) {
-        let callee_instance = use_.expect_instance();
-
-        // Recurse into the instantiated call. Keep the call span for diagnostics.
         // Try to update the lint node if possible, but use the lint node of the caller if the
         // callee is cross-crate.
         // FIXME: we have enough info here to show a backtrace of how the function was instantiated,
@@ -184,26 +210,59 @@ impl<'a, 'tcx> LintPostMono<'a, 'tcx> {
             },
         };
 
+        // Lint this use.
         self.linter.check_use(lint_node, use_);
 
-        let site =
-            if Some(self.instance.def_id()) == self.linter.tcx.lang_items().drop_in_place_fn() {
-                // We want to show a better span; drop_in_place is never interesting since the body is
-                // synthesized by a MIR shim anyway.
-                // Note that we saw it, though, so diagnostics can say "dropped here".
-                InstantiationSite {
-                    drop_fn: Some(callee_instance.def_id()),
-                    ..self.from_instantiation.unwrap()
-                }
-            } else {
-                InstantiationSite {
-                    drop_fn: None,
-                    lint_node,
-                    caller_instance: self.instance,
-                    caller_span: use_.span,
-                    pre_mono_callee,
-                }
-            };
+        // Recurse into the instantiated call.
+        let callee_instance = match use_.kind {
+            UseKind::TraitObjectCast(
+                UnvalidatedImplCause::UnresolvedGenericImpl(_, trait_ref),
+                source_ty,
+            ) => span_bug!(
+                use_.span,
+                "failed to resolve generic parameters in cast from {source_ty:?} -> {trait_ref:?}",
+            ),
+            // This can happen if we see a function like the following:
+            // ```rust
+            // fn foo<T, I: Iterator<Item = T> + 'static>(x: I) -> Box<dyn Iterator<Item = T>> {
+            //     Box::new(x)
+            // }
+            //
+            // fn main() {
+            //     let v = foo(std::iter::once(1)).collect::<Vec<_>>();
+            // }
+            // ```
+            // Here, we will notice a TraitObjectCast when we cast `x` to `dyn Iterator`,
+            // getting back a DefId for `<iter::Once as Iterator>::collect` or something like that.
+            // But we are not guaranteed that `collect` is fully monomorphized, because we can
+            // still choose its generic parameters at the call site; we won't know until we check
+            // `main`.
+            //
+            // Therefore we don't have an instance and can't check its body.
+            UseKind::TraitObjectCast(UnvalidatedImplCause::AssocFn(_), _) => return,
+            // In any other case we should have fully monomorphized the function.
+            _ => use_.opt_instance().unwrap_or_else(|| {
+                span_bug!(use_.span, "called expect_instance on a THIR-only lint kind")
+            }),
+        };
+
+        // Keep the call span for diagnostics.
+        let site = if Some(self.instance.def_id())
+            == self.linter.tcx.lang_items().drop_in_place_fn()
+        {
+            // We want to show a better span; drop_in_place is never interesting since the body is
+            // synthesized by a MIR shim anyway.
+            // Note that we saw it, though, so diagnostics can say "dropped here".
+            InstantiationSite { drop_fn: Some(use_.def_id()), ..self.from_instantiation.unwrap() }
+        } else {
+            InstantiationSite {
+                drop_fn: None,
+                lint_node,
+                caller_instance: self.instance,
+                caller_span: use_.span,
+                pre_mono_callee,
+            }
+        };
 
         if self.roots.contains(&MonoItem::Fn(callee_instance)) {
             info!("don't need to recurse into {callee_instance:?}, we'll lint it separately");
@@ -382,14 +441,5 @@ impl<'a, 'tcx> LintPostMono<'a, 'tcx> {
             EarlyBinder::bind(generic_args),
         );
         (args, env)
-    }
-}
-
-impl<'tcx> Use<'tcx> {
-    #[track_caller]
-    fn expect_instance(self) -> Instance<'tcx> {
-        self.opt_instance().unwrap_or_else(|| {
-            span_bug!(self.span, "called expect_instance on a THIR-only lint kind")
-        })
     }
 }

--- a/compiler/rustc_lint/src/ferrocene/post_mono.rs
+++ b/compiler/rustc_lint/src/ferrocene/post_mono.rs
@@ -216,7 +216,7 @@ impl<'a, 'tcx> LintPostMono<'a, 'tcx> {
         // Recurse into the instantiated call.
         let callee_instance = match use_.kind {
             UseKind::TraitObjectCast(
-                UnvalidatedImplCause::UnresolvedGenericImpl(_, trait_ref),
+                UnvalidatedImplCause::UnresolvedGenericImpl(trait_ref),
                 source_ty,
             ) => span_bug!(
                 use_.span,

--- a/compiler/rustc_lint/src/ferrocene/post_mono.rs
+++ b/compiler/rustc_lint/src/ferrocene/post_mono.rs
@@ -25,7 +25,7 @@ use rustc_hir::{CRATE_HIR_ID, HirId};
 use rustc_middle::mir::mono::MonoItem;
 use rustc_middle::mir::visit::Visitor as _;
 use rustc_middle::mir::{
-    self, Body, CastKind, ClearCrossCrate, Location, Rvalue, SourceInfo, Terminator, TerminatorKind,
+    self, Body, CastKind, Location, Rvalue, SourceScope, Terminator, TerminatorKind,
 };
 use rustc_middle::span_bug;
 use rustc_middle::ty::adjustment::PointerCoercion;
@@ -126,15 +126,17 @@ impl<'a, 'tcx> mir::visit::Visitor<'tcx> for LintPostMono<'a, 'tcx> {
         if let Some((callee_instance, pre_mono_call)) = self.get_call_def_mir(terminator, location)
         {
             let use_ = self.use_(UseKind::Called(callee_instance), terminator.source_info.span);
-            self.on_edge(use_, &terminator.source_info, pre_mono_call);
+            self.on_edge(use_, terminator.source_info.scope, pre_mono_call);
         }
+        self.super_terminator(terminator, location);
     }
 
     fn visit_rvalue(&mut self, rval: &Rvalue<'tcx>, location: Location) {
         let Some((call_span, use_kind)) = self.find_dynamic_cast(rval) else { return };
         let source_info = self.body.source_info(location);
         let use_ = self.use_(use_kind, call_span);
-        self.on_edge(use_, source_info, use_.def_id());
+        self.on_edge(use_, source_info.scope, use_.def_id());
+        self.super_rvalue(rval, location);
     }
 }
 
@@ -190,16 +192,14 @@ impl<'a, 'tcx> LintPostMono<'a, 'tcx> {
         Use { kind, span, from_instantiation: self.from_instantiation }
     }
 
-    fn on_edge(&mut self, use_: Use<'tcx>, source_info: &SourceInfo, pre_mono_callee: DefId) {
+    fn lint(&mut self, use_: Use<'tcx>, scope: SourceScope) -> HirId {
         // Try to update the lint node if possible, but use the lint node of the caller if the
         // callee is cross-crate.
         // FIXME: we have enough info here to show a backtrace of how the function was instantiated,
         // maybe pass that in so we can show it?
-        let lint_node = match self.body.source_scopes[source_info.scope].local_data.as_ref() {
-            ClearCrossCrate::Set(data) => data.lint_root,
-            // We assume that all roots come from the current crate.
-            // This is checked earlier in `lint_validated_roots`.
-            ClearCrossCrate::Clear => match self.from_instantiation.as_ref() {
+        let lint_node = match scope.lint_root(&self.body.source_scopes) {
+            Some(node) => node,
+            None => match self.from_instantiation.as_ref() {
                 // This is a bit odd - we use the HIR id of the caller function,
                 // not the callee that actually caused the error.
                 // The callee is in another crate so we don't have any choice here.
@@ -212,6 +212,12 @@ impl<'a, 'tcx> LintPostMono<'a, 'tcx> {
 
         // Lint this use.
         self.linter.check_use(lint_node, use_);
+
+        lint_node
+    }
+
+    fn on_edge(&mut self, use_: Use<'tcx>, scope: SourceScope, pre_mono_callee: DefId) {
+        let lint_node = self.lint(use_, scope);
 
         // Recurse into the instantiated call.
         let callee_instance = match use_.kind {
@@ -333,9 +339,26 @@ impl<'a, 'tcx> LintPostMono<'a, 'tcx> {
         }
 
         let body = tcx.instance_mir(instance.def);
+        trace!(body = ?body, "visiting body");
         let mut this = LintPostMono { linter, visited, roots, instance, body, from_instantiation };
-        for (bb, data) in mir::traversal::reachable(body) {
+        for (bb, data) in mir::traversal::preorder(body) {
             this.visit_basic_block_data(bb, data);
+        }
+
+        // If the MIR inliner ran, we may not see all original function calls.
+        // Usually these are preserved in the source scopes for each statement,  but if the
+        // inliner has completely deleted every statement in the body we can't rely on that.
+        // Iterate through every source scope we know about just in case.
+        for (scope, scope_data) in body.source_scopes.iter_enumerated() {
+            trace!("saw scope {scope_data:?}");
+            if let Some((instance, span)) = scope_data.inlined {
+                debug!("saw inlined instance {instance:?}");
+                let use_ = this.use_(UseKind::Called(instance), span);
+                // NOTE: we can't use `on_edge` here because it won't properly substitute generic
+                // parameters when it recurses. That's ok: since we're visiting every source scope in
+                // this body, we'll catch all the other inlined calls when we see their `scope_data`.
+                this.lint(use_, scope);
+            }
         }
     }
 

--- a/compiler/rustc_lint/src/ferrocene/thir.rs
+++ b/compiler/rustc_lint/src/ferrocene/thir.rs
@@ -22,7 +22,7 @@ use rustc_middle::ty::{
 use rustc_span::Span;
 use tracing::{debug, info};
 
-use crate::ferrocene::{InstantiateResult, LintState, Use, UseKind};
+use crate::ferrocene::{InstantiateResult, LintState, UnvalidatedImplCause, Use, UseKind};
 
 pub(super) struct LintThir<'thir, 'tcx> {
     thir: &'thir Thir<'tcx>,
@@ -38,6 +38,12 @@ impl<'thir, 'tcx: 'thir> thir::visit::Visitor<'thir, 'tcx> for LintThir<'thir, '
     fn visit_expr(&mut self, expr: &'thir thir::Expr<'tcx>) {
         let use_ = match self.find_unvalidated_use(expr) {
             None => return,
+            // Didn't have all the generic parameters in scope.
+            // This will be caught later by the post-mono pass.
+            Some(Use {
+                kind: UseKind::TraitObjectCast(UnvalidatedImplCause::UnresolvedGenericImpl(..), _),
+                ..
+            }) => return,
             Some(use_) => use_,
         };
         let hir_id = HirId { owner: self.owner, local_id: expr.temp_scope_id };

--- a/compiler/rustc_lint/src/ferrocene/thir.rs
+++ b/compiler/rustc_lint/src/ferrocene/thir.rs
@@ -52,6 +52,8 @@ impl<'thir, 'tcx: 'thir> LintThir<'thir, 'tcx> {
     /// We need a separate `owner` to be able to synthesize `HirId`s from expression IDs.
     /// `item` might not be an owner if it's a closure.
     pub(super) fn check_item(tcx: TyCtxt<'tcx>, owner: OwnerId, item: LocalDefId) -> Option<()> {
+        tracing::trace!("checking {item:?}");
+
         if tcx.sess.opts.test
             && tcx.entry_fn(()).and_then(|(id, _)| id.as_local()) == Some(owner.def_id)
         {
@@ -62,8 +64,11 @@ impl<'thir, 'tcx: 'thir> LintThir<'thir, 'tcx> {
 
         let linter = LintState::new(tcx, item)?;
         // thir_body can return ErrorGuaranteed if this is a const block that failed evaluation.
-        let body = tcx.thir_body(item).ok()?;
-        let thir = &body.0.borrow();
+        let body = tcx.thir_body(item).ok();
+        if body.is_none() {
+            info!("skipping item {item:?} without body");
+        }
+        let thir = &body?.0.borrow();
         let mut visitor = LintThir { linter, thir, owner };
         for expr in &*thir.exprs {
             visitor.visit_expr(expr);

--- a/ferrocene/doc/symbol-report.csv
+++ b/ferrocene/doc/symbol-report.csv
@@ -943,6 +943,7 @@
 <&isize as core::ops::bit::Shr<u8>>::shr
 <&isize as core::ops::bit::Shr<usize>>::shr
 <&mut I as core::iter::traits::double_ended::DoubleEndedIteratorRefSpec>::spec_rfold
+<&mut I as core::iter::traits::double_ended::DoubleEndedIteratorRefSpec>::spec_try_rfold
 <&mut I as core::iter::traits::exact_size::ExactSizeIterator>::is_empty
 <&mut I as core::iter::traits::exact_size::ExactSizeIterator>::len
 <&mut I as core::iter::traits::iterator::Iterator>::advance_by
@@ -951,6 +952,7 @@
 <&mut I as core::iter::traits::iterator::Iterator>::size_hint
 <&mut I as core::iter::traits::iterator::Iterator>::try_fold
 <&mut I as core::iter::traits::iterator::IteratorRefSpec>::spec_fold
+<&mut I as core::iter::traits::iterator::IteratorRefSpec>::spec_try_fold
 <&mut I as core::iter::traits::iterator::IteratorRefSpec>::spec_try_fold
 <&mut T as core::borrow::Borrow<T>>::borrow
 <&mut T as core::borrow::BorrowMut<T>>::borrow_mut
@@ -1620,7 +1622,9 @@
 <core::intrinsics::AtomicOrdering as core::cmp::PartialEq>::eq
 <core::intrinsics::AtomicOrdering as core::fmt::Debug>::fmt
 <core::iter::adapters::GenericShunt<'_, I, R> as core::iter::traits::iterator::Iterator>::fold
+<core::iter::adapters::GenericShunt<'_, I, R> as core::iter::traits::iterator::Iterator>::try_fold
 <core::iter::adapters::array_chunks::ArrayChunks<I, N> as core::iter::traits::double_ended::DoubleEndedIterator>::rfold
+<core::iter::adapters::array_chunks::ArrayChunks<I, N> as core::iter::traits::double_ended::DoubleEndedIterator>::try_rfold
 <core::iter::adapters::chain::Chain<A, B> as core::clone::Clone>::clone
 <core::iter::adapters::chain::Chain<A, B> as core::fmt::Debug>::fmt
 <core::iter::adapters::chain::Chain<A, B> as core::iter::traits::iterator::Iterator>::advance_by
@@ -1694,6 +1698,7 @@
 <core::iter::adapters::map::Map<I, F> as core::iter::traits::iterator::Iterator>::try_fold
 <core::iter::adapters::map::Map<I, F> as core::iter::traits::unchecked_iterator::UncheckedIterator>::next_unchecked
 <core::iter::adapters::map_while::MapWhile<I, P> as core::iter::traits::iterator::Iterator>::fold
+<core::iter::adapters::map_while::MapWhile<I, P> as core::iter::traits::iterator::Iterator>::try_fold
 <core::iter::adapters::rev::Rev<I> as core::iter::traits::double_ended::DoubleEndedIterator>::advance_back_by
 <core::iter::adapters::rev::Rev<I> as core::iter::traits::double_ended::DoubleEndedIterator>::next_back
 <core::iter::adapters::rev::Rev<I> as core::iter::traits::double_ended::DoubleEndedIterator>::nth_back
@@ -1710,6 +1715,8 @@
 <core::iter::adapters::rev::Rev<T> as core::clone::Clone>::clone
 <core::iter::adapters::rev::Rev<T> as core::fmt::Debug>::fmt
 <core::iter::adapters::scan::Scan<I, St, F> as core::iter::traits::iterator::Iterator>::fold
+<core::iter::adapters::scan::Scan<I, St, F> as core::iter::traits::iterator::Iterator>::try_fold
+<core::iter::adapters::scan::Scan<I, St, F> as core::iter::traits::iterator::Iterator>::try_fold::scan
 <core::iter::adapters::skip::Skip<I> as core::clone::Clone>::clone
 <core::iter::adapters::skip::Skip<I> as core::fmt::Debug>::fmt
 <core::iter::adapters::skip::Skip<I> as core::iter::traits::double_ended::DoubleEndedIterator>::advance_back_by
@@ -2009,654 +2016,1326 @@
 <core::num::nonzero::NonZero<T> as core::fmt::UpperExp>::fmt
 <core::num::nonzero::NonZero<T> as core::fmt::UpperHex>::fmt
 <core::num::nonzero::NonZero<T> as core::hash::Hash>::hash
+<core::num::nonzero::NonZero<i128> as core::ops::arith::Neg>::neg
+<core::num::nonzero::NonZero<i16> as core::ops::arith::Neg>::neg
+<core::num::nonzero::NonZero<i32> as core::ops::arith::Neg>::neg
+<core::num::nonzero::NonZero<i64> as core::ops::arith::Neg>::neg
+<core::num::nonzero::NonZero<i8> as core::ops::arith::Neg>::neg
+<core::num::nonzero::NonZero<isize> as core::ops::arith::Neg>::neg
 <core::num::saturating::Saturating<i128> as core::ops::arith::Add<&core::num::saturating::Saturating<i128>>>::add
+<core::num::saturating::Saturating<i128> as core::ops::arith::Add>::add
 <core::num::saturating::Saturating<i128> as core::ops::arith::AddAssign<&core::num::saturating::Saturating<i128>>>::add_assign
 <core::num::saturating::Saturating<i128> as core::ops::arith::AddAssign<&i128>>::add_assign
+<core::num::saturating::Saturating<i128> as core::ops::arith::AddAssign<i128>>::add_assign
+<core::num::saturating::Saturating<i128> as core::ops::arith::AddAssign>::add_assign
 <core::num::saturating::Saturating<i128> as core::ops::arith::Div<&core::num::saturating::Saturating<i128>>>::div
+<core::num::saturating::Saturating<i128> as core::ops::arith::Div>::div
 <core::num::saturating::Saturating<i128> as core::ops::arith::DivAssign<&core::num::saturating::Saturating<i128>>>::div_assign
 <core::num::saturating::Saturating<i128> as core::ops::arith::DivAssign<&i128>>::div_assign
+<core::num::saturating::Saturating<i128> as core::ops::arith::DivAssign<i128>>::div_assign
+<core::num::saturating::Saturating<i128> as core::ops::arith::DivAssign>::div_assign
 <core::num::saturating::Saturating<i128> as core::ops::arith::Mul<&core::num::saturating::Saturating<i128>>>::mul
+<core::num::saturating::Saturating<i128> as core::ops::arith::Mul>::mul
 <core::num::saturating::Saturating<i128> as core::ops::arith::MulAssign<&core::num::saturating::Saturating<i128>>>::mul_assign
 <core::num::saturating::Saturating<i128> as core::ops::arith::MulAssign<&i128>>::mul_assign
+<core::num::saturating::Saturating<i128> as core::ops::arith::MulAssign<i128>>::mul_assign
+<core::num::saturating::Saturating<i128> as core::ops::arith::MulAssign>::mul_assign
+<core::num::saturating::Saturating<i128> as core::ops::arith::Neg>::neg
 <core::num::saturating::Saturating<i128> as core::ops::arith::Rem<&core::num::saturating::Saturating<i128>>>::rem
+<core::num::saturating::Saturating<i128> as core::ops::arith::Rem>::rem
 <core::num::saturating::Saturating<i128> as core::ops::arith::RemAssign<&core::num::saturating::Saturating<i128>>>::rem_assign
 <core::num::saturating::Saturating<i128> as core::ops::arith::RemAssign<&i128>>::rem_assign
+<core::num::saturating::Saturating<i128> as core::ops::arith::RemAssign<i128>>::rem_assign
+<core::num::saturating::Saturating<i128> as core::ops::arith::RemAssign>::rem_assign
 <core::num::saturating::Saturating<i128> as core::ops::arith::Sub<&core::num::saturating::Saturating<i128>>>::sub
+<core::num::saturating::Saturating<i128> as core::ops::arith::Sub>::sub
 <core::num::saturating::Saturating<i128> as core::ops::arith::SubAssign<&core::num::saturating::Saturating<i128>>>::sub_assign
 <core::num::saturating::Saturating<i128> as core::ops::arith::SubAssign<&i128>>::sub_assign
+<core::num::saturating::Saturating<i128> as core::ops::arith::SubAssign<i128>>::sub_assign
+<core::num::saturating::Saturating<i128> as core::ops::arith::SubAssign>::sub_assign
 <core::num::saturating::Saturating<i128> as core::ops::bit::BitAnd<&core::num::saturating::Saturating<i128>>>::bitand
+<core::num::saturating::Saturating<i128> as core::ops::bit::BitAnd>::bitand
 <core::num::saturating::Saturating<i128> as core::ops::bit::BitAndAssign<&core::num::saturating::Saturating<i128>>>::bitand_assign
 <core::num::saturating::Saturating<i128> as core::ops::bit::BitAndAssign<&i128>>::bitand_assign
+<core::num::saturating::Saturating<i128> as core::ops::bit::BitAndAssign<i128>>::bitand_assign
+<core::num::saturating::Saturating<i128> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::saturating::Saturating<i128> as core::ops::bit::BitOr<&core::num::saturating::Saturating<i128>>>::bitor
+<core::num::saturating::Saturating<i128> as core::ops::bit::BitOr>::bitor
 <core::num::saturating::Saturating<i128> as core::ops::bit::BitOrAssign<&core::num::saturating::Saturating<i128>>>::bitor_assign
 <core::num::saturating::Saturating<i128> as core::ops::bit::BitOrAssign<&i128>>::bitor_assign
+<core::num::saturating::Saturating<i128> as core::ops::bit::BitOrAssign<i128>>::bitor_assign
+<core::num::saturating::Saturating<i128> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::saturating::Saturating<i128> as core::ops::bit::BitXor<&core::num::saturating::Saturating<i128>>>::bitxor
+<core::num::saturating::Saturating<i128> as core::ops::bit::BitXor>::bitxor
 <core::num::saturating::Saturating<i128> as core::ops::bit::BitXorAssign<&core::num::saturating::Saturating<i128>>>::bitxor_assign
 <core::num::saturating::Saturating<i128> as core::ops::bit::BitXorAssign<&i128>>::bitxor_assign
+<core::num::saturating::Saturating<i128> as core::ops::bit::BitXorAssign<i128>>::bitxor_assign
+<core::num::saturating::Saturating<i128> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::saturating::Saturating<i128> as core::ops::bit::Not>::not
 <core::num::saturating::Saturating<i16> as core::ops::arith::Add<&core::num::saturating::Saturating<i16>>>::add
+<core::num::saturating::Saturating<i16> as core::ops::arith::Add>::add
 <core::num::saturating::Saturating<i16> as core::ops::arith::AddAssign<&core::num::saturating::Saturating<i16>>>::add_assign
 <core::num::saturating::Saturating<i16> as core::ops::arith::AddAssign<&i16>>::add_assign
+<core::num::saturating::Saturating<i16> as core::ops::arith::AddAssign<i16>>::add_assign
+<core::num::saturating::Saturating<i16> as core::ops::arith::AddAssign>::add_assign
 <core::num::saturating::Saturating<i16> as core::ops::arith::Div<&core::num::saturating::Saturating<i16>>>::div
+<core::num::saturating::Saturating<i16> as core::ops::arith::Div>::div
 <core::num::saturating::Saturating<i16> as core::ops::arith::DivAssign<&core::num::saturating::Saturating<i16>>>::div_assign
 <core::num::saturating::Saturating<i16> as core::ops::arith::DivAssign<&i16>>::div_assign
+<core::num::saturating::Saturating<i16> as core::ops::arith::DivAssign<i16>>::div_assign
+<core::num::saturating::Saturating<i16> as core::ops::arith::DivAssign>::div_assign
 <core::num::saturating::Saturating<i16> as core::ops::arith::Mul<&core::num::saturating::Saturating<i16>>>::mul
+<core::num::saturating::Saturating<i16> as core::ops::arith::Mul>::mul
 <core::num::saturating::Saturating<i16> as core::ops::arith::MulAssign<&core::num::saturating::Saturating<i16>>>::mul_assign
 <core::num::saturating::Saturating<i16> as core::ops::arith::MulAssign<&i16>>::mul_assign
+<core::num::saturating::Saturating<i16> as core::ops::arith::MulAssign<i16>>::mul_assign
+<core::num::saturating::Saturating<i16> as core::ops::arith::MulAssign>::mul_assign
+<core::num::saturating::Saturating<i16> as core::ops::arith::Neg>::neg
 <core::num::saturating::Saturating<i16> as core::ops::arith::Rem<&core::num::saturating::Saturating<i16>>>::rem
+<core::num::saturating::Saturating<i16> as core::ops::arith::Rem>::rem
 <core::num::saturating::Saturating<i16> as core::ops::arith::RemAssign<&core::num::saturating::Saturating<i16>>>::rem_assign
 <core::num::saturating::Saturating<i16> as core::ops::arith::RemAssign<&i16>>::rem_assign
+<core::num::saturating::Saturating<i16> as core::ops::arith::RemAssign<i16>>::rem_assign
+<core::num::saturating::Saturating<i16> as core::ops::arith::RemAssign>::rem_assign
 <core::num::saturating::Saturating<i16> as core::ops::arith::Sub<&core::num::saturating::Saturating<i16>>>::sub
+<core::num::saturating::Saturating<i16> as core::ops::arith::Sub>::sub
 <core::num::saturating::Saturating<i16> as core::ops::arith::SubAssign<&core::num::saturating::Saturating<i16>>>::sub_assign
 <core::num::saturating::Saturating<i16> as core::ops::arith::SubAssign<&i16>>::sub_assign
+<core::num::saturating::Saturating<i16> as core::ops::arith::SubAssign<i16>>::sub_assign
+<core::num::saturating::Saturating<i16> as core::ops::arith::SubAssign>::sub_assign
 <core::num::saturating::Saturating<i16> as core::ops::bit::BitAnd<&core::num::saturating::Saturating<i16>>>::bitand
+<core::num::saturating::Saturating<i16> as core::ops::bit::BitAnd>::bitand
 <core::num::saturating::Saturating<i16> as core::ops::bit::BitAndAssign<&core::num::saturating::Saturating<i16>>>::bitand_assign
 <core::num::saturating::Saturating<i16> as core::ops::bit::BitAndAssign<&i16>>::bitand_assign
+<core::num::saturating::Saturating<i16> as core::ops::bit::BitAndAssign<i16>>::bitand_assign
+<core::num::saturating::Saturating<i16> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::saturating::Saturating<i16> as core::ops::bit::BitOr<&core::num::saturating::Saturating<i16>>>::bitor
+<core::num::saturating::Saturating<i16> as core::ops::bit::BitOr>::bitor
 <core::num::saturating::Saturating<i16> as core::ops::bit::BitOrAssign<&core::num::saturating::Saturating<i16>>>::bitor_assign
 <core::num::saturating::Saturating<i16> as core::ops::bit::BitOrAssign<&i16>>::bitor_assign
+<core::num::saturating::Saturating<i16> as core::ops::bit::BitOrAssign<i16>>::bitor_assign
+<core::num::saturating::Saturating<i16> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::saturating::Saturating<i16> as core::ops::bit::BitXor<&core::num::saturating::Saturating<i16>>>::bitxor
+<core::num::saturating::Saturating<i16> as core::ops::bit::BitXor>::bitxor
 <core::num::saturating::Saturating<i16> as core::ops::bit::BitXorAssign<&core::num::saturating::Saturating<i16>>>::bitxor_assign
 <core::num::saturating::Saturating<i16> as core::ops::bit::BitXorAssign<&i16>>::bitxor_assign
+<core::num::saturating::Saturating<i16> as core::ops::bit::BitXorAssign<i16>>::bitxor_assign
+<core::num::saturating::Saturating<i16> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::saturating::Saturating<i16> as core::ops::bit::Not>::not
 <core::num::saturating::Saturating<i32> as core::ops::arith::Add<&core::num::saturating::Saturating<i32>>>::add
+<core::num::saturating::Saturating<i32> as core::ops::arith::Add>::add
 <core::num::saturating::Saturating<i32> as core::ops::arith::AddAssign<&core::num::saturating::Saturating<i32>>>::add_assign
 <core::num::saturating::Saturating<i32> as core::ops::arith::AddAssign<&i32>>::add_assign
+<core::num::saturating::Saturating<i32> as core::ops::arith::AddAssign<i32>>::add_assign
+<core::num::saturating::Saturating<i32> as core::ops::arith::AddAssign>::add_assign
 <core::num::saturating::Saturating<i32> as core::ops::arith::Div<&core::num::saturating::Saturating<i32>>>::div
+<core::num::saturating::Saturating<i32> as core::ops::arith::Div>::div
 <core::num::saturating::Saturating<i32> as core::ops::arith::DivAssign<&core::num::saturating::Saturating<i32>>>::div_assign
 <core::num::saturating::Saturating<i32> as core::ops::arith::DivAssign<&i32>>::div_assign
+<core::num::saturating::Saturating<i32> as core::ops::arith::DivAssign<i32>>::div_assign
+<core::num::saturating::Saturating<i32> as core::ops::arith::DivAssign>::div_assign
 <core::num::saturating::Saturating<i32> as core::ops::arith::Mul<&core::num::saturating::Saturating<i32>>>::mul
+<core::num::saturating::Saturating<i32> as core::ops::arith::Mul>::mul
 <core::num::saturating::Saturating<i32> as core::ops::arith::MulAssign<&core::num::saturating::Saturating<i32>>>::mul_assign
 <core::num::saturating::Saturating<i32> as core::ops::arith::MulAssign<&i32>>::mul_assign
+<core::num::saturating::Saturating<i32> as core::ops::arith::MulAssign<i32>>::mul_assign
+<core::num::saturating::Saturating<i32> as core::ops::arith::MulAssign>::mul_assign
+<core::num::saturating::Saturating<i32> as core::ops::arith::Neg>::neg
 <core::num::saturating::Saturating<i32> as core::ops::arith::Rem<&core::num::saturating::Saturating<i32>>>::rem
+<core::num::saturating::Saturating<i32> as core::ops::arith::Rem>::rem
 <core::num::saturating::Saturating<i32> as core::ops::arith::RemAssign<&core::num::saturating::Saturating<i32>>>::rem_assign
 <core::num::saturating::Saturating<i32> as core::ops::arith::RemAssign<&i32>>::rem_assign
+<core::num::saturating::Saturating<i32> as core::ops::arith::RemAssign<i32>>::rem_assign
+<core::num::saturating::Saturating<i32> as core::ops::arith::RemAssign>::rem_assign
 <core::num::saturating::Saturating<i32> as core::ops::arith::Sub<&core::num::saturating::Saturating<i32>>>::sub
+<core::num::saturating::Saturating<i32> as core::ops::arith::Sub>::sub
 <core::num::saturating::Saturating<i32> as core::ops::arith::SubAssign<&core::num::saturating::Saturating<i32>>>::sub_assign
 <core::num::saturating::Saturating<i32> as core::ops::arith::SubAssign<&i32>>::sub_assign
+<core::num::saturating::Saturating<i32> as core::ops::arith::SubAssign<i32>>::sub_assign
+<core::num::saturating::Saturating<i32> as core::ops::arith::SubAssign>::sub_assign
 <core::num::saturating::Saturating<i32> as core::ops::bit::BitAnd<&core::num::saturating::Saturating<i32>>>::bitand
+<core::num::saturating::Saturating<i32> as core::ops::bit::BitAnd>::bitand
 <core::num::saturating::Saturating<i32> as core::ops::bit::BitAndAssign<&core::num::saturating::Saturating<i32>>>::bitand_assign
 <core::num::saturating::Saturating<i32> as core::ops::bit::BitAndAssign<&i32>>::bitand_assign
+<core::num::saturating::Saturating<i32> as core::ops::bit::BitAndAssign<i32>>::bitand_assign
+<core::num::saturating::Saturating<i32> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::saturating::Saturating<i32> as core::ops::bit::BitOr<&core::num::saturating::Saturating<i32>>>::bitor
+<core::num::saturating::Saturating<i32> as core::ops::bit::BitOr>::bitor
 <core::num::saturating::Saturating<i32> as core::ops::bit::BitOrAssign<&core::num::saturating::Saturating<i32>>>::bitor_assign
 <core::num::saturating::Saturating<i32> as core::ops::bit::BitOrAssign<&i32>>::bitor_assign
+<core::num::saturating::Saturating<i32> as core::ops::bit::BitOrAssign<i32>>::bitor_assign
+<core::num::saturating::Saturating<i32> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::saturating::Saturating<i32> as core::ops::bit::BitXor<&core::num::saturating::Saturating<i32>>>::bitxor
+<core::num::saturating::Saturating<i32> as core::ops::bit::BitXor>::bitxor
 <core::num::saturating::Saturating<i32> as core::ops::bit::BitXorAssign<&core::num::saturating::Saturating<i32>>>::bitxor_assign
 <core::num::saturating::Saturating<i32> as core::ops::bit::BitXorAssign<&i32>>::bitxor_assign
+<core::num::saturating::Saturating<i32> as core::ops::bit::BitXorAssign<i32>>::bitxor_assign
+<core::num::saturating::Saturating<i32> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::saturating::Saturating<i32> as core::ops::bit::Not>::not
 <core::num::saturating::Saturating<i64> as core::ops::arith::Add<&core::num::saturating::Saturating<i64>>>::add
+<core::num::saturating::Saturating<i64> as core::ops::arith::Add>::add
 <core::num::saturating::Saturating<i64> as core::ops::arith::AddAssign<&core::num::saturating::Saturating<i64>>>::add_assign
 <core::num::saturating::Saturating<i64> as core::ops::arith::AddAssign<&i64>>::add_assign
+<core::num::saturating::Saturating<i64> as core::ops::arith::AddAssign<i64>>::add_assign
+<core::num::saturating::Saturating<i64> as core::ops::arith::AddAssign>::add_assign
 <core::num::saturating::Saturating<i64> as core::ops::arith::Div<&core::num::saturating::Saturating<i64>>>::div
+<core::num::saturating::Saturating<i64> as core::ops::arith::Div>::div
 <core::num::saturating::Saturating<i64> as core::ops::arith::DivAssign<&core::num::saturating::Saturating<i64>>>::div_assign
 <core::num::saturating::Saturating<i64> as core::ops::arith::DivAssign<&i64>>::div_assign
+<core::num::saturating::Saturating<i64> as core::ops::arith::DivAssign<i64>>::div_assign
+<core::num::saturating::Saturating<i64> as core::ops::arith::DivAssign>::div_assign
 <core::num::saturating::Saturating<i64> as core::ops::arith::Mul<&core::num::saturating::Saturating<i64>>>::mul
+<core::num::saturating::Saturating<i64> as core::ops::arith::Mul>::mul
 <core::num::saturating::Saturating<i64> as core::ops::arith::MulAssign<&core::num::saturating::Saturating<i64>>>::mul_assign
 <core::num::saturating::Saturating<i64> as core::ops::arith::MulAssign<&i64>>::mul_assign
+<core::num::saturating::Saturating<i64> as core::ops::arith::MulAssign<i64>>::mul_assign
+<core::num::saturating::Saturating<i64> as core::ops::arith::MulAssign>::mul_assign
+<core::num::saturating::Saturating<i64> as core::ops::arith::Neg>::neg
 <core::num::saturating::Saturating<i64> as core::ops::arith::Rem<&core::num::saturating::Saturating<i64>>>::rem
+<core::num::saturating::Saturating<i64> as core::ops::arith::Rem>::rem
 <core::num::saturating::Saturating<i64> as core::ops::arith::RemAssign<&core::num::saturating::Saturating<i64>>>::rem_assign
 <core::num::saturating::Saturating<i64> as core::ops::arith::RemAssign<&i64>>::rem_assign
+<core::num::saturating::Saturating<i64> as core::ops::arith::RemAssign<i64>>::rem_assign
+<core::num::saturating::Saturating<i64> as core::ops::arith::RemAssign>::rem_assign
 <core::num::saturating::Saturating<i64> as core::ops::arith::Sub<&core::num::saturating::Saturating<i64>>>::sub
+<core::num::saturating::Saturating<i64> as core::ops::arith::Sub>::sub
 <core::num::saturating::Saturating<i64> as core::ops::arith::SubAssign<&core::num::saturating::Saturating<i64>>>::sub_assign
 <core::num::saturating::Saturating<i64> as core::ops::arith::SubAssign<&i64>>::sub_assign
+<core::num::saturating::Saturating<i64> as core::ops::arith::SubAssign<i64>>::sub_assign
+<core::num::saturating::Saturating<i64> as core::ops::arith::SubAssign>::sub_assign
 <core::num::saturating::Saturating<i64> as core::ops::bit::BitAnd<&core::num::saturating::Saturating<i64>>>::bitand
+<core::num::saturating::Saturating<i64> as core::ops::bit::BitAnd>::bitand
 <core::num::saturating::Saturating<i64> as core::ops::bit::BitAndAssign<&core::num::saturating::Saturating<i64>>>::bitand_assign
 <core::num::saturating::Saturating<i64> as core::ops::bit::BitAndAssign<&i64>>::bitand_assign
+<core::num::saturating::Saturating<i64> as core::ops::bit::BitAndAssign<i64>>::bitand_assign
+<core::num::saturating::Saturating<i64> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::saturating::Saturating<i64> as core::ops::bit::BitOr<&core::num::saturating::Saturating<i64>>>::bitor
+<core::num::saturating::Saturating<i64> as core::ops::bit::BitOr>::bitor
 <core::num::saturating::Saturating<i64> as core::ops::bit::BitOrAssign<&core::num::saturating::Saturating<i64>>>::bitor_assign
 <core::num::saturating::Saturating<i64> as core::ops::bit::BitOrAssign<&i64>>::bitor_assign
+<core::num::saturating::Saturating<i64> as core::ops::bit::BitOrAssign<i64>>::bitor_assign
+<core::num::saturating::Saturating<i64> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::saturating::Saturating<i64> as core::ops::bit::BitXor<&core::num::saturating::Saturating<i64>>>::bitxor
+<core::num::saturating::Saturating<i64> as core::ops::bit::BitXor>::bitxor
 <core::num::saturating::Saturating<i64> as core::ops::bit::BitXorAssign<&core::num::saturating::Saturating<i64>>>::bitxor_assign
 <core::num::saturating::Saturating<i64> as core::ops::bit::BitXorAssign<&i64>>::bitxor_assign
+<core::num::saturating::Saturating<i64> as core::ops::bit::BitXorAssign<i64>>::bitxor_assign
+<core::num::saturating::Saturating<i64> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::saturating::Saturating<i64> as core::ops::bit::Not>::not
 <core::num::saturating::Saturating<i8> as core::ops::arith::Add<&core::num::saturating::Saturating<i8>>>::add
+<core::num::saturating::Saturating<i8> as core::ops::arith::Add>::add
 <core::num::saturating::Saturating<i8> as core::ops::arith::AddAssign<&core::num::saturating::Saturating<i8>>>::add_assign
 <core::num::saturating::Saturating<i8> as core::ops::arith::AddAssign<&i8>>::add_assign
+<core::num::saturating::Saturating<i8> as core::ops::arith::AddAssign<i8>>::add_assign
+<core::num::saturating::Saturating<i8> as core::ops::arith::AddAssign>::add_assign
 <core::num::saturating::Saturating<i8> as core::ops::arith::Div<&core::num::saturating::Saturating<i8>>>::div
+<core::num::saturating::Saturating<i8> as core::ops::arith::Div>::div
 <core::num::saturating::Saturating<i8> as core::ops::arith::DivAssign<&core::num::saturating::Saturating<i8>>>::div_assign
 <core::num::saturating::Saturating<i8> as core::ops::arith::DivAssign<&i8>>::div_assign
+<core::num::saturating::Saturating<i8> as core::ops::arith::DivAssign<i8>>::div_assign
+<core::num::saturating::Saturating<i8> as core::ops::arith::DivAssign>::div_assign
 <core::num::saturating::Saturating<i8> as core::ops::arith::Mul<&core::num::saturating::Saturating<i8>>>::mul
+<core::num::saturating::Saturating<i8> as core::ops::arith::Mul>::mul
 <core::num::saturating::Saturating<i8> as core::ops::arith::MulAssign<&core::num::saturating::Saturating<i8>>>::mul_assign
 <core::num::saturating::Saturating<i8> as core::ops::arith::MulAssign<&i8>>::mul_assign
+<core::num::saturating::Saturating<i8> as core::ops::arith::MulAssign<i8>>::mul_assign
+<core::num::saturating::Saturating<i8> as core::ops::arith::MulAssign>::mul_assign
+<core::num::saturating::Saturating<i8> as core::ops::arith::Neg>::neg
 <core::num::saturating::Saturating<i8> as core::ops::arith::Rem<&core::num::saturating::Saturating<i8>>>::rem
+<core::num::saturating::Saturating<i8> as core::ops::arith::Rem>::rem
 <core::num::saturating::Saturating<i8> as core::ops::arith::RemAssign<&core::num::saturating::Saturating<i8>>>::rem_assign
 <core::num::saturating::Saturating<i8> as core::ops::arith::RemAssign<&i8>>::rem_assign
+<core::num::saturating::Saturating<i8> as core::ops::arith::RemAssign<i8>>::rem_assign
+<core::num::saturating::Saturating<i8> as core::ops::arith::RemAssign>::rem_assign
 <core::num::saturating::Saturating<i8> as core::ops::arith::Sub<&core::num::saturating::Saturating<i8>>>::sub
+<core::num::saturating::Saturating<i8> as core::ops::arith::Sub>::sub
 <core::num::saturating::Saturating<i8> as core::ops::arith::SubAssign<&core::num::saturating::Saturating<i8>>>::sub_assign
 <core::num::saturating::Saturating<i8> as core::ops::arith::SubAssign<&i8>>::sub_assign
+<core::num::saturating::Saturating<i8> as core::ops::arith::SubAssign<i8>>::sub_assign
+<core::num::saturating::Saturating<i8> as core::ops::arith::SubAssign>::sub_assign
 <core::num::saturating::Saturating<i8> as core::ops::bit::BitAnd<&core::num::saturating::Saturating<i8>>>::bitand
+<core::num::saturating::Saturating<i8> as core::ops::bit::BitAnd>::bitand
 <core::num::saturating::Saturating<i8> as core::ops::bit::BitAndAssign<&core::num::saturating::Saturating<i8>>>::bitand_assign
 <core::num::saturating::Saturating<i8> as core::ops::bit::BitAndAssign<&i8>>::bitand_assign
+<core::num::saturating::Saturating<i8> as core::ops::bit::BitAndAssign<i8>>::bitand_assign
+<core::num::saturating::Saturating<i8> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::saturating::Saturating<i8> as core::ops::bit::BitOr<&core::num::saturating::Saturating<i8>>>::bitor
+<core::num::saturating::Saturating<i8> as core::ops::bit::BitOr>::bitor
 <core::num::saturating::Saturating<i8> as core::ops::bit::BitOrAssign<&core::num::saturating::Saturating<i8>>>::bitor_assign
 <core::num::saturating::Saturating<i8> as core::ops::bit::BitOrAssign<&i8>>::bitor_assign
+<core::num::saturating::Saturating<i8> as core::ops::bit::BitOrAssign<i8>>::bitor_assign
+<core::num::saturating::Saturating<i8> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::saturating::Saturating<i8> as core::ops::bit::BitXor<&core::num::saturating::Saturating<i8>>>::bitxor
+<core::num::saturating::Saturating<i8> as core::ops::bit::BitXor>::bitxor
 <core::num::saturating::Saturating<i8> as core::ops::bit::BitXorAssign<&core::num::saturating::Saturating<i8>>>::bitxor_assign
 <core::num::saturating::Saturating<i8> as core::ops::bit::BitXorAssign<&i8>>::bitxor_assign
+<core::num::saturating::Saturating<i8> as core::ops::bit::BitXorAssign<i8>>::bitxor_assign
+<core::num::saturating::Saturating<i8> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::saturating::Saturating<i8> as core::ops::bit::Not>::not
 <core::num::saturating::Saturating<isize> as core::ops::arith::Add<&core::num::saturating::Saturating<isize>>>::add
+<core::num::saturating::Saturating<isize> as core::ops::arith::Add>::add
 <core::num::saturating::Saturating<isize> as core::ops::arith::AddAssign<&core::num::saturating::Saturating<isize>>>::add_assign
 <core::num::saturating::Saturating<isize> as core::ops::arith::AddAssign<&isize>>::add_assign
+<core::num::saturating::Saturating<isize> as core::ops::arith::AddAssign<isize>>::add_assign
+<core::num::saturating::Saturating<isize> as core::ops::arith::AddAssign>::add_assign
 <core::num::saturating::Saturating<isize> as core::ops::arith::Div<&core::num::saturating::Saturating<isize>>>::div
+<core::num::saturating::Saturating<isize> as core::ops::arith::Div>::div
 <core::num::saturating::Saturating<isize> as core::ops::arith::DivAssign<&core::num::saturating::Saturating<isize>>>::div_assign
 <core::num::saturating::Saturating<isize> as core::ops::arith::DivAssign<&isize>>::div_assign
+<core::num::saturating::Saturating<isize> as core::ops::arith::DivAssign<isize>>::div_assign
+<core::num::saturating::Saturating<isize> as core::ops::arith::DivAssign>::div_assign
 <core::num::saturating::Saturating<isize> as core::ops::arith::Mul<&core::num::saturating::Saturating<isize>>>::mul
+<core::num::saturating::Saturating<isize> as core::ops::arith::Mul>::mul
 <core::num::saturating::Saturating<isize> as core::ops::arith::MulAssign<&core::num::saturating::Saturating<isize>>>::mul_assign
 <core::num::saturating::Saturating<isize> as core::ops::arith::MulAssign<&isize>>::mul_assign
+<core::num::saturating::Saturating<isize> as core::ops::arith::MulAssign<isize>>::mul_assign
+<core::num::saturating::Saturating<isize> as core::ops::arith::MulAssign>::mul_assign
+<core::num::saturating::Saturating<isize> as core::ops::arith::Neg>::neg
 <core::num::saturating::Saturating<isize> as core::ops::arith::Rem<&core::num::saturating::Saturating<isize>>>::rem
+<core::num::saturating::Saturating<isize> as core::ops::arith::Rem>::rem
 <core::num::saturating::Saturating<isize> as core::ops::arith::RemAssign<&core::num::saturating::Saturating<isize>>>::rem_assign
 <core::num::saturating::Saturating<isize> as core::ops::arith::RemAssign<&isize>>::rem_assign
+<core::num::saturating::Saturating<isize> as core::ops::arith::RemAssign<isize>>::rem_assign
+<core::num::saturating::Saturating<isize> as core::ops::arith::RemAssign>::rem_assign
 <core::num::saturating::Saturating<isize> as core::ops::arith::Sub<&core::num::saturating::Saturating<isize>>>::sub
+<core::num::saturating::Saturating<isize> as core::ops::arith::Sub>::sub
 <core::num::saturating::Saturating<isize> as core::ops::arith::SubAssign<&core::num::saturating::Saturating<isize>>>::sub_assign
 <core::num::saturating::Saturating<isize> as core::ops::arith::SubAssign<&isize>>::sub_assign
+<core::num::saturating::Saturating<isize> as core::ops::arith::SubAssign<isize>>::sub_assign
+<core::num::saturating::Saturating<isize> as core::ops::arith::SubAssign>::sub_assign
 <core::num::saturating::Saturating<isize> as core::ops::bit::BitAnd<&core::num::saturating::Saturating<isize>>>::bitand
+<core::num::saturating::Saturating<isize> as core::ops::bit::BitAnd>::bitand
 <core::num::saturating::Saturating<isize> as core::ops::bit::BitAndAssign<&core::num::saturating::Saturating<isize>>>::bitand_assign
 <core::num::saturating::Saturating<isize> as core::ops::bit::BitAndAssign<&isize>>::bitand_assign
+<core::num::saturating::Saturating<isize> as core::ops::bit::BitAndAssign<isize>>::bitand_assign
+<core::num::saturating::Saturating<isize> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::saturating::Saturating<isize> as core::ops::bit::BitOr<&core::num::saturating::Saturating<isize>>>::bitor
+<core::num::saturating::Saturating<isize> as core::ops::bit::BitOr>::bitor
 <core::num::saturating::Saturating<isize> as core::ops::bit::BitOrAssign<&core::num::saturating::Saturating<isize>>>::bitor_assign
 <core::num::saturating::Saturating<isize> as core::ops::bit::BitOrAssign<&isize>>::bitor_assign
+<core::num::saturating::Saturating<isize> as core::ops::bit::BitOrAssign<isize>>::bitor_assign
+<core::num::saturating::Saturating<isize> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::saturating::Saturating<isize> as core::ops::bit::BitXor<&core::num::saturating::Saturating<isize>>>::bitxor
+<core::num::saturating::Saturating<isize> as core::ops::bit::BitXor>::bitxor
 <core::num::saturating::Saturating<isize> as core::ops::bit::BitXorAssign<&core::num::saturating::Saturating<isize>>>::bitxor_assign
 <core::num::saturating::Saturating<isize> as core::ops::bit::BitXorAssign<&isize>>::bitxor_assign
+<core::num::saturating::Saturating<isize> as core::ops::bit::BitXorAssign<isize>>::bitxor_assign
+<core::num::saturating::Saturating<isize> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::saturating::Saturating<isize> as core::ops::bit::Not>::not
 <core::num::saturating::Saturating<u128> as core::ops::arith::Add<&core::num::saturating::Saturating<u128>>>::add
+<core::num::saturating::Saturating<u128> as core::ops::arith::Add>::add
 <core::num::saturating::Saturating<u128> as core::ops::arith::AddAssign<&core::num::saturating::Saturating<u128>>>::add_assign
 <core::num::saturating::Saturating<u128> as core::ops::arith::AddAssign<&u128>>::add_assign
+<core::num::saturating::Saturating<u128> as core::ops::arith::AddAssign<u128>>::add_assign
+<core::num::saturating::Saturating<u128> as core::ops::arith::AddAssign>::add_assign
 <core::num::saturating::Saturating<u128> as core::ops::arith::Div<&core::num::saturating::Saturating<u128>>>::div
+<core::num::saturating::Saturating<u128> as core::ops::arith::Div>::div
 <core::num::saturating::Saturating<u128> as core::ops::arith::DivAssign<&core::num::saturating::Saturating<u128>>>::div_assign
 <core::num::saturating::Saturating<u128> as core::ops::arith::DivAssign<&u128>>::div_assign
+<core::num::saturating::Saturating<u128> as core::ops::arith::DivAssign<u128>>::div_assign
+<core::num::saturating::Saturating<u128> as core::ops::arith::DivAssign>::div_assign
 <core::num::saturating::Saturating<u128> as core::ops::arith::Mul<&core::num::saturating::Saturating<u128>>>::mul
+<core::num::saturating::Saturating<u128> as core::ops::arith::Mul>::mul
 <core::num::saturating::Saturating<u128> as core::ops::arith::MulAssign<&core::num::saturating::Saturating<u128>>>::mul_assign
 <core::num::saturating::Saturating<u128> as core::ops::arith::MulAssign<&u128>>::mul_assign
+<core::num::saturating::Saturating<u128> as core::ops::arith::MulAssign<u128>>::mul_assign
+<core::num::saturating::Saturating<u128> as core::ops::arith::MulAssign>::mul_assign
 <core::num::saturating::Saturating<u128> as core::ops::arith::Rem<&core::num::saturating::Saturating<u128>>>::rem
+<core::num::saturating::Saturating<u128> as core::ops::arith::Rem>::rem
 <core::num::saturating::Saturating<u128> as core::ops::arith::RemAssign<&core::num::saturating::Saturating<u128>>>::rem_assign
 <core::num::saturating::Saturating<u128> as core::ops::arith::RemAssign<&u128>>::rem_assign
+<core::num::saturating::Saturating<u128> as core::ops::arith::RemAssign<u128>>::rem_assign
+<core::num::saturating::Saturating<u128> as core::ops::arith::RemAssign>::rem_assign
 <core::num::saturating::Saturating<u128> as core::ops::arith::Sub<&core::num::saturating::Saturating<u128>>>::sub
+<core::num::saturating::Saturating<u128> as core::ops::arith::Sub>::sub
 <core::num::saturating::Saturating<u128> as core::ops::arith::SubAssign<&core::num::saturating::Saturating<u128>>>::sub_assign
 <core::num::saturating::Saturating<u128> as core::ops::arith::SubAssign<&u128>>::sub_assign
+<core::num::saturating::Saturating<u128> as core::ops::arith::SubAssign<u128>>::sub_assign
+<core::num::saturating::Saturating<u128> as core::ops::arith::SubAssign>::sub_assign
 <core::num::saturating::Saturating<u128> as core::ops::bit::BitAnd<&core::num::saturating::Saturating<u128>>>::bitand
+<core::num::saturating::Saturating<u128> as core::ops::bit::BitAnd>::bitand
 <core::num::saturating::Saturating<u128> as core::ops::bit::BitAndAssign<&core::num::saturating::Saturating<u128>>>::bitand_assign
 <core::num::saturating::Saturating<u128> as core::ops::bit::BitAndAssign<&u128>>::bitand_assign
+<core::num::saturating::Saturating<u128> as core::ops::bit::BitAndAssign<u128>>::bitand_assign
+<core::num::saturating::Saturating<u128> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::saturating::Saturating<u128> as core::ops::bit::BitOr<&core::num::saturating::Saturating<u128>>>::bitor
+<core::num::saturating::Saturating<u128> as core::ops::bit::BitOr>::bitor
 <core::num::saturating::Saturating<u128> as core::ops::bit::BitOrAssign<&core::num::saturating::Saturating<u128>>>::bitor_assign
 <core::num::saturating::Saturating<u128> as core::ops::bit::BitOrAssign<&u128>>::bitor_assign
+<core::num::saturating::Saturating<u128> as core::ops::bit::BitOrAssign<u128>>::bitor_assign
+<core::num::saturating::Saturating<u128> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::saturating::Saturating<u128> as core::ops::bit::BitXor<&core::num::saturating::Saturating<u128>>>::bitxor
+<core::num::saturating::Saturating<u128> as core::ops::bit::BitXor>::bitxor
 <core::num::saturating::Saturating<u128> as core::ops::bit::BitXorAssign<&core::num::saturating::Saturating<u128>>>::bitxor_assign
 <core::num::saturating::Saturating<u128> as core::ops::bit::BitXorAssign<&u128>>::bitxor_assign
+<core::num::saturating::Saturating<u128> as core::ops::bit::BitXorAssign<u128>>::bitxor_assign
+<core::num::saturating::Saturating<u128> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::saturating::Saturating<u128> as core::ops::bit::Not>::not
 <core::num::saturating::Saturating<u16> as core::ops::arith::Add<&core::num::saturating::Saturating<u16>>>::add
+<core::num::saturating::Saturating<u16> as core::ops::arith::Add>::add
 <core::num::saturating::Saturating<u16> as core::ops::arith::AddAssign<&core::num::saturating::Saturating<u16>>>::add_assign
 <core::num::saturating::Saturating<u16> as core::ops::arith::AddAssign<&u16>>::add_assign
+<core::num::saturating::Saturating<u16> as core::ops::arith::AddAssign<u16>>::add_assign
+<core::num::saturating::Saturating<u16> as core::ops::arith::AddAssign>::add_assign
 <core::num::saturating::Saturating<u16> as core::ops::arith::Div<&core::num::saturating::Saturating<u16>>>::div
+<core::num::saturating::Saturating<u16> as core::ops::arith::Div>::div
 <core::num::saturating::Saturating<u16> as core::ops::arith::DivAssign<&core::num::saturating::Saturating<u16>>>::div_assign
 <core::num::saturating::Saturating<u16> as core::ops::arith::DivAssign<&u16>>::div_assign
+<core::num::saturating::Saturating<u16> as core::ops::arith::DivAssign<u16>>::div_assign
+<core::num::saturating::Saturating<u16> as core::ops::arith::DivAssign>::div_assign
 <core::num::saturating::Saturating<u16> as core::ops::arith::Mul<&core::num::saturating::Saturating<u16>>>::mul
+<core::num::saturating::Saturating<u16> as core::ops::arith::Mul>::mul
 <core::num::saturating::Saturating<u16> as core::ops::arith::MulAssign<&core::num::saturating::Saturating<u16>>>::mul_assign
 <core::num::saturating::Saturating<u16> as core::ops::arith::MulAssign<&u16>>::mul_assign
+<core::num::saturating::Saturating<u16> as core::ops::arith::MulAssign<u16>>::mul_assign
+<core::num::saturating::Saturating<u16> as core::ops::arith::MulAssign>::mul_assign
 <core::num::saturating::Saturating<u16> as core::ops::arith::Rem<&core::num::saturating::Saturating<u16>>>::rem
+<core::num::saturating::Saturating<u16> as core::ops::arith::Rem>::rem
 <core::num::saturating::Saturating<u16> as core::ops::arith::RemAssign<&core::num::saturating::Saturating<u16>>>::rem_assign
 <core::num::saturating::Saturating<u16> as core::ops::arith::RemAssign<&u16>>::rem_assign
+<core::num::saturating::Saturating<u16> as core::ops::arith::RemAssign<u16>>::rem_assign
+<core::num::saturating::Saturating<u16> as core::ops::arith::RemAssign>::rem_assign
 <core::num::saturating::Saturating<u16> as core::ops::arith::Sub<&core::num::saturating::Saturating<u16>>>::sub
+<core::num::saturating::Saturating<u16> as core::ops::arith::Sub>::sub
 <core::num::saturating::Saturating<u16> as core::ops::arith::SubAssign<&core::num::saturating::Saturating<u16>>>::sub_assign
 <core::num::saturating::Saturating<u16> as core::ops::arith::SubAssign<&u16>>::sub_assign
+<core::num::saturating::Saturating<u16> as core::ops::arith::SubAssign<u16>>::sub_assign
+<core::num::saturating::Saturating<u16> as core::ops::arith::SubAssign>::sub_assign
 <core::num::saturating::Saturating<u16> as core::ops::bit::BitAnd<&core::num::saturating::Saturating<u16>>>::bitand
+<core::num::saturating::Saturating<u16> as core::ops::bit::BitAnd>::bitand
 <core::num::saturating::Saturating<u16> as core::ops::bit::BitAndAssign<&core::num::saturating::Saturating<u16>>>::bitand_assign
 <core::num::saturating::Saturating<u16> as core::ops::bit::BitAndAssign<&u16>>::bitand_assign
+<core::num::saturating::Saturating<u16> as core::ops::bit::BitAndAssign<u16>>::bitand_assign
+<core::num::saturating::Saturating<u16> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::saturating::Saturating<u16> as core::ops::bit::BitOr<&core::num::saturating::Saturating<u16>>>::bitor
+<core::num::saturating::Saturating<u16> as core::ops::bit::BitOr>::bitor
 <core::num::saturating::Saturating<u16> as core::ops::bit::BitOrAssign<&core::num::saturating::Saturating<u16>>>::bitor_assign
 <core::num::saturating::Saturating<u16> as core::ops::bit::BitOrAssign<&u16>>::bitor_assign
+<core::num::saturating::Saturating<u16> as core::ops::bit::BitOrAssign<u16>>::bitor_assign
+<core::num::saturating::Saturating<u16> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::saturating::Saturating<u16> as core::ops::bit::BitXor<&core::num::saturating::Saturating<u16>>>::bitxor
+<core::num::saturating::Saturating<u16> as core::ops::bit::BitXor>::bitxor
 <core::num::saturating::Saturating<u16> as core::ops::bit::BitXorAssign<&core::num::saturating::Saturating<u16>>>::bitxor_assign
 <core::num::saturating::Saturating<u16> as core::ops::bit::BitXorAssign<&u16>>::bitxor_assign
+<core::num::saturating::Saturating<u16> as core::ops::bit::BitXorAssign<u16>>::bitxor_assign
+<core::num::saturating::Saturating<u16> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::saturating::Saturating<u16> as core::ops::bit::Not>::not
 <core::num::saturating::Saturating<u32> as core::ops::arith::Add<&core::num::saturating::Saturating<u32>>>::add
+<core::num::saturating::Saturating<u32> as core::ops::arith::Add>::add
 <core::num::saturating::Saturating<u32> as core::ops::arith::AddAssign<&core::num::saturating::Saturating<u32>>>::add_assign
 <core::num::saturating::Saturating<u32> as core::ops::arith::AddAssign<&u32>>::add_assign
+<core::num::saturating::Saturating<u32> as core::ops::arith::AddAssign<u32>>::add_assign
+<core::num::saturating::Saturating<u32> as core::ops::arith::AddAssign>::add_assign
 <core::num::saturating::Saturating<u32> as core::ops::arith::Div<&core::num::saturating::Saturating<u32>>>::div
+<core::num::saturating::Saturating<u32> as core::ops::arith::Div>::div
 <core::num::saturating::Saturating<u32> as core::ops::arith::DivAssign<&core::num::saturating::Saturating<u32>>>::div_assign
 <core::num::saturating::Saturating<u32> as core::ops::arith::DivAssign<&u32>>::div_assign
+<core::num::saturating::Saturating<u32> as core::ops::arith::DivAssign<u32>>::div_assign
+<core::num::saturating::Saturating<u32> as core::ops::arith::DivAssign>::div_assign
 <core::num::saturating::Saturating<u32> as core::ops::arith::Mul<&core::num::saturating::Saturating<u32>>>::mul
+<core::num::saturating::Saturating<u32> as core::ops::arith::Mul>::mul
 <core::num::saturating::Saturating<u32> as core::ops::arith::MulAssign<&core::num::saturating::Saturating<u32>>>::mul_assign
 <core::num::saturating::Saturating<u32> as core::ops::arith::MulAssign<&u32>>::mul_assign
+<core::num::saturating::Saturating<u32> as core::ops::arith::MulAssign<u32>>::mul_assign
+<core::num::saturating::Saturating<u32> as core::ops::arith::MulAssign>::mul_assign
 <core::num::saturating::Saturating<u32> as core::ops::arith::Rem<&core::num::saturating::Saturating<u32>>>::rem
+<core::num::saturating::Saturating<u32> as core::ops::arith::Rem>::rem
 <core::num::saturating::Saturating<u32> as core::ops::arith::RemAssign<&core::num::saturating::Saturating<u32>>>::rem_assign
 <core::num::saturating::Saturating<u32> as core::ops::arith::RemAssign<&u32>>::rem_assign
+<core::num::saturating::Saturating<u32> as core::ops::arith::RemAssign<u32>>::rem_assign
+<core::num::saturating::Saturating<u32> as core::ops::arith::RemAssign>::rem_assign
 <core::num::saturating::Saturating<u32> as core::ops::arith::Sub<&core::num::saturating::Saturating<u32>>>::sub
+<core::num::saturating::Saturating<u32> as core::ops::arith::Sub>::sub
 <core::num::saturating::Saturating<u32> as core::ops::arith::SubAssign<&core::num::saturating::Saturating<u32>>>::sub_assign
 <core::num::saturating::Saturating<u32> as core::ops::arith::SubAssign<&u32>>::sub_assign
+<core::num::saturating::Saturating<u32> as core::ops::arith::SubAssign<u32>>::sub_assign
+<core::num::saturating::Saturating<u32> as core::ops::arith::SubAssign>::sub_assign
 <core::num::saturating::Saturating<u32> as core::ops::bit::BitAnd<&core::num::saturating::Saturating<u32>>>::bitand
+<core::num::saturating::Saturating<u32> as core::ops::bit::BitAnd>::bitand
 <core::num::saturating::Saturating<u32> as core::ops::bit::BitAndAssign<&core::num::saturating::Saturating<u32>>>::bitand_assign
 <core::num::saturating::Saturating<u32> as core::ops::bit::BitAndAssign<&u32>>::bitand_assign
+<core::num::saturating::Saturating<u32> as core::ops::bit::BitAndAssign<u32>>::bitand_assign
+<core::num::saturating::Saturating<u32> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::saturating::Saturating<u32> as core::ops::bit::BitOr<&core::num::saturating::Saturating<u32>>>::bitor
+<core::num::saturating::Saturating<u32> as core::ops::bit::BitOr>::bitor
 <core::num::saturating::Saturating<u32> as core::ops::bit::BitOrAssign<&core::num::saturating::Saturating<u32>>>::bitor_assign
 <core::num::saturating::Saturating<u32> as core::ops::bit::BitOrAssign<&u32>>::bitor_assign
+<core::num::saturating::Saturating<u32> as core::ops::bit::BitOrAssign<u32>>::bitor_assign
+<core::num::saturating::Saturating<u32> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::saturating::Saturating<u32> as core::ops::bit::BitXor<&core::num::saturating::Saturating<u32>>>::bitxor
+<core::num::saturating::Saturating<u32> as core::ops::bit::BitXor>::bitxor
 <core::num::saturating::Saturating<u32> as core::ops::bit::BitXorAssign<&core::num::saturating::Saturating<u32>>>::bitxor_assign
 <core::num::saturating::Saturating<u32> as core::ops::bit::BitXorAssign<&u32>>::bitxor_assign
+<core::num::saturating::Saturating<u32> as core::ops::bit::BitXorAssign<u32>>::bitxor_assign
+<core::num::saturating::Saturating<u32> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::saturating::Saturating<u32> as core::ops::bit::Not>::not
 <core::num::saturating::Saturating<u64> as core::ops::arith::Add<&core::num::saturating::Saturating<u64>>>::add
+<core::num::saturating::Saturating<u64> as core::ops::arith::Add>::add
 <core::num::saturating::Saturating<u64> as core::ops::arith::AddAssign<&core::num::saturating::Saturating<u64>>>::add_assign
 <core::num::saturating::Saturating<u64> as core::ops::arith::AddAssign<&u64>>::add_assign
+<core::num::saturating::Saturating<u64> as core::ops::arith::AddAssign<u64>>::add_assign
+<core::num::saturating::Saturating<u64> as core::ops::arith::AddAssign>::add_assign
 <core::num::saturating::Saturating<u64> as core::ops::arith::Div<&core::num::saturating::Saturating<u64>>>::div
+<core::num::saturating::Saturating<u64> as core::ops::arith::Div>::div
 <core::num::saturating::Saturating<u64> as core::ops::arith::DivAssign<&core::num::saturating::Saturating<u64>>>::div_assign
 <core::num::saturating::Saturating<u64> as core::ops::arith::DivAssign<&u64>>::div_assign
+<core::num::saturating::Saturating<u64> as core::ops::arith::DivAssign<u64>>::div_assign
+<core::num::saturating::Saturating<u64> as core::ops::arith::DivAssign>::div_assign
 <core::num::saturating::Saturating<u64> as core::ops::arith::Mul<&core::num::saturating::Saturating<u64>>>::mul
+<core::num::saturating::Saturating<u64> as core::ops::arith::Mul>::mul
 <core::num::saturating::Saturating<u64> as core::ops::arith::MulAssign<&core::num::saturating::Saturating<u64>>>::mul_assign
 <core::num::saturating::Saturating<u64> as core::ops::arith::MulAssign<&u64>>::mul_assign
+<core::num::saturating::Saturating<u64> as core::ops::arith::MulAssign<u64>>::mul_assign
+<core::num::saturating::Saturating<u64> as core::ops::arith::MulAssign>::mul_assign
 <core::num::saturating::Saturating<u64> as core::ops::arith::Rem<&core::num::saturating::Saturating<u64>>>::rem
+<core::num::saturating::Saturating<u64> as core::ops::arith::Rem>::rem
 <core::num::saturating::Saturating<u64> as core::ops::arith::RemAssign<&core::num::saturating::Saturating<u64>>>::rem_assign
 <core::num::saturating::Saturating<u64> as core::ops::arith::RemAssign<&u64>>::rem_assign
+<core::num::saturating::Saturating<u64> as core::ops::arith::RemAssign<u64>>::rem_assign
+<core::num::saturating::Saturating<u64> as core::ops::arith::RemAssign>::rem_assign
 <core::num::saturating::Saturating<u64> as core::ops::arith::Sub<&core::num::saturating::Saturating<u64>>>::sub
+<core::num::saturating::Saturating<u64> as core::ops::arith::Sub>::sub
 <core::num::saturating::Saturating<u64> as core::ops::arith::SubAssign<&core::num::saturating::Saturating<u64>>>::sub_assign
 <core::num::saturating::Saturating<u64> as core::ops::arith::SubAssign<&u64>>::sub_assign
+<core::num::saturating::Saturating<u64> as core::ops::arith::SubAssign<u64>>::sub_assign
+<core::num::saturating::Saturating<u64> as core::ops::arith::SubAssign>::sub_assign
 <core::num::saturating::Saturating<u64> as core::ops::bit::BitAnd<&core::num::saturating::Saturating<u64>>>::bitand
+<core::num::saturating::Saturating<u64> as core::ops::bit::BitAnd>::bitand
 <core::num::saturating::Saturating<u64> as core::ops::bit::BitAndAssign<&core::num::saturating::Saturating<u64>>>::bitand_assign
 <core::num::saturating::Saturating<u64> as core::ops::bit::BitAndAssign<&u64>>::bitand_assign
+<core::num::saturating::Saturating<u64> as core::ops::bit::BitAndAssign<u64>>::bitand_assign
+<core::num::saturating::Saturating<u64> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::saturating::Saturating<u64> as core::ops::bit::BitOr<&core::num::saturating::Saturating<u64>>>::bitor
+<core::num::saturating::Saturating<u64> as core::ops::bit::BitOr>::bitor
 <core::num::saturating::Saturating<u64> as core::ops::bit::BitOrAssign<&core::num::saturating::Saturating<u64>>>::bitor_assign
 <core::num::saturating::Saturating<u64> as core::ops::bit::BitOrAssign<&u64>>::bitor_assign
+<core::num::saturating::Saturating<u64> as core::ops::bit::BitOrAssign<u64>>::bitor_assign
+<core::num::saturating::Saturating<u64> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::saturating::Saturating<u64> as core::ops::bit::BitXor<&core::num::saturating::Saturating<u64>>>::bitxor
+<core::num::saturating::Saturating<u64> as core::ops::bit::BitXor>::bitxor
 <core::num::saturating::Saturating<u64> as core::ops::bit::BitXorAssign<&core::num::saturating::Saturating<u64>>>::bitxor_assign
 <core::num::saturating::Saturating<u64> as core::ops::bit::BitXorAssign<&u64>>::bitxor_assign
+<core::num::saturating::Saturating<u64> as core::ops::bit::BitXorAssign<u64>>::bitxor_assign
+<core::num::saturating::Saturating<u64> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::saturating::Saturating<u64> as core::ops::bit::Not>::not
 <core::num::saturating::Saturating<u8> as core::ops::arith::Add<&core::num::saturating::Saturating<u8>>>::add
+<core::num::saturating::Saturating<u8> as core::ops::arith::Add>::add
 <core::num::saturating::Saturating<u8> as core::ops::arith::AddAssign<&core::num::saturating::Saturating<u8>>>::add_assign
 <core::num::saturating::Saturating<u8> as core::ops::arith::AddAssign<&u8>>::add_assign
+<core::num::saturating::Saturating<u8> as core::ops::arith::AddAssign<u8>>::add_assign
+<core::num::saturating::Saturating<u8> as core::ops::arith::AddAssign>::add_assign
 <core::num::saturating::Saturating<u8> as core::ops::arith::Div<&core::num::saturating::Saturating<u8>>>::div
+<core::num::saturating::Saturating<u8> as core::ops::arith::Div>::div
 <core::num::saturating::Saturating<u8> as core::ops::arith::DivAssign<&core::num::saturating::Saturating<u8>>>::div_assign
 <core::num::saturating::Saturating<u8> as core::ops::arith::DivAssign<&u8>>::div_assign
+<core::num::saturating::Saturating<u8> as core::ops::arith::DivAssign<u8>>::div_assign
+<core::num::saturating::Saturating<u8> as core::ops::arith::DivAssign>::div_assign
 <core::num::saturating::Saturating<u8> as core::ops::arith::Mul<&core::num::saturating::Saturating<u8>>>::mul
+<core::num::saturating::Saturating<u8> as core::ops::arith::Mul>::mul
 <core::num::saturating::Saturating<u8> as core::ops::arith::MulAssign<&core::num::saturating::Saturating<u8>>>::mul_assign
 <core::num::saturating::Saturating<u8> as core::ops::arith::MulAssign<&u8>>::mul_assign
+<core::num::saturating::Saturating<u8> as core::ops::arith::MulAssign<u8>>::mul_assign
+<core::num::saturating::Saturating<u8> as core::ops::arith::MulAssign>::mul_assign
 <core::num::saturating::Saturating<u8> as core::ops::arith::Rem<&core::num::saturating::Saturating<u8>>>::rem
+<core::num::saturating::Saturating<u8> as core::ops::arith::Rem>::rem
 <core::num::saturating::Saturating<u8> as core::ops::arith::RemAssign<&core::num::saturating::Saturating<u8>>>::rem_assign
 <core::num::saturating::Saturating<u8> as core::ops::arith::RemAssign<&u8>>::rem_assign
+<core::num::saturating::Saturating<u8> as core::ops::arith::RemAssign<u8>>::rem_assign
+<core::num::saturating::Saturating<u8> as core::ops::arith::RemAssign>::rem_assign
 <core::num::saturating::Saturating<u8> as core::ops::arith::Sub<&core::num::saturating::Saturating<u8>>>::sub
+<core::num::saturating::Saturating<u8> as core::ops::arith::Sub>::sub
 <core::num::saturating::Saturating<u8> as core::ops::arith::SubAssign<&core::num::saturating::Saturating<u8>>>::sub_assign
 <core::num::saturating::Saturating<u8> as core::ops::arith::SubAssign<&u8>>::sub_assign
+<core::num::saturating::Saturating<u8> as core::ops::arith::SubAssign<u8>>::sub_assign
+<core::num::saturating::Saturating<u8> as core::ops::arith::SubAssign>::sub_assign
 <core::num::saturating::Saturating<u8> as core::ops::bit::BitAnd<&core::num::saturating::Saturating<u8>>>::bitand
+<core::num::saturating::Saturating<u8> as core::ops::bit::BitAnd>::bitand
 <core::num::saturating::Saturating<u8> as core::ops::bit::BitAndAssign<&core::num::saturating::Saturating<u8>>>::bitand_assign
 <core::num::saturating::Saturating<u8> as core::ops::bit::BitAndAssign<&u8>>::bitand_assign
+<core::num::saturating::Saturating<u8> as core::ops::bit::BitAndAssign<u8>>::bitand_assign
+<core::num::saturating::Saturating<u8> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::saturating::Saturating<u8> as core::ops::bit::BitOr<&core::num::saturating::Saturating<u8>>>::bitor
+<core::num::saturating::Saturating<u8> as core::ops::bit::BitOr>::bitor
 <core::num::saturating::Saturating<u8> as core::ops::bit::BitOrAssign<&core::num::saturating::Saturating<u8>>>::bitor_assign
 <core::num::saturating::Saturating<u8> as core::ops::bit::BitOrAssign<&u8>>::bitor_assign
+<core::num::saturating::Saturating<u8> as core::ops::bit::BitOrAssign<u8>>::bitor_assign
+<core::num::saturating::Saturating<u8> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::saturating::Saturating<u8> as core::ops::bit::BitXor<&core::num::saturating::Saturating<u8>>>::bitxor
+<core::num::saturating::Saturating<u8> as core::ops::bit::BitXor>::bitxor
 <core::num::saturating::Saturating<u8> as core::ops::bit::BitXorAssign<&core::num::saturating::Saturating<u8>>>::bitxor_assign
 <core::num::saturating::Saturating<u8> as core::ops::bit::BitXorAssign<&u8>>::bitxor_assign
+<core::num::saturating::Saturating<u8> as core::ops::bit::BitXorAssign<u8>>::bitxor_assign
+<core::num::saturating::Saturating<u8> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::saturating::Saturating<u8> as core::ops::bit::Not>::not
 <core::num::saturating::Saturating<usize> as core::ops::arith::Add<&core::num::saturating::Saturating<usize>>>::add
+<core::num::saturating::Saturating<usize> as core::ops::arith::Add>::add
 <core::num::saturating::Saturating<usize> as core::ops::arith::AddAssign<&core::num::saturating::Saturating<usize>>>::add_assign
 <core::num::saturating::Saturating<usize> as core::ops::arith::AddAssign<&usize>>::add_assign
+<core::num::saturating::Saturating<usize> as core::ops::arith::AddAssign<usize>>::add_assign
+<core::num::saturating::Saturating<usize> as core::ops::arith::AddAssign>::add_assign
 <core::num::saturating::Saturating<usize> as core::ops::arith::Div<&core::num::saturating::Saturating<usize>>>::div
+<core::num::saturating::Saturating<usize> as core::ops::arith::Div>::div
 <core::num::saturating::Saturating<usize> as core::ops::arith::DivAssign<&core::num::saturating::Saturating<usize>>>::div_assign
 <core::num::saturating::Saturating<usize> as core::ops::arith::DivAssign<&usize>>::div_assign
+<core::num::saturating::Saturating<usize> as core::ops::arith::DivAssign<usize>>::div_assign
+<core::num::saturating::Saturating<usize> as core::ops::arith::DivAssign>::div_assign
 <core::num::saturating::Saturating<usize> as core::ops::arith::Mul<&core::num::saturating::Saturating<usize>>>::mul
+<core::num::saturating::Saturating<usize> as core::ops::arith::Mul>::mul
 <core::num::saturating::Saturating<usize> as core::ops::arith::MulAssign<&core::num::saturating::Saturating<usize>>>::mul_assign
 <core::num::saturating::Saturating<usize> as core::ops::arith::MulAssign<&usize>>::mul_assign
+<core::num::saturating::Saturating<usize> as core::ops::arith::MulAssign<usize>>::mul_assign
+<core::num::saturating::Saturating<usize> as core::ops::arith::MulAssign>::mul_assign
 <core::num::saturating::Saturating<usize> as core::ops::arith::Rem<&core::num::saturating::Saturating<usize>>>::rem
+<core::num::saturating::Saturating<usize> as core::ops::arith::Rem>::rem
 <core::num::saturating::Saturating<usize> as core::ops::arith::RemAssign<&core::num::saturating::Saturating<usize>>>::rem_assign
 <core::num::saturating::Saturating<usize> as core::ops::arith::RemAssign<&usize>>::rem_assign
+<core::num::saturating::Saturating<usize> as core::ops::arith::RemAssign<usize>>::rem_assign
+<core::num::saturating::Saturating<usize> as core::ops::arith::RemAssign>::rem_assign
 <core::num::saturating::Saturating<usize> as core::ops::arith::Sub<&core::num::saturating::Saturating<usize>>>::sub
+<core::num::saturating::Saturating<usize> as core::ops::arith::Sub>::sub
 <core::num::saturating::Saturating<usize> as core::ops::arith::SubAssign<&core::num::saturating::Saturating<usize>>>::sub_assign
 <core::num::saturating::Saturating<usize> as core::ops::arith::SubAssign<&usize>>::sub_assign
+<core::num::saturating::Saturating<usize> as core::ops::arith::SubAssign<usize>>::sub_assign
+<core::num::saturating::Saturating<usize> as core::ops::arith::SubAssign>::sub_assign
 <core::num::saturating::Saturating<usize> as core::ops::bit::BitAnd<&core::num::saturating::Saturating<usize>>>::bitand
+<core::num::saturating::Saturating<usize> as core::ops::bit::BitAnd>::bitand
 <core::num::saturating::Saturating<usize> as core::ops::bit::BitAndAssign<&core::num::saturating::Saturating<usize>>>::bitand_assign
 <core::num::saturating::Saturating<usize> as core::ops::bit::BitAndAssign<&usize>>::bitand_assign
+<core::num::saturating::Saturating<usize> as core::ops::bit::BitAndAssign<usize>>::bitand_assign
+<core::num::saturating::Saturating<usize> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::saturating::Saturating<usize> as core::ops::bit::BitOr<&core::num::saturating::Saturating<usize>>>::bitor
+<core::num::saturating::Saturating<usize> as core::ops::bit::BitOr>::bitor
 <core::num::saturating::Saturating<usize> as core::ops::bit::BitOrAssign<&core::num::saturating::Saturating<usize>>>::bitor_assign
 <core::num::saturating::Saturating<usize> as core::ops::bit::BitOrAssign<&usize>>::bitor_assign
+<core::num::saturating::Saturating<usize> as core::ops::bit::BitOrAssign<usize>>::bitor_assign
+<core::num::saturating::Saturating<usize> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::saturating::Saturating<usize> as core::ops::bit::BitXor<&core::num::saturating::Saturating<usize>>>::bitxor
+<core::num::saturating::Saturating<usize> as core::ops::bit::BitXor>::bitxor
 <core::num::saturating::Saturating<usize> as core::ops::bit::BitXorAssign<&core::num::saturating::Saturating<usize>>>::bitxor_assign
 <core::num::saturating::Saturating<usize> as core::ops::bit::BitXorAssign<&usize>>::bitxor_assign
+<core::num::saturating::Saturating<usize> as core::ops::bit::BitXorAssign<usize>>::bitxor_assign
+<core::num::saturating::Saturating<usize> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::saturating::Saturating<usize> as core::ops::bit::Not>::not
 <core::num::wrapping::Wrapping<i128> as core::iter::traits::accum::Sum<&'a core::num::wrapping::Wrapping<i128>>>::sum
 <core::num::wrapping::Wrapping<i128> as core::iter::traits::accum::Sum>::sum
 <core::num::wrapping::Wrapping<i128> as core::ops::arith::Add<&core::num::wrapping::Wrapping<i128>>>::add
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::Add>::add
 <core::num::wrapping::Wrapping<i128> as core::ops::arith::AddAssign<&core::num::wrapping::Wrapping<i128>>>::add_assign
 <core::num::wrapping::Wrapping<i128> as core::ops::arith::AddAssign<&i128>>::add_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::AddAssign<i128>>::add_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::AddAssign>::add_assign
 <core::num::wrapping::Wrapping<i128> as core::ops::arith::Div<&core::num::wrapping::Wrapping<i128>>>::div
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::Div>::div
 <core::num::wrapping::Wrapping<i128> as core::ops::arith::DivAssign<&core::num::wrapping::Wrapping<i128>>>::div_assign
 <core::num::wrapping::Wrapping<i128> as core::ops::arith::DivAssign<&i128>>::div_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::DivAssign<i128>>::div_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::DivAssign>::div_assign
 <core::num::wrapping::Wrapping<i128> as core::ops::arith::Mul<&core::num::wrapping::Wrapping<i128>>>::mul
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::Mul>::mul
 <core::num::wrapping::Wrapping<i128> as core::ops::arith::MulAssign<&core::num::wrapping::Wrapping<i128>>>::mul_assign
 <core::num::wrapping::Wrapping<i128> as core::ops::arith::MulAssign<&i128>>::mul_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::MulAssign<i128>>::mul_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::MulAssign>::mul_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::Neg>::neg
 <core::num::wrapping::Wrapping<i128> as core::ops::arith::Rem<&core::num::wrapping::Wrapping<i128>>>::rem
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::Rem>::rem
 <core::num::wrapping::Wrapping<i128> as core::ops::arith::RemAssign<&core::num::wrapping::Wrapping<i128>>>::rem_assign
 <core::num::wrapping::Wrapping<i128> as core::ops::arith::RemAssign<&i128>>::rem_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::RemAssign<i128>>::rem_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::RemAssign>::rem_assign
 <core::num::wrapping::Wrapping<i128> as core::ops::arith::Sub<&core::num::wrapping::Wrapping<i128>>>::sub
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::Sub>::sub
 <core::num::wrapping::Wrapping<i128> as core::ops::arith::SubAssign<&core::num::wrapping::Wrapping<i128>>>::sub_assign
 <core::num::wrapping::Wrapping<i128> as core::ops::arith::SubAssign<&i128>>::sub_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::SubAssign<i128>>::sub_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::arith::SubAssign>::sub_assign
 <core::num::wrapping::Wrapping<i128> as core::ops::bit::BitAnd<&core::num::wrapping::Wrapping<i128>>>::bitand
+<core::num::wrapping::Wrapping<i128> as core::ops::bit::BitAnd>::bitand
 <core::num::wrapping::Wrapping<i128> as core::ops::bit::BitAndAssign<&core::num::wrapping::Wrapping<i128>>>::bitand_assign
 <core::num::wrapping::Wrapping<i128> as core::ops::bit::BitAndAssign<&i128>>::bitand_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::bit::BitAndAssign<i128>>::bitand_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::wrapping::Wrapping<i128> as core::ops::bit::BitOr<&core::num::wrapping::Wrapping<i128>>>::bitor
+<core::num::wrapping::Wrapping<i128> as core::ops::bit::BitOr>::bitor
 <core::num::wrapping::Wrapping<i128> as core::ops::bit::BitOrAssign<&core::num::wrapping::Wrapping<i128>>>::bitor_assign
 <core::num::wrapping::Wrapping<i128> as core::ops::bit::BitOrAssign<&i128>>::bitor_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::bit::BitOrAssign<i128>>::bitor_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::wrapping::Wrapping<i128> as core::ops::bit::BitXor<&core::num::wrapping::Wrapping<i128>>>::bitxor
+<core::num::wrapping::Wrapping<i128> as core::ops::bit::BitXor>::bitxor
 <core::num::wrapping::Wrapping<i128> as core::ops::bit::BitXorAssign<&core::num::wrapping::Wrapping<i128>>>::bitxor_assign
 <core::num::wrapping::Wrapping<i128> as core::ops::bit::BitXorAssign<&i128>>::bitxor_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::bit::BitXorAssign<i128>>::bitxor_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::bit::Not>::not
 <core::num::wrapping::Wrapping<i128> as core::ops::bit::Shl<&usize>>::shl
+<core::num::wrapping::Wrapping<i128> as core::ops::bit::Shl<usize>>::shl
 <core::num::wrapping::Wrapping<i128> as core::ops::bit::ShlAssign<&usize>>::shl_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::bit::ShlAssign<usize>>::shl_assign
 <core::num::wrapping::Wrapping<i128> as core::ops::bit::Shr<&usize>>::shr
+<core::num::wrapping::Wrapping<i128> as core::ops::bit::Shr<usize>>::shr
 <core::num::wrapping::Wrapping<i128> as core::ops::bit::ShrAssign<&usize>>::shr_assign
+<core::num::wrapping::Wrapping<i128> as core::ops::bit::ShrAssign<usize>>::shr_assign
 <core::num::wrapping::Wrapping<i16> as core::iter::traits::accum::Sum<&'a core::num::wrapping::Wrapping<i16>>>::sum
 <core::num::wrapping::Wrapping<i16> as core::iter::traits::accum::Sum>::sum
 <core::num::wrapping::Wrapping<i16> as core::ops::arith::Add<&core::num::wrapping::Wrapping<i16>>>::add
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::Add>::add
 <core::num::wrapping::Wrapping<i16> as core::ops::arith::AddAssign<&core::num::wrapping::Wrapping<i16>>>::add_assign
 <core::num::wrapping::Wrapping<i16> as core::ops::arith::AddAssign<&i16>>::add_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::AddAssign<i16>>::add_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::AddAssign>::add_assign
 <core::num::wrapping::Wrapping<i16> as core::ops::arith::Div<&core::num::wrapping::Wrapping<i16>>>::div
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::Div>::div
 <core::num::wrapping::Wrapping<i16> as core::ops::arith::DivAssign<&core::num::wrapping::Wrapping<i16>>>::div_assign
 <core::num::wrapping::Wrapping<i16> as core::ops::arith::DivAssign<&i16>>::div_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::DivAssign<i16>>::div_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::DivAssign>::div_assign
 <core::num::wrapping::Wrapping<i16> as core::ops::arith::Mul<&core::num::wrapping::Wrapping<i16>>>::mul
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::Mul>::mul
 <core::num::wrapping::Wrapping<i16> as core::ops::arith::MulAssign<&core::num::wrapping::Wrapping<i16>>>::mul_assign
 <core::num::wrapping::Wrapping<i16> as core::ops::arith::MulAssign<&i16>>::mul_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::MulAssign<i16>>::mul_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::MulAssign>::mul_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::Neg>::neg
 <core::num::wrapping::Wrapping<i16> as core::ops::arith::Rem<&core::num::wrapping::Wrapping<i16>>>::rem
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::Rem>::rem
 <core::num::wrapping::Wrapping<i16> as core::ops::arith::RemAssign<&core::num::wrapping::Wrapping<i16>>>::rem_assign
 <core::num::wrapping::Wrapping<i16> as core::ops::arith::RemAssign<&i16>>::rem_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::RemAssign<i16>>::rem_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::RemAssign>::rem_assign
 <core::num::wrapping::Wrapping<i16> as core::ops::arith::Sub<&core::num::wrapping::Wrapping<i16>>>::sub
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::Sub>::sub
 <core::num::wrapping::Wrapping<i16> as core::ops::arith::SubAssign<&core::num::wrapping::Wrapping<i16>>>::sub_assign
 <core::num::wrapping::Wrapping<i16> as core::ops::arith::SubAssign<&i16>>::sub_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::SubAssign<i16>>::sub_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::arith::SubAssign>::sub_assign
 <core::num::wrapping::Wrapping<i16> as core::ops::bit::BitAnd<&core::num::wrapping::Wrapping<i16>>>::bitand
+<core::num::wrapping::Wrapping<i16> as core::ops::bit::BitAnd>::bitand
 <core::num::wrapping::Wrapping<i16> as core::ops::bit::BitAndAssign<&core::num::wrapping::Wrapping<i16>>>::bitand_assign
 <core::num::wrapping::Wrapping<i16> as core::ops::bit::BitAndAssign<&i16>>::bitand_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::bit::BitAndAssign<i16>>::bitand_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::wrapping::Wrapping<i16> as core::ops::bit::BitOr<&core::num::wrapping::Wrapping<i16>>>::bitor
+<core::num::wrapping::Wrapping<i16> as core::ops::bit::BitOr>::bitor
 <core::num::wrapping::Wrapping<i16> as core::ops::bit::BitOrAssign<&core::num::wrapping::Wrapping<i16>>>::bitor_assign
 <core::num::wrapping::Wrapping<i16> as core::ops::bit::BitOrAssign<&i16>>::bitor_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::bit::BitOrAssign<i16>>::bitor_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::wrapping::Wrapping<i16> as core::ops::bit::BitXor<&core::num::wrapping::Wrapping<i16>>>::bitxor
+<core::num::wrapping::Wrapping<i16> as core::ops::bit::BitXor>::bitxor
 <core::num::wrapping::Wrapping<i16> as core::ops::bit::BitXorAssign<&core::num::wrapping::Wrapping<i16>>>::bitxor_assign
 <core::num::wrapping::Wrapping<i16> as core::ops::bit::BitXorAssign<&i16>>::bitxor_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::bit::BitXorAssign<i16>>::bitxor_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::bit::Not>::not
 <core::num::wrapping::Wrapping<i16> as core::ops::bit::Shl<&usize>>::shl
+<core::num::wrapping::Wrapping<i16> as core::ops::bit::Shl<usize>>::shl
 <core::num::wrapping::Wrapping<i16> as core::ops::bit::ShlAssign<&usize>>::shl_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::bit::ShlAssign<usize>>::shl_assign
 <core::num::wrapping::Wrapping<i16> as core::ops::bit::Shr<&usize>>::shr
+<core::num::wrapping::Wrapping<i16> as core::ops::bit::Shr<usize>>::shr
 <core::num::wrapping::Wrapping<i16> as core::ops::bit::ShrAssign<&usize>>::shr_assign
+<core::num::wrapping::Wrapping<i16> as core::ops::bit::ShrAssign<usize>>::shr_assign
 <core::num::wrapping::Wrapping<i32> as core::iter::traits::accum::Sum<&'a core::num::wrapping::Wrapping<i32>>>::sum
 <core::num::wrapping::Wrapping<i32> as core::iter::traits::accum::Sum>::sum
 <core::num::wrapping::Wrapping<i32> as core::ops::arith::Add<&core::num::wrapping::Wrapping<i32>>>::add
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::Add>::add
 <core::num::wrapping::Wrapping<i32> as core::ops::arith::AddAssign<&core::num::wrapping::Wrapping<i32>>>::add_assign
 <core::num::wrapping::Wrapping<i32> as core::ops::arith::AddAssign<&i32>>::add_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::AddAssign<i32>>::add_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::AddAssign>::add_assign
 <core::num::wrapping::Wrapping<i32> as core::ops::arith::Div<&core::num::wrapping::Wrapping<i32>>>::div
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::Div>::div
 <core::num::wrapping::Wrapping<i32> as core::ops::arith::DivAssign<&core::num::wrapping::Wrapping<i32>>>::div_assign
 <core::num::wrapping::Wrapping<i32> as core::ops::arith::DivAssign<&i32>>::div_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::DivAssign<i32>>::div_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::DivAssign>::div_assign
 <core::num::wrapping::Wrapping<i32> as core::ops::arith::Mul<&core::num::wrapping::Wrapping<i32>>>::mul
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::Mul>::mul
 <core::num::wrapping::Wrapping<i32> as core::ops::arith::MulAssign<&core::num::wrapping::Wrapping<i32>>>::mul_assign
 <core::num::wrapping::Wrapping<i32> as core::ops::arith::MulAssign<&i32>>::mul_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::MulAssign<i32>>::mul_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::MulAssign>::mul_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::Neg>::neg
 <core::num::wrapping::Wrapping<i32> as core::ops::arith::Rem<&core::num::wrapping::Wrapping<i32>>>::rem
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::Rem>::rem
 <core::num::wrapping::Wrapping<i32> as core::ops::arith::RemAssign<&core::num::wrapping::Wrapping<i32>>>::rem_assign
 <core::num::wrapping::Wrapping<i32> as core::ops::arith::RemAssign<&i32>>::rem_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::RemAssign<i32>>::rem_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::RemAssign>::rem_assign
 <core::num::wrapping::Wrapping<i32> as core::ops::arith::Sub<&core::num::wrapping::Wrapping<i32>>>::sub
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::Sub>::sub
 <core::num::wrapping::Wrapping<i32> as core::ops::arith::SubAssign<&core::num::wrapping::Wrapping<i32>>>::sub_assign
 <core::num::wrapping::Wrapping<i32> as core::ops::arith::SubAssign<&i32>>::sub_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::SubAssign<i32>>::sub_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::arith::SubAssign>::sub_assign
 <core::num::wrapping::Wrapping<i32> as core::ops::bit::BitAnd<&core::num::wrapping::Wrapping<i32>>>::bitand
+<core::num::wrapping::Wrapping<i32> as core::ops::bit::BitAnd>::bitand
 <core::num::wrapping::Wrapping<i32> as core::ops::bit::BitAndAssign<&core::num::wrapping::Wrapping<i32>>>::bitand_assign
 <core::num::wrapping::Wrapping<i32> as core::ops::bit::BitAndAssign<&i32>>::bitand_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::bit::BitAndAssign<i32>>::bitand_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::wrapping::Wrapping<i32> as core::ops::bit::BitOr<&core::num::wrapping::Wrapping<i32>>>::bitor
+<core::num::wrapping::Wrapping<i32> as core::ops::bit::BitOr>::bitor
 <core::num::wrapping::Wrapping<i32> as core::ops::bit::BitOrAssign<&core::num::wrapping::Wrapping<i32>>>::bitor_assign
 <core::num::wrapping::Wrapping<i32> as core::ops::bit::BitOrAssign<&i32>>::bitor_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::bit::BitOrAssign<i32>>::bitor_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::wrapping::Wrapping<i32> as core::ops::bit::BitXor<&core::num::wrapping::Wrapping<i32>>>::bitxor
+<core::num::wrapping::Wrapping<i32> as core::ops::bit::BitXor>::bitxor
 <core::num::wrapping::Wrapping<i32> as core::ops::bit::BitXorAssign<&core::num::wrapping::Wrapping<i32>>>::bitxor_assign
 <core::num::wrapping::Wrapping<i32> as core::ops::bit::BitXorAssign<&i32>>::bitxor_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::bit::BitXorAssign<i32>>::bitxor_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::bit::Not>::not
 <core::num::wrapping::Wrapping<i32> as core::ops::bit::Shl<&usize>>::shl
+<core::num::wrapping::Wrapping<i32> as core::ops::bit::Shl<usize>>::shl
 <core::num::wrapping::Wrapping<i32> as core::ops::bit::ShlAssign<&usize>>::shl_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::bit::ShlAssign<usize>>::shl_assign
 <core::num::wrapping::Wrapping<i32> as core::ops::bit::Shr<&usize>>::shr
+<core::num::wrapping::Wrapping<i32> as core::ops::bit::Shr<usize>>::shr
 <core::num::wrapping::Wrapping<i32> as core::ops::bit::ShrAssign<&usize>>::shr_assign
+<core::num::wrapping::Wrapping<i32> as core::ops::bit::ShrAssign<usize>>::shr_assign
 <core::num::wrapping::Wrapping<i64> as core::iter::traits::accum::Sum<&'a core::num::wrapping::Wrapping<i64>>>::sum
 <core::num::wrapping::Wrapping<i64> as core::iter::traits::accum::Sum>::sum
 <core::num::wrapping::Wrapping<i64> as core::ops::arith::Add<&core::num::wrapping::Wrapping<i64>>>::add
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::Add>::add
 <core::num::wrapping::Wrapping<i64> as core::ops::arith::AddAssign<&core::num::wrapping::Wrapping<i64>>>::add_assign
 <core::num::wrapping::Wrapping<i64> as core::ops::arith::AddAssign<&i64>>::add_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::AddAssign<i64>>::add_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::AddAssign>::add_assign
 <core::num::wrapping::Wrapping<i64> as core::ops::arith::Div<&core::num::wrapping::Wrapping<i64>>>::div
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::Div>::div
 <core::num::wrapping::Wrapping<i64> as core::ops::arith::DivAssign<&core::num::wrapping::Wrapping<i64>>>::div_assign
 <core::num::wrapping::Wrapping<i64> as core::ops::arith::DivAssign<&i64>>::div_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::DivAssign<i64>>::div_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::DivAssign>::div_assign
 <core::num::wrapping::Wrapping<i64> as core::ops::arith::Mul<&core::num::wrapping::Wrapping<i64>>>::mul
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::Mul>::mul
 <core::num::wrapping::Wrapping<i64> as core::ops::arith::MulAssign<&core::num::wrapping::Wrapping<i64>>>::mul_assign
 <core::num::wrapping::Wrapping<i64> as core::ops::arith::MulAssign<&i64>>::mul_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::MulAssign<i64>>::mul_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::MulAssign>::mul_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::Neg>::neg
 <core::num::wrapping::Wrapping<i64> as core::ops::arith::Rem<&core::num::wrapping::Wrapping<i64>>>::rem
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::Rem>::rem
 <core::num::wrapping::Wrapping<i64> as core::ops::arith::RemAssign<&core::num::wrapping::Wrapping<i64>>>::rem_assign
 <core::num::wrapping::Wrapping<i64> as core::ops::arith::RemAssign<&i64>>::rem_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::RemAssign<i64>>::rem_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::RemAssign>::rem_assign
 <core::num::wrapping::Wrapping<i64> as core::ops::arith::Sub<&core::num::wrapping::Wrapping<i64>>>::sub
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::Sub>::sub
 <core::num::wrapping::Wrapping<i64> as core::ops::arith::SubAssign<&core::num::wrapping::Wrapping<i64>>>::sub_assign
 <core::num::wrapping::Wrapping<i64> as core::ops::arith::SubAssign<&i64>>::sub_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::SubAssign<i64>>::sub_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::arith::SubAssign>::sub_assign
 <core::num::wrapping::Wrapping<i64> as core::ops::bit::BitAnd<&core::num::wrapping::Wrapping<i64>>>::bitand
+<core::num::wrapping::Wrapping<i64> as core::ops::bit::BitAnd>::bitand
 <core::num::wrapping::Wrapping<i64> as core::ops::bit::BitAndAssign<&core::num::wrapping::Wrapping<i64>>>::bitand_assign
 <core::num::wrapping::Wrapping<i64> as core::ops::bit::BitAndAssign<&i64>>::bitand_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::bit::BitAndAssign<i64>>::bitand_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::wrapping::Wrapping<i64> as core::ops::bit::BitOr<&core::num::wrapping::Wrapping<i64>>>::bitor
+<core::num::wrapping::Wrapping<i64> as core::ops::bit::BitOr>::bitor
 <core::num::wrapping::Wrapping<i64> as core::ops::bit::BitOrAssign<&core::num::wrapping::Wrapping<i64>>>::bitor_assign
 <core::num::wrapping::Wrapping<i64> as core::ops::bit::BitOrAssign<&i64>>::bitor_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::bit::BitOrAssign<i64>>::bitor_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::wrapping::Wrapping<i64> as core::ops::bit::BitXor<&core::num::wrapping::Wrapping<i64>>>::bitxor
+<core::num::wrapping::Wrapping<i64> as core::ops::bit::BitXor>::bitxor
 <core::num::wrapping::Wrapping<i64> as core::ops::bit::BitXorAssign<&core::num::wrapping::Wrapping<i64>>>::bitxor_assign
 <core::num::wrapping::Wrapping<i64> as core::ops::bit::BitXorAssign<&i64>>::bitxor_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::bit::BitXorAssign<i64>>::bitxor_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::bit::Not>::not
 <core::num::wrapping::Wrapping<i64> as core::ops::bit::Shl<&usize>>::shl
+<core::num::wrapping::Wrapping<i64> as core::ops::bit::Shl<usize>>::shl
 <core::num::wrapping::Wrapping<i64> as core::ops::bit::ShlAssign<&usize>>::shl_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::bit::ShlAssign<usize>>::shl_assign
 <core::num::wrapping::Wrapping<i64> as core::ops::bit::Shr<&usize>>::shr
+<core::num::wrapping::Wrapping<i64> as core::ops::bit::Shr<usize>>::shr
 <core::num::wrapping::Wrapping<i64> as core::ops::bit::ShrAssign<&usize>>::shr_assign
+<core::num::wrapping::Wrapping<i64> as core::ops::bit::ShrAssign<usize>>::shr_assign
 <core::num::wrapping::Wrapping<i8> as core::iter::traits::accum::Sum<&'a core::num::wrapping::Wrapping<i8>>>::sum
 <core::num::wrapping::Wrapping<i8> as core::iter::traits::accum::Sum>::sum
 <core::num::wrapping::Wrapping<i8> as core::ops::arith::Add<&core::num::wrapping::Wrapping<i8>>>::add
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::Add>::add
 <core::num::wrapping::Wrapping<i8> as core::ops::arith::AddAssign<&core::num::wrapping::Wrapping<i8>>>::add_assign
 <core::num::wrapping::Wrapping<i8> as core::ops::arith::AddAssign<&i8>>::add_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::AddAssign<i8>>::add_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::AddAssign>::add_assign
 <core::num::wrapping::Wrapping<i8> as core::ops::arith::Div<&core::num::wrapping::Wrapping<i8>>>::div
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::Div>::div
 <core::num::wrapping::Wrapping<i8> as core::ops::arith::DivAssign<&core::num::wrapping::Wrapping<i8>>>::div_assign
 <core::num::wrapping::Wrapping<i8> as core::ops::arith::DivAssign<&i8>>::div_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::DivAssign<i8>>::div_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::DivAssign>::div_assign
 <core::num::wrapping::Wrapping<i8> as core::ops::arith::Mul<&core::num::wrapping::Wrapping<i8>>>::mul
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::Mul>::mul
 <core::num::wrapping::Wrapping<i8> as core::ops::arith::MulAssign<&core::num::wrapping::Wrapping<i8>>>::mul_assign
 <core::num::wrapping::Wrapping<i8> as core::ops::arith::MulAssign<&i8>>::mul_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::MulAssign<i8>>::mul_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::MulAssign>::mul_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::Neg>::neg
 <core::num::wrapping::Wrapping<i8> as core::ops::arith::Rem<&core::num::wrapping::Wrapping<i8>>>::rem
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::Rem>::rem
 <core::num::wrapping::Wrapping<i8> as core::ops::arith::RemAssign<&core::num::wrapping::Wrapping<i8>>>::rem_assign
 <core::num::wrapping::Wrapping<i8> as core::ops::arith::RemAssign<&i8>>::rem_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::RemAssign<i8>>::rem_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::RemAssign>::rem_assign
 <core::num::wrapping::Wrapping<i8> as core::ops::arith::Sub<&core::num::wrapping::Wrapping<i8>>>::sub
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::Sub>::sub
 <core::num::wrapping::Wrapping<i8> as core::ops::arith::SubAssign<&core::num::wrapping::Wrapping<i8>>>::sub_assign
 <core::num::wrapping::Wrapping<i8> as core::ops::arith::SubAssign<&i8>>::sub_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::SubAssign<i8>>::sub_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::arith::SubAssign>::sub_assign
 <core::num::wrapping::Wrapping<i8> as core::ops::bit::BitAnd<&core::num::wrapping::Wrapping<i8>>>::bitand
+<core::num::wrapping::Wrapping<i8> as core::ops::bit::BitAnd>::bitand
 <core::num::wrapping::Wrapping<i8> as core::ops::bit::BitAndAssign<&core::num::wrapping::Wrapping<i8>>>::bitand_assign
 <core::num::wrapping::Wrapping<i8> as core::ops::bit::BitAndAssign<&i8>>::bitand_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::bit::BitAndAssign<i8>>::bitand_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::wrapping::Wrapping<i8> as core::ops::bit::BitOr<&core::num::wrapping::Wrapping<i8>>>::bitor
+<core::num::wrapping::Wrapping<i8> as core::ops::bit::BitOr>::bitor
 <core::num::wrapping::Wrapping<i8> as core::ops::bit::BitOrAssign<&core::num::wrapping::Wrapping<i8>>>::bitor_assign
 <core::num::wrapping::Wrapping<i8> as core::ops::bit::BitOrAssign<&i8>>::bitor_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::bit::BitOrAssign<i8>>::bitor_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::wrapping::Wrapping<i8> as core::ops::bit::BitXor<&core::num::wrapping::Wrapping<i8>>>::bitxor
+<core::num::wrapping::Wrapping<i8> as core::ops::bit::BitXor>::bitxor
 <core::num::wrapping::Wrapping<i8> as core::ops::bit::BitXorAssign<&core::num::wrapping::Wrapping<i8>>>::bitxor_assign
 <core::num::wrapping::Wrapping<i8> as core::ops::bit::BitXorAssign<&i8>>::bitxor_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::bit::BitXorAssign<i8>>::bitxor_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::bit::Not>::not
 <core::num::wrapping::Wrapping<i8> as core::ops::bit::Shl<&usize>>::shl
+<core::num::wrapping::Wrapping<i8> as core::ops::bit::Shl<usize>>::shl
 <core::num::wrapping::Wrapping<i8> as core::ops::bit::ShlAssign<&usize>>::shl_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::bit::ShlAssign<usize>>::shl_assign
 <core::num::wrapping::Wrapping<i8> as core::ops::bit::Shr<&usize>>::shr
+<core::num::wrapping::Wrapping<i8> as core::ops::bit::Shr<usize>>::shr
 <core::num::wrapping::Wrapping<i8> as core::ops::bit::ShrAssign<&usize>>::shr_assign
+<core::num::wrapping::Wrapping<i8> as core::ops::bit::ShrAssign<usize>>::shr_assign
 <core::num::wrapping::Wrapping<isize> as core::iter::traits::accum::Sum<&'a core::num::wrapping::Wrapping<isize>>>::sum
 <core::num::wrapping::Wrapping<isize> as core::iter::traits::accum::Sum>::sum
 <core::num::wrapping::Wrapping<isize> as core::ops::arith::Add<&core::num::wrapping::Wrapping<isize>>>::add
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::Add>::add
 <core::num::wrapping::Wrapping<isize> as core::ops::arith::AddAssign<&core::num::wrapping::Wrapping<isize>>>::add_assign
 <core::num::wrapping::Wrapping<isize> as core::ops::arith::AddAssign<&isize>>::add_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::AddAssign<isize>>::add_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::AddAssign>::add_assign
 <core::num::wrapping::Wrapping<isize> as core::ops::arith::Div<&core::num::wrapping::Wrapping<isize>>>::div
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::Div>::div
 <core::num::wrapping::Wrapping<isize> as core::ops::arith::DivAssign<&core::num::wrapping::Wrapping<isize>>>::div_assign
 <core::num::wrapping::Wrapping<isize> as core::ops::arith::DivAssign<&isize>>::div_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::DivAssign<isize>>::div_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::DivAssign>::div_assign
 <core::num::wrapping::Wrapping<isize> as core::ops::arith::Mul<&core::num::wrapping::Wrapping<isize>>>::mul
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::Mul>::mul
 <core::num::wrapping::Wrapping<isize> as core::ops::arith::MulAssign<&core::num::wrapping::Wrapping<isize>>>::mul_assign
 <core::num::wrapping::Wrapping<isize> as core::ops::arith::MulAssign<&isize>>::mul_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::MulAssign<isize>>::mul_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::MulAssign>::mul_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::Neg>::neg
 <core::num::wrapping::Wrapping<isize> as core::ops::arith::Rem<&core::num::wrapping::Wrapping<isize>>>::rem
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::Rem>::rem
 <core::num::wrapping::Wrapping<isize> as core::ops::arith::RemAssign<&core::num::wrapping::Wrapping<isize>>>::rem_assign
 <core::num::wrapping::Wrapping<isize> as core::ops::arith::RemAssign<&isize>>::rem_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::RemAssign<isize>>::rem_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::RemAssign>::rem_assign
 <core::num::wrapping::Wrapping<isize> as core::ops::arith::Sub<&core::num::wrapping::Wrapping<isize>>>::sub
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::Sub>::sub
 <core::num::wrapping::Wrapping<isize> as core::ops::arith::SubAssign<&core::num::wrapping::Wrapping<isize>>>::sub_assign
 <core::num::wrapping::Wrapping<isize> as core::ops::arith::SubAssign<&isize>>::sub_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::SubAssign<isize>>::sub_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::arith::SubAssign>::sub_assign
 <core::num::wrapping::Wrapping<isize> as core::ops::bit::BitAnd<&core::num::wrapping::Wrapping<isize>>>::bitand
+<core::num::wrapping::Wrapping<isize> as core::ops::bit::BitAnd>::bitand
 <core::num::wrapping::Wrapping<isize> as core::ops::bit::BitAndAssign<&core::num::wrapping::Wrapping<isize>>>::bitand_assign
 <core::num::wrapping::Wrapping<isize> as core::ops::bit::BitAndAssign<&isize>>::bitand_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::bit::BitAndAssign<isize>>::bitand_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::wrapping::Wrapping<isize> as core::ops::bit::BitOr<&core::num::wrapping::Wrapping<isize>>>::bitor
+<core::num::wrapping::Wrapping<isize> as core::ops::bit::BitOr>::bitor
 <core::num::wrapping::Wrapping<isize> as core::ops::bit::BitOrAssign<&core::num::wrapping::Wrapping<isize>>>::bitor_assign
 <core::num::wrapping::Wrapping<isize> as core::ops::bit::BitOrAssign<&isize>>::bitor_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::bit::BitOrAssign<isize>>::bitor_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::wrapping::Wrapping<isize> as core::ops::bit::BitXor<&core::num::wrapping::Wrapping<isize>>>::bitxor
+<core::num::wrapping::Wrapping<isize> as core::ops::bit::BitXor>::bitxor
 <core::num::wrapping::Wrapping<isize> as core::ops::bit::BitXorAssign<&core::num::wrapping::Wrapping<isize>>>::bitxor_assign
 <core::num::wrapping::Wrapping<isize> as core::ops::bit::BitXorAssign<&isize>>::bitxor_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::bit::BitXorAssign<isize>>::bitxor_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::bit::Not>::not
 <core::num::wrapping::Wrapping<isize> as core::ops::bit::Shl<&usize>>::shl
+<core::num::wrapping::Wrapping<isize> as core::ops::bit::Shl<usize>>::shl
 <core::num::wrapping::Wrapping<isize> as core::ops::bit::ShlAssign<&usize>>::shl_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::bit::ShlAssign<usize>>::shl_assign
 <core::num::wrapping::Wrapping<isize> as core::ops::bit::Shr<&usize>>::shr
+<core::num::wrapping::Wrapping<isize> as core::ops::bit::Shr<usize>>::shr
 <core::num::wrapping::Wrapping<isize> as core::ops::bit::ShrAssign<&usize>>::shr_assign
+<core::num::wrapping::Wrapping<isize> as core::ops::bit::ShrAssign<usize>>::shr_assign
 <core::num::wrapping::Wrapping<u128> as core::iter::traits::accum::Sum<&'a core::num::wrapping::Wrapping<u128>>>::sum
 <core::num::wrapping::Wrapping<u128> as core::iter::traits::accum::Sum>::sum
 <core::num::wrapping::Wrapping<u128> as core::ops::arith::Add<&core::num::wrapping::Wrapping<u128>>>::add
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::Add>::add
 <core::num::wrapping::Wrapping<u128> as core::ops::arith::AddAssign<&core::num::wrapping::Wrapping<u128>>>::add_assign
 <core::num::wrapping::Wrapping<u128> as core::ops::arith::AddAssign<&u128>>::add_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::AddAssign<u128>>::add_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::AddAssign>::add_assign
 <core::num::wrapping::Wrapping<u128> as core::ops::arith::Div<&core::num::wrapping::Wrapping<u128>>>::div
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::Div>::div
 <core::num::wrapping::Wrapping<u128> as core::ops::arith::DivAssign<&core::num::wrapping::Wrapping<u128>>>::div_assign
 <core::num::wrapping::Wrapping<u128> as core::ops::arith::DivAssign<&u128>>::div_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::DivAssign<u128>>::div_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::DivAssign>::div_assign
 <core::num::wrapping::Wrapping<u128> as core::ops::arith::Mul<&core::num::wrapping::Wrapping<u128>>>::mul
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::Mul>::mul
 <core::num::wrapping::Wrapping<u128> as core::ops::arith::MulAssign<&core::num::wrapping::Wrapping<u128>>>::mul_assign
 <core::num::wrapping::Wrapping<u128> as core::ops::arith::MulAssign<&u128>>::mul_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::MulAssign<u128>>::mul_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::MulAssign>::mul_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::Neg>::neg
 <core::num::wrapping::Wrapping<u128> as core::ops::arith::Rem<&core::num::wrapping::Wrapping<u128>>>::rem
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::Rem>::rem
 <core::num::wrapping::Wrapping<u128> as core::ops::arith::RemAssign<&core::num::wrapping::Wrapping<u128>>>::rem_assign
 <core::num::wrapping::Wrapping<u128> as core::ops::arith::RemAssign<&u128>>::rem_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::RemAssign<u128>>::rem_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::RemAssign>::rem_assign
 <core::num::wrapping::Wrapping<u128> as core::ops::arith::Sub<&core::num::wrapping::Wrapping<u128>>>::sub
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::Sub>::sub
 <core::num::wrapping::Wrapping<u128> as core::ops::arith::SubAssign<&core::num::wrapping::Wrapping<u128>>>::sub_assign
 <core::num::wrapping::Wrapping<u128> as core::ops::arith::SubAssign<&u128>>::sub_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::SubAssign<u128>>::sub_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::arith::SubAssign>::sub_assign
 <core::num::wrapping::Wrapping<u128> as core::ops::bit::BitAnd<&core::num::wrapping::Wrapping<u128>>>::bitand
+<core::num::wrapping::Wrapping<u128> as core::ops::bit::BitAnd>::bitand
 <core::num::wrapping::Wrapping<u128> as core::ops::bit::BitAndAssign<&core::num::wrapping::Wrapping<u128>>>::bitand_assign
 <core::num::wrapping::Wrapping<u128> as core::ops::bit::BitAndAssign<&u128>>::bitand_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::bit::BitAndAssign<u128>>::bitand_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::wrapping::Wrapping<u128> as core::ops::bit::BitOr<&core::num::wrapping::Wrapping<u128>>>::bitor
+<core::num::wrapping::Wrapping<u128> as core::ops::bit::BitOr>::bitor
 <core::num::wrapping::Wrapping<u128> as core::ops::bit::BitOrAssign<&core::num::wrapping::Wrapping<u128>>>::bitor_assign
 <core::num::wrapping::Wrapping<u128> as core::ops::bit::BitOrAssign<&u128>>::bitor_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::bit::BitOrAssign<u128>>::bitor_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::wrapping::Wrapping<u128> as core::ops::bit::BitXor<&core::num::wrapping::Wrapping<u128>>>::bitxor
+<core::num::wrapping::Wrapping<u128> as core::ops::bit::BitXor>::bitxor
 <core::num::wrapping::Wrapping<u128> as core::ops::bit::BitXorAssign<&core::num::wrapping::Wrapping<u128>>>::bitxor_assign
 <core::num::wrapping::Wrapping<u128> as core::ops::bit::BitXorAssign<&u128>>::bitxor_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::bit::BitXorAssign<u128>>::bitxor_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::bit::Not>::not
 <core::num::wrapping::Wrapping<u128> as core::ops::bit::Shl<&usize>>::shl
+<core::num::wrapping::Wrapping<u128> as core::ops::bit::Shl<usize>>::shl
 <core::num::wrapping::Wrapping<u128> as core::ops::bit::ShlAssign<&usize>>::shl_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::bit::ShlAssign<usize>>::shl_assign
 <core::num::wrapping::Wrapping<u128> as core::ops::bit::Shr<&usize>>::shr
+<core::num::wrapping::Wrapping<u128> as core::ops::bit::Shr<usize>>::shr
 <core::num::wrapping::Wrapping<u128> as core::ops::bit::ShrAssign<&usize>>::shr_assign
+<core::num::wrapping::Wrapping<u128> as core::ops::bit::ShrAssign<usize>>::shr_assign
 <core::num::wrapping::Wrapping<u16> as core::iter::traits::accum::Sum<&'a core::num::wrapping::Wrapping<u16>>>::sum
 <core::num::wrapping::Wrapping<u16> as core::iter::traits::accum::Sum>::sum
 <core::num::wrapping::Wrapping<u16> as core::ops::arith::Add<&core::num::wrapping::Wrapping<u16>>>::add
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::Add>::add
 <core::num::wrapping::Wrapping<u16> as core::ops::arith::AddAssign<&core::num::wrapping::Wrapping<u16>>>::add_assign
 <core::num::wrapping::Wrapping<u16> as core::ops::arith::AddAssign<&u16>>::add_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::AddAssign<u16>>::add_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::AddAssign>::add_assign
 <core::num::wrapping::Wrapping<u16> as core::ops::arith::Div<&core::num::wrapping::Wrapping<u16>>>::div
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::Div>::div
 <core::num::wrapping::Wrapping<u16> as core::ops::arith::DivAssign<&core::num::wrapping::Wrapping<u16>>>::div_assign
 <core::num::wrapping::Wrapping<u16> as core::ops::arith::DivAssign<&u16>>::div_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::DivAssign<u16>>::div_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::DivAssign>::div_assign
 <core::num::wrapping::Wrapping<u16> as core::ops::arith::Mul<&core::num::wrapping::Wrapping<u16>>>::mul
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::Mul>::mul
 <core::num::wrapping::Wrapping<u16> as core::ops::arith::MulAssign<&core::num::wrapping::Wrapping<u16>>>::mul_assign
 <core::num::wrapping::Wrapping<u16> as core::ops::arith::MulAssign<&u16>>::mul_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::MulAssign<u16>>::mul_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::MulAssign>::mul_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::Neg>::neg
 <core::num::wrapping::Wrapping<u16> as core::ops::arith::Rem<&core::num::wrapping::Wrapping<u16>>>::rem
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::Rem>::rem
 <core::num::wrapping::Wrapping<u16> as core::ops::arith::RemAssign<&core::num::wrapping::Wrapping<u16>>>::rem_assign
 <core::num::wrapping::Wrapping<u16> as core::ops::arith::RemAssign<&u16>>::rem_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::RemAssign<u16>>::rem_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::RemAssign>::rem_assign
 <core::num::wrapping::Wrapping<u16> as core::ops::arith::Sub<&core::num::wrapping::Wrapping<u16>>>::sub
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::Sub>::sub
 <core::num::wrapping::Wrapping<u16> as core::ops::arith::SubAssign<&core::num::wrapping::Wrapping<u16>>>::sub_assign
 <core::num::wrapping::Wrapping<u16> as core::ops::arith::SubAssign<&u16>>::sub_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::SubAssign<u16>>::sub_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::arith::SubAssign>::sub_assign
 <core::num::wrapping::Wrapping<u16> as core::ops::bit::BitAnd<&core::num::wrapping::Wrapping<u16>>>::bitand
+<core::num::wrapping::Wrapping<u16> as core::ops::bit::BitAnd>::bitand
 <core::num::wrapping::Wrapping<u16> as core::ops::bit::BitAndAssign<&core::num::wrapping::Wrapping<u16>>>::bitand_assign
 <core::num::wrapping::Wrapping<u16> as core::ops::bit::BitAndAssign<&u16>>::bitand_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::bit::BitAndAssign<u16>>::bitand_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::wrapping::Wrapping<u16> as core::ops::bit::BitOr<&core::num::wrapping::Wrapping<u16>>>::bitor
+<core::num::wrapping::Wrapping<u16> as core::ops::bit::BitOr>::bitor
 <core::num::wrapping::Wrapping<u16> as core::ops::bit::BitOrAssign<&core::num::wrapping::Wrapping<u16>>>::bitor_assign
 <core::num::wrapping::Wrapping<u16> as core::ops::bit::BitOrAssign<&u16>>::bitor_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::bit::BitOrAssign<u16>>::bitor_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::wrapping::Wrapping<u16> as core::ops::bit::BitXor<&core::num::wrapping::Wrapping<u16>>>::bitxor
+<core::num::wrapping::Wrapping<u16> as core::ops::bit::BitXor>::bitxor
 <core::num::wrapping::Wrapping<u16> as core::ops::bit::BitXorAssign<&core::num::wrapping::Wrapping<u16>>>::bitxor_assign
 <core::num::wrapping::Wrapping<u16> as core::ops::bit::BitXorAssign<&u16>>::bitxor_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::bit::BitXorAssign<u16>>::bitxor_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::bit::Not>::not
 <core::num::wrapping::Wrapping<u16> as core::ops::bit::Shl<&usize>>::shl
+<core::num::wrapping::Wrapping<u16> as core::ops::bit::Shl<usize>>::shl
 <core::num::wrapping::Wrapping<u16> as core::ops::bit::ShlAssign<&usize>>::shl_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::bit::ShlAssign<usize>>::shl_assign
 <core::num::wrapping::Wrapping<u16> as core::ops::bit::Shr<&usize>>::shr
+<core::num::wrapping::Wrapping<u16> as core::ops::bit::Shr<usize>>::shr
 <core::num::wrapping::Wrapping<u16> as core::ops::bit::ShrAssign<&usize>>::shr_assign
+<core::num::wrapping::Wrapping<u16> as core::ops::bit::ShrAssign<usize>>::shr_assign
 <core::num::wrapping::Wrapping<u32> as core::iter::traits::accum::Sum<&'a core::num::wrapping::Wrapping<u32>>>::sum
 <core::num::wrapping::Wrapping<u32> as core::iter::traits::accum::Sum>::sum
 <core::num::wrapping::Wrapping<u32> as core::ops::arith::Add<&core::num::wrapping::Wrapping<u32>>>::add
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::Add>::add
 <core::num::wrapping::Wrapping<u32> as core::ops::arith::AddAssign<&core::num::wrapping::Wrapping<u32>>>::add_assign
 <core::num::wrapping::Wrapping<u32> as core::ops::arith::AddAssign<&u32>>::add_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::AddAssign<u32>>::add_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::AddAssign>::add_assign
 <core::num::wrapping::Wrapping<u32> as core::ops::arith::Div<&core::num::wrapping::Wrapping<u32>>>::div
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::Div>::div
 <core::num::wrapping::Wrapping<u32> as core::ops::arith::DivAssign<&core::num::wrapping::Wrapping<u32>>>::div_assign
 <core::num::wrapping::Wrapping<u32> as core::ops::arith::DivAssign<&u32>>::div_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::DivAssign<u32>>::div_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::DivAssign>::div_assign
 <core::num::wrapping::Wrapping<u32> as core::ops::arith::Mul<&core::num::wrapping::Wrapping<u32>>>::mul
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::Mul>::mul
 <core::num::wrapping::Wrapping<u32> as core::ops::arith::MulAssign<&core::num::wrapping::Wrapping<u32>>>::mul_assign
 <core::num::wrapping::Wrapping<u32> as core::ops::arith::MulAssign<&u32>>::mul_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::MulAssign<u32>>::mul_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::MulAssign>::mul_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::Neg>::neg
 <core::num::wrapping::Wrapping<u32> as core::ops::arith::Rem<&core::num::wrapping::Wrapping<u32>>>::rem
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::Rem>::rem
 <core::num::wrapping::Wrapping<u32> as core::ops::arith::RemAssign<&core::num::wrapping::Wrapping<u32>>>::rem_assign
 <core::num::wrapping::Wrapping<u32> as core::ops::arith::RemAssign<&u32>>::rem_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::RemAssign<u32>>::rem_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::RemAssign>::rem_assign
 <core::num::wrapping::Wrapping<u32> as core::ops::arith::Sub<&core::num::wrapping::Wrapping<u32>>>::sub
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::Sub>::sub
 <core::num::wrapping::Wrapping<u32> as core::ops::arith::SubAssign<&core::num::wrapping::Wrapping<u32>>>::sub_assign
 <core::num::wrapping::Wrapping<u32> as core::ops::arith::SubAssign<&u32>>::sub_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::SubAssign<u32>>::sub_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::arith::SubAssign>::sub_assign
 <core::num::wrapping::Wrapping<u32> as core::ops::bit::BitAnd<&core::num::wrapping::Wrapping<u32>>>::bitand
+<core::num::wrapping::Wrapping<u32> as core::ops::bit::BitAnd>::bitand
 <core::num::wrapping::Wrapping<u32> as core::ops::bit::BitAndAssign<&core::num::wrapping::Wrapping<u32>>>::bitand_assign
 <core::num::wrapping::Wrapping<u32> as core::ops::bit::BitAndAssign<&u32>>::bitand_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::bit::BitAndAssign<u32>>::bitand_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::wrapping::Wrapping<u32> as core::ops::bit::BitOr<&core::num::wrapping::Wrapping<u32>>>::bitor
+<core::num::wrapping::Wrapping<u32> as core::ops::bit::BitOr>::bitor
 <core::num::wrapping::Wrapping<u32> as core::ops::bit::BitOrAssign<&core::num::wrapping::Wrapping<u32>>>::bitor_assign
 <core::num::wrapping::Wrapping<u32> as core::ops::bit::BitOrAssign<&u32>>::bitor_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::bit::BitOrAssign<u32>>::bitor_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::wrapping::Wrapping<u32> as core::ops::bit::BitXor<&core::num::wrapping::Wrapping<u32>>>::bitxor
+<core::num::wrapping::Wrapping<u32> as core::ops::bit::BitXor>::bitxor
 <core::num::wrapping::Wrapping<u32> as core::ops::bit::BitXorAssign<&core::num::wrapping::Wrapping<u32>>>::bitxor_assign
 <core::num::wrapping::Wrapping<u32> as core::ops::bit::BitXorAssign<&u32>>::bitxor_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::bit::BitXorAssign<u32>>::bitxor_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::bit::Not>::not
 <core::num::wrapping::Wrapping<u32> as core::ops::bit::Shl<&usize>>::shl
+<core::num::wrapping::Wrapping<u32> as core::ops::bit::Shl<usize>>::shl
 <core::num::wrapping::Wrapping<u32> as core::ops::bit::ShlAssign<&usize>>::shl_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::bit::ShlAssign<usize>>::shl_assign
 <core::num::wrapping::Wrapping<u32> as core::ops::bit::Shr<&usize>>::shr
+<core::num::wrapping::Wrapping<u32> as core::ops::bit::Shr<usize>>::shr
 <core::num::wrapping::Wrapping<u32> as core::ops::bit::ShrAssign<&usize>>::shr_assign
+<core::num::wrapping::Wrapping<u32> as core::ops::bit::ShrAssign<usize>>::shr_assign
 <core::num::wrapping::Wrapping<u64> as core::iter::traits::accum::Sum<&'a core::num::wrapping::Wrapping<u64>>>::sum
 <core::num::wrapping::Wrapping<u64> as core::iter::traits::accum::Sum>::sum
 <core::num::wrapping::Wrapping<u64> as core::ops::arith::Add<&core::num::wrapping::Wrapping<u64>>>::add
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::Add>::add
 <core::num::wrapping::Wrapping<u64> as core::ops::arith::AddAssign<&core::num::wrapping::Wrapping<u64>>>::add_assign
 <core::num::wrapping::Wrapping<u64> as core::ops::arith::AddAssign<&u64>>::add_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::AddAssign<u64>>::add_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::AddAssign>::add_assign
 <core::num::wrapping::Wrapping<u64> as core::ops::arith::Div<&core::num::wrapping::Wrapping<u64>>>::div
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::Div>::div
 <core::num::wrapping::Wrapping<u64> as core::ops::arith::DivAssign<&core::num::wrapping::Wrapping<u64>>>::div_assign
 <core::num::wrapping::Wrapping<u64> as core::ops::arith::DivAssign<&u64>>::div_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::DivAssign<u64>>::div_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::DivAssign>::div_assign
 <core::num::wrapping::Wrapping<u64> as core::ops::arith::Mul<&core::num::wrapping::Wrapping<u64>>>::mul
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::Mul>::mul
 <core::num::wrapping::Wrapping<u64> as core::ops::arith::MulAssign<&core::num::wrapping::Wrapping<u64>>>::mul_assign
 <core::num::wrapping::Wrapping<u64> as core::ops::arith::MulAssign<&u64>>::mul_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::MulAssign<u64>>::mul_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::MulAssign>::mul_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::Neg>::neg
 <core::num::wrapping::Wrapping<u64> as core::ops::arith::Rem<&core::num::wrapping::Wrapping<u64>>>::rem
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::Rem>::rem
 <core::num::wrapping::Wrapping<u64> as core::ops::arith::RemAssign<&core::num::wrapping::Wrapping<u64>>>::rem_assign
 <core::num::wrapping::Wrapping<u64> as core::ops::arith::RemAssign<&u64>>::rem_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::RemAssign<u64>>::rem_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::RemAssign>::rem_assign
 <core::num::wrapping::Wrapping<u64> as core::ops::arith::Sub<&core::num::wrapping::Wrapping<u64>>>::sub
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::Sub>::sub
 <core::num::wrapping::Wrapping<u64> as core::ops::arith::SubAssign<&core::num::wrapping::Wrapping<u64>>>::sub_assign
 <core::num::wrapping::Wrapping<u64> as core::ops::arith::SubAssign<&u64>>::sub_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::SubAssign<u64>>::sub_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::arith::SubAssign>::sub_assign
 <core::num::wrapping::Wrapping<u64> as core::ops::bit::BitAnd<&core::num::wrapping::Wrapping<u64>>>::bitand
+<core::num::wrapping::Wrapping<u64> as core::ops::bit::BitAnd>::bitand
 <core::num::wrapping::Wrapping<u64> as core::ops::bit::BitAndAssign<&core::num::wrapping::Wrapping<u64>>>::bitand_assign
 <core::num::wrapping::Wrapping<u64> as core::ops::bit::BitAndAssign<&u64>>::bitand_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::bit::BitAndAssign<u64>>::bitand_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::wrapping::Wrapping<u64> as core::ops::bit::BitOr<&core::num::wrapping::Wrapping<u64>>>::bitor
+<core::num::wrapping::Wrapping<u64> as core::ops::bit::BitOr>::bitor
 <core::num::wrapping::Wrapping<u64> as core::ops::bit::BitOrAssign<&core::num::wrapping::Wrapping<u64>>>::bitor_assign
 <core::num::wrapping::Wrapping<u64> as core::ops::bit::BitOrAssign<&u64>>::bitor_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::bit::BitOrAssign<u64>>::bitor_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::wrapping::Wrapping<u64> as core::ops::bit::BitXor<&core::num::wrapping::Wrapping<u64>>>::bitxor
+<core::num::wrapping::Wrapping<u64> as core::ops::bit::BitXor>::bitxor
 <core::num::wrapping::Wrapping<u64> as core::ops::bit::BitXorAssign<&core::num::wrapping::Wrapping<u64>>>::bitxor_assign
 <core::num::wrapping::Wrapping<u64> as core::ops::bit::BitXorAssign<&u64>>::bitxor_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::bit::BitXorAssign<u64>>::bitxor_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::bit::Not>::not
 <core::num::wrapping::Wrapping<u64> as core::ops::bit::Shl<&usize>>::shl
+<core::num::wrapping::Wrapping<u64> as core::ops::bit::Shl<usize>>::shl
 <core::num::wrapping::Wrapping<u64> as core::ops::bit::ShlAssign<&usize>>::shl_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::bit::ShlAssign<usize>>::shl_assign
 <core::num::wrapping::Wrapping<u64> as core::ops::bit::Shr<&usize>>::shr
+<core::num::wrapping::Wrapping<u64> as core::ops::bit::Shr<usize>>::shr
 <core::num::wrapping::Wrapping<u64> as core::ops::bit::ShrAssign<&usize>>::shr_assign
+<core::num::wrapping::Wrapping<u64> as core::ops::bit::ShrAssign<usize>>::shr_assign
 <core::num::wrapping::Wrapping<u8> as core::iter::traits::accum::Sum<&'a core::num::wrapping::Wrapping<u8>>>::sum
 <core::num::wrapping::Wrapping<u8> as core::iter::traits::accum::Sum>::sum
 <core::num::wrapping::Wrapping<u8> as core::ops::arith::Add<&core::num::wrapping::Wrapping<u8>>>::add
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::Add>::add
 <core::num::wrapping::Wrapping<u8> as core::ops::arith::AddAssign<&core::num::wrapping::Wrapping<u8>>>::add_assign
 <core::num::wrapping::Wrapping<u8> as core::ops::arith::AddAssign<&u8>>::add_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::AddAssign<u8>>::add_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::AddAssign>::add_assign
 <core::num::wrapping::Wrapping<u8> as core::ops::arith::Div<&core::num::wrapping::Wrapping<u8>>>::div
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::Div>::div
 <core::num::wrapping::Wrapping<u8> as core::ops::arith::DivAssign<&core::num::wrapping::Wrapping<u8>>>::div_assign
 <core::num::wrapping::Wrapping<u8> as core::ops::arith::DivAssign<&u8>>::div_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::DivAssign<u8>>::div_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::DivAssign>::div_assign
 <core::num::wrapping::Wrapping<u8> as core::ops::arith::Mul<&core::num::wrapping::Wrapping<u8>>>::mul
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::Mul>::mul
 <core::num::wrapping::Wrapping<u8> as core::ops::arith::MulAssign<&core::num::wrapping::Wrapping<u8>>>::mul_assign
 <core::num::wrapping::Wrapping<u8> as core::ops::arith::MulAssign<&u8>>::mul_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::MulAssign<u8>>::mul_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::MulAssign>::mul_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::Neg>::neg
 <core::num::wrapping::Wrapping<u8> as core::ops::arith::Rem<&core::num::wrapping::Wrapping<u8>>>::rem
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::Rem>::rem
 <core::num::wrapping::Wrapping<u8> as core::ops::arith::RemAssign<&core::num::wrapping::Wrapping<u8>>>::rem_assign
 <core::num::wrapping::Wrapping<u8> as core::ops::arith::RemAssign<&u8>>::rem_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::RemAssign<u8>>::rem_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::RemAssign>::rem_assign
 <core::num::wrapping::Wrapping<u8> as core::ops::arith::Sub<&core::num::wrapping::Wrapping<u8>>>::sub
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::Sub>::sub
 <core::num::wrapping::Wrapping<u8> as core::ops::arith::SubAssign<&core::num::wrapping::Wrapping<u8>>>::sub_assign
 <core::num::wrapping::Wrapping<u8> as core::ops::arith::SubAssign<&u8>>::sub_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::SubAssign<u8>>::sub_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::arith::SubAssign>::sub_assign
 <core::num::wrapping::Wrapping<u8> as core::ops::bit::BitAnd<&core::num::wrapping::Wrapping<u8>>>::bitand
+<core::num::wrapping::Wrapping<u8> as core::ops::bit::BitAnd>::bitand
 <core::num::wrapping::Wrapping<u8> as core::ops::bit::BitAndAssign<&core::num::wrapping::Wrapping<u8>>>::bitand_assign
 <core::num::wrapping::Wrapping<u8> as core::ops::bit::BitAndAssign<&u8>>::bitand_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::bit::BitAndAssign<u8>>::bitand_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::wrapping::Wrapping<u8> as core::ops::bit::BitOr<&core::num::wrapping::Wrapping<u8>>>::bitor
+<core::num::wrapping::Wrapping<u8> as core::ops::bit::BitOr>::bitor
 <core::num::wrapping::Wrapping<u8> as core::ops::bit::BitOrAssign<&core::num::wrapping::Wrapping<u8>>>::bitor_assign
 <core::num::wrapping::Wrapping<u8> as core::ops::bit::BitOrAssign<&u8>>::bitor_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::bit::BitOrAssign<u8>>::bitor_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::wrapping::Wrapping<u8> as core::ops::bit::BitXor<&core::num::wrapping::Wrapping<u8>>>::bitxor
+<core::num::wrapping::Wrapping<u8> as core::ops::bit::BitXor>::bitxor
 <core::num::wrapping::Wrapping<u8> as core::ops::bit::BitXorAssign<&core::num::wrapping::Wrapping<u8>>>::bitxor_assign
 <core::num::wrapping::Wrapping<u8> as core::ops::bit::BitXorAssign<&u8>>::bitxor_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::bit::BitXorAssign<u8>>::bitxor_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::bit::Not>::not
 <core::num::wrapping::Wrapping<u8> as core::ops::bit::Shl<&usize>>::shl
+<core::num::wrapping::Wrapping<u8> as core::ops::bit::Shl<usize>>::shl
 <core::num::wrapping::Wrapping<u8> as core::ops::bit::ShlAssign<&usize>>::shl_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::bit::ShlAssign<usize>>::shl_assign
 <core::num::wrapping::Wrapping<u8> as core::ops::bit::Shr<&usize>>::shr
+<core::num::wrapping::Wrapping<u8> as core::ops::bit::Shr<usize>>::shr
 <core::num::wrapping::Wrapping<u8> as core::ops::bit::ShrAssign<&usize>>::shr_assign
+<core::num::wrapping::Wrapping<u8> as core::ops::bit::ShrAssign<usize>>::shr_assign
 <core::num::wrapping::Wrapping<usize> as core::iter::traits::accum::Sum<&'a core::num::wrapping::Wrapping<usize>>>::sum
 <core::num::wrapping::Wrapping<usize> as core::iter::traits::accum::Sum>::sum
 <core::num::wrapping::Wrapping<usize> as core::ops::arith::Add<&core::num::wrapping::Wrapping<usize>>>::add
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::Add>::add
 <core::num::wrapping::Wrapping<usize> as core::ops::arith::AddAssign<&core::num::wrapping::Wrapping<usize>>>::add_assign
 <core::num::wrapping::Wrapping<usize> as core::ops::arith::AddAssign<&usize>>::add_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::AddAssign<usize>>::add_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::AddAssign>::add_assign
 <core::num::wrapping::Wrapping<usize> as core::ops::arith::Div<&core::num::wrapping::Wrapping<usize>>>::div
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::Div>::div
 <core::num::wrapping::Wrapping<usize> as core::ops::arith::DivAssign<&core::num::wrapping::Wrapping<usize>>>::div_assign
 <core::num::wrapping::Wrapping<usize> as core::ops::arith::DivAssign<&usize>>::div_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::DivAssign<usize>>::div_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::DivAssign>::div_assign
 <core::num::wrapping::Wrapping<usize> as core::ops::arith::Mul<&core::num::wrapping::Wrapping<usize>>>::mul
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::Mul>::mul
 <core::num::wrapping::Wrapping<usize> as core::ops::arith::MulAssign<&core::num::wrapping::Wrapping<usize>>>::mul_assign
 <core::num::wrapping::Wrapping<usize> as core::ops::arith::MulAssign<&usize>>::mul_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::MulAssign<usize>>::mul_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::MulAssign>::mul_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::Neg>::neg
 <core::num::wrapping::Wrapping<usize> as core::ops::arith::Rem<&core::num::wrapping::Wrapping<usize>>>::rem
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::Rem>::rem
 <core::num::wrapping::Wrapping<usize> as core::ops::arith::RemAssign<&core::num::wrapping::Wrapping<usize>>>::rem_assign
 <core::num::wrapping::Wrapping<usize> as core::ops::arith::RemAssign<&usize>>::rem_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::RemAssign<usize>>::rem_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::RemAssign>::rem_assign
 <core::num::wrapping::Wrapping<usize> as core::ops::arith::Sub<&core::num::wrapping::Wrapping<usize>>>::sub
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::Sub>::sub
 <core::num::wrapping::Wrapping<usize> as core::ops::arith::SubAssign<&core::num::wrapping::Wrapping<usize>>>::sub_assign
 <core::num::wrapping::Wrapping<usize> as core::ops::arith::SubAssign<&usize>>::sub_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::SubAssign<usize>>::sub_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::arith::SubAssign>::sub_assign
 <core::num::wrapping::Wrapping<usize> as core::ops::bit::BitAnd<&core::num::wrapping::Wrapping<usize>>>::bitand
+<core::num::wrapping::Wrapping<usize> as core::ops::bit::BitAnd>::bitand
 <core::num::wrapping::Wrapping<usize> as core::ops::bit::BitAndAssign<&core::num::wrapping::Wrapping<usize>>>::bitand_assign
 <core::num::wrapping::Wrapping<usize> as core::ops::bit::BitAndAssign<&usize>>::bitand_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::bit::BitAndAssign<usize>>::bitand_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::bit::BitAndAssign>::bitand_assign
 <core::num::wrapping::Wrapping<usize> as core::ops::bit::BitOr<&core::num::wrapping::Wrapping<usize>>>::bitor
+<core::num::wrapping::Wrapping<usize> as core::ops::bit::BitOr>::bitor
 <core::num::wrapping::Wrapping<usize> as core::ops::bit::BitOrAssign<&core::num::wrapping::Wrapping<usize>>>::bitor_assign
 <core::num::wrapping::Wrapping<usize> as core::ops::bit::BitOrAssign<&usize>>::bitor_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::bit::BitOrAssign<usize>>::bitor_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::bit::BitOrAssign>::bitor_assign
 <core::num::wrapping::Wrapping<usize> as core::ops::bit::BitXor<&core::num::wrapping::Wrapping<usize>>>::bitxor
+<core::num::wrapping::Wrapping<usize> as core::ops::bit::BitXor>::bitxor
 <core::num::wrapping::Wrapping<usize> as core::ops::bit::BitXorAssign<&core::num::wrapping::Wrapping<usize>>>::bitxor_assign
 <core::num::wrapping::Wrapping<usize> as core::ops::bit::BitXorAssign<&usize>>::bitxor_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::bit::BitXorAssign<usize>>::bitxor_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::bit::BitXorAssign>::bitxor_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::bit::Not>::not
 <core::num::wrapping::Wrapping<usize> as core::ops::bit::Shl<&usize>>::shl
+<core::num::wrapping::Wrapping<usize> as core::ops::bit::Shl<usize>>::shl
 <core::num::wrapping::Wrapping<usize> as core::ops::bit::ShlAssign<&usize>>::shl_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::bit::ShlAssign<usize>>::shl_assign
 <core::num::wrapping::Wrapping<usize> as core::ops::bit::Shr<&usize>>::shr
+<core::num::wrapping::Wrapping<usize> as core::ops::bit::Shr<usize>>::shr
 <core::num::wrapping::Wrapping<usize> as core::ops::bit::ShrAssign<&usize>>::shr_assign
+<core::num::wrapping::Wrapping<usize> as core::ops::bit::ShrAssign<usize>>::shr_assign
 <core::ops::control_flow::ControlFlow<B, C> as core::clone::Clone>::clone
 <core::ops::control_flow::ControlFlow<B, C> as core::cmp::Eq>::assert_fields_are_eq
 <core::ops::control_flow::ControlFlow<B, C> as core::cmp::PartialEq>::eq
@@ -5020,6 +5699,8 @@ core::array::<impl [T; N]>::as_slice
 core::array::<impl [T; N]>::map
 core::array::<impl [T; N]>::try_map
 core::array::<impl core::clone::Clone for [T; N]>::clone
+core::array::<impl core::cmp::Ord for [T; N]>::cmp
+core::array::<impl core::cmp::PartialOrd for [T; N]>::partial_cmp
 core::array::<impl core::convert::AsRef<[T]> for [T; N]>::as_ref
 core::array::<impl core::convert::TryFrom<&'a [T]> for &'a [T; N]>::try_from
 core::array::<impl core::convert::TryFrom<&'a mut [T]> for &'a mut [T; N]>::try_from
@@ -5053,6 +5734,7 @@ core::array::from_mut
 core::array::from_ref
 core::array::from_trusted_iterator
 core::array::iter::<impl core::iter::traits::collect::IntoIterator for [T; N]>::into_iter
+core::array::iter::IntoIter::<T, N>::as_mut_slice
 core::array::iter::IntoIter::<T, N>::unsize
 core::array::iter::IntoIter::<T, N>::unsize_mut
 core::array::iter::iter_inner::PolymorphicIter::<DATA>::len
@@ -5060,6 +5742,7 @@ core::array::iter::iter_inner::PolymorphicIter::<[core::mem::maybe_uninit::Maybe
 core::array::iter::iter_inner::PolymorphicIter::<[core::mem::maybe_uninit::MaybeUninit<T>; N]>::new_unchecked
 core::array::iter::iter_inner::PolymorphicIter::<[core::mem::maybe_uninit::MaybeUninit<T>]>::advance_back_by
 core::array::iter::iter_inner::PolymorphicIter::<[core::mem::maybe_uninit::MaybeUninit<T>]>::advance_by
+core::array::iter::iter_inner::PolymorphicIter::<[core::mem::maybe_uninit::MaybeUninit<T>]>::as_mut_slice
 core::array::iter::iter_inner::PolymorphicIter::<[core::mem::maybe_uninit::MaybeUninit<T>]>::as_slice
 core::array::iter::iter_inner::PolymorphicIter::<[core::mem::maybe_uninit::MaybeUninit<T>]>::fold
 core::array::iter::iter_inner::PolymorphicIter::<[core::mem::maybe_uninit::MaybeUninit<T>]>::next
@@ -5116,20 +5799,29 @@ core::cell::panic_already_mutably_borrowed::do_panic::runtime
 core::char::EscapeDebug::backslash
 core::char::EscapeDebug::printable
 core::char::EscapeDebug::unicode
+core::char::EscapeDefault::backslash
+core::char::EscapeDefault::printable
+core::char::EscapeDefault::unicode
+core::char::EscapeUnicode::new
 core::char::convert::<impl core::convert::From<u8> for char>::from
 core::char::convert::char_try_from_u32
 core::char::convert::from_u32_unchecked
 core::char::convert::from_u32_unchecked::precondition_check
 core::char::decode::DecodeUtf16Error::unpaired_surrogate
 core::char::decode::decode_utf16
+core::char::methods::<impl char>::as_ascii
 core::char::methods::<impl char>::as_ascii_unchecked::precondition_check
 core::char::methods::<impl char>::decode_utf16
 core::char::methods::<impl char>::encode_utf8
 core::char::methods::<impl char>::escape_debug
 core::char::methods::<impl char>::escape_debug_ext
+core::char::methods::<impl char>::escape_default
+core::char::methods::<impl char>::escape_unicode
 core::char::methods::<impl char>::from_u32_unchecked
 core::char::methods::<impl char>::is_ascii
+core::char::methods::<impl char>::is_ascii_whitespace
 core::char::methods::<impl char>::is_grapheme_extended
+core::char::methods::<impl char>::is_whitespace
 core::char::methods::<impl char>::len_utf8
 core::char::methods::<impl char>::to_digit
 core::char::methods::encode_utf16_raw::do_panic
@@ -5189,6 +5881,7 @@ core::cmp::PartialOrd::le
 core::cmp::PartialOrd::lt
 core::cmp::default_chaining_impl
 core::cmp::impls::<impl core::cmp::Ord for !>::cmp
+core::cmp::impls::<impl core::cmp::Ord for &A>::cmp
 core::cmp::impls::<impl core::cmp::Ord for ()>::cmp
 core::cmp::impls::<impl core::cmp::Ord for bool>::clamp
 core::cmp::impls::<impl core::cmp::Ord for bool>::cmp
@@ -6079,6 +6772,7 @@ core::intrinsics::ub_checks
 core::intrinsics::unchecked_funnel_shl
 core::intrinsics::unchecked_funnel_shr
 core::intrinsics::unlikely
+core::iter::adapters::array_chunks::ArrayChunks::<I, N>::next_back_remainder
 core::iter::adapters::chain::Chain::<A, B>::new
 core::iter::adapters::chain::and_then_or_clear
 core::iter::adapters::cloned::Cloned::<I>::new
@@ -6176,6 +6870,7 @@ core::iter::traits::iterator::Iterator::last::some
 core::iter::traits::iterator::Iterator::map
 core::iter::traits::iterator::Iterator::max_by
 core::iter::traits::iterator::Iterator::max_by::fold
+core::iter::traits::iterator::Iterator::next_chunk
 core::iter::traits::iterator::Iterator::nth
 core::iter::traits::iterator::Iterator::position
 core::iter::traits::iterator::Iterator::position::check
@@ -6260,11 +6955,18 @@ core::num::<impl i128>::is_negative
 core::num::<impl i128>::leading_zeros
 core::num::<impl i128>::overflowing_add
 core::num::<impl i128>::overflowing_add_unsigned
+core::num::<impl i128>::overflowing_div
 core::num::<impl i128>::overflowing_mul
 core::num::<impl i128>::overflowing_neg
+core::num::<impl i128>::overflowing_rem
 core::num::<impl i128>::overflowing_sub
 core::num::<impl i128>::overflowing_sub_unsigned
 core::num::<impl i128>::rotate_left
+core::num::<impl i128>::saturating_add
+core::num::<impl i128>::saturating_div
+core::num::<impl i128>::saturating_mul
+core::num::<impl i128>::saturating_neg
+core::num::<impl i128>::saturating_sub
 core::num::<impl i128>::to_le
 core::num::<impl i128>::to_le_bytes
 core::num::<impl i128>::to_ne_bytes
@@ -6283,8 +6985,10 @@ core::num::<impl i128>::unchecked_sub::precondition_check
 core::num::<impl i128>::unsigned_abs
 core::num::<impl i128>::wrapping_abs
 core::num::<impl i128>::wrapping_add
+core::num::<impl i128>::wrapping_div
 core::num::<impl i128>::wrapping_mul
 core::num::<impl i128>::wrapping_neg
+core::num::<impl i128>::wrapping_rem
 core::num::<impl i128>::wrapping_shl
 core::num::<impl i128>::wrapping_shr
 core::num::<impl i128>::wrapping_sub
@@ -6311,11 +7015,18 @@ core::num::<impl i16>::is_negative
 core::num::<impl i16>::leading_zeros
 core::num::<impl i16>::overflowing_add
 core::num::<impl i16>::overflowing_add_unsigned
+core::num::<impl i16>::overflowing_div
 core::num::<impl i16>::overflowing_mul
 core::num::<impl i16>::overflowing_neg
+core::num::<impl i16>::overflowing_rem
 core::num::<impl i16>::overflowing_sub
 core::num::<impl i16>::overflowing_sub_unsigned
 core::num::<impl i16>::rotate_left
+core::num::<impl i16>::saturating_add
+core::num::<impl i16>::saturating_div
+core::num::<impl i16>::saturating_mul
+core::num::<impl i16>::saturating_neg
+core::num::<impl i16>::saturating_sub
 core::num::<impl i16>::to_le
 core::num::<impl i16>::to_le_bytes
 core::num::<impl i16>::to_ne_bytes
@@ -6334,8 +7045,10 @@ core::num::<impl i16>::unchecked_sub::precondition_check
 core::num::<impl i16>::unsigned_abs
 core::num::<impl i16>::wrapping_abs
 core::num::<impl i16>::wrapping_add
+core::num::<impl i16>::wrapping_div
 core::num::<impl i16>::wrapping_mul
 core::num::<impl i16>::wrapping_neg
+core::num::<impl i16>::wrapping_rem
 core::num::<impl i16>::wrapping_shl
 core::num::<impl i16>::wrapping_shr
 core::num::<impl i16>::wrapping_sub
@@ -6362,11 +7075,18 @@ core::num::<impl i32>::is_negative
 core::num::<impl i32>::leading_zeros
 core::num::<impl i32>::overflowing_add
 core::num::<impl i32>::overflowing_add_unsigned
+core::num::<impl i32>::overflowing_div
 core::num::<impl i32>::overflowing_mul
 core::num::<impl i32>::overflowing_neg
+core::num::<impl i32>::overflowing_rem
 core::num::<impl i32>::overflowing_sub
 core::num::<impl i32>::overflowing_sub_unsigned
 core::num::<impl i32>::rotate_left
+core::num::<impl i32>::saturating_add
+core::num::<impl i32>::saturating_div
+core::num::<impl i32>::saturating_mul
+core::num::<impl i32>::saturating_neg
+core::num::<impl i32>::saturating_sub
 core::num::<impl i32>::to_le
 core::num::<impl i32>::to_le_bytes
 core::num::<impl i32>::to_ne_bytes
@@ -6385,8 +7105,10 @@ core::num::<impl i32>::unchecked_sub::precondition_check
 core::num::<impl i32>::unsigned_abs
 core::num::<impl i32>::wrapping_abs
 core::num::<impl i32>::wrapping_add
+core::num::<impl i32>::wrapping_div
 core::num::<impl i32>::wrapping_mul
 core::num::<impl i32>::wrapping_neg
+core::num::<impl i32>::wrapping_rem
 core::num::<impl i32>::wrapping_shl
 core::num::<impl i32>::wrapping_shr
 core::num::<impl i32>::wrapping_sub
@@ -6413,11 +7135,18 @@ core::num::<impl i64>::is_negative
 core::num::<impl i64>::leading_zeros
 core::num::<impl i64>::overflowing_add
 core::num::<impl i64>::overflowing_add_unsigned
+core::num::<impl i64>::overflowing_div
 core::num::<impl i64>::overflowing_mul
 core::num::<impl i64>::overflowing_neg
+core::num::<impl i64>::overflowing_rem
 core::num::<impl i64>::overflowing_sub
 core::num::<impl i64>::overflowing_sub_unsigned
 core::num::<impl i64>::rotate_left
+core::num::<impl i64>::saturating_add
+core::num::<impl i64>::saturating_div
+core::num::<impl i64>::saturating_mul
+core::num::<impl i64>::saturating_neg
+core::num::<impl i64>::saturating_sub
 core::num::<impl i64>::to_le
 core::num::<impl i64>::to_le_bytes
 core::num::<impl i64>::to_ne_bytes
@@ -6436,8 +7165,10 @@ core::num::<impl i64>::unchecked_sub::precondition_check
 core::num::<impl i64>::unsigned_abs
 core::num::<impl i64>::wrapping_abs
 core::num::<impl i64>::wrapping_add
+core::num::<impl i64>::wrapping_div
 core::num::<impl i64>::wrapping_mul
 core::num::<impl i64>::wrapping_neg
+core::num::<impl i64>::wrapping_rem
 core::num::<impl i64>::wrapping_shl
 core::num::<impl i64>::wrapping_shr
 core::num::<impl i64>::wrapping_sub
@@ -6464,11 +7195,18 @@ core::num::<impl i8>::is_negative
 core::num::<impl i8>::leading_zeros
 core::num::<impl i8>::overflowing_add
 core::num::<impl i8>::overflowing_add_unsigned
+core::num::<impl i8>::overflowing_div
 core::num::<impl i8>::overflowing_mul
 core::num::<impl i8>::overflowing_neg
+core::num::<impl i8>::overflowing_rem
 core::num::<impl i8>::overflowing_sub
 core::num::<impl i8>::overflowing_sub_unsigned
 core::num::<impl i8>::rotate_left
+core::num::<impl i8>::saturating_add
+core::num::<impl i8>::saturating_div
+core::num::<impl i8>::saturating_mul
+core::num::<impl i8>::saturating_neg
+core::num::<impl i8>::saturating_sub
 core::num::<impl i8>::to_le
 core::num::<impl i8>::to_le_bytes
 core::num::<impl i8>::to_ne_bytes
@@ -6487,8 +7225,10 @@ core::num::<impl i8>::unchecked_sub::precondition_check
 core::num::<impl i8>::unsigned_abs
 core::num::<impl i8>::wrapping_abs
 core::num::<impl i8>::wrapping_add
+core::num::<impl i8>::wrapping_div
 core::num::<impl i8>::wrapping_mul
 core::num::<impl i8>::wrapping_neg
+core::num::<impl i8>::wrapping_rem
 core::num::<impl i8>::wrapping_shl
 core::num::<impl i8>::wrapping_shr
 core::num::<impl i8>::wrapping_sub
@@ -6515,11 +7255,18 @@ core::num::<impl isize>::is_negative
 core::num::<impl isize>::leading_zeros
 core::num::<impl isize>::overflowing_add
 core::num::<impl isize>::overflowing_add_unsigned
+core::num::<impl isize>::overflowing_div
 core::num::<impl isize>::overflowing_mul
 core::num::<impl isize>::overflowing_neg
+core::num::<impl isize>::overflowing_rem
 core::num::<impl isize>::overflowing_sub
 core::num::<impl isize>::overflowing_sub_unsigned
 core::num::<impl isize>::rotate_left
+core::num::<impl isize>::saturating_add
+core::num::<impl isize>::saturating_div
+core::num::<impl isize>::saturating_mul
+core::num::<impl isize>::saturating_neg
+core::num::<impl isize>::saturating_sub
 core::num::<impl isize>::to_le
 core::num::<impl isize>::to_le_bytes
 core::num::<impl isize>::to_ne_bytes
@@ -6538,8 +7285,10 @@ core::num::<impl isize>::unchecked_sub::precondition_check
 core::num::<impl isize>::unsigned_abs
 core::num::<impl isize>::wrapping_abs
 core::num::<impl isize>::wrapping_add
+core::num::<impl isize>::wrapping_div
 core::num::<impl isize>::wrapping_mul
 core::num::<impl isize>::wrapping_neg
+core::num::<impl isize>::wrapping_rem
 core::num::<impl isize>::wrapping_shl
 core::num::<impl isize>::wrapping_shr
 core::num::<impl isize>::wrapping_sub
@@ -6580,6 +7329,7 @@ core::num::<impl u128>::reverse_bits
 core::num::<impl u128>::rotate_left
 core::num::<impl u128>::rotate_right
 core::num::<impl u128>::saturating_add
+core::num::<impl u128>::saturating_div
 core::num::<impl u128>::saturating_mul
 core::num::<impl u128>::saturating_sub
 core::num::<impl u128>::swap_bytes
@@ -6605,8 +7355,10 @@ core::num::<impl u128>::unchecked_sub::precondition_check
 core::num::<impl u128>::widening_mul
 core::num::<impl u128>::wrapping_add
 core::num::<impl u128>::wrapping_add_signed
+core::num::<impl u128>::wrapping_div
 core::num::<impl u128>::wrapping_mul
 core::num::<impl u128>::wrapping_neg
+core::num::<impl u128>::wrapping_rem
 core::num::<impl u128>::wrapping_shl
 core::num::<impl u128>::wrapping_shr
 core::num::<impl u128>::wrapping_sub
@@ -6648,6 +7400,7 @@ core::num::<impl u16>::reverse_bits
 core::num::<impl u16>::rotate_left
 core::num::<impl u16>::rotate_right
 core::num::<impl u16>::saturating_add
+core::num::<impl u16>::saturating_div
 core::num::<impl u16>::saturating_mul
 core::num::<impl u16>::saturating_sub
 core::num::<impl u16>::swap_bytes
@@ -6673,8 +7426,10 @@ core::num::<impl u16>::unchecked_sub::precondition_check
 core::num::<impl u16>::widening_mul
 core::num::<impl u16>::wrapping_add
 core::num::<impl u16>::wrapping_add_signed
+core::num::<impl u16>::wrapping_div
 core::num::<impl u16>::wrapping_mul
 core::num::<impl u16>::wrapping_neg
+core::num::<impl u16>::wrapping_rem
 core::num::<impl u16>::wrapping_shl
 core::num::<impl u16>::wrapping_shr
 core::num::<impl u16>::wrapping_sub
@@ -6715,6 +7470,7 @@ core::num::<impl u32>::reverse_bits
 core::num::<impl u32>::rotate_left
 core::num::<impl u32>::rotate_right
 core::num::<impl u32>::saturating_add
+core::num::<impl u32>::saturating_div
 core::num::<impl u32>::saturating_mul
 core::num::<impl u32>::saturating_sub
 core::num::<impl u32>::swap_bytes
@@ -6740,8 +7496,10 @@ core::num::<impl u32>::unchecked_sub::precondition_check
 core::num::<impl u32>::widening_mul
 core::num::<impl u32>::wrapping_add
 core::num::<impl u32>::wrapping_add_signed
+core::num::<impl u32>::wrapping_div
 core::num::<impl u32>::wrapping_mul
 core::num::<impl u32>::wrapping_neg
+core::num::<impl u32>::wrapping_rem
 core::num::<impl u32>::wrapping_shl
 core::num::<impl u32>::wrapping_shr
 core::num::<impl u32>::wrapping_sub
@@ -6782,6 +7540,7 @@ core::num::<impl u64>::reverse_bits
 core::num::<impl u64>::rotate_left
 core::num::<impl u64>::rotate_right
 core::num::<impl u64>::saturating_add
+core::num::<impl u64>::saturating_div
 core::num::<impl u64>::saturating_mul
 core::num::<impl u64>::saturating_sub
 core::num::<impl u64>::swap_bytes
@@ -6807,8 +7566,10 @@ core::num::<impl u64>::unchecked_sub::precondition_check
 core::num::<impl u64>::widening_mul
 core::num::<impl u64>::wrapping_add
 core::num::<impl u64>::wrapping_add_signed
+core::num::<impl u64>::wrapping_div
 core::num::<impl u64>::wrapping_mul
 core::num::<impl u64>::wrapping_neg
+core::num::<impl u64>::wrapping_rem
 core::num::<impl u64>::wrapping_shl
 core::num::<impl u64>::wrapping_shr
 core::num::<impl u64>::wrapping_sub
@@ -6843,6 +7604,7 @@ core::num::<impl u8>::is_ascii
 core::num::<impl u8>::is_ascii_alphabetic
 core::num::<impl u8>::is_ascii_control
 core::num::<impl u8>::is_ascii_uppercase
+core::num::<impl u8>::is_ascii_whitespace
 core::num::<impl u8>::is_multiple_of
 core::num::<impl u8>::is_power_of_two
 core::num::<impl u8>::is_utf8_char_boundary
@@ -6857,6 +7619,7 @@ core::num::<impl u8>::reverse_bits
 core::num::<impl u8>::rotate_left
 core::num::<impl u8>::rotate_right
 core::num::<impl u8>::saturating_add
+core::num::<impl u8>::saturating_div
 core::num::<impl u8>::saturating_mul
 core::num::<impl u8>::saturating_sub
 core::num::<impl u8>::swap_bytes
@@ -6883,8 +7646,10 @@ core::num::<impl u8>::unchecked_sub::precondition_check
 core::num::<impl u8>::widening_mul
 core::num::<impl u8>::wrapping_add
 core::num::<impl u8>::wrapping_add_signed
+core::num::<impl u8>::wrapping_div
 core::num::<impl u8>::wrapping_mul
 core::num::<impl u8>::wrapping_neg
+core::num::<impl u8>::wrapping_rem
 core::num::<impl u8>::wrapping_shl
 core::num::<impl u8>::wrapping_shr
 core::num::<impl u8>::wrapping_sub
@@ -6927,6 +7692,7 @@ core::num::<impl usize>::reverse_bits
 core::num::<impl usize>::rotate_left
 core::num::<impl usize>::rotate_right
 core::num::<impl usize>::saturating_add
+core::num::<impl usize>::saturating_div
 core::num::<impl usize>::saturating_mul
 core::num::<impl usize>::saturating_sub
 core::num::<impl usize>::swap_bytes
@@ -6952,8 +7718,10 @@ core::num::<impl usize>::unchecked_sub::precondition_check
 core::num::<impl usize>::widening_mul
 core::num::<impl usize>::wrapping_add
 core::num::<impl usize>::wrapping_add_signed
+core::num::<impl usize>::wrapping_div
 core::num::<impl usize>::wrapping_mul
 core::num::<impl usize>::wrapping_neg
+core::num::<impl usize>::wrapping_rem
 core::num::<impl usize>::wrapping_shl
 core::num::<impl usize>::wrapping_shr
 core::num::<impl usize>::wrapping_sub
@@ -7465,6 +8233,7 @@ core::slice::<impl [T]>::as_chunks_unchecked::precondition_check
 core::slice::<impl [T]>::as_chunks_unchecked_mut::precondition_check
 core::slice::<impl [T]>::as_mut_array
 core::slice::<impl [T]>::as_mut_ptr
+core::slice::<impl [T]>::as_mut_ptr_range
 core::slice::<impl [T]>::as_ptr
 core::slice::<impl [T]>::binary_search_by
 core::slice::<impl [T]>::binary_search_by_key
@@ -7490,6 +8259,8 @@ core::slice::<impl [T]>::iter_mut
 core::slice::<impl [T]>::last
 core::slice::<impl [T]>::last_mut
 core::slice::<impl [T]>::len
+core::slice::<impl [T]>::reverse
+core::slice::<impl [T]>::reverse::revswap
 core::slice::<impl [T]>::rotate_left
 core::slice::<impl [T]>::rotate_right
 core::slice::<impl [T]>::split_at
@@ -7610,6 +8381,7 @@ core::str::<impl str>::len
 core::str::<impl str>::parse
 core::str::<impl str>::split_inclusive
 core::str::<impl str>::starts_with
+core::str::<impl str>::strip_suffix
 core::str::converts::from_raw_parts
 core::str::converts::from_raw_parts_mut
 core::str::converts::from_utf8
@@ -7943,6 +8715,8 @@ core::sync::atomic::atomic_and
 core::sync::atomic::atomic_compare_exchange
 core::sync::atomic::atomic_compare_exchange_weak
 core::sync::atomic::atomic_load
+core::sync::atomic::atomic_max
+core::sync::atomic::atomic_min
 core::sync::atomic::atomic_nand
 core::sync::atomic::atomic_or
 core::sync::atomic::atomic_store
@@ -8025,4 +8799,5 @@ core::unicode::unicode_data::ShortOffsetRunHeader::start_index
 core::unicode::unicode_data::grapheme_extend::lookup
 core::unicode::unicode_data::grapheme_extend::lookup_slow
 core::unicode::unicode_data::skip_search
+core::unicode::unicode_data::white_space::lookup
 core::unit::<impl core::iter::traits::collect::FromIterator<()> for ()>::from_iter

--- a/ferrocene/doc/symbol-report.csv
+++ b/ferrocene/doc/symbol-report.csv
@@ -6967,6 +6967,7 @@ core::num::<impl i128>::saturating_div
 core::num::<impl i128>::saturating_mul
 core::num::<impl i128>::saturating_neg
 core::num::<impl i128>::saturating_sub
+core::num::<impl i128>::swap_bytes
 core::num::<impl i128>::to_le
 core::num::<impl i128>::to_le_bytes
 core::num::<impl i128>::to_ne_bytes
@@ -7027,6 +7028,7 @@ core::num::<impl i16>::saturating_div
 core::num::<impl i16>::saturating_mul
 core::num::<impl i16>::saturating_neg
 core::num::<impl i16>::saturating_sub
+core::num::<impl i16>::swap_bytes
 core::num::<impl i16>::to_le
 core::num::<impl i16>::to_le_bytes
 core::num::<impl i16>::to_ne_bytes
@@ -7087,6 +7089,7 @@ core::num::<impl i32>::saturating_div
 core::num::<impl i32>::saturating_mul
 core::num::<impl i32>::saturating_neg
 core::num::<impl i32>::saturating_sub
+core::num::<impl i32>::swap_bytes
 core::num::<impl i32>::to_le
 core::num::<impl i32>::to_le_bytes
 core::num::<impl i32>::to_ne_bytes
@@ -7147,6 +7150,7 @@ core::num::<impl i64>::saturating_div
 core::num::<impl i64>::saturating_mul
 core::num::<impl i64>::saturating_neg
 core::num::<impl i64>::saturating_sub
+core::num::<impl i64>::swap_bytes
 core::num::<impl i64>::to_le
 core::num::<impl i64>::to_le_bytes
 core::num::<impl i64>::to_ne_bytes
@@ -7207,6 +7211,7 @@ core::num::<impl i8>::saturating_div
 core::num::<impl i8>::saturating_mul
 core::num::<impl i8>::saturating_neg
 core::num::<impl i8>::saturating_sub
+core::num::<impl i8>::swap_bytes
 core::num::<impl i8>::to_le
 core::num::<impl i8>::to_le_bytes
 core::num::<impl i8>::to_ne_bytes
@@ -7267,6 +7272,7 @@ core::num::<impl isize>::saturating_div
 core::num::<impl isize>::saturating_mul
 core::num::<impl isize>::saturating_neg
 core::num::<impl isize>::saturating_sub
+core::num::<impl isize>::swap_bytes
 core::num::<impl isize>::to_le
 core::num::<impl isize>::to_le_bytes
 core::num::<impl isize>::to_ne_bytes

--- a/ferrocene/doc/symbol-report.csv
+++ b/ferrocene/doc/symbol-report.csv
@@ -8257,6 +8257,7 @@ core::slice::<impl [T]>::is_empty
 core::slice::<impl [T]>::iter
 core::slice::<impl [T]>::iter_mut
 core::slice::<impl [T]>::last
+core::slice::<impl [T]>::last_chunk
 core::slice::<impl [T]>::last_mut
 core::slice::<impl [T]>::len
 core::slice::<impl [T]>::reverse
@@ -8283,9 +8284,12 @@ core::slice::<impl [T]>::swap_unchecked::precondition_check
 core::slice::<impl [T]>::windows
 core::slice::<impl core::default::Default for &mut [T]>::default
 core::slice::ascii::<impl [u8]>::eq_ignore_ascii_case
+core::slice::ascii::<impl [u8]>::eq_ignore_ascii_case_chunks
+core::slice::ascii::<impl [u8]>::eq_ignore_ascii_case_chunks::eq_ignore_ascii_inner
 core::slice::ascii::<impl [u8]>::eq_ignore_ascii_case_simple
 core::slice::ascii::<impl [u8]>::escape_ascii
 core::slice::ascii::<impl [u8]>::is_ascii
+core::slice::ascii::is_ascii
 core::slice::ascii::is_ascii::compiletime
 core::slice::ascii::is_ascii::runtime
 core::slice::ascii::is_ascii_simple

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -223,6 +223,7 @@ impl<T, const N: usize> IntoIter<T, N> {
     /// Returns a mutable slice of all elements that have not been yielded yet.
     #[stable(feature = "array_value_iter", since = "1.51.0")]
     #[inline]
+    #[ferrocene::prevalidated]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         self.unsize_mut().as_mut_slice()
     }

--- a/library/core/src/array/iter/iter_inner.rs
+++ b/library/core/src/array/iter/iter_inner.rs
@@ -144,6 +144,7 @@ impl<T> PolymorphicIter<[MaybeUninit<T>]> {
     }
 
     #[inline]
+    #[ferrocene::prevalidated]
     pub(super) fn as_mut_slice(&mut self) -> &mut [T] {
         // SAFETY: We know that all elements within `alive` are properly initialized.
         unsafe {

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -424,6 +424,7 @@ where
 // blocked by PartialOrd
 impl<T: PartialOrd, const N: usize> PartialOrd for [T; N] {
     #[inline]
+    #[ferrocene::prevalidated]
     fn partial_cmp(&self, other: &[T; N]) -> Option<Ordering> {
         PartialOrd::partial_cmp(&&self[..], &&other[..])
     }
@@ -449,6 +450,7 @@ impl<T: PartialOrd, const N: usize> PartialOrd for [T; N] {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Ord, const N: usize> Ord for [T; N] {
     #[inline]
+    #[ferrocene::prevalidated]
     fn cmp(&self, other: &[T; N]) -> Ordering {
         Ord::cmp(&&self[..], &&other[..])
     }

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -464,6 +464,7 @@ impl char {
                   without modifying the original"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
+    #[ferrocene::prevalidated]
     pub fn escape_unicode(self) -> EscapeUnicode {
         EscapeUnicode::new(self)
     }
@@ -587,6 +588,7 @@ impl char {
                   without modifying the original"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
+    #[ferrocene::prevalidated]
     pub fn escape_default(self) -> EscapeDefault {
         match self {
             '\t' => EscapeDefault::backslash(ascii::Char::SmallT),
@@ -897,6 +899,7 @@ impl char {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_char_classify", since = "1.87.0")]
     #[inline]
+    #[ferrocene::prevalidated]
     pub const fn is_whitespace(self) -> bool {
         match self {
             ' ' | '\x09'..='\x0d' => true,
@@ -1249,6 +1252,7 @@ impl char {
     #[must_use]
     #[unstable(feature = "ascii_char", issue = "110998")]
     #[inline]
+    #[ferrocene::prevalidated]
     pub const fn as_ascii(&self) -> Option<ascii::Char> {
         if self.is_ascii() {
             // SAFETY: Just checked that this is ASCII.
@@ -1787,6 +1791,7 @@ impl char {
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
+    #[ferrocene::prevalidated]
     pub const fn is_ascii_whitespace(&self) -> bool {
         matches!(*self, '\t' | '\n' | '\x0C' | '\r' | ' ')
     }

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -165,6 +165,7 @@ pub struct EscapeUnicode(EscapeIterInner<10, AlwaysEscaped>);
 
 impl EscapeUnicode {
     #[inline]
+    #[ferrocene::prevalidated]
     const fn new(c: char) -> Self {
         Self(EscapeIterInner::unicode(c))
     }
@@ -231,16 +232,19 @@ pub struct EscapeDefault(EscapeIterInner<10, AlwaysEscaped>);
 
 impl EscapeDefault {
     #[inline]
+    #[ferrocene::prevalidated]
     const fn printable(c: ascii::Char) -> Self {
         Self(EscapeIterInner::ascii(c.to_u8()))
     }
 
     #[inline]
+    #[ferrocene::prevalidated]
     const fn backslash(c: ascii::Char) -> Self {
         Self(EscapeIterInner::backslash(c))
     }
 
     #[inline]
+    #[ferrocene::prevalidated]
     const fn unicode(c: char) -> Self {
         Self(EscapeIterInner::unicode(c))
     }

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -2245,6 +2245,7 @@ mod impls {
         A: [const] Ord,
     {
         #[inline]
+        #[ferrocene::prevalidated]
         fn cmp(&self, other: &Self) -> Ordering {
             Ord::cmp(*self, *other)
         }

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -118,6 +118,7 @@ where
         self.try_rfold((), |(), x| ControlFlow::Break(x)).break_value()
     }
 
+    #[ferrocene::prevalidated]
     fn try_rfold<B, F, R>(&mut self, init: B, mut f: F) -> R
     where
         Self: Sized,
@@ -151,6 +152,7 @@ where
     I: DoubleEndedIterator + ExactSizeIterator,
 {
     /// Updates `self.remainder` such that `self.iter.len` is divisible by `N`.
+    #[ferrocene::prevalidated]
     fn next_back_remainder(&mut self) {
         // Make sure to not override `self.remainder` with an empty array
         // when `next_back` is called after `ArrayChunks` exhaustion.

--- a/library/core/src/iter/adapters/map_while.rs
+++ b/library/core/src/iter/adapters/map_while.rs
@@ -52,6 +52,7 @@ where
     }
 
     #[inline]
+    #[ferrocene::prevalidated]
     fn try_fold<Acc, Fold, R>(&mut self, init: Acc, mut fold: Fold) -> R
     where
         Self: Sized,

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -183,6 +183,7 @@ where
         }
     }
 
+    #[ferrocene::prevalidated]
     fn try_fold<B, F, T>(&mut self, init: B, mut f: F) -> T
     where
         F: FnMut(B, Self::Item) -> T,

--- a/library/core/src/iter/adapters/scan.rs
+++ b/library/core/src/iter/adapters/scan.rs
@@ -54,12 +54,14 @@ where
     }
 
     #[inline]
+    #[ferrocene::prevalidated]
     fn try_fold<Acc, Fold, R>(&mut self, init: Acc, fold: Fold) -> R
     where
         Self: Sized,
         Fold: FnMut(Acc, Self::Item) -> R,
         R: Try<Output = Acc>,
     {
+        #[ferrocene::prevalidated]
         fn scan<'a, T, St, B, Acc, R: Try<Output = Acc>>(
             state: &'a mut St,
             f: &'a mut impl FnMut(&mut St, T) -> Option<B>,

--- a/library/core/src/iter/traits/double_ended.rs
+++ b/library/core/src/iter/traits/double_ended.rs
@@ -451,6 +451,7 @@ impl<I: DoubleEndedIterator + ?Sized> DoubleEndedIteratorRefSpec for &mut I {
 impl<I: DoubleEndedIterator> DoubleEndedIteratorRefSpec for &mut I {
     impl_fold_via_try_fold! { spec_rfold -> spec_try_rfold }
 
+    #[ferrocene::prevalidated]
     fn spec_try_rfold<B, F, R>(&mut self, init: B, f: F) -> R
     where
         F: FnMut(B, Self::Item) -> R,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -109,6 +109,7 @@ pub const trait Iterator {
     #[inline]
     #[unstable(feature = "iter_next_chunk", issue = "98326")]
     #[rustc_non_const_trait_method]
+    #[ferrocene::prevalidated]
     fn next_chunk<const N: usize>(
         &mut self,
     ) -> Result<[Self::Item; N], array::IntoIter<Self::Item, N>>
@@ -4351,6 +4352,7 @@ impl<I: Iterator + ?Sized> IteratorRefSpec for &mut I {
 impl<I: Iterator> IteratorRefSpec for &mut I {
     impl_fold_via_try_fold! { spec_fold -> spec_try_fold }
 
+    #[ferrocene::prevalidated]
     fn spec_try_fold<B, F, R>(&mut self, init: B, f: F) -> R
     where
         F: FnMut(B, Self::Item) -> R,

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -348,6 +348,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
+        #[ferrocene::prevalidated]
         pub const fn swap_bytes(self) -> Self {
             (self as $UnsignedT).swap_bytes() as Self
         }

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1906,6 +1906,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
+        #[ferrocene::prevalidated]
         pub const fn saturating_add(self, rhs: Self) -> Self {
             intrinsics::saturating_add(self, rhs)
         }
@@ -1948,6 +1949,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
+        #[ferrocene::prevalidated]
         pub const fn saturating_sub(self, rhs: Self) -> Self {
             intrinsics::saturating_sub(self, rhs)
         }
@@ -1992,6 +1994,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
+        #[ferrocene::prevalidated]
         pub const fn saturating_neg(self) -> Self {
             intrinsics::saturating_sub(0, self)
         }
@@ -2036,6 +2039,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[ferrocene::prevalidated]
         pub const fn saturating_mul(self, rhs: Self) -> Self {
             match self.checked_mul(rhs) {
                 Some(x) => x,
@@ -2067,6 +2071,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[ferrocene::prevalidated]
         pub const fn saturating_div(self, rhs: Self) -> Self {
             match self.overflowing_div(rhs) {
                 (result, false) => result,
@@ -2213,6 +2218,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[ferrocene::prevalidated]
         pub const fn wrapping_div(self, rhs: Self) -> Self {
             self.overflowing_div(rhs).0
         }
@@ -2265,6 +2271,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[ferrocene::prevalidated]
         pub const fn wrapping_rem(self, rhs: Self) -> Self {
             self.overflowing_rem(rhs).0
         }
@@ -2859,6 +2866,7 @@ macro_rules! int_impl {
         #[rustc_const_stable(feature = "const_overflowing_int_methods", since = "1.52.0")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
+        #[ferrocene::prevalidated]
         pub const fn overflowing_div(self, rhs: Self) -> (Self, bool) {
             // Using `&` helps LLVM see that it is the same check made in division.
             if intrinsics::unlikely((self == Self::MIN) & (rhs == -1)) {
@@ -2917,6 +2925,7 @@ macro_rules! int_impl {
         #[rustc_const_stable(feature = "const_overflowing_int_methods", since = "1.52.0")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
+        #[ferrocene::prevalidated]
         pub const fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
             if intrinsics::unlikely(rhs == -1) {
                 (0, self == Self::MIN)

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1117,6 +1117,7 @@ impl u8 {
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
+    #[ferrocene::prevalidated]
     pub const fn is_ascii_whitespace(&self) -> bool {
         matches!(*self, b'\t' | b'\n' | b'\x0C' | b'\r' | b' ')
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1584,6 +1584,7 @@ macro_rules! nonzero_integer_signedness_dependent_impls {
             type Output = Self;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn neg(self) -> Self {
                 // SAFETY: negation of nonzero cannot yield zero values.
                 unsafe { Self::new_unchecked(self.get().neg()) }

--- a/library/core/src/num/saturating.rs
+++ b/library/core/src/num/saturating.rs
@@ -218,6 +218,7 @@ macro_rules! saturating_impl {
             type Output = Saturating<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn add(self, other: Saturating<$t>) -> Saturating<$t> {
                 Saturating(self.0.saturating_add(other.0))
             }
@@ -230,6 +231,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const AddAssign for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn add_assign(&mut self, other: Saturating<$t>) {
                 *self = *self + other;
             }
@@ -242,6 +244,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const AddAssign<$t> for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn add_assign(&mut self, other: $t) {
                 *self = *self + Saturating(other);
             }
@@ -256,6 +259,7 @@ macro_rules! saturating_impl {
             type Output = Saturating<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn sub(self, other: Saturating<$t>) -> Saturating<$t> {
                 Saturating(self.0.saturating_sub(other.0))
             }
@@ -268,6 +272,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const SubAssign for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn sub_assign(&mut self, other: Saturating<$t>) {
                 *self = *self - other;
             }
@@ -280,6 +285,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const SubAssign<$t> for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn sub_assign(&mut self, other: $t) {
                 *self = *self - Saturating(other);
             }
@@ -294,6 +300,7 @@ macro_rules! saturating_impl {
             type Output = Saturating<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn mul(self, other: Saturating<$t>) -> Saturating<$t> {
                 Saturating(self.0.saturating_mul(other.0))
             }
@@ -306,6 +313,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const MulAssign for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn mul_assign(&mut self, other: Saturating<$t>) {
                 *self = *self * other;
             }
@@ -318,6 +326,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const MulAssign<$t> for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn mul_assign(&mut self, other: $t) {
                 *self = *self * Saturating(other);
             }
@@ -347,6 +356,7 @@ macro_rules! saturating_impl {
             type Output = Saturating<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn div(self, other: Saturating<$t>) -> Saturating<$t> {
                 Saturating(self.0.saturating_div(other.0))
             }
@@ -359,6 +369,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const DivAssign for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn div_assign(&mut self, other: Saturating<$t>) {
                 *self = *self / other;
             }
@@ -371,6 +382,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const DivAssign<$t> for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn div_assign(&mut self, other: $t) {
                 *self = *self / Saturating(other);
             }
@@ -385,6 +397,7 @@ macro_rules! saturating_impl {
             type Output = Saturating<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn rem(self, other: Saturating<$t>) -> Saturating<$t> {
                 Saturating(self.0.rem(other.0))
             }
@@ -397,6 +410,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const RemAssign for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn rem_assign(&mut self, other: Saturating<$t>) {
                 *self = *self % other;
             }
@@ -409,6 +423,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const RemAssign<$t> for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn rem_assign(&mut self, other: $t) {
                 *self = *self % Saturating(other);
             }
@@ -423,6 +438,7 @@ macro_rules! saturating_impl {
             type Output = Saturating<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn not(self) -> Saturating<$t> {
                 Saturating(!self.0)
             }
@@ -437,6 +453,7 @@ macro_rules! saturating_impl {
             type Output = Saturating<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitxor(self, other: Saturating<$t>) -> Saturating<$t> {
                 Saturating(self.0 ^ other.0)
             }
@@ -449,6 +466,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const BitXorAssign for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitxor_assign(&mut self, other: Saturating<$t>) {
                 *self = *self ^ other;
             }
@@ -461,6 +479,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const BitXorAssign<$t> for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitxor_assign(&mut self, other: $t) {
                 *self = *self ^ Saturating(other);
             }
@@ -475,6 +494,7 @@ macro_rules! saturating_impl {
             type Output = Saturating<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitor(self, other: Saturating<$t>) -> Saturating<$t> {
                 Saturating(self.0 | other.0)
             }
@@ -487,6 +507,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const BitOrAssign for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitor_assign(&mut self, other: Saturating<$t>) {
                 *self = *self | other;
             }
@@ -499,6 +520,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const BitOrAssign<$t> for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitor_assign(&mut self, other: $t) {
                 *self = *self | Saturating(other);
             }
@@ -513,6 +535,7 @@ macro_rules! saturating_impl {
             type Output = Saturating<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitand(self, other: Saturating<$t>) -> Saturating<$t> {
                 Saturating(self.0 & other.0)
             }
@@ -525,6 +548,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const BitAndAssign for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitand_assign(&mut self, other: Saturating<$t>) {
                 *self = *self & other;
             }
@@ -537,6 +561,7 @@ macro_rules! saturating_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const BitAndAssign<$t> for Saturating<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitand_assign(&mut self, other: $t) {
                 *self = *self & Saturating(other);
             }
@@ -1004,6 +1029,7 @@ macro_rules! saturating_int_impl_signed {
         impl const Neg for Saturating<$t> {
             type Output = Self;
             #[inline]
+            #[ferrocene::prevalidated]
             fn neg(self) -> Self {
                 Saturating(self.0.saturating_neg())
             }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1717,6 +1717,9 @@ macro_rules! uint_impl {
             // Note: Like all optimizations, this is not guaranteed to be
             // applied by the compiler. If you want those specific bases,
             // use `.checked_ilog2()` or `.checked_ilog10()` directly.
+            #[ferrocene::annotation(
+                "The uncovered } at the end of this statement is a tooling bug, since the lines after are covered, the else case here is also covered."
+            )]
             if core::intrinsics::is_val_statically_known(base) {
                 if base == 2 {
                     return self.checked_ilog2();

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2442,6 +2442,7 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline]
         #[track_caller]
+        #[ferrocene::prevalidated]
         pub const fn saturating_div(self, rhs: Self) -> Self {
             // on unsigned types, there is no overflow in integer division
             self.wrapping_div(rhs)
@@ -2588,6 +2589,7 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline(always)]
         #[track_caller]
+        #[ferrocene::prevalidated]
         pub const fn wrapping_div(self, rhs: Self) -> Self {
             self / rhs
         }
@@ -2641,6 +2643,7 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline(always)]
         #[track_caller]
+        #[ferrocene::prevalidated]
         pub const fn wrapping_rem(self, rhs: Self) -> Self {
             self % rhs
         }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1717,9 +1717,6 @@ macro_rules! uint_impl {
             // Note: Like all optimizations, this is not guaranteed to be
             // applied by the compiler. If you want those specific bases,
             // use `.checked_ilog2()` or `.checked_ilog10()` directly.
-            #[ferrocene::annotation(
-                "The uncovered } at the end of this statement is a tooling bug, since the lines after are covered, the else case here is also covered."
-            )]
             if core::intrinsics::is_val_statically_known(base) {
                 if base == 2 {
                     return self.checked_ilog2();

--- a/library/core/src/num/wrapping.rs
+++ b/library/core/src/num/wrapping.rs
@@ -93,6 +93,7 @@ macro_rules! sh_impl_signed {
             type Output = Wrapping<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn shl(self, other: $f) -> Wrapping<$t> {
                 if other < 0 {
                     Wrapping(self.0.wrapping_shr(-other as u32))
@@ -109,6 +110,7 @@ macro_rules! sh_impl_signed {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const ShlAssign<$f> for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn shl_assign(&mut self, other: $f) {
                 *self = *self << other;
             }
@@ -123,6 +125,7 @@ macro_rules! sh_impl_signed {
             type Output = Wrapping<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn shr(self, other: $f) -> Wrapping<$t> {
                 if other < 0 {
                     Wrapping(self.0.wrapping_shl(-other as u32))
@@ -139,6 +142,7 @@ macro_rules! sh_impl_signed {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const ShrAssign<$f> for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn shr_assign(&mut self, other: $f) {
                 *self = *self >> other;
             }
@@ -157,6 +161,7 @@ macro_rules! sh_impl_unsigned {
             type Output = Wrapping<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn shl(self, other: $f) -> Wrapping<$t> {
                 Wrapping(self.0.wrapping_shl(other as u32))
             }
@@ -169,6 +174,7 @@ macro_rules! sh_impl_unsigned {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const ShlAssign<$f> for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn shl_assign(&mut self, other: $f) {
                 *self = *self << other;
             }
@@ -183,6 +189,7 @@ macro_rules! sh_impl_unsigned {
             type Output = Wrapping<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn shr(self, other: $f) -> Wrapping<$t> {
                 Wrapping(self.0.wrapping_shr(other as u32))
             }
@@ -195,6 +202,7 @@ macro_rules! sh_impl_unsigned {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const ShrAssign<$f> for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn shr_assign(&mut self, other: $f) {
                 *self = *self >> other;
             }
@@ -235,6 +243,7 @@ macro_rules! wrapping_impl {
             type Output = Wrapping<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn add(self, other: Wrapping<$t>) -> Wrapping<$t> {
                 Wrapping(self.0.wrapping_add(other.0))
             }
@@ -247,6 +256,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const AddAssign for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn add_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self + other;
             }
@@ -259,6 +269,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const AddAssign<$t> for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn add_assign(&mut self, other: $t) {
                 *self = *self + Wrapping(other);
             }
@@ -273,6 +284,7 @@ macro_rules! wrapping_impl {
             type Output = Wrapping<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn sub(self, other: Wrapping<$t>) -> Wrapping<$t> {
                 Wrapping(self.0.wrapping_sub(other.0))
             }
@@ -285,6 +297,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const SubAssign for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn sub_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self - other;
             }
@@ -297,6 +310,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const SubAssign<$t> for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn sub_assign(&mut self, other: $t) {
                 *self = *self - Wrapping(other);
             }
@@ -311,6 +325,7 @@ macro_rules! wrapping_impl {
             type Output = Wrapping<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn mul(self, other: Wrapping<$t>) -> Wrapping<$t> {
                 Wrapping(self.0.wrapping_mul(other.0))
             }
@@ -323,6 +338,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const MulAssign for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn mul_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self * other;
             }
@@ -335,6 +351,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const MulAssign<$t> for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn mul_assign(&mut self, other: $t) {
                 *self = *self * Wrapping(other);
             }
@@ -349,6 +366,7 @@ macro_rules! wrapping_impl {
             type Output = Wrapping<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn div(self, other: Wrapping<$t>) -> Wrapping<$t> {
                 Wrapping(self.0.wrapping_div(other.0))
             }
@@ -361,6 +379,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const DivAssign for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn div_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self / other;
             }
@@ -373,6 +392,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const DivAssign<$t> for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn div_assign(&mut self, other: $t) {
                 *self = *self / Wrapping(other);
             }
@@ -387,6 +407,7 @@ macro_rules! wrapping_impl {
             type Output = Wrapping<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn rem(self, other: Wrapping<$t>) -> Wrapping<$t> {
                 Wrapping(self.0.wrapping_rem(other.0))
             }
@@ -399,6 +420,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const RemAssign for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn rem_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self % other;
             }
@@ -411,6 +433,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const RemAssign<$t> for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn rem_assign(&mut self, other: $t) {
                 *self = *self % Wrapping(other);
             }
@@ -425,6 +448,7 @@ macro_rules! wrapping_impl {
             type Output = Wrapping<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn not(self) -> Wrapping<$t> {
                 Wrapping(!self.0)
             }
@@ -439,6 +463,7 @@ macro_rules! wrapping_impl {
             type Output = Wrapping<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitxor(self, other: Wrapping<$t>) -> Wrapping<$t> {
                 Wrapping(self.0 ^ other.0)
             }
@@ -451,6 +476,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const BitXorAssign for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitxor_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self ^ other;
             }
@@ -463,6 +489,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const BitXorAssign<$t> for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitxor_assign(&mut self, other: $t) {
                 *self = *self ^ Wrapping(other);
             }
@@ -477,6 +504,7 @@ macro_rules! wrapping_impl {
             type Output = Wrapping<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitor(self, other: Wrapping<$t>) -> Wrapping<$t> {
                 Wrapping(self.0 | other.0)
             }
@@ -489,6 +517,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const BitOrAssign for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitor_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self | other;
             }
@@ -501,6 +530,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const BitOrAssign<$t> for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitor_assign(&mut self, other: $t) {
                 *self = *self | Wrapping(other);
             }
@@ -515,6 +545,7 @@ macro_rules! wrapping_impl {
             type Output = Wrapping<$t>;
 
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitand(self, other: Wrapping<$t>) -> Wrapping<$t> {
                 Wrapping(self.0 & other.0)
             }
@@ -527,6 +558,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const BitAndAssign for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitand_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self & other;
             }
@@ -539,6 +571,7 @@ macro_rules! wrapping_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const BitAndAssign<$t> for Wrapping<$t> {
             #[inline]
+            #[ferrocene::prevalidated]
             fn bitand_assign(&mut self, other: $t) {
                 *self = *self & Wrapping(other);
             }
@@ -552,6 +585,7 @@ macro_rules! wrapping_impl {
         impl const Neg for Wrapping<$t> {
             type Output = Self;
             #[inline]
+            #[ferrocene::prevalidated]
             fn neg(self) -> Self {
                 Wrapping(0) - self
             }

--- a/library/core/src/ptr/alignment.rs
+++ b/library/core/src/ptr/alignment.rs
@@ -334,6 +334,7 @@ impl const Default for Alignment {
 #[cfg(target_pointer_width = "16")]
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(usize)]
+#[ferrocene::prevalidated]
 enum AlignmentEnum {
     _Align1Shl0 = 1 << 0,
     _Align1Shl1 = 1 << 1,
@@ -356,6 +357,7 @@ enum AlignmentEnum {
 #[cfg(target_pointer_width = "32")]
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(usize)]
+#[ferrocene::prevalidated]
 enum AlignmentEnum {
     _Align1Shl0 = 1 << 0,
     _Align1Shl1 = 1 << 1,

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -164,7 +164,7 @@ impl [u8] {
                 }
             } else {
                 #[ferrocene::annotation("
-                    This branch of is not coverable from public API. \
+                    This branch is not coverable from public API. \
                     The only caller (`eq_ignore_ascii_case`) only calls this function if both values \
                     are the same length, and that shared length is greater than the `N` chunk size.
                     The `if` statement above is currently acting to destructure the returned values.

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -157,14 +157,19 @@ impl [u8] {
 
         // If there are remaining tails, load the last N bytes in the slices to
         // avoid falling back to per-byte checking.
-        #[ferrocene::annotation("
-            A tooling bug marks the trailing `}` as uncovered, but since the `true` below is covered, we know we test the fall-through. See `test_eq_ignore_ascii_case_chunks`.
-        ")]
         if !self_rem.is_empty() {
             if let (Some(a_rem), Some(b_rem)) = (self.last_chunk::<N>(), other.last_chunk::<N>()) {
                 if !eq_ignore_ascii_inner(a_rem, b_rem) {
                     return false;
                 }
+            } else {
+                #[ferrocene::annotation("
+                    This branch of is not coverable from public API. \
+                    The only caller (`eq_ignore_ascii_case`) only calls this function if both values \
+                    are the same length, and that shared length is greater than the `N` chunk size.
+                    The `if` statement above is currently acting to destructure the returned values.
+                ")]
+                {}
             }
         }
 

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -157,6 +157,9 @@ impl [u8] {
 
         // If there are remaining tails, load the last N bytes in the slices to
         // avoid falling back to per-byte checking.
+        #[ferrocene::annotation("
+            A tooling bug marks the trailing `}` as uncovered, but since the `true` below is covered, we know we test the fall-through. See `test_eq_ignore_ascii_case_chunks`.
+        ")]
         if !self_rem.is_empty() {
             if let (Some(a_rem), Some(b_rem)) = (self.last_chunk::<N>(), other.last_chunk::<N>()) {
                 if !eq_ignore_ascii_inner(a_rem, b_rem) {

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -116,6 +116,7 @@ impl [u8] {
     ///
     /// The caller must guarantee that the slices are equal in length, and the
     /// slice lengths are greater than or equal to `N` bytes.
+    #[ferrocene::prevalidated]
     #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
     #[inline]
     const fn eq_ignore_ascii_case_chunks<const N: usize>(&self, other: &[u8]) -> bool {
@@ -126,6 +127,7 @@ impl [u8] {
         let (other_chunks, _) = other.as_chunks::<N>();
 
         // Branchless check to encourage auto-vectorization
+        #[ferrocene::prevalidated]
         #[inline(always)]
         const fn eq_ignore_ascii_inner<const L: usize>(lhs: &[u8; L], rhs: &[u8; L]) -> bool {
             let mut equal_ascii = true;
@@ -592,6 +594,7 @@ fn is_ascii_sse2(bytes: &[u8]) -> bool {
 ///
 /// Uses explicit SSE2 intrinsics to prevent LLVM from auto-vectorizing with
 /// broken AVX-512 code that extracts mask bits one-by-one.
+#[ferrocene::prevalidated]
 #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
 #[inline]
 #[rustc_allow_const_fn_unstable(const_eval_select)]

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -525,6 +525,7 @@ impl<T> [T] {
     /// let w: &[i32] = &[];
     /// assert_eq!(Some(&[]), w.last_chunk::<0>());
     /// ```
+    #[ferrocene::prevalidated]
     #[inline]
     #[stable(feature = "slice_first_last_chunk", since = "1.77.0")]
     #[rustc_const_stable(feature = "const_slice_last_chunk", since = "1.80.0")]

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -861,6 +861,7 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     #[inline]
     #[must_use]
+    #[ferrocene::prevalidated]
     pub const fn as_mut_ptr_range(&mut self) -> Range<*mut T> {
         let start = self.as_mut_ptr();
         // SAFETY: See as_ptr_range() above for why `add` here is safe.
@@ -1006,6 +1007,7 @@ impl<T> [T] {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_slice_reverse", since = "1.90.0")]
     #[inline]
+    #[ferrocene::prevalidated]
     pub const fn reverse(&mut self) {
         let half_len = self.len() / 2;
         let Range { start, end } = self.as_mut_ptr_range();
@@ -1029,6 +1031,7 @@ impl<T> [T] {
         revswap(front_half, back_half, half_len);
 
         #[inline]
+        #[ferrocene::prevalidated]
         const fn revswap<T>(a: &mut [T], b: &mut [T], n: usize) {
             debug_assert!(a.len() == n);
             debug_assert!(b.len() == n);

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2497,6 +2497,7 @@ impl str {
     #[must_use = "this returns the remaining substring as a new slice, \
                   without modifying the original"]
     #[stable(feature = "str_strip", since = "1.45.0")]
+    #[ferrocene::prevalidated]
     pub fn strip_suffix<P: Pattern>(&self, suffix: P) -> Option<&str>
     where
         for<'a> P::Searcher<'a>: ReverseSearcher<'a>,

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -4205,6 +4205,7 @@ unsafe fn atomic_xor<T: Copy, U: Copy>(dst: *mut T, val: U, order: Ordering) -> 
 #[inline]
 #[cfg(target_has_atomic)]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+#[ferrocene::prevalidated]
 unsafe fn atomic_max<T: Copy>(dst: *mut T, val: T, order: Ordering) -> T {
     // SAFETY: the caller must uphold the safety contract for `atomic_max`
     unsafe {
@@ -4222,6 +4223,7 @@ unsafe fn atomic_max<T: Copy>(dst: *mut T, val: T, order: Ordering) -> T {
 #[inline]
 #[cfg(target_has_atomic)]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+#[ferrocene::prevalidated]
 unsafe fn atomic_min<T: Copy>(dst: *mut T, val: T, order: Ordering) -> T {
     // SAFETY: the caller must uphold the safety contract for `atomic_min`
     unsafe {

--- a/library/core/src/unicode/unicode_data.rs
+++ b/library/core/src/unicode/unicode_data.rs
@@ -754,6 +754,7 @@ pub mod white_space {
         0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
     #[inline]
+    #[ferrocene::prevalidated]
     pub const fn lookup(c: char) -> bool {
         debug_assert!(!c.is_ascii());
         match c as u32 >> 8 {

--- a/library/coretests/tests/ferrocene/fmt.rs
+++ b/library/coretests/tests/ferrocene/fmt.rs
@@ -526,9 +526,9 @@ fn test_formatter_align() {
         fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
             let s = if let Some(s) = formatter.align() {
                 match s {
-                    Alignment::Left    => "left",
-                    Alignment::Right   => "right",
-                    Alignment::Center  => "center",
+                    Alignment::Left => "left",
+                    Alignment::Right => "right",
+                    Alignment::Center => "center",
                 }
             } else {
                 "into the void"

--- a/library/coretests/tests/ferrocene/fmt.rs
+++ b/library/coretests/tests/ferrocene/fmt.rs
@@ -542,20 +542,3 @@ fn test_formatter_align() {
     assert_eq!(format!("{Foo:^}"), "center");
     assert_eq!(format!("{Foo}"), "into the void");
 }
-
-#[test]
-fn test_fmt_parse_int_error_not_a_power_of_two() {
-    use core::num::IntErrorKind;
-    pub struct FakeParseIntError {
-        #[allow(dead_code)] // This is used for transmuting.
-        pub kind: IntErrorKind,
-    }
-
-    let val = FakeParseIntError { kind: IntErrorKind::NotAPowerOfTwo };
-    // We need to do a truly cursed thing here since there are no situations in public API where
-    // we can conjure ourselves a `ParseIntError` with a `NotAPowerOfTwo` in it.
-    let cursed =
-        unsafe { core::mem::transmute::<FakeParseIntError, core::num::ParseIntError>(val) };
-    let formatted = format!("{}", cursed);
-    assert_eq!(formatted, "number is not a power of two")
-}

--- a/library/coretests/tests/ferrocene/fmt.rs
+++ b/library/coretests/tests/ferrocene/fmt.rs
@@ -542,3 +542,23 @@ fn test_formatter_align() {
     assert_eq!(format!("{Foo:^}"), "center");
     assert_eq!(format!("{Foo}"), "into the void");
 }
+
+#[test]
+fn test_fmt_parse_int_error_not_a_power_of_two() {
+    use core::num::IntErrorKind;
+    pub struct FakeParseIntError {
+        #[allow(dead_code)] // This is used for transmuting.
+        pub kind: IntErrorKind,
+    }
+
+    let val = FakeParseIntError {
+        kind: IntErrorKind::NotAPowerOfTwo,
+    };
+    // We need to do a truly cursed thing here since there are no situations in public API where
+    // we can conjure ourselves a `ParseIntError` with a `NotAPowerOfTwo` in it.
+    let cursed = unsafe {
+        core::mem::transmute::<FakeParseIntError, core::num::ParseIntError>(val)
+    };
+    let formatted = format!("{}", cursed);
+    assert_eq!(formatted, "number is not a power of two")
+}

--- a/library/coretests/tests/ferrocene/fmt.rs
+++ b/library/coretests/tests/ferrocene/fmt.rs
@@ -551,14 +551,11 @@ fn test_fmt_parse_int_error_not_a_power_of_two() {
         pub kind: IntErrorKind,
     }
 
-    let val = FakeParseIntError {
-        kind: IntErrorKind::NotAPowerOfTwo,
-    };
+    let val = FakeParseIntError { kind: IntErrorKind::NotAPowerOfTwo };
     // We need to do a truly cursed thing here since there are no situations in public API where
     // we can conjure ourselves a `ParseIntError` with a `NotAPowerOfTwo` in it.
-    let cursed = unsafe {
-        core::mem::transmute::<FakeParseIntError, core::num::ParseIntError>(val)
-    };
+    let cursed =
+        unsafe { core::mem::transmute::<FakeParseIntError, core::num::ParseIntError>(val) };
     let formatted = format!("{}", cursed);
     assert_eq!(formatted, "number is not a power of two")
 }

--- a/library/coretests/tests/ferrocene/fmt.rs
+++ b/library/coretests/tests/ferrocene/fmt.rs
@@ -488,3 +488,28 @@ fn from_fn_debug_fmt() {
     let val = core::fmt::from_fn(|f| write!(f, "{msg}"));
     assert_eq!(format!("{val:?}"), msg);
 }
+
+// Covers `core::fmt::Formatter::<'a>::fill`
+// Copied from `core::fmt::Formatter::<'a>::fill` doc test
+#[test]
+fn test_formatter_fill() {
+    struct Foo;
+
+    impl fmt::Display for Foo {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let c = formatter.fill();
+            if let Some(width) = formatter.width() {
+                for _ in 0..width {
+                    write!(formatter, "{c}")?;
+                }
+                Ok(())
+            } else {
+                write!(formatter, "{c}")
+            }
+        }
+    }
+
+    // We set alignment to the right with ">".
+    assert_eq!(format!("{Foo:G>3}"), "GGG");
+    assert_eq!(format!("{Foo:t>6}"), "tttttt");
+}

--- a/library/coretests/tests/ferrocene/fmt.rs
+++ b/library/coretests/tests/ferrocene/fmt.rs
@@ -513,3 +513,32 @@ fn test_formatter_fill() {
     assert_eq!(format!("{Foo:G>3}"), "GGG");
     assert_eq!(format!("{Foo:t>6}"), "tttttt");
 }
+
+// Covers `core::fmt::Formatter::<'a>::align`
+// Copied from `core::fmt::Formatter::<'a>::align` doc test
+#[test]
+fn test_formatter_align() {
+    use std::fmt::{self, Alignment};
+
+    struct Foo;
+
+    impl fmt::Display for Foo {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let s = if let Some(s) = formatter.align() {
+                match s {
+                    Alignment::Left    => "left",
+                    Alignment::Right   => "right",
+                    Alignment::Center  => "center",
+                }
+            } else {
+                "into the void"
+            };
+            write!(formatter, "{s}")
+        }
+    }
+
+    assert_eq!(format!("{Foo:<}"), "left");
+    assert_eq!(format!("{Foo:>}"), "right");
+    assert_eq!(format!("{Foo:^}"), "center");
+    assert_eq!(format!("{Foo}"), "into the void");
+}

--- a/library/coretests/tests/ferrocene/intrinsics.rs
+++ b/library/coretests/tests/ferrocene/intrinsics.rs
@@ -133,23 +133,3 @@ test_intrinsic_unchecked_funnel! {
     u128 => test_intrinsic_unchecked_funnel_u128,
     usize => test_intrinsic_unchecked_funnel_usize,
 }
-
-#[test]
-fn test_minimum_number_nsz_f32() {
-    // x.is_nan() == true
-    assert_eq!(0.0_f32, core::intrinsics::minimum_number_nsz_f32(f32::NAN, 0.0_f32));
-    // y <= x
-    assert_eq!(0.0_f32, core::intrinsics::minimum_number_nsz_f32(1.0_32, 0.0_f32));
-    // else
-    assert_eq!(0.0_f32, core::intrinsics::minimum_number_nsz_f32(0.0_f32, 1.0_32));
-}
-
-#[test]
-fn test_maximum_number_nsz_f32() {
-    // x.is_nan() == true
-    assert_eq!(0.0_f32, core::intrinsics::maximum_number_nsz_f32(f32::NAN, 0.0_f32));
-    // y >= x
-    assert_eq!(1.0_f32, core::intrinsics::maximum_number_nsz_f32(1.0_f32, 0.0_f32));
-    // else
-    assert_eq!(1.0_f32, core::intrinsics::maximum_number_nsz_f32(0.0_f32, 1.0_f32));
-}

--- a/library/coretests/tests/ferrocene/intrinsics.rs
+++ b/library/coretests/tests/ferrocene/intrinsics.rs
@@ -133,3 +133,23 @@ test_intrinsic_unchecked_funnel! {
     u128 => test_intrinsic_unchecked_funnel_u128,
     usize => test_intrinsic_unchecked_funnel_usize,
 }
+
+#[test]
+fn test_minimum_number_nsz_f32() {
+    // x.is_nan() == true
+    assert_eq!(0.0_f32, core::intrinsics::minimum_number_nsz_f32(f32::NAN, 0.0_f32));
+    // y <= x
+    assert_eq!(0.0_f32, core::intrinsics::minimum_number_nsz_f32(1.0_32, 0.0_f32));
+    // else
+    assert_eq!(0.0_f32, core::intrinsics::minimum_number_nsz_f32(0.0_f32, 1.0_32));
+}
+
+#[test]
+fn test_maximum_number_nsz_f32() {
+    // x.is_nan() == true
+    assert_eq!(0.0_f32, core::intrinsics::maximum_number_nsz_f32(f32::NAN, 0.0_f32));
+    // y >= x
+    assert_eq!(1.0_f32, core::intrinsics::maximum_number_nsz_f32(1.0_f32, 0.0_f32));
+    // else
+    assert_eq!(1.0_f32, core::intrinsics::maximum_number_nsz_f32(0.0_f32, 1.0_f32));
+}

--- a/library/coretests/tests/ferrocene/intrinsics.rs
+++ b/library/coretests/tests/ferrocene/intrinsics.rs
@@ -93,3 +93,43 @@ test_int_carryless_mul! {
     u128 => test_u128_carryless_mul,
     usize => test_usize_carryless_mul,
 }
+
+// Covers:
+// <T as core::intrinsics::fallback::FunnelShift>::unchecked_funnel_shl
+// <T as core::intrinsics::fallback::FunnelShift>::unchecked_funnel_shr
+macro_rules! test_intrinsic_unchecked_funnel {
+    ($($T:ty => $fn:ident,)*) => {
+        $(
+        #[test]
+        fn $fn() {
+            unsafe {
+                assert_eq!(
+                    core::intrinsics::fallback::FunnelShift::unchecked_funnel_shl(12 as $T, 12 as $T, 0),
+                    12,
+                );
+                assert_eq!(
+                    core::intrinsics::fallback::FunnelShift::unchecked_funnel_shr(12 as $T, 12 as $T, 0),
+                    12,
+                );
+                assert_eq!(
+                    core::intrinsics::fallback::FunnelShift::unchecked_funnel_shl(12 as $T, 12 as $T, 2),
+                    48,
+                );
+                assert_eq!(
+                    core::intrinsics::fallback::FunnelShift::unchecked_funnel_shr(12 as $T, 12 as $T, 2),
+                    3,
+                );
+            }
+        }
+        )*
+    };
+}
+
+test_intrinsic_unchecked_funnel! {
+    u8 => test_intrinsic_unchecked_funnel_u8,
+    u16 => test_intrinsic_unchecked_funnel_u16,
+    u32 => test_intrinsic_unchecked_funnel_u32,
+    u64 => test_intrinsic_unchecked_funnel_u64,
+    u128 => test_intrinsic_unchecked_funnel_u128,
+    usize => test_intrinsic_unchecked_funnel_usize,
+}

--- a/library/coretests/tests/ferrocene/iter.rs
+++ b/library/coretests/tests/ferrocene/iter.rs
@@ -1131,3 +1131,14 @@ fn test_ref_spec_try_rfold() {
     let folded: Result<_, core::str::Utf8Error> = <&mut core::slice::IterMut<'_, _> as DoubleEndedIterator>::try_rfold(&mut &mut abstracted, 0, |acc, &mut x| Ok(acc + x));
     assert_eq!(folded, Ok(15));
 }
+
+// Covers `<core::iter::adapters::scan::Scan<I, St, F> as core::iter::traits::iterator::Iterator>::try_fold`
+#[test]
+fn test_scan_iterator_try_fold() {
+    let mut iter: core::iter::Scan<_, _, _> = [1, 2, 3, 4, 5].iter().scan(0, |acc: &mut usize, x: &usize| {
+        *acc += *x;
+        None
+    });
+    let folded = iter.try_fold(0, |_acc, _x: usize| None);
+    assert_eq!(folded, Some(0));
+}

--- a/library/coretests/tests/ferrocene/iter.rs
+++ b/library/coretests/tests/ferrocene/iter.rs
@@ -1100,3 +1100,17 @@ fn test_char_indices_count() {
     let suspect = "Hello there, I'm a code coverage test";
     assert_eq!(suspect.char_indices().count(), 37);
 }
+
+// Covers `<core::iter::adapters::map_while::MapWhile<I, P> as core::iter::traits::iterator::Iterator>::try_fold`
+#[test]
+fn test_map_while_try_fold() {
+    let mut iter = [1, 2, 3, 4, 5].iter().map_while(|x| {
+        if *x % 2 == 0 {
+            Some(*x)
+        } else {
+            None
+        }
+    });
+    let folded = iter.try_fold(0, |_acc, _x| None);
+    assert_eq!(folded, Some(0));
+}

--- a/library/coretests/tests/ferrocene/iter.rs
+++ b/library/coretests/tests/ferrocene/iter.rs
@@ -1114,3 +1114,11 @@ fn test_map_while_try_fold() {
     let folded = iter.try_fold(0, |_acc, _x| None);
     assert_eq!(folded, Some(0));
 }
+
+// Covers `core::array::<impl core::cmp::PartialOrd for [T; N]>::partial_cmp`
+#[test]
+fn test_partialord_slice_partialcmp() {
+    let x = [1, 2, 3];
+    let y = [4, 5, 6];
+    assert!(x.partial_cmp(&y).is_some());
+}

--- a/library/coretests/tests/ferrocene/iter.rs
+++ b/library/coretests/tests/ferrocene/iter.rs
@@ -1093,7 +1093,6 @@ fn test_filter_spec_assume_count_default() {
     assert_eq!(no_trusted_len.filter(|a| *a % 2 == 0).count(), 2);
 }
 
-
 // Covers `<core::str::iter::CharIndices<'a> as core::iter::traits::iterator::Iterator>::count`
 #[test]
 fn test_char_indices_count() {
@@ -1104,13 +1103,7 @@ fn test_char_indices_count() {
 // Covers `<core::iter::adapters::map_while::MapWhile<I, P> as core::iter::traits::iterator::Iterator>::try_fold`
 #[test]
 fn test_map_while_try_fold() {
-    let mut iter = [1, 2, 3, 4, 5].iter().map_while(|x| {
-        if *x % 2 == 0 {
-            Some(*x)
-        } else {
-            None
-        }
-    });
+    let mut iter = [1, 2, 3, 4, 5].iter().map_while(|x| if *x % 2 == 0 { Some(*x) } else { None });
     let folded = iter.try_fold(0, |_acc, _x| None);
     assert_eq!(folded, Some(0));
 }
@@ -1128,17 +1121,23 @@ fn test_partialord_slice_partialcmp() {
 fn test_ref_spec_try_rfold() {
     let mut suspect = [1, 2, 3, 4, 5];
     let mut abstracted = suspect.iter_mut();
-    let folded: Result<_, core::str::Utf8Error> = <&mut core::slice::IterMut<'_, _> as DoubleEndedIterator>::try_rfold(&mut &mut abstracted, 0, |acc, &mut x| Ok(acc + x));
+    let folded: Result<_, core::str::Utf8Error> =
+        <&mut core::slice::IterMut<'_, _> as DoubleEndedIterator>::try_rfold(
+            &mut &mut abstracted,
+            0,
+            |acc, &mut x| Ok(acc + x),
+        );
     assert_eq!(folded, Ok(15));
 }
 
 // Covers `<core::iter::adapters::scan::Scan<I, St, F> as core::iter::traits::iterator::Iterator>::try_fold`
 #[test]
 fn test_scan_iterator_try_fold() {
-    let mut iter: core::iter::Scan<_, _, _> = [1, 2, 3, 4, 5].iter().scan(0, |acc: &mut usize, x: &usize| {
-        *acc += *x;
-        None
-    });
+    let mut iter: core::iter::Scan<_, _, _> =
+        [1, 2, 3, 4, 5].iter().scan(0, |acc: &mut usize, x: &usize| {
+            *acc += *x;
+            None
+        });
     let folded = iter.try_fold(0, |_acc, _x: usize| None);
     assert_eq!(folded, Some(0));
 }

--- a/library/coretests/tests/ferrocene/iter.rs
+++ b/library/coretests/tests/ferrocene/iter.rs
@@ -1092,3 +1092,11 @@ fn test_filter_spec_assume_count_default() {
     let no_trusted_len: &mut dyn Iterator<Item = &i32> = &mut yes_trusted_len;
     assert_eq!(no_trusted_len.filter(|a| *a % 2 == 0).count(), 2);
 }
+
+
+// Covers `<core::str::iter::CharIndices<'a> as core::iter::traits::iterator::Iterator>::count`
+#[test]
+fn test_char_indices_count() {
+    let suspect = "Hello there, I'm a code coverage test";
+    assert_eq!(suspect.char_indices().count(), 37);
+}

--- a/library/coretests/tests/ferrocene/iter.rs
+++ b/library/coretests/tests/ferrocene/iter.rs
@@ -1122,3 +1122,12 @@ fn test_partialord_slice_partialcmp() {
     let y = [4, 5, 6];
     assert!(x.partial_cmp(&y).is_some());
 }
+
+// Covers `<&mut I as core::iter::traits::double_ended::DoubleEndedIteratorRefSpec>::spec_try_rfold`
+#[test]
+fn test_ref_spec_try_rfold() {
+    let mut suspect = [1, 2, 3, 4, 5];
+    let mut abstracted = suspect.iter_mut();
+    let folded: Result<_, core::str::Utf8Error> = <&mut core::slice::IterMut<'_, _> as DoubleEndedIterator>::try_rfold(&mut &mut abstracted, 0, |acc, &mut x| Ok(acc + x));
+    assert_eq!(folded, Ok(15));
+}

--- a/library/coretests/tests/ferrocene/num.rs
+++ b/library/coretests/tests/ferrocene/num.rs
@@ -883,3 +883,49 @@ fn test_saturating_div() {
         "i8",
     );
 }
+
+// Cover `core::num::<T>::saturating_mul`.
+#[test]
+fn test_saturating_mul() {
+    assert_eq!(
+        i128::saturating_mul(i128::MIN, 10),
+        i128::MIN,
+        "i128",
+    );
+    assert_eq!(
+        i64::saturating_mul(i64::MIN, 10),
+        i64::MIN,
+        "i64",
+    );
+    assert_eq!(
+        i32::saturating_mul(i32::MIN, 10),
+        i32::MIN,
+        "i32",
+    );
+    assert_eq!(
+        i8::saturating_mul(i8::MIN, 10),
+        i8::MIN,
+        "i8",
+    );
+
+    assert_eq!(
+        i128::saturating_mul(2 as i128, 4),
+        8 as i128,
+        "i128",
+    );
+    assert_eq!(
+        i64::saturating_mul(2 as i64, 4),
+        8 as i64,
+        "i64",
+    );
+    assert_eq!(
+        i32::saturating_mul(2 as i32, 4),
+        8 as i32,
+        "i32",
+    );
+    assert_eq!(
+        i8::saturating_mul(2 as i8, 4),
+        8 as i8,
+        "i8",
+    );
+}

--- a/library/coretests/tests/ferrocene/num.rs
+++ b/library/coretests/tests/ferrocene/num.rs
@@ -450,3 +450,411 @@ fn non_zero_ne() {
     assert!(lhs != rhs);
     assert!(!(lhs != lhs));
 }
+
+// covers
+// - <core::num::saturating::Saturating<T> as core::ops::arith::AddAssign>::add_assign
+// - <core::num::saturating::Saturating<T> as core::ops::arith::DivAssign>::div_assign
+// - <core::num::saturating::Saturating<T> as core::ops::arith::MulAssign>::mul_assign
+// - <core::num::saturating::Saturating<T> as core::ops::arith::Neg>::neg
+// - <core::num::saturating::Saturating<T> as core::ops::arith::Rem>::rem
+// - <core::num::saturating::Saturating<T> as core::ops::arith::RemAssign<T>>::rem_assign
+// - <core::num::saturating::Saturating<T> as core::ops::arith::RemAssign>::rem_assign
+// - <core::num::saturating::Saturating<T> as core::ops::arith::SubAssign>::sub_assign
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitAnd>::bitand
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitAndAssign<T>>::bitand_assign
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitAndAssign>::bitand_assign
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitOr>::bitor
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitOrAssign<T>>::bitor_assign
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitOrAssign>::bitor_assign
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitXor>::bitxor
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitXorAssign<T>>::bitxor_assign
+// - <core::num::saturating::Saturating<T> as core::ops::bit::BitXorAssign>::bitxor_assign
+// - <core::num::saturating::Saturating<T> as core::ops::bit::Not>::not
+macro_rules! test_saturating_ops {
+    ($($T:ty => $fn:ident,)*) => {
+        $(
+            #[test]
+            fn $fn() {
+                use core::num::Saturating;
+
+
+                // add_assign (Saturating)
+                {
+                    let mut max = Saturating(<$T>::MAX);
+                    max += Saturating(1 as $T);
+                    assert_eq!(max, Saturating(<$T>::MAX), "add_assign (Saturating)");
+                }
+
+                // add_assign
+                {
+                    let mut max = Saturating(<$T>::MAX);
+                    max += 1 as $T;
+                    assert_eq!(max, Saturating(<$T>::MAX), "add_assign");
+                }
+
+                // add (Saturating)
+                {
+                    let added_max = Saturating(<$T>::MAX) + Saturating(1 as $T);
+                    assert_eq!(added_max, Saturating(<$T>::MAX), "add (Saturating)");
+                }
+
+                // sub_assign (Saturating)
+                {
+                    let mut min = Saturating(<$T>::MIN);
+                    min -= Saturating(1 as $T);
+                    assert_eq!(min, Saturating(<$T>::MIN), "sub_assign (Saturating)");
+                }
+
+                // sub_assign
+                {
+                    let mut min = Saturating(<$T>::MIN);
+                    min -= 1 as $T;
+                    assert_eq!(min, Saturating(<$T>::MIN), "sub_assign");
+                }
+
+                // sub (Saturating)
+                {
+                    let subbed_min = Saturating(<$T>::MIN) - Saturating(1 as $T);
+                    assert_eq!(subbed_min, Saturating(<$T>::MIN), "sub (Saturating)");
+                }
+
+                // mul_assign (Saturating)
+                {
+                    let mut max = Saturating(<$T>::MAX);
+                    max *= Saturating(2);
+                    assert_eq!(max, Saturating(<$T>::MAX), "mul_assign (Saturating)");
+                }
+
+                // mul_assign
+                {
+                    let mut max = Saturating(<$T>::MAX);
+                    max *= 2;
+                    assert_eq!(max, Saturating(<$T>::MAX), "mul_assign");
+                }
+
+                // div_assign (Saturating)
+                {
+                    let mut max = Saturating(<$T>::MAX);
+                    max /= Saturating(2);
+                    assert_eq!(max, Saturating(<$T>::MAX / 2), "div_assign (Saturating)");
+                }
+
+                // div_assign
+                {
+                    let mut max = Saturating(<$T>::MAX);
+                    max /= 2;
+                    assert_eq!(max, Saturating(<$T>::MAX / 2), "div_assign");
+                }
+
+                // rem_assign (Saturating)
+                {
+                    let mut suspect = Saturating(15 as $T);
+                    suspect %= Saturating(2);
+                    assert_eq!(suspect, Saturating(1), "rem_assign (Saturating)");
+                }
+
+                // rem_assign
+                {
+                    let mut suspect = Saturating(15 as $T);
+                    suspect %= 2;
+                    assert_eq!(suspect, Saturating(1), "rem_assign");
+                }
+
+                // rem (Saturating)
+                {
+                    let suspect = Saturating(15 as $T) % Saturating(2 as $T);
+                    assert_eq!(suspect, Saturating(1), "rem (Saturating)");
+                }
+
+                // bit_or (Saturating)
+                {
+                    let suspect = Saturating(5 as $T) | Saturating(2 as $T);
+                    assert_eq!(suspect, Saturating(7), "bit_or (Saturating)");
+                }
+
+                // bit_or_assign (Saturating)
+                {
+                    let mut suspect = Saturating(5 as $T);
+                    suspect |= Saturating(2 as $T);
+                    assert_eq!(suspect, Saturating(7), "bit_or_assign (Saturating)");
+                }
+
+                // bit_or_assign
+                {
+                    let mut suspect = Saturating(5 as $T);
+                    suspect |= 2 as $T;
+                    assert_eq!(suspect, Saturating(7), "bit_or_assign");
+                }
+
+                // bit_and (Saturating)
+                {
+                    let suspect = Saturating(5 as $T) & Saturating(2 as $T);
+                    assert_eq!(suspect, Saturating(0), "bit_and (Saturating)");
+                }
+
+                // bit_and_assign (Saturating)
+                {
+                    let mut suspect = Saturating(5 as $T);
+                    suspect &= Saturating(2 as $T);
+                    assert_eq!(suspect, Saturating(0), "bit_and_assign (Saturating)");
+                }
+
+                // bit_and_assign
+                {
+                    let mut suspect = Saturating(5 as $T);
+                    suspect &= 2 as $T;
+                    assert_eq!(suspect, Saturating(0), "bit_and_assign");
+                }
+
+                // bit_xor (Saturating)
+                {
+                    let suspect = Saturating(5 as $T) ^ Saturating(1 as $T);
+                    assert_eq!(suspect, Saturating(4), "bit_xor");
+                }
+
+                // bit_xor_assign (Saturating)
+                {
+                    let mut suspect = Saturating(5 as $T);
+                    suspect ^= Saturating(1 as $T);
+                    assert_eq!(suspect, Saturating(4), "bit_xor_assign (Saturating)");
+                }
+
+                // bit_xor_assign
+                {
+                    let mut suspect = Saturating(5 as $T);
+                    suspect ^= 1 as $T;
+                    assert_eq!(suspect, Saturating(4), "bit_xor_assign");
+                }
+
+                // not
+                {
+                    let suspect = Saturating(<$T>::MAX);
+                    assert_eq!(!suspect, Saturating(<$T>::MIN), "not");
+                }
+            }
+
+        )*
+    };
+}
+test_saturating_ops! {
+    i128 => saturating_i128_ops,
+    i64 => saturating_i64_ops,
+    i32 => saturating_i32_ops,
+    i8 => saturating_i8_ops,
+    isize => saturating_isize_ops,
+    u128 => saturating_u128_ops,
+    u64 => saturating_u64_ops,
+    u32 => saturating_u32_ops,
+    u8 => saturating_u8_ops,
+    usize => saturating_usize_ops,
+}
+
+// covers
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::AddAssign>::add_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::DivAssign>::div_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::MulAssign>::mul_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::Neg>::neg
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::Rem>::rem
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::RemAssign<T>>::rem_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::RemAssign>::rem_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::arith::SubAssign>::sub_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitAnd>::bitand
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitAndAssign<T>>::bitand_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitAndAssign>::bitand_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitOr>::bitor
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitOrAssign<T>>::bitor_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitOrAssign>::bitor_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitXor>::bitxor
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitXorAssign<T>>::bitxor_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::BitXorAssign>::bitxor_assign
+// - <core::num::wrapping::Wrapping<T> as core::ops::bit::Not>::not
+// - <core::num::saturating::Saturating<T> as core::ops::arith::Neg>::neg
+macro_rules! test_wrapping_ops {
+    ($($T:ty => $fn:ident,)*) => {
+        $(
+            #[test]
+            fn $fn() {
+                use core::num::Wrapping;
+
+
+                // add_assign (Wrapping)
+                {
+                    let mut max = Wrapping(<$T>::MAX);
+                    max += Wrapping(1 as $T);
+                    assert_eq!(max, Wrapping(<$T>::MIN), "add_assign (Wrapping)");
+                }
+
+                // add_assign
+                {
+                    let mut max = Wrapping(<$T>::MAX);
+                    max += 1 as $T;
+                    assert_eq!(max, Wrapping(<$T>::MIN), "add_assign");
+                }
+
+                // add (Wrapping)
+                {
+                    let added_max = Wrapping(<$T>::MAX) + Wrapping(1 as $T);
+                    assert_eq!(added_max, Wrapping(<$T>::MIN), "add (Wrapping)");
+                }
+
+                // sub_assign (Wrapping)
+                {
+                    let mut min = Wrapping(<$T>::MIN);
+                    min -= Wrapping(1 as $T);
+                    assert_eq!(min, Wrapping(<$T>::MAX), "sub_assign (Wrapping)");
+                }
+
+                // sub_assign (Wrapping)
+                {
+                    let mut min = Wrapping(<$T>::MIN);
+                    min -= 1 as $T;
+                    assert_eq!(min, Wrapping(<$T>::MAX), "sub_assign (Wrapping)");
+                }
+
+                // sub (Wrapping)
+                {
+                    let subbed_min = Wrapping(<$T>::MIN) - Wrapping(1 as $T);
+                    assert_eq!(subbed_min, Wrapping(<$T>::MAX), "sub (Wrapping)");
+                }
+
+                // mul_assign (Wrapping)
+                {
+                    let mut max = Wrapping(24 as $T);
+                    max *= Wrapping(2); // Other functions test the correctness of mul in general, just worry about covering this convienence wrapper
+                    assert_eq!(max, Wrapping(48), "mul_assign (Wrapping)");
+                }
+
+                // mul_assign
+                {
+                    let mut max = Wrapping(24 as $T);
+                    max *= 2; // Other functions test the correctness of mul in general, just worry about covering this convienence wrapper
+                    assert_eq!(max, Wrapping(48), "mul_assign");
+                }
+
+                // div_assign (Wrapping)
+                {
+                    let mut max = Wrapping(<$T>::MAX);
+                    max /= Wrapping(2);
+                    assert_eq!(max, Wrapping(<$T>::MAX / 2), "div_assign (Wrapping)");
+                }
+
+                // div_assign
+                {
+                    let mut max = Wrapping(<$T>::MAX);
+                    max /= 2;
+                    assert_eq!(max, Wrapping(<$T>::MAX / 2), "div_assign");
+                }
+
+                // rem_assign (Wrapping)
+                {
+                    let mut suspect = Wrapping(15 as $T);
+                    suspect %= Wrapping(2);
+                    assert_eq!(suspect, Wrapping(1), "rem_assign (Wrapping)");
+                }
+
+                // rem_assign
+                {
+                    let mut suspect = Wrapping(15 as $T);
+                    suspect %= 2;
+                    assert_eq!(suspect, Wrapping(1), "rem_assign");
+                }
+
+                // rem (Wrapping)
+                {
+                    let suspect = Wrapping(15 as $T) % Wrapping(2 as $T);
+                    assert_eq!(suspect, Wrapping(1), "rem (Wrapping)");
+                }
+
+                // bit_or (Wrapping)
+                {
+                    let suspect = Wrapping(5 as $T) | Wrapping(2 as $T);
+                    assert_eq!(suspect, Wrapping(7), "bit_or (Wrapping)");
+                }
+
+                // bit_or_assign (Wrapping)
+                {
+                    let mut suspect = Wrapping(5 as $T);
+                    suspect |= Wrapping(2 as $T);
+                    assert_eq!(suspect, Wrapping(7), "bit_or_assign (Wrapping)");
+                }
+
+
+                // bit_or_assign
+                {
+                    let mut suspect = Wrapping(5 as $T);
+                    suspect |= 2 as $T;
+                    assert_eq!(suspect, Wrapping(7), "bit_or_assign");
+                }
+
+                // bit_and (Wrapping)
+                {
+                    let suspect = Wrapping(5 as $T) & Wrapping(2 as $T);
+                    assert_eq!(suspect, Wrapping(0), "bit_and (Wrapping)");
+                }
+
+                // bit_and_assign (Wrapping)
+                {
+                    let mut suspect = Wrapping(5 as $T);
+                    suspect &= Wrapping(2 as $T);
+                    assert_eq!(suspect, Wrapping(0), "bit_and_assign (Wrapping)");
+                }
+
+                // bit_and_assign (Wrapping)
+                {
+                    let mut suspect = Wrapping(5 as $T);
+                    suspect &= 2 as $T;
+                    assert_eq!(suspect, Wrapping(0), "bit_and_assign");
+                }
+
+                // bit_xor (Wrapping)
+                {
+                    let suspect = Wrapping(5 as $T) ^ Wrapping(1 as $T);
+                    assert_eq!(suspect, Wrapping(4), "bit_xor (Wrapping)");
+                }
+
+                // bit_xor_assign (Wrapping)
+                {
+                    let mut suspect = Wrapping(5 as $T);
+                    suspect ^= Wrapping(1 as $T);
+                    assert_eq!(suspect, Wrapping(4), "bit_xor_assign (Wrapping)");
+                }
+
+                // bit_xor_assign
+                {
+                    let mut suspect = Wrapping(5 as $T);
+                    suspect ^= 1 as $T;
+                    assert_eq!(suspect, Wrapping(4), "bit_xor_assign");
+                }
+
+                // not
+                {
+                    let suspect = Wrapping(<$T>::MAX);
+                    assert_eq!(!suspect, Wrapping(<$T>::MIN), "not");
+                }
+            }
+
+        )*
+    };
+}
+test_wrapping_ops! {
+    i128 => wrapping_i128_ops,
+    i64 => wrapping_i64_ops,
+    i32 => wrapping_i32_ops,
+    i8 => wrapping_i8_ops,
+    isize => wrapping_isize_ops,
+    u128 => wrapping_u128_ops,
+    u64 => wrapping_u64_ops,
+    u32 => wrapping_u32_ops,
+    u8 => wrapping_u8_ops,
+    usize => wrapping_usize_ops,
+}
+
+// Covers `<core::num::saturating::Saturating<T> as core::ops::arith::Neg>::neg`
+#[test]
+fn test_saturating_neg() {
+    use core::num::Saturating;
+    assert_eq!(-Saturating(42 as i128), Saturating(-42 as i128));
+    assert_eq!(-Saturating(42 as i64), Saturating(-42 as i64));
+    assert_eq!(-Saturating(42 as i32), Saturating(-42 as i32));
+    assert_eq!(-Saturating(42 as i8), Saturating(-42 as i8));
+}

--- a/library/coretests/tests/ferrocene/num.rs
+++ b/library/coretests/tests/ferrocene/num.rs
@@ -858,3 +858,28 @@ fn test_saturating_neg() {
     assert_eq!(-Saturating(42 as i32), Saturating(-42 as i32));
     assert_eq!(-Saturating(42 as i8), Saturating(-42 as i8));
 }
+
+// Cover `core::num::<T>::saturating_div`.
+#[test]
+fn test_saturating_div() {
+    assert_eq!(
+        i128::saturating_div(i128::MIN, -1 as i128),
+        i128::MAX,
+        "i128",
+    );
+    assert_eq!(
+        i64::saturating_div(i64::MIN, -1 as i64),
+        i64::MAX,
+        "i64",
+    );
+    assert_eq!(
+        i32::saturating_div(i32::MIN, -1 as i32),
+        i32::MAX,
+        "i32",
+    );
+    assert_eq!(
+        i8::saturating_div(i8::MIN, -1 as i8),
+        i8::MAX,
+        "i8",
+    );
+}

--- a/library/coretests/tests/ferrocene/num.rs
+++ b/library/coretests/tests/ferrocene/num.rs
@@ -862,70 +862,22 @@ fn test_saturating_neg() {
 // Cover `core::num::<T>::saturating_div`.
 #[test]
 fn test_saturating_div() {
-    assert_eq!(
-        i128::saturating_div(i128::MIN, -1 as i128),
-        i128::MAX,
-        "i128",
-    );
-    assert_eq!(
-        i64::saturating_div(i64::MIN, -1 as i64),
-        i64::MAX,
-        "i64",
-    );
-    assert_eq!(
-        i32::saturating_div(i32::MIN, -1 as i32),
-        i32::MAX,
-        "i32",
-    );
-    assert_eq!(
-        i8::saturating_div(i8::MIN, -1 as i8),
-        i8::MAX,
-        "i8",
-    );
+    assert_eq!(i128::saturating_div(i128::MIN, -1 as i128), i128::MAX, "i128",);
+    assert_eq!(i64::saturating_div(i64::MIN, -1 as i64), i64::MAX, "i64",);
+    assert_eq!(i32::saturating_div(i32::MIN, -1 as i32), i32::MAX, "i32",);
+    assert_eq!(i8::saturating_div(i8::MIN, -1 as i8), i8::MAX, "i8",);
 }
 
 // Cover `core::num::<T>::saturating_mul`.
 #[test]
 fn test_saturating_mul() {
-    assert_eq!(
-        i128::saturating_mul(i128::MIN, 10),
-        i128::MIN,
-        "i128",
-    );
-    assert_eq!(
-        i64::saturating_mul(i64::MIN, 10),
-        i64::MIN,
-        "i64",
-    );
-    assert_eq!(
-        i32::saturating_mul(i32::MIN, 10),
-        i32::MIN,
-        "i32",
-    );
-    assert_eq!(
-        i8::saturating_mul(i8::MIN, 10),
-        i8::MIN,
-        "i8",
-    );
+    assert_eq!(i128::saturating_mul(i128::MIN, 10), i128::MIN, "i128",);
+    assert_eq!(i64::saturating_mul(i64::MIN, 10), i64::MIN, "i64",);
+    assert_eq!(i32::saturating_mul(i32::MIN, 10), i32::MIN, "i32",);
+    assert_eq!(i8::saturating_mul(i8::MIN, 10), i8::MIN, "i8",);
 
-    assert_eq!(
-        i128::saturating_mul(2 as i128, 4),
-        8 as i128,
-        "i128",
-    );
-    assert_eq!(
-        i64::saturating_mul(2 as i64, 4),
-        8 as i64,
-        "i64",
-    );
-    assert_eq!(
-        i32::saturating_mul(2 as i32, 4),
-        8 as i32,
-        "i32",
-    );
-    assert_eq!(
-        i8::saturating_mul(2 as i8, 4),
-        8 as i8,
-        "i8",
-    );
+    assert_eq!(i128::saturating_mul(2 as i128, 4), 8 as i128, "i128",);
+    assert_eq!(i64::saturating_mul(2 as i64, 4), 8 as i64, "i64",);
+    assert_eq!(i32::saturating_mul(2 as i32, 4), 8 as i32, "i32",);
+    assert_eq!(i8::saturating_mul(2 as i8, 4), 8 as i8, "i8",);
 }

--- a/library/coretests/tests/ferrocene/slice.rs
+++ b/library/coretests/tests/ferrocene/slice.rs
@@ -305,3 +305,17 @@ fn slice_split_first_chunk() {
     assert_eq!(slice.split_first_chunk::<3>(), Some((&[1, 2, 3], [4, 5].as_slice())));
     assert_eq!(slice.split_first_chunk::<10>(), None);
 }
+
+// covers `core::slice::ascii::<impl [u8]>::eq_ignore_ascii_case_chunks`
+#[test]
+fn test_eq_ignore_ascii_case_chunks() {
+    // Two equal sized (16 chunked) values with an inequality at the end.
+    let x = b"absentmindednessabsentmindednessabsentmindednessabsentmindedness";
+    let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNES0";
+    assert!(!x.eq_ignore_ascii_case(y));
+
+    // Two inequal sized (16 chunked) values with an inequality at the end.
+    let x = b"absentmindednessabsentmindednessabsentmindednessabsentmindedness00";
+    let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESS01";
+    assert!(!x.eq_ignore_ascii_case(y));
+}

--- a/library/coretests/tests/ferrocene/slice.rs
+++ b/library/coretests/tests/ferrocene/slice.rs
@@ -314,6 +314,11 @@ fn test_eq_ignore_ascii_case_chunks() {
     let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNES0";
     assert!(!x.eq_ignore_ascii_case(y));
 
+    // Two equal sized (16 chunked) values that are equal.
+    let x = b"absentmindednessabsentmindednessabsentmindednessabsentmindedness";
+    let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESS";
+    assert!(x.eq_ignore_ascii_case(y));
+
     // Two inequal sized (16 chunked) values with an inequality at the end.
     let x = b"absentmindednessabsentmindednessabsentmindednessabsentmindedness00";
     let y = b"ABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESSABSENTMINDEDNESS01";

--- a/library/coretests/tests/ferrocene/str.rs
+++ b/library/coretests/tests/ferrocene/str.rs
@@ -195,6 +195,11 @@ fn test_utf8_chunks_next() {
     let mut chunks = replacement_character.utf8_chunks();
     assert_eq!("�", chunks.next().unwrap().valid());
     assert!(chunks.next().is_none());
+
+    let two_width_chars = "§ɮʃ ͒ʦ";
+    for two_width_char in two_width_chars.as_bytes().utf8_chunks() {
+        println!("{two_width_char:?}");
+    }
 }
 
 // covers:

--- a/library/coretests/tests/ferrocene/unicode.rs
+++ b/library/coretests/tests/ferrocene/unicode.rs
@@ -33,3 +33,14 @@ fn test_unicode_skip_search() {
     // 0x300 makes `binary_search_by_key` return `Ok`
     assert_eq!(string('\u{300}'), "\\u{300}");
 }
+
+// Cover `core::unicode::unicode_data::white_space::lookup`
+#[test]
+fn test_white_space_lookup() {
+    assert!("\u{1680}".chars().all(|c| c.is_whitespace())); // ogham space mark
+    assert!("\u{3000}".chars().all(|c| c.is_whitespace())); // ideographic space
+
+    assert!("\u{1681}".chars().all(|c| !c.is_whitespace())); // Fall through
+    assert!("\u{2060}".chars().all(|c| !c.is_whitespace())); // Fall through
+    assert!("\u{FEFF}".chars().all(|c| !c.is_whitespace())); // Fall through
+}

--- a/tests/ui/ferrocene/lint-prevalidated/basic.dedup.stderr
+++ b/tests/ui/ferrocene/lint-prevalidated/basic.dedup.stderr
@@ -1,3 +1,27 @@
+error: validated method calls an unvalidated associated function
+  --> $DIR/basic.rs:73:9
+   |
+LL |         String::new()
+   |         ^^^^^^^^^^^
+   |
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
+   |
+   = note: `String::new` is unvalidated
+   |
+   = help: contact Ferrocene support to see if this associated function is possible to certify
+note: `<Validated as ToString>::to_string` is validated
+  --> $DIR/basic.rs:72:8
+   |
+LL |     #[ferrocene::prevalidated]
+   |     -------------------------- marked as validated here
+LL |     fn to_string(&self) -> String {
+   |        ^^^^^^^^^
+note: the lint level is defined here
+  --> $DIR/basic.rs:11:9
+   |
+LL | #![deny(ferrocene::unvalidated)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
 error: validated closure calls an unvalidated function
   --> $DIR/basic.rs:90:42
    |
@@ -14,11 +38,6 @@ LL | #[ferrocene::prevalidated]
    | -------------------------- marked as validated here
 LL | const CERTIFIED_CLOSURE_CONST: fn() = || normal_def();
    |                                       ^^
-note: the lint level is defined here
-  --> $DIR/basic.rs:11:9
-   |
-LL | #![deny(ferrocene::unvalidated)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: validated closure calls an unvalidated function
   --> $DIR/basic.rs:92:44
@@ -191,5 +210,5 @@ LL |     UNCERTIFIED_DYN_STATIC.partial_cmp(&Unvalidated);
    = note: `UNCERTIFIED_DYN_STATIC` contains a function pointer that might be called at runtime
    = note: the Ferrocene compiler does not know if the `dyn PartialOrd<Unvalidated> + Sync` was verified, so it must assume it is unverified
 
-error: aborting due to 14 previous errors
+error: aborting due to 15 previous errors
 

--- a/tests/ui/ferrocene/lint-prevalidated/basic.no-dedup.stderr
+++ b/tests/ui/ferrocene/lint-prevalidated/basic.no-dedup.stderr
@@ -1,3 +1,27 @@
+error: validated method calls an unvalidated associated function
+  --> $DIR/basic.rs:73:9
+   |
+LL |         String::new()
+   |         ^^^^^^^^^^^
+   |
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
+   |
+   = note: `String::new` is unvalidated
+   |
+   = help: contact Ferrocene support to see if this associated function is possible to certify
+note: `<Validated as ToString>::to_string` is validated
+  --> $DIR/basic.rs:72:8
+   |
+LL |     #[ferrocene::prevalidated]
+   |     -------------------------- marked as validated here
+LL |     fn to_string(&self) -> String {
+   |        ^^^^^^^^^
+note: the lint level is defined here
+  --> $DIR/basic.rs:11:9
+   |
+LL | #![deny(ferrocene::unvalidated)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
 error: validated closure calls an unvalidated function
   --> $DIR/basic.rs:90:42
    |
@@ -14,11 +38,6 @@ LL | #[ferrocene::prevalidated]
    | -------------------------- marked as validated here
 LL | const CERTIFIED_CLOSURE_CONST: fn() = || normal_def();
    |                                       ^^
-note: the lint level is defined here
-  --> $DIR/basic.rs:11:9
-   |
-LL | #![deny(ferrocene::unvalidated)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: validated closure calls an unvalidated function
   --> $DIR/basic.rs:92:44
@@ -259,5 +278,5 @@ LL | fn normal_def() {
 LL |     rename();
    |     ^^^^^^
 
-error: aborting due to 20 previous errors
+error: aborting due to 21 previous errors
 

--- a/tests/ui/ferrocene/lint-prevalidated/basic.rs
+++ b/tests/ui/ferrocene/lint-prevalidated/basic.rs
@@ -70,7 +70,7 @@ impl PartialEq<Unvalidated> for Unvalidated {
 impl ToString for Validated {
     #[ferrocene::prevalidated]
     fn to_string(&self) -> String {
-        String::new()
+        String::new() //~ ERROR unvalidated
     }
 }
 

--- a/tests/ui/ferrocene/lint-prevalidated/dyn-cast-post-mono.post-mono.stderr
+++ b/tests/ui/ferrocene/lint-prevalidated/dyn-cast-post-mono.post-mono.stderr
@@ -1,0 +1,27 @@
+error: validated function possibly calls an unvalidated method
+  --> $DIR/dyn-cast-post-mono.rs:42:16
+   |
+LL |     fn collect<C>(self) -> C where Self: Sized {
+   |        ------- `MyIterator::collect` is unvalidated
+...
+LL |     MyBox::new(&x)
+   |                ^^
+   |
+   = note: once `Once<i32>` is cast to a dynamic trait object, Ferrocene can no longer tell whether it is validated
+   = note: as a precaution, it must assume you will eventually call `MyIterator::collect`
+note: `main` is validated
+  --> $DIR/dyn-cast-post-mono.rs:49:4
+   |
+LL | fn main() {
+   |    ^^^^
+LL |     cast(iter_once(1));
+   |     ------------------ generic function `cast` instantiated by `main`
+   = note: main functions are assumed to be validated
+note: the lint level is defined here
+  --> $DIR/dyn-cast-post-mono.rs:5:9
+   |
+LL | #![deny(ferrocene::unvalidated)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/ferrocene/lint-prevalidated/dyn-cast-post-mono.rs
+++ b/tests/ui/ferrocene/lint-prevalidated/dyn-cast-post-mono.rs
@@ -1,0 +1,51 @@
+//@ revisions: thir post-mono
+//@[thir] check-pass
+//@[post-mono] build-fail
+
+#![deny(ferrocene::unvalidated)] //[post-mono]~ NOTE level
+
+use std::marker::PhantomData;
+
+// Setup so we don't depend on core.
+
+struct MyBox<T: ?Sized>(PhantomData<T>);
+impl<T: ?Sized> MyBox<T> {
+    #[ferrocene::prevalidated]
+    fn new(x: &T) -> Self {
+        Self(PhantomData)
+    }
+}
+
+struct Once<T>(T);
+#[ferrocene::prevalidated]
+fn iter_once<T>(x: T) -> Once<T> {
+    Once(x)
+}
+
+trait MyIterator {
+    type Item;
+    fn collect<C>(self) -> C where Self: Sized { //[post-mono]~ NOTE unvalidated
+        loop {}
+    }
+}
+impl<T> MyIterator for Once<T> {
+    type Item = T;
+}
+impl<T> MyIterator for MyBox<dyn MyIterator<Item = T>> {
+    type Item = T;
+}
+
+// Actual test
+
+#[ferrocene::prevalidated]
+fn cast<T, I: 'static + MyIterator<Item = T>>(x: I) -> MyBox<dyn MyIterator<Item = T>> {
+    MyBox::new(&x) //[post-mono]~ ERROR unvalidated
+    //[post-mono]~^ NOTE dynamic trait object
+    //[post-mono]~^^ NOTE `MyIterator::collect`
+    //[post-mono]~^^^ NOTE main functions
+}
+
+
+fn main() { //[post-mono]~ NOTE validated
+    cast(iter_once(1)); //[post-mono]~ NOTE instantiated
+}

--- a/tests/ui/ferrocene/lint-prevalidated/mir-inlining.post-mono-inlining.stderr
+++ b/tests/ui/ferrocene/lint-prevalidated/mir-inlining.post-mono-inlining.stderr
@@ -1,0 +1,33 @@
+error: validated function calls an unvalidated method
+  --> $DIR/mir-inlining.rs:17:5
+   |
+LL |     f(x);
+   |     ^^^^
+   |
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
+   |
+   = note: `<fn(u32) -> u32 {trailing_ones} as FnOnce<(u32,)>>::call_once` is unvalidated
+   |
+   = help: contact Ferrocene support to see if this method is possible to certify
+note: `main` is validated
+  --> $DIR/mir-inlining.rs:25:4
+   |
+LL | fn main() {
+   |    ^^^^
+   = note: main functions are assumed to be validated
+note: the lint level is defined here
+  --> $DIR/mir-inlining.rs:8:9
+   |
+LL | #![deny(ferrocene::unvalidated)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: validated function calls an unvalidated function
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
+   |
+  ::: $DIR/mir-inlining.rs:11:14
+   |
+LL | pub const fn trailing_ones(_: u32) -> u32 {
+   |              ------------- `trailing_ones` is unvalidated
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/ferrocene/lint-prevalidated/mir-inlining.post-mono.stderr
+++ b/tests/ui/ferrocene/lint-prevalidated/mir-inlining.post-mono.stderr
@@ -1,0 +1,25 @@
+error: validated function calls an unvalidated function
+  --> $DIR/mir-inlining.rs:17:5
+   |
+LL | pub const fn trailing_ones(_: u32) -> u32 {
+   |              ------------- `trailing_ones` is unvalidated
+...
+LL |     f(x);
+   |     ^^^^
+   |
+note: `main` is validated
+  --> $DIR/mir-inlining.rs:25:4
+   |
+LL | fn main() {
+   |    ^^^^
+LL |     call(123_u32, trailing_ones);
+   |     ---------------------------- generic function `call` instantiated by `main`
+   = note: main functions are assumed to be validated
+note: the lint level is defined here
+  --> $DIR/mir-inlining.rs:8:9
+   |
+LL | #![deny(ferrocene::unvalidated)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/ferrocene/lint-prevalidated/mir-inlining.rs
+++ b/tests/ui/ferrocene/lint-prevalidated/mir-inlining.rs
@@ -1,0 +1,27 @@
+//@ revisions: thir post-mono post-mono-inlining
+//@[thir] check-pass
+//@[post-mono] build-fail
+//@[post-mono] compile-flags: -Z inline-mir=no
+//@[post-mono-inlining] build-fail
+//@[post-mono-inlining] compile-flags: -Z inline-mir=yes
+
+#![deny(ferrocene::unvalidated)]
+
+#[inline(always)]
+pub const fn trailing_ones(_: u32) -> u32 {
+    0
+}
+
+#[ferrocene::prevalidated]
+fn call(x: u32, f: impl FnOnce(u32) -> u32) {
+    f(x);
+    //[post-mono]~^ ERROR unvalidated
+    //[post-mono-inlining]~^^ ERROR unvalidated
+    // This error points to `<{trailing_ones} as FnOnce>::call_once`, which kinda sucks, but it's
+    // ok for now.
+    //[post-mono-inlining]~? ERROR unvalidated
+}
+
+fn main() {
+    call(123_u32, trailing_ones);
+}

--- a/tests/ui/ferrocene/lint-prevalidated/post-mono-cross-crate.no-dedup.stderr
+++ b/tests/ui/ferrocene/lint-prevalidated/post-mono-cross-crate.no-dedup.stderr
@@ -64,7 +64,7 @@ LL |     fn clone(&self) -> Self { Unvalidated }
 LL |         *self = other.clone();
    |                 ^^^^^^^^^^^^^
    |
-note: generic method `std::clone::Clone::clone_from` instantiated by `uninstantiated_generic::<Unvalidated>`, which is called from a validated entrypoint
+note: generic method `<Unvalidated as std::clone::Clone>::clone_from` instantiated by `uninstantiated_generic::<Unvalidated>`, which is called from a validated entrypoint
   --> $DIR/auxiliary/unvalidated-post-mono.rs:7:34
    |
 LL |     let fn_ptr: fn(&mut T, &T) = T::clone_from;

--- a/tests/ui/ferrocene/lint-prevalidated/post-mono.no-dedup.stderr
+++ b/tests/ui/ferrocene/lint-prevalidated/post-mono.no-dedup.stderr
@@ -58,7 +58,7 @@ LL |     fn clone(&self) -> Self { Unvalidated }
 LL |         *self = other.clone();
    |                 ^^^^^^^^^^^^^
    |
-note: generic method `std::clone::Clone::clone_from` instantiated by `uninstantiated_generic::<Unvalidated>`, which is called from a validated entrypoint
+note: generic method `<Unvalidated as std::clone::Clone>::clone_from` instantiated by `uninstantiated_generic::<Unvalidated>`, which is called from a validated entrypoint
   --> $DIR/post-mono.rs:52:34
    |
 LL |     let fn_ptr: fn(&mut T, &T) = T::clone_from;

--- a/tests/ui/ferrocene/lint-prevalidated/stable-lint-order.rs
+++ b/tests/ui/ferrocene/lint-prevalidated/stable-lint-order.rs
@@ -9,11 +9,16 @@
 
 fn unvalidated() {} //~ NOTE unvalidated
 
+#[ferrocene::prevalidated]
+fn call(f: impl FnOnce()) {
+    f(); //~ ERROR calls
+}
+
 struct Validated;
 impl Drop for Validated {
     #[ferrocene::prevalidated] //~ NOTE marked
     fn drop(&mut self) { //~ NOTE validated
-        unvalidated(); //~ ERROR calls
+        call(unvalidated); //~ NOTE instantiated
     }
 }
 

--- a/tests/ui/ferrocene/lint-prevalidated/stable-lint-order.stderr
+++ b/tests/ui/ferrocene/lint-prevalidated/stable-lint-order.stderr
@@ -1,19 +1,21 @@
 error: validated method calls an unvalidated function
-  --> $DIR/stable-lint-order.rs:16:9
+  --> $DIR/stable-lint-order.rs:14:5
    |
 LL | fn unvalidated() {}
    |    ----------- `unvalidated` is unvalidated
 ...
-LL |         unvalidated();
-   |         ^^^^^^^^^^^^^
+LL |     f();
+   |     ^^^
    |
 note: `<Validated as Drop>::drop` is validated
-  --> $DIR/stable-lint-order.rs:15:8
+  --> $DIR/stable-lint-order.rs:20:8
    |
 LL |     #[ferrocene::prevalidated]
    |     -------------------------- marked as validated here
 LL |     fn drop(&mut self) {
    |        ^^^^
+LL |         call(unvalidated);
+   |         ----------------- generic function `call` instantiated by `<Validated as Drop>::drop`
 note: the lint level is defined here
   --> $DIR/stable-lint-order.rs:8:9
    |

--- a/tests/ui/ferrocene/lint-prevalidated/thir-impl-item.rs
+++ b/tests/ui/ferrocene/lint-prevalidated/thir-impl-item.rs
@@ -1,0 +1,18 @@
+// Make sure our THIR visitor recurses into functions in impl blocks.
+
+//@ check-fail
+#![crate_type = "lib"]
+#![deny(ferrocene::unvalidated)]
+
+pub struct A(u32);
+
+const fn unvalidated() {}
+
+impl A {
+    #[ferrocene::prevalidated]
+    #[inline]
+    pub const fn b(&self) -> u32 {
+        unvalidated(); //~ ERROR: unvalidated
+        0
+    }
+}

--- a/tests/ui/ferrocene/lint-prevalidated/thir-impl-item.stderr
+++ b/tests/ui/ferrocene/lint-prevalidated/thir-impl-item.stderr
@@ -1,0 +1,25 @@
+error: validated method calls an unvalidated function
+  --> $DIR/thir-impl-item.rs:15:9
+   |
+LL | const fn unvalidated() {}
+   |          ----------- `unvalidated` is unvalidated
+...
+LL |         unvalidated();
+   |         ^^^^^^^^^^^
+   |
+note: `A::b` is validated
+  --> $DIR/thir-impl-item.rs:14:18
+   |
+LL |     #[ferrocene::prevalidated]
+   |     -------------------------- marked as validated here
+LL |     #[inline]
+LL |     pub const fn b(&self) -> u32 {
+   |                  ^
+note: the lint level is defined here
+  --> $DIR/thir-impl-item.rs:5:9
+   |
+LL | #![deny(ferrocene::unvalidated)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Backports https://github.com/ferrocene/ferrocene/pull/2336 and https://github.com/ferrocene/ferrocene/pull/2364 as well as [`a96a73b`](https://github.com/ferrocene/ferrocene/pull/2365/commits/a96a73b5aab760701332bdad831afffc5770e51b) which is new.