### PR TITLE
Replace all mentions of `x.py run update-certified-core-symbols`

### DIFF
--- a/ferrocene/etc/upstream-pull-basic-checks.sh
+++ b/ferrocene/etc/upstream-pull-basic-checks.sh
@@ -32,7 +32,7 @@ if [ -n "$BLESS" ]; then
     if ! ./x test bootstrap; then
         cargo insta review --manifest-path src/bootstrap/Cargo.toml
     fi
-    ./x run update-certified-core-symbols
+    ./x test certified-core-symbols --bless
 else
     ./x test bootstrap
     ./x test certified-core-symbols

--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: The Ferrocene Developers
 

--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -419,10 +419,10 @@ ferrocene/ci/scripts/fix-stage0-branch.py || automation_warning "Could not fix s
 commit_if_modified src/stage0 "update src/stage0"
 
 echo "pull-upstream: trying to fix ferrocene/doc/symbol-report.csv"
-if ./x.py run update-certified-core-symbols --set rust.debug-assertions-std=true; then
+if ./x.py test certified-core-symbols --bless --set rust.debug-assertions-std=true; then
     commit_if_modified ferrocene/doc/symbol-report.csv "update symbol report"
 else
-    automation_warning "Couldn't regenerate the symbol report. Please run './x run update-certified-core-symbols' after fixing the conflicts."
+    automation_warning "Couldn't regenerate the symbol report. Please run './x test certified-core-symbols --bless' after fixing the conflicts."
 fi
 
 git branch -D "${TEMP_BRANCH}"

--- a/src/bootstrap/src/ferrocene/test/certified_core_symbols.rs
+++ b/src/bootstrap/src/ferrocene/test/certified_core_symbols.rs
@@ -82,7 +82,7 @@ impl Step for CertifiedCoreSymbols {
 
         builder.info(&format!(
             "The certified core symbol report is out of date. \
-            Run `./x run update-certified-core-symbols` to update it."
+            Run `./x test certified-core-symbols --bless` to update it."
         ));
         crate::exit!(1);
     }


### PR DESCRIPTION
This was probably missed during https://github.com/ferrocene/ferrocene/pull/2362, cc @jyn514

Its use in `pull.sh` gave me the following error:
```
ERROR: no `run` rules matched [update-certified-core-symbols]
HELP: run `x.py run --help --verbose` to show a list of available paths
NOTE: if you are adding a new Step to bootstrap itself, make sure you register it with `describe!`
```
so I'm assuming it should be removed everywhere