### PR TITLE
Expand qnx docs

### DIFF
--- a/ferrocene/doc/internal-procedures/src/partners/qnx.rst
+++ b/ferrocene/doc/internal-procedures/src/partners/qnx.rst
@@ -206,7 +206,6 @@ Create a deployment containing Linux and Windows toolchains:
         -deployLicense $LICENSE_KEY \
         -installationDeployAs qnx/qnx710-472-deployment
 
-
 Create an archive of the deployment (with dereferenced symlinks) and upload it to the S3 URL which the CI attempts to pull from:
 
 .. code-block::
@@ -217,7 +216,7 @@ Create an archive of the deployment (with dereferenced symlinks) and upload it t
 .. note::
 
     If the existing license isn't expired yet, do a test run uploading to a test location, then
-    editing the CI workflows to refer to ``test-qnx710-472-deployment.tar.zst`` instead:
+    edit the CI workflows to refer to ``test-qnx710-472-deployment.tar.zst`` instead:
 
     .. code-block::
 

--- a/ferrocene/doc/internal-procedures/src/partners/qnx.rst
+++ b/ferrocene/doc/internal-procedures/src/partners/qnx.rst
@@ -206,12 +206,27 @@ Create a deployment containing Linux and Windows toolchains:
         -deployLicense $LICENSE_KEY \
         -installationDeployAs qnx/qnx710-472-deployment
 
-Finally, create an archive of the deployment (with dereferenced symlinks) and upload it to the S3 URL which the CI attempts to pull from:
+
+Create an archive of the deployment (with dereferenced symlinks) and upload it to the S3 URL which the CI attempts to pull from:
 
 .. code-block::
 
     cd $HOME
     tar -cv --dereference -I 'zstd -T0' -f qnx/qnx710-472-deployment.tar.zst -C qnx/qnx710-472-deployment/ qnx710-472
+
+.. note::
+
+    If the existing license isn't expired yet, do a test run uploading to a test location, then
+    editing the CI workflows to refer to ``test-qnx710-472-deployment.tar.zst`` instead:
+
+    .. code-block::
+
+        aws s3 cp qnx/qnx710-472-deployment.tar.zst s3://ferrocene-ci-mirrors/manual/qnx/test-qnx710-472-deployment.tar.zst
+
+Finally, upload the archive to the production location:
+
+.. code-block::
+
     aws s3 cp qnx/qnx710-472-deployment.tar.zst s3://ferrocene-ci-mirrors/manual/qnx/qnx710-472-deployment.tar.zst
 
 On CI/CD hosts we use a Python script to setup the toolchain:


### PR DESCRIPTION
Was updating our QNX license and wanted to add docs for testing to the page.

Also, testing the new license in [this pipeline](https://app.circleci.com/pipelines/github/ferrocene?created_after=2026-04-27T00%3A00%3A00.000Z&created_preset=Last+2+weeks&selectedPipeline=gh%2Fferrocene%2Fferrocene%2F17961&filter=branch%3Aequals%3Ahoverbear%2Fexpand-qnx-docs&filter=pipeline_definition_id%3Aequals%3Adba3cb85-0bda-5146-a100-54431a9e4c34&useNewPipelines=true&workflowId=2b72571f-870c-49b8-8675-3c2fe421501d). :)