### PR TITLE
misc cleanups to FlipLink tests

### DIFF
--- a/src/bootstrap/src/ferrocene/test/flip_link.rs
+++ b/src/bootstrap/src/ferrocene/test/flip_link.rs
@@ -1,5 +1,6 @@
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::core::build_steps::compile::Std;
+use crate::core::config::TargetSelection;
 use crate::ferrocene::test::{SourceType, tool};
 use crate::ferrocene::tool::flip_link::PATH as FLIP_LINK_PATH;
 use crate::{Kind, Mode};
@@ -12,7 +13,8 @@ impl Step for FlipLink {
     const IS_HOST: bool = true;
 
     fn is_default_step(builder: &Builder<'_>) -> bool {
-        builder.targets.iter().any(|target| target.contains("thumbv7em"))
+        // The flip link tests require a thumbv7em-none-eabi target to exist
+        builder.targets.iter().any(|target| target.triple == "thumbv7em-none-eabi")
     }
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
@@ -24,14 +26,23 @@ impl Step for FlipLink {
     }
 
     fn run(self, builder: &Builder<'_>) -> Self::Output {
+        let thumb = TargetSelection::from_user("thumbv7em-none-eabi");
+        if !builder.targets.contains(&thumb) {
+            eprintln!("can't run flip-link tests without thumbv7 built!");
+            crate::exit!(1);
+        }
+        if !builder.config.lld_enabled {
+            eprintln!("can't run flip-link tests without LLD built!");
+            crate::exit!(1);
+        }
+
         let host = builder.config.host_target;
         let compiler = builder.compiler(builder.top_stage, host);
         builder.ensure(Std::new(compiler, host));
-        // The flip link tests require a thumbv7em-none-eabi target to exist
-        let thumb = crate::TargetSelection::from_user("thumbv7em-none-eabi");
         builder.ensure(Std::new(compiler, thumb));
 
         builder.info("Testing ferrocene/tools/flip-link");
+        builder.require_submodule("ferrocene/tools/flip-link", None);
         let mut cmd = tool::prepare_tool_cargo(
             builder,
             compiler,


### PR DESCRIPTION
- Checkout the submodule if it hasn't been already
- Give better errors if we know the tests will fail.
- flip-link hardcodes exactly thumbv7em-none-eabi, so we have to do the same in `is_default_step`.