### PR TITLE
Fix a coverage test that was not consistently covering

### DIFF
--- a/library/coretests/tests/ferrocene/slice.rs
+++ b/library/coretests/tests/ferrocene/slice.rs
@@ -101,7 +101,7 @@ fn split_at_mut_panics() {
 
 // covers `core::slice::<impl [T]>::align_to_mut`
 #[test]
-fn align_to_mut() {
+fn slice_align_to_mut() {
     let mut zst_arr = [(); 5];
     assert_eq!(
         unsafe { zst_arr.align_to_mut::<u8>() },
@@ -112,11 +112,21 @@ fn align_to_mut() {
     #[derive(Debug, PartialEq)]
     struct Foo([u8; 256]);
 
-    let mut arr = [0u8; 1];
+    // Try to avoid getting a value that's aligned with 256 by subslicing
+    let mut large_buffer = vec![0_u8; 256 * 2];
+    let arr = &mut large_buffer[1..2];
+    // Check we're hitting target line in the function
+    assert!(arr.as_ptr().align_offset(align_of::<Foo>()) > arr.len(), "{} > {}", arr.as_ptr().align_offset(align_of::<Foo>()), arr.len());
     assert_eq!(
         unsafe { arr.align_to_mut::<Foo>() },
-        ([0u8; 1].as_mut_slice(), [].as_mut_slice(), [].as_mut_slice())
+        ([0u8; 1].as_mut_slice(), [].as_mut_slice(), [].as_mut_slice()),
     );
+
+    // From doctests
+    unsafe {
+        let mut bytes: [u8; 7] = [1, 2, 3, 4, 5, 6, 7];
+        let (_prefix, _shorts, _suffix) = bytes.align_to_mut::<u16>();
+    }
 }
 
 // covers `core::slice::rotate::ptr_rotate`


### PR DESCRIPTION
Previously `./x.py test --coverage=library library/core --no-doc -- align_to_mut` would not consistently cover [library/core/src/slice/mod.rs:4650
](https://github.com/ferrocene/ferrocene/blob/e0f8fffa59e0213d1d62e8540c3c524685ad149e/library/core/src/slice/mod.rs#L4650).

This adds mitigation: Ensure the condition to hit that line is met in the respective test, and take steps to ensure we are *not* aligned in a situation that could return 0.

Check coverage with `./x.py test --coverage=library library/core --no-doc -- slice_align_to_mut`
