### PR TITLE
Remove `./x test certified-core-symbols` and some small related refactors

### DIFF
--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -104,9 +104,7 @@ JOBS_DEFINITION: JobsDefinition = {
             # needs to be verified. To avoid wasting resources, run it in the
             # docs builder along with the rest of the steps that build docs.
             "ferrocene-check-document-signatures",
-            # Following two names refer to the same bootstrap step, but both
-            # have to be added for it to be properly excluded.
-            "certified-core-symbols",
+            # The core symbol report requires building the core library, which takes a while to build
             "ferrocene/doc/symbol-report.csv",
         ],
 

--- a/ferrocene/etc/upstream-pull-basic-checks.sh
+++ b/ferrocene/etc/upstream-pull-basic-checks.sh
@@ -32,10 +32,10 @@ if [ -n "$BLESS" ]; then
     if ! ./x test bootstrap; then
         cargo insta review --manifest-path src/bootstrap/Cargo.toml
     fi
-    ./x test certified-core-symbols --bless
+    ./x test ferrocene/doc/symbol-report.csv --bless
 else
     ./x test bootstrap
-    ./x test certified-core-symbols
+    ./x test ferrocene/doc/symbol-report.csv
 fi
 
 ./x test --coverage=library library/core library/alloc --tests

--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -422,10 +422,10 @@ ferrocene/ci/scripts/fix-stage0-branch.py || automation_warning "Could not fix s
 commit_if_modified src/stage0 "update src/stage0"
 
 echo "pull-upstream: trying to fix ferrocene/doc/symbol-report.csv"
-if ./x.py test certified-core-symbols --bless --set rust.debug-assertions-std=true; then
+if ./x.py test ferrocene/doc/symbol-report.csv --bless --set rust.debug-assertions-std=true; then
     commit_if_modified ferrocene/doc/symbol-report.csv "update symbol report"
 else
-    automation_warning "Couldn't regenerate the symbol report. Please run './x test certified-core-symbols --bless' after fixing the conflicts."
+    automation_warning "Couldn't regenerate the symbol report. Please run './x test ferrocene/doc/symbol-report.csv --bless' after fixing the conflicts."
 fi
 
 git branch -D "${TEMP_BRANCH}"

--- a/src/bootstrap/src/ferrocene/run.rs
+++ b/src/bootstrap/src/ferrocene/run.rs
@@ -132,10 +132,6 @@ impl Step for CertifiedCoreSymbols {
         run.never()
     }
 
-    fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(CertifiedCoreSymbols::new(run.builder, run.target));
-    }
-
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         if !builder.config.std_debug_assertions {
             panic!("generating the core symbol report requires `rust.debug-assertions-std=true`");

--- a/src/bootstrap/src/ferrocene/test/certified_core_symbols.rs
+++ b/src/bootstrap/src/ferrocene/test/certified_core_symbols.rs
@@ -20,7 +20,7 @@ impl Step for CertifiedCoreSymbols {
     const IS_HOST: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.path(TRACKED_FILE).alias("certified-core-symbols")
+        run.path(TRACKED_FILE)
     }
 
     fn is_default_step(builder: &Builder<'_>) -> bool {
@@ -44,8 +44,8 @@ impl Step for CertifiedCoreSymbols {
         // load the expected list of qualified functions
         let expected_path = Path::new(TRACKED_FILE);
         let mut expected: Vec<String> = Default::default();
-        let reader = builder.read(expected_path);
-        for qualified_name in reader.lines() {
+        let expected_content = builder.read(expected_path);
+        for qualified_name in expected_content.lines() {
             expected.push(qualified_name.to_string());
         }
 
@@ -57,33 +57,27 @@ impl Step for CertifiedCoreSymbols {
 
         // compare the two
         if actual == expected {
-            builder.info(&format!("The certified core symbol report is up to date."));
-            return;
+            builder.info(&format!("{TRACKED_FILE} is up to date."));
+        } else {
+            let actual_content = actual.join("\n");
+            if builder.config.cmd.bless() {
+                std::fs::write(TRACKED_FILE, actual_content).unwrap();
+                builder.info(&format!("Updated {TRACKED_FILE}"));
+            } else {
+                builder.info(&format!(
+                    "Diff of {} and {}:",
+                    expected_path.display(),
+                    actual_symbol_report_path.display(),
+                ));
+
+                diff_text(&expected_content, &actual_content);
+
+                builder.info(&format!(
+                    "The certified core symbol report is out of date. \
+                    Run `./x test {TRACKED_FILE} --bless` to update it."
+                ));
+                crate::exit!(1);
+            }
         }
-
-        if builder.config.cmd.bless() {
-            let qualified_name_list = actual_symbol_report.to_qualified_fn_list();
-            std::fs::write(TRACKED_FILE, qualified_name_list.join("\n")).unwrap();
-
-            eprintln!("Updated {TRACKED_FILE}");
-
-            return;
-        }
-
-        builder.info(&format!(
-            "Diff of {} and {}:",
-            expected_path.display(),
-            actual_symbol_report_path.display(),
-        ));
-
-        let actual_content = actual.join("\n");
-        let expected_content = builder.read(expected_path);
-        diff_text(&expected_content, &actual_content);
-
-        builder.info(&format!(
-            "The certified core symbol report is out of date. \
-            Run `./x test certified-core-symbols --bless` to update it."
-        ));
-        crate::exit!(1);
     }
 }


### PR DESCRIPTION
Now `./x test ferrocene/doc/symbol-report.csv [,--bless]` is the one and only command to check and update the core symbol report.