### PR TITLE
[1.95] Adjust qualification scope and annotate more for 6.21

### DIFF
--- a/ferrocene/doc/core-certification/signature/signature.toml
+++ b/ferrocene/doc/core-certification/signature/signature.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+[files]
+"pinned.toml" = "939799cc-53c2-4398-a07f-6f1e4d9e2ad3"
+"safety-manager.cosign-bundle" = "af21e4bf-ef68-49e1-ad1f-922be48fb7ed"

--- a/ferrocene/doc/document-list/signature/signature.toml
+++ b/ferrocene/doc/document-list/signature/signature.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+[files]
+"pinned.toml" = "04e9aaf3-07c3-4dbe-8334-b854136e1e0e"
+"safety-manager.cosign-bundle" = "a157c653-21aa-4999-a742-5a1284989514"

--- a/ferrocene/doc/evaluation-plan/signature/signature.toml
+++ b/ferrocene/doc/evaluation-plan/signature/signature.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+[files]
+"pinned.toml" = "a87e6720-d106-40c6-9678-73090ed5b3ea"
+"safety-manager.cosign-bundle" = "484f2752-5dfa-47b8-96b1-308c560ef8ec"

--- a/ferrocene/doc/evaluation-report/signature/signature.toml
+++ b/ferrocene/doc/evaluation-report/signature/signature.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+[files]
+"pinned.toml" = "7a48c79d-8e94-4f85-8960-df14702e2645"
+"safety-manager.cosign-bundle" = "e1b57a89-6718-40a9-bdc2-1d4f402138f2"

--- a/ferrocene/doc/internal-procedures/signature/signature.toml
+++ b/ferrocene/doc/internal-procedures/signature/signature.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+[files]
+"pinned.toml" = "f8c7d67c-735f-4c2f-be3e-dcdb42e79cc0"
+"safety-manager.cosign-bundle" = "f716e8ad-b21c-465b-ab0f-a76e52bdc080"

--- a/ferrocene/doc/qualification-plan/signature/signature.toml
+++ b/ferrocene/doc/qualification-plan/signature/signature.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+[files]
+"pinned.toml" = "8e1efe24-aa42-4076-b8fa-7afda38fa355"
+"safety-manager.cosign-bundle" = "74cb2e1f-b32e-4eb7-bc55-22be62bfaabe"

--- a/ferrocene/doc/qualification-report/signature/signature.toml
+++ b/ferrocene/doc/qualification-report/signature/signature.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+[files]
+"pinned.toml" = "7e3f8214-0123-448e-9194-92d9467739f8"
+"safety-manager.cosign-bundle" = "5183b18b-89dd-4435-926c-cf19e894e289"

--- a/ferrocene/doc/safety-manual/signature/signature.toml
+++ b/ferrocene/doc/safety-manual/signature/signature.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+[files]
+"pinned.toml" = "4a46d698-174f-4376-95dd-597f671f39a3"
+"safety-manager.cosign-bundle" = "101f8afb-5226-4b9d-8486-39a926fb1f46"

--- a/ferrocene/doc/safety-manual/src/scope.rst
+++ b/ferrocene/doc/safety-manual/src/scope.rst
@@ -22,6 +22,12 @@ This qualification is restricted to the following environment:
      - Uncertified Libraries
      - Qualified Libraries
 
+   * - :target:`aarch64-unknown-linux-gnu`
+     - :target:`aarch64-rhivos2-linux-gnu`
+     - ``core``
+     - ``alloc``
+     -
+
    * - :target:`x86_64-unknown-linux-gnu`
      - :target:`aarch64-unknown-none`
      - ``core``

--- a/tests/ui/async-await/async-closures/precise-captures.rs
+++ b/tests/ui/async-await/async-closures/precise-captures.rs
@@ -155,3 +155,6 @@ async fn async_main() {
 fn main() {
     block_on::block_on(async_main());
 }
+
+// ferrocene-annotations: fls_g64vdciyb2is
+// Capture precision

--- a/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.rs
+++ b/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.rs
@@ -59,3 +59,6 @@ fn through_method<'a>(x: &'a i32) {
 }
 
 fn main() {}
+
+// ferrocene-annotations: fls_g64vdciyb2is
+// Capture precision

--- a/tests/ui/closures/2229_closure_analysis/issue-88476.rs
+++ b/tests/ui/closures/2229_closure_analysis/issue-88476.rs
@@ -62,3 +62,6 @@ fn test2() {
 }
 
 fn main() {}
+
+// ferrocene-annotations: fls_g64vdciyb2is
+// Capture precision

--- a/tests/ui/closures/2229_closure_analysis/only-inhabited-variant-stable.rs
+++ b/tests/ui/closures/2229_closure_analysis/only-inhabited-variant-stable.rs
@@ -20,3 +20,6 @@ pub fn main() {
     g();
     assert!(matches!(r, Err((1, 2))));
 }
+
+// ferrocene-annotations: fls_g64vdciyb2is
+// Capture precision

--- a/tests/ui/closures/2229_closure_analysis/only-inhabited-variant.rs
+++ b/tests/ui/closures/2229_closure_analysis/only-inhabited-variant.rs
@@ -22,3 +22,6 @@ pub fn main() {
     g();
     assert_eq!(r, Err((1, 2)));
 }
+
+// ferrocene-annotations: fls_g64vdciyb2is
+// Capture precision

--- a/tests/ui/closures/2229_closure_analysis/run_pass/issue-88476.rs
+++ b/tests/ui/closures/2229_closure_analysis/run_pass/issue-88476.rs
@@ -48,3 +48,6 @@ fn main() {}
 
 // ferrocene-annotations: fls_u2mzjgiwbkz0
 // Destructors
+//
+// ferrocene-annotations: fls_g64vdciyb2is
+// Capture precision

--- a/tests/ui/closures/2229_closure_analysis/unsafe_ptr.rs
+++ b/tests/ui/closures/2229_closure_analysis/unsafe_ptr.rs
@@ -68,3 +68,6 @@ fn main() {
 //
 // ferrocene-annotations: fls_jep7p27kaqlp
 // Unsafety
+//
+// ferrocene-annotations: fls_g64vdciyb2is
+// Capture precision


### PR DESCRIPTION
A few additions flagged by our assessor. :)

They noted we didn't say RHIVOS2 in the qualification scope of the safety manual, and that we only had one test for a section which perhaps could have used more.