### PR TITLE
Resolve a caching issue with `symbol-report`'s builds.

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -518,6 +518,13 @@ impl Builder<'_> {
                 cargo.arg("miri").arg("test");
                 cargo
             }
+            // Ferrocene addition: If we're running symbol report, use `check`
+            // The `Kind` variant is to bust caching.
+            Kind::SymbolReport => {
+                let mut cargo = command(&self.initial_cargo);
+                cargo.arg("check");
+                cargo
+            }
             _ => {
                 let mut cargo = command(&self.initial_cargo);
                 cargo.arg(cmd_kind.as_str());
@@ -917,6 +924,11 @@ impl Builder<'_> {
         // `rustc_driver` being built. This can cause builds of different version numbers to produce
         // `librustc_driver*.so` artifacts that end up with identical filename hashes.
         metadata.push_str(&self.version);
+
+        // Ferrocene addition: If we're running symbol report, push a str to prevent caching issues
+        if cmd_kind == Kind::SymbolReport {
+            metadata.push_str("symbol-report");
+        }
 
         cargo.env("__CARGO_DEFAULT_LIB_METADATA", &metadata);
 

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -670,7 +670,8 @@ pub enum Kind {
     Setup,
     Vendor,
     Perf,
-    Sign, // for Ferrocene
+    Sign,         // for Ferrocene
+    SymbolReport, // for Ferrocene
 }
 
 impl Kind {
@@ -694,7 +695,8 @@ impl Kind {
             Kind::Setup => "setup",
             Kind::Vendor => "vendor",
             Kind::Perf => "perf",
-            Kind::Sign => "sign", // for Ferrocene
+            Kind::Sign => "sign",                  // for Ferrocene
+            Kind::SymbolReport => "symbol_report", // for Ferrocene
         }
     }
 
@@ -1121,6 +1123,8 @@ impl<'a> Builder<'a> {
             // special-cased in Build::build()
             Kind::Format | Kind::Perf => vec![],
             Kind::MiriTest | Kind::MiriSetup => unreachable!(),
+            // Ferrocene addition
+            Kind::SymbolReport => unreachable!(),
         }
     }
 

--- a/src/bootstrap/src/ferrocene/run.rs
+++ b/src/bootstrap/src/ferrocene/run.rs
@@ -145,8 +145,14 @@ impl Step for CertifiedCoreSymbols {
         let symbol_report = builder.ensure(SymbolReport { target_compiler: build_compiler });
 
         // c.f. check::std
-        let mut cargo =
-            Cargo::new(builder, build_compiler, Mode::Std, SourceType::InTree, target, Kind::Check);
+        let mut cargo = Cargo::new(
+            builder,
+            build_compiler,
+            Mode::Std,
+            SourceType::InTree,
+            target,
+            Kind::SymbolReport,
+        );
         let crates = vec!["core".to_owned()]; // currently, only core is certified
         std_cargo(builder, target, &mut cargo, &crates);
         cargo.env("RUSTC_REAL", symbol_report);


### PR DESCRIPTION
If a user ran the following:

```
x.py clean
ferrocene/etc/upstream-pull-basic-checks.sh
```

They'd see something like

```
Generated report at
/home/ana/git/ferrocene/ferrocene/build/x86_64-unknown-linux-gnu/stage1-std/x86_64-unknown-linux-gnu/dist/symbol-report.json

thread 'main' (125911) panicked at
src/bootstrap/src/ferrocene/run/update_certified_core_symbols.rs:37:77:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind:
NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a
backtrace
Build completed unsuccessfully in 0:00:05
```

This was due to a caching issue. I spoke with @jyn514 and we think this might be the least worst solution for that problem.