### PR TITLE
Split platform manuals

### DIFF
--- a/ferrocene/doc/document-list/src/project-documents.rst
+++ b/ferrocene/doc/document-list/src/project-documents.rst
@@ -41,3 +41,12 @@ Project Documents
    * - :doc:`core-certification:index`
      - :document-id:`core-certification`
      - |ferrocene_version|
+   * - :doc:`qnx7-manual:index`
+     - :document-id:`qnx7-manual`
+     - |ferrocene_version|
+   * - :doc:`qnx8-manual:index`
+     - :document-id:`qnx8-manual`
+     - |ferrocene_version|
+   * - :doc:`rhivos-manual:index`
+     - :document-id:`rhivos-manual`
+     - |ferrocene_version|

--- a/ferrocene/doc/index/index.html
+++ b/ferrocene/doc/index/index.html
@@ -57,15 +57,15 @@
                 <div class="docs">
                     <a href="targets/rhivos-manual/index.html">
                         <h3>RHIVOS Manual</h3>
-                        <p>An easy-to-read, how-to manual for operating Ferrocene in a qualified environment.</p>
+                        <p>User manual for Red Hat® In-Vehicle Operating System target.</p>
                     </a>
                     <a href="targets/qnx7-manual/index.html">
                         <h3>QNX7 Manual</h3>
-                        <p>An easy-to-read, how-to manual for operating Ferrocene in a qualified environment.</p>
+                        <p>User manual for QNX® SDP 7 target.</p>
                     </a>
                     <a href="targets/qnx8-manual/index.html">
                         <h3>QNX8 Manual</h3>
-                        <p>An easy-to-read, how-to manual for operating Ferrocene in a qualified environment.</p>
+                        <p>User manual for QNX® SDP 8 target.</p>
                     </a>
                 </div>
             </section>

--- a/ferrocene/doc/index/index.html
+++ b/ferrocene/doc/index/index.html
@@ -51,6 +51,25 @@
                     </a>
                 </div>
             </section>
+
+            <section>
+                <h2>Target specific documentation</h2>
+                <div class="docs">
+                    <a href="targets/rhivos-manual/index.html">
+                        <h3>RHIVOS Manual</h3>
+                        <p>An easy-to-read, how-to manual for operating Ferrocene in a qualified environment.</p>
+                    </a>
+                    <a href="targets/qnx7-manual/index.html">
+                        <h3>QNX7 Manual</h3>
+                        <p>An easy-to-read, how-to manual for operating Ferrocene in a qualified environment.</p>
+                    </a>
+                    <a href="targets/qnx8-manual/index.html">
+                        <h3>QNX8 Manual</h3>
+                        <p>An easy-to-read, how-to manual for operating Ferrocene in a qualified environment.</p>
+                    </a>
+                </div>
+            </section>
+
             <section id="ferrocene-qualification-material">
                 <h2>Ferrocene Qualification Material</h2>
                 <div class="docs">

--- a/ferrocene/doc/qnx7-manual/src/conf.py
+++ b/ferrocene/doc/qnx7-manual/src/conf.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+import os
+import sys
+
+sys.path.append(os.path.abspath("../../qualification-report/exts"))
+
+project = "QNX7 Manual"
+copyright = "The Ferrocene Developers"
+author = "The Ferrocene Developers"
+
+extensions = [
+    "ferrocene_autoglossary",
+    "ferrocene_toctrees",
+    "ferrocene_qualification",
+    "ferrocene_test_outcomes",
+    "ferrocene_domain_cli",
+    "myst_parser",
+    "sphinx.ext.autosectionlabel",
+]
+
+# autosectionlabel unique names settings
+autosectionlabel_prefix_document = True
+
+ferrocene_id = "QNXSM"
+
+html_theme = "ferrocene"
+html_title = "QNX7 Manual"
+html_short_title = "QNX7 Manual"
+
+# Do not generate the index pages. We don't need them, and they cause
+# linkchecker to fail due to them including *all* glossary entries, including
+# entries that were removed by autoglossary.
+html_use_index = False
+
+myst_heading_anchors = 7
+
+suppress_warnings = ["myst.header", "autosectionlabel.*"]

--- a/ferrocene/doc/qnx7-manual/src/index.rst
+++ b/ferrocene/doc/qnx7-manual/src/index.rst
@@ -1,0 +1,36 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+QNX7 Manual
+===========
+
+.. toctree::
+   :numbered:
+   :maxdepth: 2
+   :caption: About this manual
+
+   overview
+   scope
+
+.. toctree::
+   :numbered:
+   :maxdepth: 1
+   :caption: Compilation targets
+
+   targets/index
+   targets/aarch64-unknown-nto-qnx710
+   targets/x86_64-pc-nto-qnx710
+
+.. toctree::
+   :caption: rustc test results:
+   :numbered:
+   :maxdepth: 2
+
+   rustc/index
+   rustc/aarch64-unknown-nto-qnx710
+   rustc/x86_64-pc-nto-qnx710
+
+Indices and tables
+------------------
+
+* :ref:`search`

--- a/ferrocene/doc/qnx7-manual/src/overview.rst
+++ b/ferrocene/doc/qnx7-manual/src/overview.rst
@@ -1,0 +1,26 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Overview
+========
+
+This Manual describes the use of Ferrocene |ferrocene_version|, the |iso_26262_ref|,
+|iec_61508_ref|, and |iec_62304_ref| qualified version of the Rust toolchain on QNX7.
+Ferrocene is based on ``rustc``, ``cargo``, and ``rustdoc`` version |rust_version|.
+
+This Manual assumes familiarity with rustc and the Rust language, and outlines
+usage instructions specific to Ferrocene.
+
+Further Relevant Documentation
+------------------------------
+
+The Ferrocene documentation package includes:
+
+* The :doc:`specification:index`, which describes the expected behavior of Rust.
+
+* The :doc:`safety-manual:index`, which includes usage and constraints
+  guidelines of using the Ferrocene toolchain according to functional
+  safety standards.
+
+* The :doc:`user-manual:index`, a how-to manual for operating Ferrocene in a
+  qualified environment.

--- a/ferrocene/doc/qnx7-manual/src/rustc/aarch64-unknown-nto-qnx710.rst
+++ b/ferrocene/doc/qnx7-manual/src/rustc/aarch64-unknown-nto-qnx710.rst
@@ -1,6 +1,6 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-.. render-outcomes-template:: templates/tests.jinja2
+.. render-outcomes-template:: ../../qualification-report/src/templates/tests.jinja2
    :host: x86_64-unknown-linux-gnu
    :target: aarch64-unknown-nto-qnx710

--- a/ferrocene/doc/qnx7-manual/src/rustc/index.rst
+++ b/ferrocene/doc/qnx7-manual/src/rustc/index.rst
@@ -1,0 +1,12 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+.. _test-results-overview:
+
+Test results overview
+=====================
+
+Ferrocene has been tested on all the platforms we support as part of the
+qualification. For ease of access, each platform has its own page.
+
+.. render-summary::

--- a/ferrocene/doc/qnx7-manual/src/rustc/x86_64-pc-nto-qnx710.rst
+++ b/ferrocene/doc/qnx7-manual/src/rustc/x86_64-pc-nto-qnx710.rst
@@ -1,6 +1,6 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-.. render-outcomes-template:: templates/tests.jinja2
+.. render-outcomes-template:: ../../qualification-report/src/templates/tests.jinja2
    :host: x86_64-unknown-linux-gnu
    :target: x86_64-pc-nto-qnx710

--- a/ferrocene/doc/qnx7-manual/src/scope.rst
+++ b/ferrocene/doc/qnx7-manual/src/scope.rst
@@ -1,0 +1,35 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Qualification scope
+===================
+
+This qualification applies to Ferrocene |ferrocene_version|, limited to:
+
+* rustc |rust_version|, limited to the Rust language as described in the
+  :doc:`specification:index`, and according to the requirements and
+  restrictions outlined in this safety manual.
+
+This qualification is restricted to the following environment:
+
+.. list-table::
+   :align: left
+   :header-rows: 1
+
+   * - Host
+     - Target
+     - Certified Libraries
+     - Uncertified Libraries
+     - Qualified Libraries
+
+   * - :target:`x86_64-unknown-linux-gnu`
+     - :target:`aarch64-unknown-nto-qnx710`
+     - ``core``
+     - ``alloc``, ``std``, ``test``
+     - ``proc_macro``
+
+   * - :target:`x86_64-unknown-linux-gnu`
+     - :target:`x86_64-pc-nto-qnx710`
+     - ``core``
+     - ``alloc``, ``std``, ``test``
+     - ``proc_macro``

--- a/ferrocene/doc/qnx7-manual/src/targets/aarch64-unknown-nto-qnx710.rst
+++ b/ferrocene/doc/qnx7-manual/src/targets/aarch64-unknown-nto-qnx710.rst
@@ -1,17 +1,17 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-.. _aarch64-unknown-qnx:
+.. _aarch64-unknown-nto-qnx710:
 
-:target:`aarch64-unknown-qnx`
+:target:`aarch64-unknown-nto-qnx710`
 ====================================
 
-The ``aarch64-unknown-qnx`` Ferrocene target provides support for QNX SDP 8.0+ on
+The ``aarch64-unknown-nto-qnx710`` Ferrocene target provides support for QNX on
 ARMv8-A processors operating in AArch64 mode.
 
 .. note::
 
-    QNX SDP 8.0 only supports :ref:`x86_64-unknown-linux-gnu` and
+    QNX SDP 7.1.0 only supports :ref:`x86_64-unknown-linux-gnu` and
     :ref:`x86_64-pc-windows-msvc` as host platforms.
 
     Currently, Ferrocene only qualifies cross compilation to this target from
@@ -22,31 +22,28 @@ ARMv8-A processors operating in AArch64 mode.
 Prerequisites
 -------------
 
-This target requires `QNX Software Development Platform 8.0.5 (QNX SDP 8.0.5)
-<https://blackberry.qnx.com/en/products/foundation-software/qnx-software-development-platform>`_
+This target requires `QNX Software Development Platform 7.1.0 (QNX SDP 7.1.0)
+<https://blackberry.qnx.com/en/products/foundation-software/qnx-software-development-platform/sdp-7-1>`_
 to be installed.
 
 Typically this is done through `QNX Software Center
 <https://www.qnx.com/download/group.html?programid=29178>`_.
 
 Ferrocene is qualified using a specific version QNX SDP version. In safety
-critical contexts you must ensure that `com.qnx.qnx800.patchset805` (also
-known as GA 8.0.5) is installed.
+critical contexts you must ensure 7.1.0.00472T202006132107S (also known as
+7.1 BuildID 472) is used.
 
 .. code-block::
 
-    QNX_VERSION="8.0.0.00141T202311271501L"
-    PATCHSET_VERSION="8.0.5.00390T202606231321L"
+    QNX_VERSION="7.1.0.00472T202006132107S"
 
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
-        -installBaseline com.qnx.qnx800/$QNX_VERSION \
-        -installPackage com.qnx.qnx800.patchset805/$PATCHSET_VERSION \
-        -destination $HOME/qnx800 \
+        -installBaseline com.qnx.qnx710/$QNX_VERSION \
+        -destination qnx/qnx710-472 \
         -cleanInstall
 
-In an existing QNX SDP 8.0 install you can check for the presence of the
-``.packages/metadata/com.qnx.qnx800.target.microkernel.core/2.6.0.00145T202606051700L``
-directory.
+In an existing QNX 7.1.0 install you can check for the presence of the
+``.packages/metadata/com.qnx.qnx710/7.1.0.00472T202006132107S/`` directory.
 
 Ferrocene documents how our internal QNX toolchains are installed and
 configured in :doc:`internal procedures (QNX) <internal-procedures:partners/qnx>`.
@@ -55,23 +52,23 @@ Your organizational and licensing needs may differ.
 Archives to install
 -------------------
 
-The following archives are needed when :doc:`installing </rustc/install>` this
+The following archives are needed when :doc:`installing <user-manual:rustc/install>` this
 target as a cross-compilation target:
 
-* ``rust-std-aarch64-unknown-qnx``
+* ``rust-std-aarch64-unknown-nto-qnx710``
 
 Required shell environment
---------------------------
+------------------------------
 
 To use the target, the following procedures must be undertaken in the shell
 running the build.
 
 You must ensure ``$HOME`` is set to a valid path, then source ``qnxsdp-env.sh``
-from your QNX SDP 8.0 installation:
+from your QNX SDP 7.1.0 installation:
 
 .. code-block::
 
-    source $HOME/qnx800/qnxsdp-env.sh
+    source $QNX_SDP_710_INSTALL/qnxsdp-env.sh
 
 
 On :ref:`x86_64-pc-windows-msvc`, there exists a ``qnxsdp-env.bat`` if
@@ -85,8 +82,8 @@ Required compiler flags
 To use the target, the following additional flags must be provided to
 ``rustc``:
 
-* ``--target=aarch64-unknown-qnx``
+* ``--target=aarch64-unknown-nto-qnx710``
 
-.. _aarch64-ferrocene-qnx:
+.. _aarch64-ferrocene-nto-qnx710:
 
 .. NOTE: this is a std target so we redirect to a no-std equivalent for certified core.

--- a/ferrocene/doc/qnx7-manual/src/targets/index.rst
+++ b/ferrocene/doc/qnx7-manual/src/targets/index.rst
@@ -1,0 +1,45 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Compilation targets overview
+============================
+
+Ferrocene has support for multiple compilation targets and host platforms.
+Targets are categorized into :doc:`levels of support <user-manual:targets/index>`.
+
+This page lists the current support status for QNX7 targets, and individual
+pages with more details are provided for QNX7 Qualified targets.
+
+.. _qualified-targets:
+
+Qualified QNX7 targets
+----------------------
+
+
+.. list-table::
+   :header-rows: 1
+
+   * - Target
+     - Tuple
+     - Kind
+     - Standard library
+     - Notes
+
+   * - :ref:`aarch64-unknown-nto-qnx710`
+     - ``aarch64-unknown-nto-qnx710``
+     - Cross-compilation
+     - Full
+     - Only qualified when cross-compiled from :ref:`x86_64-unknown-linux-gnu`.
+
+   * - :ref:`x86_64-pc-nto-qnx710`
+     - ``x86_64-pc-nto-qnx710``
+     - Cross-compilation
+     - Full
+     - Only qualified when cross-compiled from :ref:`x86_64-unknown-linux-gnu`.
+
+Unsupported targets
+-------------------
+
+The Rust compiler includes support for additional targets that are not yet
+included in Ferrocene. If you need support for them please reach out to the
+Ferrocene support team.

--- a/ferrocene/doc/qnx7-manual/src/targets/x86_64-pc-nto-qnx710.rst
+++ b/ferrocene/doc/qnx7-manual/src/targets/x86_64-pc-nto-qnx710.rst
@@ -1,13 +1,13 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-.. _aarch64-unknown-nto-qnx710:
+.. _x86_64-pc-nto-qnx710:
 
-:target:`aarch64-unknown-nto-qnx710`
-====================================
+:target:`x86_64-pc-nto-qnx710`
+==============================
 
-The ``aarch64-unknown-nto-qnx710`` Ferrocene target provides support for QNX on
-ARMv8-A processors operating in AArch64 mode.
+The ``x86_64-pc-nto-qnx710`` Ferrocene target provides support for QNX on
+x86-64 processors.
 
 .. note::
 
@@ -52,10 +52,10 @@ Your organizational and licensing needs may differ.
 Archives to install
 -------------------
 
-The following archives are needed when :doc:`installing </rustc/install>` this
+The following archives are needed when :doc:`installing <user-manual:rustc/install>` this
 target as a cross-compilation target:
 
-* ``rust-std-aarch64-unknown-nto-qnx710``
+* ``rust-std-x86_64-pc-nto-qnx710``
 
 Required shell environment
 ------------------------------
@@ -82,8 +82,4 @@ Required compiler flags
 To use the target, the following additional flags must be provided to
 ``rustc``:
 
-* ``--target=aarch64-unknown-nto-qnx710``
-
-.. _aarch64-ferrocene-nto-qnx710:
-
-.. NOTE: this is a std target so we redirect to a no-std equivalent for certified core.
+* ``--target=x86_64-pc-nto-qnx710``

--- a/ferrocene/doc/qnx8-manual/src/conf.py
+++ b/ferrocene/doc/qnx8-manual/src/conf.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+import os
+import sys
+
+sys.path.append(os.path.abspath("../../qualification-report/exts"))
+
+project = "QNX8 Manual"
+copyright = "The Ferrocene Developers"
+author = "The Ferrocene Developers"
+
+extensions = [
+    "ferrocene_autoglossary",
+    "ferrocene_toctrees",
+    "ferrocene_qualification",
+    "ferrocene_test_outcomes",
+    "ferrocene_domain_cli",
+    "myst_parser",
+    "sphinx.ext.autosectionlabel",
+]
+
+# autosectionlabel unique names settings
+autosectionlabel_prefix_document = True
+
+ferrocene_id = "QNXEM"
+
+html_theme = "ferrocene"
+html_title = "QNX8 Manual"
+html_short_title = "QNX8 Manual"
+
+# Do not generate the index pages. We don't need them, and they cause
+# linkchecker to fail due to them including *all* glossary entries, including
+# entries that were removed by autoglossary.
+html_use_index = False
+
+myst_heading_anchors = 7
+
+suppress_warnings = ["myst.header", "autosectionlabel.*"]

--- a/ferrocene/doc/qnx8-manual/src/index.rst
+++ b/ferrocene/doc/qnx8-manual/src/index.rst
@@ -1,0 +1,36 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+QNX8 Manual
+===========
+
+.. toctree::
+   :numbered:
+   :maxdepth: 2
+   :caption: About this manual
+
+   overview
+   scope
+
+.. toctree::
+   :numbered:
+   :maxdepth: 1
+   :caption: Compilation targets
+
+   targets/index
+   targets/aarch64-unknown-qnx
+   targets/x86_64-pc-qnx
+
+.. toctree::
+   :caption: rustc test results:
+   :numbered:
+   :maxdepth: 2
+
+   rustc/index
+   rustc/aarch64-unknown-qnx
+   rustc/x86_64-pc-qnx
+
+Indices and tables
+------------------
+
+* :ref:`search`

--- a/ferrocene/doc/qnx8-manual/src/overview.rst
+++ b/ferrocene/doc/qnx8-manual/src/overview.rst
@@ -1,0 +1,26 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Overview
+========
+
+This Manual describes the use of Ferrocene |ferrocene_version|, the |iso_26262_ref|,
+|iec_61508_ref|, and |iec_62304_ref| qualified version of the Rust toolchain on QNX8.
+Ferrocene is based on ``rustc``, ``cargo``, and ``rustdoc`` version |rust_version|.
+
+This Manual assumes familiarity with rustc and the Rust language, and outlines
+usage instructions specific to Ferrocene.
+
+Further Relevant Documentation
+------------------------------
+
+The Ferrocene documentation package includes:
+
+* The :doc:`specification:index`, which describes the expected behavior of Rust.
+
+* The :doc:`safety-manual:index`, which includes usage and constraints
+  guidelines of using the Ferrocene toolchain according to functional
+  safety standards.
+
+* The :doc:`user-manual:index`, a how-to manual for operating Ferrocene in a
+  qualified environment.

--- a/ferrocene/doc/qnx8-manual/src/rustc/aarch64-unknown-qnx.rst
+++ b/ferrocene/doc/qnx8-manual/src/rustc/aarch64-unknown-qnx.rst
@@ -1,6 +1,6 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-.. render-outcomes-template:: templates/tests.jinja2
+.. render-outcomes-template:: ../../qualification-report/src/templates/tests.jinja2
    :host: x86_64-unknown-linux-gnu
    :target: aarch64-unknown-qnx

--- a/ferrocene/doc/qnx8-manual/src/rustc/index.rst
+++ b/ferrocene/doc/qnx8-manual/src/rustc/index.rst
@@ -1,0 +1,12 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+.. _test-results-overview:
+
+Test results overview
+=====================
+
+Ferrocene has been tested on all the platforms we support as part of the
+qualification. For ease of access, each platform has its own page.
+
+.. render-summary::

--- a/ferrocene/doc/qnx8-manual/src/rustc/x86_64-pc-qnx.rst
+++ b/ferrocene/doc/qnx8-manual/src/rustc/x86_64-pc-qnx.rst
@@ -1,6 +1,6 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-.. render-outcomes-template:: templates/tests.jinja2
+.. render-outcomes-template:: ../../qualification-report/src/templates/tests.jinja2
    :host: x86_64-unknown-linux-gnu
    :target: x86_64-pc-qnx

--- a/ferrocene/doc/qnx8-manual/src/scope.rst
+++ b/ferrocene/doc/qnx8-manual/src/scope.rst
@@ -1,0 +1,36 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Qualification scope
+===================
+
+This qualification applies to Ferrocene |ferrocene_version|, limited to:
+
+* rustc |rust_version|, limited to the Rust language as described in the
+  :doc:`specification:index`, and according to the requirements and
+  restrictions outlined in this safety manual.
+
+This qualification is restricted to the following environment:
+
+.. list-table::
+   :align: left
+   :header-rows: 1
+
+   * - Host
+     - Target
+     - Certified Libraries
+     - Uncertified Libraries
+     - Qualified Libraries
+
+   * - :target:`x86_64-unknown-linux-gnu`
+     - :target:`x86_64-pc-qnx`
+     - ``core``
+     - ``alloc``, ``std``, ``test``
+     - ``proc_macro``
+
+
+   * - :target:`x86_64-unknown-linux-gnu`
+     - :target:`aarch64-unknown-qnx`
+     - ``core``
+     - ``alloc``, ``std``, ``test``
+     - ``proc_macro``

--- a/ferrocene/doc/qnx8-manual/src/targets/aarch64-unknown-qnx.rst
+++ b/ferrocene/doc/qnx8-manual/src/targets/aarch64-unknown-qnx.rst
@@ -1,17 +1,17 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-.. _x86_64-pc-nto-qnx710:
+.. _aarch64-unknown-qnx:
 
-:target:`x86_64-pc-nto-qnx710`
-==============================
+:target:`aarch64-unknown-qnx`
+====================================
 
-The ``x86_64-pc-nto-qnx710`` Ferrocene target provides support for QNX on
-x86-64 processors.
+The ``aarch64-unknown-qnx`` Ferrocene target provides support for QNX SDP 8.0+ on
+ARMv8-A processors operating in AArch64 mode.
 
 .. note::
 
-    QNX SDP 7.1.0 only supports :ref:`x86_64-unknown-linux-gnu` and
+    QNX SDP 8.0 only supports :ref:`x86_64-unknown-linux-gnu` and
     :ref:`x86_64-pc-windows-msvc` as host platforms.
 
     Currently, Ferrocene only qualifies cross compilation to this target from
@@ -22,28 +22,31 @@ x86-64 processors.
 Prerequisites
 -------------
 
-This target requires `QNX Software Development Platform 7.1.0 (QNX SDP 7.1.0)
-<https://blackberry.qnx.com/en/products/foundation-software/qnx-software-development-platform/sdp-7-1>`_
+This target requires `QNX Software Development Platform 8.0.5 (QNX SDP 8.0.5)
+<https://blackberry.qnx.com/en/products/foundation-software/qnx-software-development-platform>`_
 to be installed.
 
 Typically this is done through `QNX Software Center
 <https://www.qnx.com/download/group.html?programid=29178>`_.
 
 Ferrocene is qualified using a specific version QNX SDP version. In safety
-critical contexts you must ensure 7.1.0.00472T202006132107S (also known as
-7.1 BuildID 472) is used.
+critical contexts you must ensure that `com.qnx.qnx800.patchset805` (also
+known as GA 8.0.5) is installed.
 
 .. code-block::
 
-    QNX_VERSION="7.1.0.00472T202006132107S"
+    QNX_VERSION="8.0.0.00141T202311271501L"
+    PATCHSET_VERSION="8.0.5.00390T202606231321L"
 
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
-        -installBaseline com.qnx.qnx710/$QNX_VERSION \
-        -destination qnx/qnx710-472 \
+        -installBaseline com.qnx.qnx800/$QNX_VERSION \
+        -installPackage com.qnx.qnx800.patchset805/$PATCHSET_VERSION \
+        -destination $HOME/qnx800 \
         -cleanInstall
 
-In an existing QNX 7.1.0 install you can check for the presence of the
-``.packages/metadata/com.qnx.qnx710/7.1.0.00472T202006132107S/`` directory.
+In an existing QNX SDP 8.0 install you can check for the presence of the
+``.packages/metadata/com.qnx.qnx800.target.microkernel.core/2.6.0.00145T202606051700L``
+directory.
 
 Ferrocene documents how our internal QNX toolchains are installed and
 configured in :doc:`internal procedures (QNX) <internal-procedures:partners/qnx>`.
@@ -52,23 +55,23 @@ Your organizational and licensing needs may differ.
 Archives to install
 -------------------
 
-The following archives are needed when :doc:`installing </rustc/install>` this
+The following archives are needed when :doc:`installing <user-manual:rustc/install>` this
 target as a cross-compilation target:
 
-* ``rust-std-x86_64-pc-nto-qnx710``
+* ``rust-std-aarch64-unknown-qnx``
 
 Required shell environment
-------------------------------
+--------------------------
 
 To use the target, the following procedures must be undertaken in the shell
 running the build.
 
 You must ensure ``$HOME`` is set to a valid path, then source ``qnxsdp-env.sh``
-from your QNX SDP 7.1.0 installation:
+from your QNX SDP 8.0 installation:
 
 .. code-block::
 
-    source $QNX_SDP_710_INSTALL/qnxsdp-env.sh
+    source $HOME/qnx800/qnxsdp-env.sh
 
 
 On :ref:`x86_64-pc-windows-msvc`, there exists a ``qnxsdp-env.bat`` if
@@ -82,4 +85,8 @@ Required compiler flags
 To use the target, the following additional flags must be provided to
 ``rustc``:
 
-* ``--target=x86_64-pc-nto-qnx710``
+* ``--target=aarch64-unknown-qnx``
+
+.. _aarch64-ferrocene-qnx:
+
+.. NOTE: this is a std target so we redirect to a no-std equivalent for certified core.

--- a/ferrocene/doc/qnx8-manual/src/targets/index.rst
+++ b/ferrocene/doc/qnx8-manual/src/targets/index.rst
@@ -1,0 +1,46 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Compilation targets overview
+============================
+
+Ferrocene has support for multiple compilation targets and host platforms.
+.. Targets are categorized into :doc:`levels of support <user-manual:targets/index>`.
+
+This page lists the current support status for QNX8 targets, and individual
+pages with more details are provided for QNX8 Qualified targets.
+
+.. _qualified-targets:
+
+Qualified QNX8 targets
+----------------------
+
+
+.. list-table::
+   :header-rows: 1
+
+   * - Target
+     - Tuple
+     - Kind
+     - Standard library
+     - Notes
+
+   * - :target:`x86_64-unknown-linux-gnu`
+     - :target:`aarch64-unknown-qnx`
+     - ``core``
+     - ``alloc``, ``std``, ``test``
+     - ``proc_macro``
+
+   * - :target:`x86_64-unknown-linux-gnu`
+     - :target:`x86_64-pc-qnx`
+     - ``core``
+     - ``alloc``, ``std``, ``test``
+     - ``proc_macro``
+
+
+Unsupported targets
+-------------------
+
+The Rust compiler includes support for additional targets that are not yet
+included in Ferrocene. If you need support for them please reach out to the
+Ferrocene support team.

--- a/ferrocene/doc/qnx8-manual/src/targets/x86_64-pc-qnx.rst
+++ b/ferrocene/doc/qnx8-manual/src/targets/x86_64-pc-qnx.rst
@@ -55,7 +55,7 @@ Your organizational and licensing needs may differ.
 Archives to install
 -------------------
 
-The following archives are needed when :doc:`installing </rustc/install>` this
+The following archives are needed when :doc:`installing <user-manual:rustc/install>` this
 target as a cross-compilation target:
 
 * ``rust-std-x86_64-pc-qnx``

--- a/ferrocene/doc/qualification-report/src/index.rst
+++ b/ferrocene/doc/qualification-report/src/index.rst
@@ -23,16 +23,11 @@ qualification, in accordance to the standards above.
 
    rustc/index
    rustc/aarch64-unknown-linux-gnu
-   rustc/aarch64-rhivos2-linux-gnu
    rustc/aarch64-unknown-none
-   rustc/aarch64-unknown-nto-qnx710
-   rustc/aarch64-unknown-qnx
-   rustc/armv7r-none-eabihf
+   rustc/armv7r-none-eabihf.rst
    rustc/thumbv7em-none-eabi
    rustc/thumbv7em-none-eabihf
    rustc/x86_64-unknown-linux-gnu
-   rustc/x86_64-pc-nto-qnx710
-   rustc/x86_64-pc-qnx
 
 .. appendices::
    :caption: Appendices:

--- a/ferrocene/doc/qualification-report/src/rustc/armv7r-none-eabihf.rst
+++ b/ferrocene/doc/qualification-report/src/rustc/armv7r-none-eabihf.rst
@@ -1,6 +1,6 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-.. render-outcomes-template:: templates/tests.jinja2
+.. render-outcomes-template:: ../../qualification-report/src/templates/tests.jinja2
    :host: x86_64-unknown-linux-gnu
    :target: armv7r-none-eabihf

--- a/ferrocene/doc/rhivos-manual/src/conf.py
+++ b/ferrocene/doc/rhivos-manual/src/conf.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+import os
+import sys
+
+sys.path.append(os.path.abspath("../../qualification-report/exts"))
+
+project = "RHIVOS Manual"
+copyright = "The Ferrocene Developers"
+author = "The Ferrocene Developers"
+
+extensions = [
+    "ferrocene_autoglossary",
+    "ferrocene_toctrees",
+    "ferrocene_qualification",
+    "ferrocene_test_outcomes",
+    "ferrocene_domain_cli",
+    "myst_parser",
+    "sphinx.ext.autosectionlabel",
+]
+
+# autosectionlabel unique names settings
+autosectionlabel_prefix_document = True
+
+ferrocene_id = "RM"
+
+html_theme = "ferrocene"
+html_title = "RHIVOS Manual"
+html_short_title = "RHIVOS Manual"
+
+# Do not generate the index pages. We don't need them, and they cause
+# linkchecker to fail due to them including *all* glossary entries, including
+# entries that were removed by autoglossary.
+html_use_index = False
+
+myst_heading_anchors = 7
+
+suppress_warnings = ["myst.header", "autosectionlabel.*"]

--- a/ferrocene/doc/rhivos-manual/src/index.rst
+++ b/ferrocene/doc/rhivos-manual/src/index.rst
@@ -1,0 +1,35 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+RHIVOS Manual
+=============
+
+.. toctree::
+   :numbered:
+   :maxdepth: 2
+   :caption: About this manual
+
+   overview
+   scope
+
+.. toctree::
+   :numbered:
+   :maxdepth: 1
+   :caption: Compilation targets
+
+   targets/index
+   targets/aarch64-rhivos2-linux-gnu
+   targets/aarch64-unknown-linux-gnu
+
+.. toctree::
+   :caption: rustc test results:
+   :numbered:
+   :maxdepth: 2
+
+   rustc/index
+   rustc/aarch64-rhivos2-linux-gnu
+
+Indices and tables
+------------------
+
+* :ref:`search`

--- a/ferrocene/doc/rhivos-manual/src/overview.rst
+++ b/ferrocene/doc/rhivos-manual/src/overview.rst
@@ -1,0 +1,26 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Overview
+========
+
+This Manual describes the use of Ferrocene |ferrocene_version|, the |iso_26262_ref|,
+|iec_61508_ref|, and |iec_62304_ref| qualified version of the Rust toolchain on RHIVOS.
+Ferrocene is based on ``rustc``, ``cargo``, and ``rustdoc`` version |rust_version|.
+
+This Manual assumes familiarity with rustc and the Rust language, and outlines
+usage instructions specific to Ferrocene.
+
+Further Relevant Documentation
+------------------------------
+
+The Ferrocene documentation package includes:
+
+* The :doc:`specification:index`, which describes the expected behavior of Rust.
+
+* The :doc:`safety-manual:index`, which includes usage and constraints
+  guidelines of using the Ferrocene toolchain according to functional
+  safety standards.
+
+* The :doc:`user-manual:index`, a how-to manual for operating Ferrocene in a
+  qualified environment.

--- a/ferrocene/doc/rhivos-manual/src/rustc/aarch64-rhivos2-linux-gnu.rst
+++ b/ferrocene/doc/rhivos-manual/src/rustc/aarch64-rhivos2-linux-gnu.rst
@@ -1,7 +1,7 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-.. render-outcomes-template:: templates/tests.jinja2
+.. render-outcomes-template:: ../../qualification-report/src/templates/tests.jinja2
    :host: aarch64-unknown-linux-gnu
    :target: aarch64-rhivos2-linux-gnu
    :remote_testing:

--- a/ferrocene/doc/rhivos-manual/src/rustc/index.rst
+++ b/ferrocene/doc/rhivos-manual/src/rustc/index.rst
@@ -1,0 +1,12 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+.. _test-results-overview:
+
+Test results overview
+=====================
+
+Ferrocene has been tested on all the platforms we support as part of the
+qualification. For ease of access, each platform has its own page.
+
+.. render-summary::

--- a/ferrocene/doc/rhivos-manual/src/scope.rst
+++ b/ferrocene/doc/rhivos-manual/src/scope.rst
@@ -1,0 +1,29 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Qualification scope
+===================
+
+This qualification applies to Ferrocene |ferrocene_version|, limited to:
+
+* rustc |rust_version|, limited to the Rust language as described in the
+  :doc:`specification:index`, and according to the requirements and
+  restrictions outlined in this safety manual.
+
+This qualification is restricted to the following environment:
+
+.. list-table::
+   :align: left
+   :header-rows: 1
+
+   * - Host
+     - Target
+     - Certified Libraries
+     - Uncertified Libraries
+     - Qualified Libraries
+
+   * - :target:`aarch64-unknown-linux-gnu`
+     - :target:`aarch64-rhivos2-linux-gnu`
+     - ``core``
+     - ``alloc``
+     -

--- a/ferrocene/doc/rhivos-manual/src/targets/aarch64-rhivos2-linux-gnu.rst
+++ b/ferrocene/doc/rhivos-manual/src/targets/aarch64-rhivos2-linux-gnu.rst
@@ -1,19 +1,27 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-.. _aarch64-unknown-linux-gnu:
+.. _aarch64-rhivos2-linux-gnu:
 
-:target:`aarch64-unknown-linux-gnu`
+:target:`aarch64-rhivos2-linux-gnu`
 ===================================
 .. note::
 
-   Only qualified when cross-compiling to :ref:`aarch64-rhivos2-linux-gnu`.
+   This is a variant of the generic :target:`aarch64-unknown-linux-gnu` target that specifically targets
+   Red Hat In-Vehicle Operating System 2 (RHIVOS 2). As per the RHIVOS 2 guidelines, qualified use requires
+   compilation on the matching host platform Red Hat Enterprise Linux 10 using the
+   :ref:`aarch64-unknown-linux-gnu` host compiler.
 
-The ``aarch64-unknown-linux-gnu`` Ferrocene target provides support for Linux on
-aarch64 using glibc 2.31 or higher.
+The ``aarch64-rhivos2-linux-gnu`` Ferrocene target provides support for Red Hat In-Vehicle Operating System 2
+(RHIVOS 2) on aarch64 using glibc 2.31 or higher.
 
 Prerequisites
 -------------
+
+While this target is technically a full Linux and capable of hosting a compiler,
+the target is only qualified if cross-compiled from RHEL 10 on aarch64 in the
+version specified by the RHIVOS 2 documentation. This requirement stems from the
+RHIVOS 2 assumptions of use. The host compiler is :target:`aarch64-unknown-linux-gnu`.
 
 This target uses the LLVM ``ld.lld`` linker. To locate the system C libraries
 required to create a functional Linux binary, this target drives the ``ld.lld``
@@ -31,26 +39,15 @@ You must have a C compiler which:
 - Supplies to ``ld.lld`` only those linker arguments specified in the
   :doc:`Safety Manual <safety-manual:rustc/options>`
 
-On Ubuntu 20.04 LTS you can install a suitable C compiler with:
-
-.. code-block::
-
-   $ sudo apt install gcc
+Please refer to the Red Hat Enterprise Linux 10 documentation for installation instructions.
 
 Archives to install
 -------------------
 
-The following archives are needed when :doc:`installing </rustc/install>` this
-target as a host platform:
-
-* ``rustc-aarch64-unknown-linux-gnu``
-* ``rust-std-aarch64-unknown-linux-gnu``
-* ``ferrocene-self-test-aarch64-unknown-linux-gnu``
-
-The following archives are needed when :doc:`installing </rustc/install>` this
+The following archives are needed when :doc:`installing <user-manual:rustc/install>` this
 target as a cross-compilation target:
 
-* ``rust-std-aarch64-unknown-linux-gnu``
+* ``rust-std-aarch64-rhivos2-linux-gnu``
 
 Required compiler flags
 -----------------------
@@ -58,7 +55,7 @@ Required compiler flags
 To use the target, the following additional flags must be provided to
 ``rustc``:
 
-- ``--target=aarch64-unknown-linux-gnu``
+- ``--target=aarch64-rhivos2-linux-gnu``
 
 - ``-C linker=<your-c-compiler>``
 

--- a/ferrocene/doc/rhivos-manual/src/targets/aarch64-unknown-linux-gnu.rst
+++ b/ferrocene/doc/rhivos-manual/src/targets/aarch64-unknown-linux-gnu.rst
@@ -1,27 +1,19 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-.. _aarch64-rhivos2-linux-gnu:
+.. _aarch64-unknown-linux-gnu:
 
-:target:`aarch64-rhivos2-linux-gnu`
+:target:`aarch64-unknown-linux-gnu`
 ===================================
 .. note::
 
-   This is a variant of the generic :target:`aarch64-unknown-linux-gnu` target that specifically targets
-   Red Hat In-Vehicle Operating System 2 (RHIVOS 2). As per the RHIVOS 2 guidelines, qualified use requires
-   compilation on the matching host platform Red Hat Enterprise Linux 10 using using the
-   :ref:`aarch64-unknown-linux-gnu` host compiler.
+   Only qualified when cross-compiling to :ref:`aarch64-rhivos2-linux-gnu`.
 
-The ``aarch64-rhivos2-linux-gnu`` Ferrocene target provides support for Red Hat In-Vehicle Operating System 2
-(RHIVOS 2) on aarch64 using glibc 2.31 or higher.
+The ``aarch64-unknown-linux-gnu`` Ferrocene target provides support for Linux on
+aarch64 using glibc 2.31 or higher.
 
 Prerequisites
 -------------
-
-While this target is technically a full linux and capable of hosting a compiler,
-the target is only qualified if cross-compiled from RHEL 10 on aarch64 in the
-version specified by the RHIVOS 2 documentation. This requirement stems from the
-RHIVOS 2 assumptions of use. The host compiler is :target:`aarch64-unknown-linux-gnu`.
 
 This target uses the LLVM ``ld.lld`` linker. To locate the system C libraries
 required to create a functional Linux binary, this target drives the ``ld.lld``
@@ -39,15 +31,26 @@ You must have a C compiler which:
 - Supplies to ``ld.lld`` only those linker arguments specified in the
   :doc:`Safety Manual <safety-manual:rustc/options>`
 
-Please refer to the Red Hat Enterprise Linux 10 documentation for installation instructions.
+On Ubuntu 20.04 LTS you can install a suitable C compiler with:
+
+.. code-block::
+
+   $ sudo apt install gcc
 
 Archives to install
 -------------------
 
-The following archives are needed when :doc:`installing </rustc/install>` this
+The following archives are needed when :doc:`installing <user-manual:rustc/install>` this
+target as a host platform:
+
+* ``rustc-aarch64-unknown-linux-gnu``
+* ``rust-std-aarch64-unknown-linux-gnu``
+* ``ferrocene-self-test-aarch64-unknown-linux-gnu``
+
+The following archives are needed when :doc:`installing <user-manual:rustc/install>` this
 target as a cross-compilation target:
 
-* ``rust-std-aarch64-rhivos2-linux-gnu``
+* ``rust-std-aarch64-unknown-linux-gnu``
 
 Required compiler flags
 -----------------------
@@ -55,7 +58,7 @@ Required compiler flags
 To use the target, the following additional flags must be provided to
 ``rustc``:
 
-- ``--target=aarch64-rhivos2-linux-gnu``
+- ``--target=aarch64-unknown-linux-gnu``
 
 - ``-C linker=<your-c-compiler>``
 

--- a/ferrocene/doc/rhivos-manual/src/targets/index.rst
+++ b/ferrocene/doc/rhivos-manual/src/targets/index.rst
@@ -1,0 +1,45 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Compilation targets overview
+============================
+
+Ferrocene has support for multiple compilation targets and host platforms.
+Targets are categorized into :doc:`levels of support <user-manual:targets/index>`.
+
+This page lists the current support status for RHIVOS targets, and individual
+pages with more details are provided for RHIVOS Qualified targets.
+
+.. _qualified-targets:
+
+Qualified RHIVOS targets
+------------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Target
+     - Tuple
+     - Kind
+     - Standard library
+     - Notes
+
+   * - :ref:`aarch64-unknown-linux-gnu`
+     - ``aarch64-unknown-linux-gnu``
+     - Host platform
+     - Full
+     - Only qualified when cross-compiling to :ref:`aarch64-rhivos2-linux-gnu`.
+
+   * - :ref:`aarch64-rhivos2-linux-gnu`
+     - ``aarch64-rhivos2-linux-gnu``
+     - Cross-compilation
+     - Full
+     - This is a variant of the generic :target:`aarch64-unknown-linux-gnu` target that specifically targets RHIVOS2 automotive Linux. As per the RHIVOS2 guidelines, qualified use requires compilation on the matching host platform RedHat Enterprise Linux 10 using the :ref:`aarch64-unknown-linux-gnu` host compiler.
+
+
+Unsupported targets
+-------------------
+
+The Rust compiler includes support for additional targets that are not yet
+included in Ferrocene. If you need support for them please reach out to the
+Ferrocene support team.

--- a/ferrocene/doc/safety-manual/src/scope.rst
+++ b/ferrocene/doc/safety-manual/src/scope.rst
@@ -10,7 +10,8 @@ This qualification applies to Ferrocene |ferrocene_version|, limited to:
   :doc:`specification:index`, and according to the requirements and
   restrictions outlined in this safety manual.
 
-This qualification is restricted to the following environment:
+This qualification is restricted to the environments listed in the following table,
+as well as environments listed in target specific documentation:
 
 .. list-table::
    :align: left
@@ -29,22 +30,11 @@ This qualification is restricted to the following environment:
      -
 
    * - :target:`x86_64-unknown-linux-gnu`
-     - :target:`aarch64-unknown-nto-qnx710`
-     - ``core``
-     - ``alloc``, ``std``, ``test``
-     - ``proc_macro``
-
-   * - :target:`x86_64-unknown-linux-gnu`
      - :target:`armv7r-none-eabihf`
      - ``core``
      - ``alloc``
      -
 
-   * - :target:`x86_64-unknown-linux-gnu`
-     - :target:`aarch64-unknown-qnx`
-     - ``core``
-     - ``alloc``, ``std``, ``test``
-     - ``proc_macro``
 
    * - :target:`x86_64-unknown-linux-gnu`
      - :target:`thumbv7em-none-eabi`
@@ -63,19 +53,6 @@ This qualification is restricted to the following environment:
      - ``core``
      - ``alloc``, ``std``, ``test``
      - ``proc_macro``
-
-   * - :target:`x86_64-unknown-linux-gnu`
-     - :target:`x86_64-pc-nto-qnx710`
-     - ``core``
-     - ``alloc``, ``std``, ``test``
-     - ``proc_macro``
-
-   * - :target:`x86_64-unknown-linux-gnu`
-     - :target:`x86_64-pc-qnx`
-     - ``core``
-     - ``alloc``, ``std``, ``test``
-     - ``proc_macro``
-
 
 The uncertified libraries provided are evaluated and tested within the scope of
 Ferrocene qualification for compiler use only. The use of these libraries by

--- a/ferrocene/doc/user-manual/src/index.rst
+++ b/ferrocene/doc/user-manual/src/index.rst
@@ -36,15 +36,9 @@ Ferrocene User Manual
    targets/armv7r-none-eabihf
    targets/thumbv7em-none-eabi
    targets/thumbv7em-none-eabihf
-   targets/aarch64-unknown-linux-gnu
-   targets/aarch64-rhivos2-linux-gnu
    targets/aarch64-unknown-none
-   targets/aarch64-unknown-nto-qnx710
-   targets/aarch64-unknown-qnx
    targets/aarch64-apple-darwin
    targets/x86_64-unknown-linux-gnu
-   targets/x86_64-pc-nto-qnx710
-   targets/x86_64-pc-qnx
    targets/x86_64-pc-windows-msvc
 
 .. toctree::

--- a/ferrocene/doc/user-manual/src/targets/index.rst
+++ b/ferrocene/doc/user-manual/src/targets/index.rst
@@ -90,34 +90,10 @@ qualified upon request.
      - Bare-metal
      - Only qualified when cross-compiled from :ref:`x86_64-unknown-linux-gnu`.
 
-   * - :ref:`aarch64-unknown-linux-gnu`
-     - ``aarch64-unknown-linux-gnu``
-     - Host platform
-     - Full
-     - Only qualified when cross-compiling to :ref:`aarch64-rhivos2-linux-gnu`.
-
-   * - :ref:`aarch64-rhivos2-linux-gnu`
-     - ``aarch64-rhivos2-linux-gnu``
-     - Cross-compilation
-     - Full
-     - This is a variant of the generic :target:`aarch64-unknown-linux-gnu` target that specifically targets RHIVOS2 automotive linux. As per the RHIVOS2 guidelines, qualified use requires compilation on the matching host platform RedHat Enterprise Linux 10 using using the :ref:`aarch64-unknown-linux-gnu` host compiler.
-
-   * - :ref:`aarch64-unknown-nto-qnx710`
-     - ``aarch64-unknown-nto-qnx710``
-     - Cross-compilation
-     - Full
-     - Only qualified when cross-compiled from :ref:`x86_64-unknown-linux-gnu`.
-
    * - :ref:`armv7r-none-eabihf`
      - ``armv7r-none-eabihf``
      - Cross-compilation
      - Bare-metal
-     - Only qualified when cross-compiled from :ref:`x86_64-unknown-linux-gnu`.
-
-   * - :ref:`aarch64-unknown-qnx`
-     - ``aarch64-unknown-qnx``
-     - Cross-compilation
-     - Full
      - Only qualified when cross-compiled from :ref:`x86_64-unknown-linux-gnu`.
 
    * - :ref:`thumbv7em-none-eabi`
@@ -137,18 +113,6 @@ qualified upon request.
      - Host platform
      - Full
      - \-
-
-   * - :ref:`x86_64-pc-nto-qnx710`
-     - ``x86_64-pc-nto-qnx710``
-     - Cross-compilation
-     - Full
-     - Only qualified when cross-compiled from :ref:`x86_64-unknown-linux-gnu`.
-
-   * - :ref:`x86_64-pc-qnx`
-     - ``x86_64-pc-qnx``
-     - Cross-compilation
-     - Full
-     - Only qualified when cross-compiled from :ref:`x86_64-unknown-linux-gnu`.
 
 Quality managed targets
 -----------------------

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_doc.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_doc.snap
@@ -74,6 +74,15 @@ expression: doc
 [Doc] bootstrap::ferrocene::doc::ReleaseNotes
     targets: [aarch64-unknown-linux-gnu]
     - Set({doc::ferrocene/doc/release-notes})
+[Doc] bootstrap::ferrocene::doc::QNX7Manual
+    targets: [aarch64-unknown-linux-gnu]
+    - Set({doc::ferrocene/doc/qnx7-manual})
+[Doc] bootstrap::ferrocene::doc::QNX8Manual
+    targets: [aarch64-unknown-linux-gnu]
+    - Set({doc::ferrocene/doc/qnx8-manual})
+[Doc] bootstrap::ferrocene::doc::RHIVOSManual
+    targets: [aarch64-unknown-linux-gnu]
+    - Set({doc::ferrocene/doc/rhivos-manual})
 [Doc] bootstrap::ferrocene::doc::DocumentList
     targets: [aarch64-unknown-linux-gnu]
     - Set({doc::ferrocene/doc/document-list})

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -995,6 +995,10 @@ impl<'a> Builder<'a> {
                 crate::ferrocene::doc::Specification,
                 crate::ferrocene::doc::UserManual,
                 crate::ferrocene::doc::ReleaseNotes,
+                //Targets
+                crate::ferrocene::doc::QNX7Manual,
+                crate::ferrocene::doc::QNX8Manual,
+                crate::ferrocene::doc::RHIVOSManual,
                 // Qualification Documents
                 crate::ferrocene::doc::DocumentList,
                 crate::ferrocene::doc::EvaluationPlan,

--- a/src/bootstrap/src/ferrocene/doc/mod.rs
+++ b/src/bootstrap/src/ferrocene/doc/mod.rs
@@ -734,6 +734,24 @@ sphinx_books! [
         src: "ferrocene/doc/core-certification",
         dest: "certification/core",
     },
+    {
+        ty: QNX7Manual,
+        name: "qnx7-manual",
+        src: "ferrocene/doc/qnx7-manual",
+        dest: "targets/qnx7-manual",
+    },
+    {
+        ty: QNX8Manual,
+        name: "qnx8-manual",
+        src: "ferrocene/doc/qnx8-manual",
+        dest: "targets/qnx8-manual",
+    },
+    {
+        ty: RHIVOSManual,
+        name: "rhivos-manual",
+        src: "ferrocene/doc/rhivos-manual",
+        dest: "targets/rhivos-manual",
+    },
 ];
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]


### PR DESCRIPTION
This PR splits out the following docs from safety manual, user manual and qualification docs:

- QNX7
- QNX8
- RHIVOS

Into a single manual per target that contains the relevant content from the 3 documents. I've made the minimal changes required for those to make sense.

Still to do:

- [x] update tests so CI passes 
- [x] update index.html to reference the new targets?
- [x] RHIVOS qualified targets?
- [x] update doc list

Review:

- [ ] be great if someone familiar with the test outcomes could make sure that all looks ok
- [ ] be great if someone could eyeball the new docs with fresh eyes and sure it all seems ok
