### PR TITLE
Workaround failing windows jobs due to no lscpu

### DIFF
--- a/ferrocene/ci/scripts/reset-mtime-to-last-commit.sh
+++ b/ferrocene/ci/scripts/reset-mtime-to-last-commit.sh
@@ -20,7 +20,10 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-if [[ "${OSTYPE}" =~ ^darwin.* ]]; then
+parent=$(cd $(dirname $0) && pwd)
+source "$parent/../../../src/ci/shared.sh"
+
+if isMacOS; then
     # Darwin's bash does not support RFC2822 on `touch`
     # `%ct` outputs the commit date formatted according UNIX timestamp
     git_log_format="%ct"

--- a/ferrocene/ci/scripts/run-self-test.sh
+++ b/ferrocene/ci/scripts/run-self-test.sh
@@ -13,11 +13,15 @@ PREFIX="ferrocene/dist/${COMMIT}"
 
 TAR="tar"
 FERROCENE_SELF_TEST="ferrocene-self-test"
+
+parent=$(cd $(dirname $0) && pwd)
+source "$parent/../../../src/ci/shared.sh"
+
 # Ensure we use GNU tar on Windows, bsdtar will not handle links well.
 # bsdtar (the default tar.exe) does not handle symlinks properly,
 # and will get 'stuck' in a cycle while unpacking and packing.
 # GNU Tar does not have this issue.
-if [[ "${OSTYPE}" = "msys" ]]; then
+if isWindows; then
     TAR="/c/Program Files/Git/usr/bin/tar.exe"
     FERROCENE_SELF_TEST="ferrocene-self-test.exe"
 fi

--- a/ferrocene/ci/scripts/setup-windows.sh
+++ b/ferrocene/ci/scripts/setup-windows.sh
@@ -20,8 +20,11 @@ setup_python3() {
     fi
 }
 
-if [[ "${OSTYPE}" != "msys" ]]; then
-    echo "error: the script can only run on Windows (under MSYS)"
+parent=$(cd $(dirname $0) && pwd)
+source "$parent/../../../src/ci/shared.sh"
+
+if ! isWindows; then
+    echo "error: the script can only run on Windows (under CYGWIN)"
     exit 1
 fi
 
@@ -41,6 +44,6 @@ choco install -y cmake.portable ninja llvm
 choco install -y zstandard --version=1.5.6 # 1.5.7 was reporting a mismatched SHA
 
 # Followed: https://docs.chocolatey.org/en-us/guides/create/recompile-packages/#how-to-internalizerecompile-an-existing-package-manually
-# From: https://developer.arm.com/-/media/Files/downloads/gnu/15.2.rel1/binrel/arm-gnu-toolchain-15.2.rel1-mingw-w64-x86_64-arm-none-eabi.msi 
+# From: https://developer.arm.com/-/media/Files/downloads/gnu/15.2.rel1/binrel/arm-gnu-toolchain-15.2.rel1-mingw-w64-x86_64-arm-none-eabi.msi
 aws s3 cp s3://ferrocene-ci-mirrors/manual/arm-compiler/gcc-arm-embedded.10.3.1.20251211.nupkg gcc-arm-embedded.10.3.1.20251211.nupkg
 choco install gcc-arm-embedded --version="10.3.1.20251211" --source .

--- a/ferrocene/ci/scripts/show-environment.sh
+++ b/ferrocene/ci/scripts/show-environment.sh
@@ -5,26 +5,32 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+parent=$(cd $(dirname $0) && pwd)
+source "$parent/../../../src/ci/shared.sh"
+
 echo "CPU"
 echo "==="
-if [[ "${OSTYPE}" =~ ^darwin.* ]]; then
+if isMacOS; then
     sysctl -n machdep.cpu.brand_string
-elif [[ "${OSTYPE}" = "msys" ]]; then
+elif isWindows; then
     systeminfo
-else
+elif isLinux; then
     lscpu
+else
+    echo "Unknown OS"
 fi
 
 echo
 echo "System memory"
 echo "============="
-if [[ "${OSTYPE}" =~ ^darwin.* ]]; then
+if isMacOS; then
     vm_stat
-elif [[ "${OSTYPE}" != "msys" ]]; then
+elif isLinux; then
     free -h
 
     echo "Disk"
     echo "===="
     df -h
+else
+    echo "Unknown OS"
 fi
-

--- a/ferrocene/ci/scripts/shrink-build-directory.sh
+++ b/ferrocene/ci/scripts/shrink-build-directory.sh
@@ -8,7 +8,10 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-if [[ "${OSTYPE}" != "msys" ]]; then
+parent=$(cd $(dirname $0) && pwd)
+source "$parent/../../../src/ci/shared.sh"
+
+if ! isWindows; then
     echo "build directory size:"
     du -sh build/*/* | sort -hr
 fi


### PR DESCRIPTION
CircleCI changed its windows runner and now the OSTYPE env variable is not `msys` anymore but `cygwin`, which resulted in failures, see below. This PR changes the Ferrocene CI scripts to use the `isWindows` function and friends from Rust upstream, since those functions handle the different OSTYPEs.

Failures:
* https://app.circleci.com/pipelines/github/ferrocene/ferrocene/18055/workflows/873a43af-b178-47f9-a42c-51e147d3c212/jobs/156808
* https://app.circleci.com/pipelines/github/ferrocene/ferrocene/18054/workflows/a586f4b7-9227-4a4e-8abf-2d5c3c7c9bba/jobs/156718
* https://app.circleci.com/pipelines/github/ferrocene/ferrocene/18056/workflows/be7b24f7-5f6f-4b29-a2f5-ab36d28fcfe7/jobs/156869