### PR TITLE
avoid panic when checking symbol-report on not-x86

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -136,6 +136,7 @@ impl Cargo {
 
         match cmd_kind {
             // No need to configure the target linker for these command types.
+            Kind::SymbolReport | // Ferrocene addition
             Kind::Clean | Kind::Check | Kind::Format | Kind::Setup => {}
             _ => {
                 cargo.configure_linker(builder);


### PR DESCRIPTION
We hardcode x86_64-unknown-linux-gnu as target when we run symbol report (`x test ferrocene/doc/symbol-report.csv`), and that resulted in a panic due to calling a function that checks for a linker of that target, a linker that will likely not exist outside of that target.