### PR TITLE
Update circleci xcode image to 27.0.0

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -603,7 +603,7 @@ jobs:
 
   aarch64-darwin-llvm:
     macos:
-      xcode: "26.0.1"
+      xcode: "27.0.0"
     resource_class: m4pro.medium # 6 cores
     environment:
       FERROCENE_HOST: aarch64-apple-darwin
@@ -635,7 +635,7 @@ jobs:
 
   aarch64-darwin-build:
     macos:
-      xcode: "26.0.1"
+      xcode: "27.0.0"
     resource_class: m4pro.medium # 6 cores
     environment:
       FERROCENE_HOST: aarch64-apple-darwin
@@ -656,7 +656,7 @@ jobs:
 
   aarch64-darwin-dist:
     macos:
-      xcode: "26.0.1"
+      xcode: "27.0.0"
     resource_class: m4pro.medium # 6 cores
     environment:
       FERROCENE_HOST: aarch64-apple-darwin
@@ -678,7 +678,7 @@ jobs:
 
   aarch64-darwin-dist-tools:
     macos:
-      xcode: "26.0.1"
+      xcode: "27.0.0"
     resource_class: m4pro.medium # 6 cores
     environment:
       FERROCENE_HOST: aarch64-apple-darwin
@@ -699,7 +699,7 @@ jobs:
 
   aarch64-darwin-self-test:
     macos:
-      xcode: "26.0.1"
+      xcode: "27.0.0"
     resource_class: m4pro.medium # 6 cores
     environment:
       FERROCENE_HOST: aarch64-apple-darwin
@@ -726,7 +726,7 @@ jobs:
 
   aarch64-darwin-generic-test-runner:
     macos:
-      xcode: "26.0.1"
+      xcode: "27.0.0"
     parameters:
       job:
         type: string

--- a/ferrocene/ci/scripts/setup-darwin.sh
+++ b/ferrocene/ci/scripts/setup-darwin.sh
@@ -4,6 +4,7 @@
 set -xeuo pipefail
 
 # On Mac, XCode's LLVM cannot build for WASM.
+brew update
 brew install cmake ninja zstd llvm tidy-html5
 
 # Needed for thumbv7em-none-eabihf & armv8r-none-eabihf cross-compilation.


### PR DESCRIPTION
The version `26.0.1` we used before is deprecated since 02.06.2026: https://circleci.com/changelog/deprecation-of-xcode-16-3-0-and-26-0-1/. `27.0.0` is the currently latest version: https://circleci.com/developer/machine/image/xcode.