### PR TITLE
Fix `brew install`

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -508,7 +508,7 @@ jobs:
             # Darwin does not come with awscli, setup it before aws steps
             - run:
                 name: Install AWSCLIv2
-                command: brew install awscli
+                command: brew install awscli -y
             - aws-oidc-auth
             - ferrocene-setup-darwin # Darwin does not come with awscli, setup it before aws steps
             - setup-uv
@@ -597,7 +597,7 @@ jobs:
             # Darwin does not come with awscli, setup it before aws steps
             - run:
                 name: Install AWSCLIv2
-                command: brew install awscli
+                command: brew install awscli -y
             - aws-oidc-auth
             - ferrocene-setup-darwin
             - setup-uv
@@ -1501,7 +1501,7 @@ commands:
           steps:
             - run:
                 name: Install AWSCLIv2
-                command: brew install awscli
+                command: brew install awscli -y
       - aws-oidc-auth
       - when:
           condition:
@@ -1549,7 +1549,7 @@ commands:
           steps:
             - run:
                 name: Install AWSCLIv2
-                command: brew install awscli
+                command: brew install awscli -y
       - aws-oidc-auth
       - when:
           condition:
@@ -1592,7 +1592,7 @@ commands:
           steps:
             - run:
                 name: Install AWSCLIv2
-                command: brew install awscli
+                command: brew install awscli -y
       - setup-uv
       - aws-oidc-auth
       - when:

--- a/ferrocene/ci/scripts/setup-darwin.sh
+++ b/ferrocene/ci/scripts/setup-darwin.sh
@@ -4,7 +4,7 @@
 set -xeuo pipefail
 
 # On Mac, XCode's LLVM cannot build for WASM.
-brew install cmake ninja zstd llvm tidy-html5
+brew install -y cmake ninja zstd llvm tidy-html5
 
 # Needed for thumbv7em-none-eabihf & armv8r-none-eabihf cross-compilation.
 # See ferrocene/ci/mirrors/README.md.

--- a/src/ci/scripts/install-ninja.sh
+++ b/src/ci/scripts/install-ninja.sh
@@ -14,5 +14,5 @@ if isWindows; then
     ciCommandSetEnv "RUST_CONFIGURE_ARGS" "${RUST_CONFIGURE_ARGS} --enable-ninja"
     ciCommandAddPath "$(cygpath -m "$(pwd)/ninja")"
 elif isMacOS; then
-    brew install ninja
+    brew install -y ninja
 fi

--- a/src/ci/scripts/install-tidy.sh
+++ b/src/ci/scripts/install-tidy.sh
@@ -15,7 +15,7 @@ if isMacOS; then
         x86_64)
             ;;
         arm64)
-            brew install tidy-html5
+            brew install -y tidy-html5
             ;;
         *)
             echo "unsupported architecture: ${platform}"


### PR DESCRIPTION
Since brew v6.0.0 it is required to pass `-y`. Without it the installs hangs for 10mins and then aborts.