### PR TITLE
make the persist-between-jobs less clever and more verbose

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -377,6 +377,9 @@ jobs:
         # the IP address of the QNX VMs is configured in ferrocene/ci/scripts/qnx-common.sh
         set +u; source ./qnx710-472/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.105:12345 ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >> << parameters.extra-args >>
     steps:
+      - aws-cli/install:
+          version: << pipeline.parameters.awscli-version >>
+          override_installed: true
       - aws-oidc-auth
       - ferrocene-checkout
       - setup-uv
@@ -408,6 +411,9 @@ jobs:
       SCRIPT: |
         set +u; source ./qnx800-141/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.105:12345 ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >> << parameters.extra-args >>
     steps:
+      - aws-cli/install:
+          version: << pipeline.parameters.awscli-version >>
+          override_installed: true
       - aws-oidc-auth
       - ferrocene-checkout
       - setup-uv

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -110,8 +110,14 @@ parameters:
     type: string
     default: ""
 
+  # CircleCI has no local variables and the recommendation is to use a parameter with a default value
+  # but since our paramters are all provided by calculate-parameters.py, we need to have the default there.
+  awscli-version:
+    type: string
+    default: ""
+
 orbs:
-  aws-cli: circleci/aws-cli@4.0
+  aws-cli: circleci/aws-cli@5.4.2
   win: circleci/windows@5.0
 
 jobs:
@@ -566,9 +572,9 @@ jobs:
           steps:
             - ferrocene-checkout
             # Darwin does not come with awscli, setup it before aws steps
-            - run:
-                name: Install AWSCLIv2
-                command: brew install awscli
+            - aws-cli/install:
+                version: << pipeline.parameters.awscli-version >>
+                override_installed: true
             - aws-oidc-auth
             - ferrocene-setup-darwin # Darwin does not come with awscli, setup it before aws steps
             - setup-uv
@@ -655,9 +661,9 @@ jobs:
             - ferrocene-git-shallow-clone:
                 depth: 1
             # Darwin does not come with awscli, setup it before aws steps
-            - run:
-                name: Install AWSCLIv2
-                command: brew install awscli
+            - aws-cli/install:
+                version: << pipeline.parameters.awscli-version >>
+                override_installed: true
             - aws-oidc-auth
             - ferrocene-setup-darwin
             - setup-uv
@@ -836,6 +842,9 @@ jobs:
       - aws-oidc-auth
       - ferrocene-checkout
       - setup-uv
+      - aws-cli/install:
+          version: << pipeline.parameters.awscli-version >>
+          override_installed: true
       - run:
           name: Restore files from the x86_64-linux-build job
           command: ferrocene/ci/scripts/persist-between-jobs.sh restore x86_64-linux-build
@@ -882,6 +891,9 @@ jobs:
       - aws-oidc-auth
       - ferrocene-checkout
       - setup-uv
+      - aws-cli/install:
+          version: << pipeline.parameters.awscli-version >>
+          override_installed: true
       - setup-qnx-toolchain:
           source-env-script: false
       - ferrocene-job-test-vm:
@@ -913,6 +925,9 @@ jobs:
       - aws-oidc-auth
       - ferrocene-checkout
       - setup-uv
+      - aws-cli/install:
+          version: << pipeline.parameters.awscli-version >>
+          override_installed: true
       - setup-qnx8-toolchain:
           source-env-script: false
       - ferrocene-job-test-vm:
@@ -946,7 +961,9 @@ jobs:
       - when:
           condition: << parameters.rebuild >>
           steps:
-            - aws-cli/install
+            - aws-cli/install:
+                version: << pipeline.parameters.awscli-version >>
+                override_installed: true
             - aws-oidc-auth
             - ferrocene-git-shallow-clone:
                 depth: 1
@@ -981,7 +998,9 @@ jobs:
       - when:
           condition: << parameters.rebuild >>
           steps:
-            - aws-cli/install
+            - aws-cli/install:
+                version: << pipeline.parameters.awscli-version >>
+                override_installed: true
             - aws-oidc-auth
             - ferrocene-git-shallow-clone:
                 depth: 1
@@ -1004,7 +1023,9 @@ jobs:
       - image: cimg/base:current
     resource_class: arm.medium # 2-core
     steps:
-      - aws-cli/install
+      - aws-cli/install:
+          version: << pipeline.parameters.awscli-version >>
+          override_installed: true
       - aws-oidc-auth
       - ferrocene-git-shallow-clone:
           depth: 1
@@ -1030,7 +1051,9 @@ jobs:
       - image: cimg/base:current
     resource_class: arm.medium # 2-core
     steps:
-      - aws-cli/install
+      - aws-cli/install:
+          version: << pipeline.parameters.awscli-version >>
+          override_installed: true
       - aws-oidc-auth
       - ferrocene-git-shallow-clone:
           depth: 1
@@ -1696,9 +1719,9 @@ commands:
           condition:
             equal: [<<parameters.os>>, "darwin"]
           steps:
-            - run:
-                name: Install AWSCLIv2
-                command: brew install awscli
+            - aws-cli/install:
+                version: << pipeline.parameters.awscli-version >>
+                override_installed: true
       - aws-oidc-auth
       - when:
           condition:
@@ -1747,9 +1770,9 @@ commands:
           condition:
             equal: [<<parameters.os>>, "darwin"]
           steps:
-            - run:
-                name: Install AWSCLIv2
-                command: brew install awscli
+            - aws-cli/install:
+                version: << pipeline.parameters.awscli-version >>
+                override_installed: true
       - aws-oidc-auth
       - when:
           condition:
@@ -1795,9 +1818,9 @@ commands:
           condition:
             equal: [<<parameters.os>>, "darwin"]
           steps:
-            - run:
-                name: Install AWSCLIv2
-                command: brew install awscli
+            - aws-cli/install:
+                version: << pipeline.parameters.awscli-version >>
+                override_installed: true
       - setup-uv
       - aws-oidc-auth
       - when:

--- a/ferrocene/ci/docker-images/common/setup-awscli.sh
+++ b/ferrocene/ci/docker-images/common/setup-awscli.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+  
+rm -rf /tmp/awscli /tmp/awscli.zip
+set -xe
+if [ "$TARGETPLATFORM" = "linux/amd64" ]; then
+    ARCH="x86_64"
+    SHA="d4bbcb5532c8bf43f9149f1b1e0d09f77f388df088656e349570637c06b76d2d"
+elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then
+    ARCH="aarch64"
+    SHA="df18f41e85b1305747a51b2da3886dd17ecde7412614068ed19905d6b245c69b"
+else
+    echo "Unsupported platform"
+    exit 1
+fi
+PACKAGE_URL="https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}-2.35.11.zip"
+curl -Lo /tmp/awscli.zip $PACKAGE_URL
+echo "${SHA} /tmp/awscli.zip" | sha256sum -c
+unzip -q -d /tmp/awscli /tmp/awscli.zip
+# we want to update any install previously found
+/tmp/awscli/aws/install --update
+
+# some of our environments record all downloaded packages here
+if [ test -x "/ferrocene/packages" ]; then
+    echo "$SHA $PACKAGE_URL" >> /ferrocene/packages/downloads
+fi

--- a/ferrocene/ci/docker-images/common/setup-awscli.sh
+++ b/ferrocene/ci/docker-images/common/setup-awscli.sh
@@ -12,6 +12,8 @@ else
     echo "Unsupported platform"
     exit 1
 fi
+# The version defined here needs to be kept in sync with the version defined in
+# ferrocene/ci/scripts/calculate-parameters.py
 PACKAGE_URL="https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}-2.35.11.zip"
 curl -Lo /tmp/awscli.zip $PACKAGE_URL
 echo "${SHA} /tmp/awscli.zip" | sha256sum -c

--- a/ferrocene/ci/docker-images/common/setup-awscli.sh
+++ b/ferrocene/ci/docker-images/common/setup-awscli.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
-  
+
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
 rm -rf /tmp/awscli /tmp/awscli.zip
 set -xe
 if [ "$TARGETPLATFORM" = "linux/amd64" ]; then

--- a/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
@@ -217,27 +217,8 @@ ENV PATH "/opt/nodejs/bin:$PATH"
 # `aws ecr get-login-password`.
 # Install AWS CLI from the published binaries, as no source tarball is provided
 # and the version in the Ubuntu 24.04 is a snap.
-RUN <<-EOF
-    set -xe
-    if [ "$TARGETPLATFORM" = "linux/amd64" ]; then
-        ARCH="x86_64"
-        SHA="d4bbcb5532c8bf43f9149f1b1e0d09f77f388df088656e349570637c06b76d2d"
-    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then
-        ARCH="aarch64"
-        SHA="df18f41e85b1305747a51b2da3886dd17ecde7412614068ed19905d6b245c69b"
-    else
-        echo "Unsupported platform"
-        exit 1
-    fi
-    PACKAGE_URL="https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}-2.35.11.zip"
-    curl -Lo /tmp/awscli.zip $PACKAGE_URL
-    echo "${SHA} /tmp/awscli.zip" | sha256sum -c
-    unzip -q -d /tmp/awscli /tmp/awscli.zip
-    /tmp/awscli/aws/install
-    rm -rf /tmp/awscli /tmp/awscli.zip
-
-    echo "$SHA $PACKAGE_URL" >> /ferrocene/packages/downloads
-EOF
+COPY --chmod=0700 ferrocene/ci/docker-images/common/setup-awscli.sh /tmp/setup-awscli.sh
+RUN /tmp/setup-awscli.sh
 
 # Install pre-built packages for Ubuntu 20.
 # See ferrocene/ci/mirrors/README.md.

--- a/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-20/Dockerfile
@@ -221,15 +221,15 @@ RUN <<-EOF
     set -xe
     if [ "$TARGETPLATFORM" = "linux/amd64" ]; then
         ARCH="x86_64"
-        SHA="0556162145e68889a27f835307b9dad56de60fda4256d2e246e9699f24535a08"
+        SHA="d4bbcb5532c8bf43f9149f1b1e0d09f77f388df088656e349570637c06b76d2d"
     elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then
         ARCH="aarch64"
-        SHA="33b1c2a9daab91ae458516e934b1532e2174643aea2ccfa81ab8c5e9d4ed381b"
+        SHA="df18f41e85b1305747a51b2da3886dd17ecde7412614068ed19905d6b245c69b"
     else
         echo "Unsupported platform"
         exit 1
     fi
-    PACKAGE_URL="https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}-2.12.4.zip"
+    PACKAGE_URL="https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}-2.35.11.zip"
     curl -Lo /tmp/awscli.zip $PACKAGE_URL
     echo "${SHA} /tmp/awscli.zip" | sha256sum -c
     unzip -q -d /tmp/awscli /tmp/awscli.zip

--- a/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
@@ -68,25 +68,10 @@ EOF
 
 # Install AWS CLI from the published binaries, as no source tarball is provided
 # and the version in the Ubuntu 24.04 is a snap.
-RUN <<-EOF
-    set -xe
-    if [ "$TARGETPLATFORM" = "linux/amd64" ]; then
-        ARCH="x86_64"
-        SHA="d4bbcb5532c8bf43f9149f1b1e0d09f77f388df088656e349570637c06b76d2d"
-    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then
-        ARCH="aarch64"
-        SHA="df18f41e85b1305747a51b2da3886dd17ecde7412614068ed19905d6b245c69b"
-    else
-        echo "Unsupported platform"
-        exit 1
-    fi
-    PACKAGE_URL="https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}-2.35.11.zip"
-    curl -Lo /tmp/awscli.zip $PACKAGE_URL
-    echo "${SHA} /tmp/awscli.zip" | sha256sum -c
-    unzip -q -d /tmp/awscli /tmp/awscli.zip
-    /tmp/awscli/aws/install
-    rm -rf /tmp/awscli /tmp/awscli.zip
-EOF
+#
+# Using the provided script also ensures that all versions are in sync
+COPY --chmod=0700 ferrocene/ci/docker-images/common/setup-awscli.sh /tmp/setup-awscli.sh
+RUN /tmp/setup-awscli.sh
 
 # Tell programs relying on the system language (like Python) to use UTF-8.
 ENV LANG=C.UTF-8

--- a/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
@@ -72,15 +72,16 @@ RUN <<-EOF
     set -xe
     if [ "$TARGETPLATFORM" = "linux/amd64" ]; then
         ARCH="x86_64"
-        SHA="0556162145e68889a27f835307b9dad56de60fda4256d2e246e9699f24535a08"
+        SHA="d4bbcb5532c8bf43f9149f1b1e0d09f77f388df088656e349570637c06b76d2d"
     elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then
         ARCH="aarch64"
-        SHA="33b1c2a9daab91ae458516e934b1532e2174643aea2ccfa81ab8c5e9d4ed381b"
+        SHA="df18f41e85b1305747a51b2da3886dd17ecde7412614068ed19905d6b245c69b"
     else
         echo "Unsupported platform"
         exit 1
     fi
-    curl -Lo /tmp/awscli.zip https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}-2.12.4.zip
+    PACKAGE_URL="https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}-2.35.11.zip"
+    curl -Lo /tmp/awscli.zip $PACKAGE_URL
     echo "${SHA} /tmp/awscli.zip" | sha256sum -c
     unzip -q -d /tmp/awscli /tmp/awscli.zip
     /tmp/awscli/aws/install

--- a/ferrocene/ci/scripts/calculate_parameters.py
+++ b/ferrocene/ci/scripts/calculate_parameters.py
@@ -244,9 +244,11 @@ def calculate_targets(host_plus_stage: str):
 def workflow_id(*dummy):
     return os.environ.get("CIRCLE_WORKFLOW_ID")
 
-## This needs to be kept in sync with the version in ferrocene/ci/docker-images/common/install-awscli.sh
+
+# This needs to be kept in sync with the version in ferrocene/ci/docker-images/common/install-awscli.sh
 def awscli_version(*dummy):
     return "2.35.11"
+
 
 def prepare_parameters():
     with open(CIRCLECI_CONFIGURATION) as f:

--- a/ferrocene/ci/scripts/calculate_parameters.py
+++ b/ferrocene/ci/scripts/calculate_parameters.py
@@ -244,6 +244,7 @@ def calculate_targets(host_plus_stage: str):
 def workflow_id(*dummy):
     return os.environ.get("CIRCLE_WORKFLOW_ID")
 
+## This needs to be kept in sync with the version in ferrocene/ci/docker-images/common/install-awscli.sh
 def awscli_version(*dummy):
     return "2.35.11"
 

--- a/ferrocene/ci/scripts/calculate_parameters.py
+++ b/ferrocene/ci/scripts/calculate_parameters.py
@@ -244,6 +244,8 @@ def calculate_targets(host_plus_stage: str):
 def workflow_id(*dummy):
     return os.environ.get("CIRCLE_WORKFLOW_ID")
 
+def awscli_version(*dummy):
+    return "2.35.11"
 
 def prepare_parameters():
     with open(CIRCLECI_CONFIGURATION) as f:
@@ -256,6 +258,7 @@ def prepare_parameters():
         "llvm-rebuild--": calculate_llvm_rebuild,
         "targets--": calculate_targets,
         "stable-workflow-id": workflow_id,
+        "awscli-version": awscli_version,
     }
 
     parameters: dict[str, str] = {}

--- a/ferrocene/ci/scripts/persist-between-jobs.sh
+++ b/ferrocene/ci/scripts/persist-between-jobs.sh
@@ -52,7 +52,7 @@ case "$1" in
         # :NOTE: This compression level is good for our current setup, changes such
         # as faster CPU and/or different networks speeds have impact on the optimum
         echo "Creating tar archive"
-        tar c --checkpoint=1000 --exclude build/metrics.json $@ | zstd -10 -T0 -o /tmp/persist_${CIRCLE_JOB}.tar.zst
+        tar c --checkpoint=1000 --exclude build/metrics.json "$@" | zstd -10 -T0 -o /tmp/persist_${CIRCLE_JOB}.tar.zst
         echo "Uploading tar archive"
         # if you intend to add retries here, configure them in the AWS cli settings
         # read https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html

--- a/ferrocene/ci/scripts/persist-between-jobs.sh
+++ b/ferrocene/ci/scripts/persist-between-jobs.sh
@@ -51,8 +51,12 @@ case "$1" in
         # compression level chosen after light experimentation.
         # :NOTE: This compression level is good for our current setup, changes such
         # as faster CPU and/or different networks speeds have impact on the optimum
+        #
+        # Use verbose to produce output while packing so that we can see the job is
+        # progressing. It shouldn't slow us down much here since we're largely dominated
+        # by the effort of packing.
         echo "Creating tar archive"
-        tar c --checkpoint=1000 --exclude build/metrics.json "$@" | zstd -10 -T0 -o /tmp/persist_${CIRCLE_JOB}.tar.zst
+        tar c --verbose --exclude build/metrics.json "$@" | zstd -10 -T0 -o /tmp/persist_${CIRCLE_JOB}.tar.zst
         echo "Uploading tar archive"
         # if you intend to add retries here, configure them in the AWS cli settings
         # read https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html
@@ -70,7 +74,10 @@ case "$1" in
         # read https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html
         aws s3 --progress-frequency=10 --progress-multiline cp "$(s3_url "${job}")" /tmp/persist_${CIRCLE_JOB}.tar.zst
         echo "Unpacking tar archive"
-        unzstd --stdout /tmp/persist_${CIRCLE_JOB}.tar.zst  | tar x --checkpoint=1000
+        # Unpacking is faster than packing and logging each file causes a significant
+        # slowdown, so no verbose here.
+        unzstd --stdout /tmp/persist_${CIRCLE_JOB}.tar.zst  | tar x
+        echo "Done unpacking"
         ;;
     *)
         usage 1>&2

--- a/ferrocene/ci/scripts/persist-between-jobs.sh
+++ b/ferrocene/ci/scripts/persist-between-jobs.sh
@@ -48,9 +48,15 @@ case "$1" in
         fi
 
         # Call `zstd` separately to be able to use all cores available (`-T0`)
-        # and the lowest compression level possible, to speed the compression
-        # as much as possible.
-        tar c --exclude build/metrics.json $@ | zstd -1 -T0 | aws s3 cp - "$(s3_url "${CIRCLE_JOB}")"
+        # compression level chosen after light experimentation.
+        # :NOTE: This compression level is good for our current setup, changes such
+        # as faster CPU and/or different networks speeds have impact on the optimum
+        echo "Creating tar archive"
+        tar c --checkpoint=1000 --exclude build/metrics.json $@ | zstd -10 -T0 -o /tmp/persist_${CIRCLE_JOB}.tar.zst
+        echo "Uploading tar archive"
+        # if you intend to add retries here, configure them in the AWS cli settings
+        # read https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html
+        aws s3 --progress-frequency=10 --progress-multiline cp /tmp/persist_${CIRCLE_JOB}.tar.zst "$(s3_url "${CIRCLE_JOB}")"
         ;;
     restore)
         if [[ "$#" -ne 2 ]]; then
@@ -59,7 +65,12 @@ case "$1" in
         fi
         job="$2"
 
-        aws s3 cp "$(s3_url "${job}")" - | unzstd --stdout | tar x
+        echo "Downloading tar archive"
+        # if you intend to add retries here, configure them in the AWS cli settings
+        # read https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html
+        aws s3 --progress-frequency=10 --progress-multiline cp "$(s3_url "${job}")" /tmp/persist_${CIRCLE_JOB}.tar.zst
+        echo "Unpacking tar archive"
+        unzstd --stdout /tmp/persist_${CIRCLE_JOB}.tar.zst  | tar x --checkpoint=1000
         ;;
     *)
         usage 1>&2


### PR DESCRIPTION
* Write out the tar archive as a file
* Upload/download the archive as a separate call
* bump aws-cli version in dockerfiles to support --progress-* options

This allows us to get progress on the individual operations and also pinpoint where things fail