### PR TITLE
update QNX scripts to work with QEMU built from source

### DIFF
--- a/ferrocene/ci/scripts/emulated-aarch64-qnx-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-aarch64-qnx-test-runner.sh
@@ -10,7 +10,7 @@ IFS=$'\n\t'
 nto_target=aarch64-unknown-nto-qnx710
 
 start_vm() {
-    qnx7_set_up_bridge_network
+    qnx7_set_up_bridge_network aarch64
 
     echo
     echo "===> creating virtual SD card"

--- a/ferrocene/ci/scripts/emulated-aarch64-qnx8-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-aarch64-qnx8-test-runner.sh
@@ -11,7 +11,7 @@ nto_target=aarch64-unknown-nto-qnx800
 vm_hostname=aarch64-qnx8-vm
 
 start_vm() {
-    qnx8_set_up_bridge_network
+    qnx8_set_up_bridge_network aarch64
 
     echo
     echo "===> starting QEMU"

--- a/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-x86_64-qnx-test-runner.sh
@@ -11,7 +11,7 @@ nto_target=x86_64-pc-nto-qnx710
 vm_hostname=x86_64-qnx-vm
 
 start_vm() {
-    qnx7_set_up_bridge_network
+    qnx7_set_up_bridge_network x86_64
 
     echo
     echo "===> starting QEMU"

--- a/ferrocene/ci/scripts/emulated-x86_64-qnx8-test-runner.sh
+++ b/ferrocene/ci/scripts/emulated-x86_64-qnx8-test-runner.sh
@@ -11,7 +11,7 @@ nto_target=x86_64-pc-nto-qnx800
 vm_hostname=x86_64-qnx8-vm
 
 start_vm() {
-    qnx8_set_up_bridge_network
+    qnx8_set_up_bridge_network x86_64
 
     echo
     echo "===> starting QEMU"

--- a/ferrocene/ci/scripts/qnx-common.sh
+++ b/ferrocene/ci/scripts/qnx-common.sh
@@ -47,18 +47,24 @@ locate_qemu_bridge_helper() {
 }
 
 locate_bridge_conf() {
-    helperdir="$(dirname "$1")"
-    # default search location when built from source
-    conf1="$helperdir/../etc/qemu/bridge.conf"
-    # location in Debian/Ubuntu package
-    conf2="$helperdir/../../../etc/qemu/bridge.conf"
-    if [ -f "$conf1" ]; then
-        echo "$(readlink -f "$conf1")"
-    elif [ -f "$conf2" ]; then
-        echo "$(readlink -f "$conf2")"
-    else
-        panic "bridge.conf not found; update this search logic (helper=$1)"
-    fi
+    qemu_bridge_helper="$1"
+
+    # The location where `qemu-bridge-helper` expects `bride.conf` to be is
+    # different on a custom QEMU build vs on the Debian packaged QEMU. Also, the
+    # file is not contained in the Debian package not created by
+    # `make install` on a custom build; instead the QNX SDP's `net.sh` script
+    # will create it. As `bridge.conf` does not exist we cannot search for it
+    # using `find`. The most reliable way to get its expected location seems to
+    # be to extract the location directly from the helper binary itself
+    #
+    # Examples of bridge-qemu-helper and bridge.conf locations
+    # - Ubuntu/Debian package:
+    #   - `/usr/lib/qemu/qemu-bridge-helper`;
+    #   - `/etc/qemu/bridge.conf`
+    # - custom build:
+    #   - `$PREFIX/libexec/qemu-bridge-helper`;
+    #   - `$PREFIX/etc/qemu/bridge.conf`
+    strings "$qemu_bridge_helper" | grep '^/.*/bridge.conf$'
 }
 
 check_no_other_emulator_is_running() {

--- a/ferrocene/ci/scripts/qnx-common.sh
+++ b/ferrocene/ci/scripts/qnx-common.sh
@@ -18,13 +18,47 @@ panic() {
 qnx7_set_up_bridge_network() {
     echo
     echo "===> setting up QEMU bridge network"
-    sudo "${qnxdir}"/host/common/mkqnximage/qemu/net.sh /usr/lib/qemu/qemu-bridge-helper /etc/qemu/bridge.conf
+    helper="$(locate_qemu_bridge_helper $1)"
+    conf="$(locate_bridge_conf "$helper")"
+    sudo "${qnxdir}"/host/common/mkqnximage/qemu/net.sh "$helper" "$conf"
 }
 
 qnx8_set_up_bridge_network() {
     echo
     echo "===> setting up QEMU bridge network"
-    sudo "${qnxdir}"/host/common/mkqnximage/qemu/net.sh /usr/lib/qemu/qemu-bridge-helper /etc/qemu/bridge.conf nat
+    helper="$(locate_qemu_bridge_helper $1)"
+    conf="$(locate_bridge_conf "$helper")"
+    sudo "${qnxdir}"/host/common/mkqnximage/qemu/net.sh "$helper" "$conf" nat
+}
+
+locate_qemu_bridge_helper() {
+    bindir="$(dirname "$(which qemu-system-$1)")"
+    # default location when built from source
+    helper1="$bindir/../libexec/qemu-bridge-helper"
+    # location in Debian/Ubuntu package
+    helper2="$bindir/../lib/qemu/qemu-bridge-helper"
+    if [ -f "$helper1" ]; then
+        echo "$(readlink -f "$helper1")"
+    elif [ -f "$helper2" ]; then
+        echo "$(readlink -f "$helper2")"
+    else
+        panic "qemu-bridge-helper not found; update this search logic (arch=$1)"
+    fi
+}
+
+locate_bridge_conf() {
+    helperdir="$(dirname "$1")"
+    # default search location when built from source
+    conf1="$helperdir/../etc/qemu/bridge.conf"
+    # location in Debian/Ubuntu package
+    conf2="$helperdir/../../../etc/qemu/bridge.conf"
+    if [ -f "$conf1" ]; then
+        echo "$(readlink -f "$conf1")"
+    elif [ -f "$conf2" ]; then
+        echo "$(readlink -f "$conf2")"
+    else
+        panic "bridge.conf not found; update this search logic (helper=$1)"
+    fi
 }
 
 check_no_other_emulator_is_running() {


### PR DESCRIPTION
`qemu-system-$ARCH -netdev bridge,(..)` uses the qemu-bridge-helper script that was installed with `qemu-system-$ARCH`. However, to set up the bridge network in the QNX scripts, we are using the qemu-bridge-helper of the system installed QEMU.

When using a QEMU built from source, we have seen the VM fail to initialize due to a different version of qemu-bridge-helper being used to set up the network bridge. To ensure the right qemu-bridge-helper is using in the QNX script, we search for it using the absolute path of the `qemu-system-$ARCH` as the reference, instead of assuming it'll be in `/usr` as that only works when the system installed QEMU is used.