### PR TITLE
Fix symbol report in CI

### DIFF
--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -422,7 +422,7 @@ ferrocene/ci/scripts/fix-stage0-branch.py || automation_warning "Could not fix s
 commit_if_modified src/stage0 "update src/stage0"
 
 echo "pull-upstream: trying to fix ferrocene/doc/symbol-report.csv"
-if ./x.py test ferrocene/doc/symbol-report.csv --bless --set rust.debug-assertions-std=true; then
+if ./x.py test ferrocene/doc/symbol-report.csv --stage 1 --bless --set rust.debug-assertions-std=true; then
     commit_if_modified ferrocene/doc/symbol-report.csv "update symbol report"
 else
     automation_warning "Couldn't regenerate the symbol report. Please run './x test ferrocene/doc/symbol-report.csv --bless' after fixing the conflicts."

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1399,7 +1399,9 @@ impl Config {
                 | Subcommand::Install => {
                     assert_eq!(
                         stage, 2,
-                        "x.py should be run with `--stage 2` on CI, but was run with `--stage {stage}`",
+                        "\
+x.py was run under CI with an implicit `--stage {stage}`. This is probably wrong and you want stage 2.
+NOTE: Please add `--stage 2` to your command line, or if you're sure you want to run stage {stage} then add `--stage {stage}` explicitly"
                     );
                 }
                 Subcommand::Clean { .. }


### PR DESCRIPTION
The pull-upstream script attempts to update the symbol report, but this was always failing with a message:

    assertion `left == right` failed: x.py should be run with `--stage 2` on CI, but was run with `--stage 1`

This is a bit misleading: we really do want to use stage 1, and that *is* permitted as long as it's requested explicitly. It's only implicit use of stage 1 which is disallowed, because that's usually wrong.

Improve the error message to better reflect the actual error condition, and add an explicit `--stage 1` to our CI script to bypass the error.