### PR TITLE
Feature/orbify things

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,8 @@ parameters:
     default: true
 
 orbs:
-  aws-cli: circleci/aws-cli@4.0
+  aws-cli: circleci/aws-cli@5.4.2
+  ferrocene: ferrocene/ferrocene-common@0.0.2
   continuation: circleci/continuation@0.2.0
 
 jobs:
@@ -31,51 +32,13 @@ jobs:
       - image: cimg/python:3.12
     resource_class: ferrocene/k8s-arm64-small # 1-core
     steps:
-      - aws-cli/install
+      - aws-cli/install:
+          version: 2.35.11
+          override_installed: true
 
-      - run:
-          name: Prepare environment for AWS authentication
-          command: |
-            # Load the JWT token into a file
-            touch /tmp/awsjwt
-            chmod 0600 /tmp/awsjwt
-            echo "${CIRCLE_OIDC_TOKEN_V2}" > /tmp/awsjwt
-
-            set_env() {
-              echo "export $1=\"$2\"" >> "${BASH_ENV}"
-            }
-
-            # Set environment variables to authenticate with OIDC
-            set_env AWS_WEB_IDENTITY_TOKEN_FILE /tmp/awsjwt
-            set_env AWS_ROLE_SESSION_NAME circleci
-            set_env AWS_DEFAULT_REGION eu-central-1
-
-            # Avoid reaching out to the EC2 metadata server, which just
-            # timeouts outside of EC2.
-            set_env AWS_EC2_METADATA_DISABLED true
-
-            # Some versions of AWS CLI fail if `less` is not installed, so
-            # disable pager support to suppress the error.
-            set_env AWS_PAGER ""
-
-      - run:
-          name: Authenticate with AWS
-          command: aws sts get-caller-identity
-
-      - run:
-          name: Checkout the source code
-          command: |
-            mkdir -p ~/.ssh
-            ssh-keyscan github.com &>> ~/.ssh/known_hosts
-
-            git init .
-            git remote add origin "${CIRCLE_REPOSITORY_URL}"
-            git fetch --depth=1 origin "${CIRCLE_SHA1}"
-            git checkout -b "${CIRCLE_BRANCH}" "${CIRCLE_SHA1}"
-
-      - run:
-          name: Setup uv
-          command: ferrocene/ci/scripts/setup-uv.sh
+      - ferrocene/aws_oidc_auth
+      - ferrocene/checkout
+      - ferrocene/setup_uv
 
       - run:
           name: Calculate the parameters for the workflow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ parameters:
 
 orbs:
   aws-cli: circleci/aws-cli@5.4.2
-  ferrocene: ferrocene/ferrocene-common@0.0.2
+  ferrocene: ferrocene/ferrocene-common@26080.3.0
   continuation: circleci/continuation@0.2.0
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,6 @@ parameters:
     default: true
 
 orbs:
-  aws-cli: circleci/aws-cli@5.4.2
   ferrocene: ferrocene/ferrocene-common@26080.3.0 # https://circleci.com/developer/orbs/orb/ferrocene/ferrocene-common?version=26080.3.0#orb-source
   continuation: circleci/continuation@0.2.0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ parameters:
 
 orbs:
   aws-cli: circleci/aws-cli@5.4.2
-  ferrocene: ferrocene/ferrocene-common@26080.3.0
+  ferrocene: ferrocene/ferrocene-common@26080.3.0 # https://circleci.com/developer/orbs/orb/ferrocene/ferrocene-common?version=26080.3.0#orb-source
   continuation: circleci/continuation@0.2.0
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,13 +29,12 @@ orbs:
 jobs:
   setup:
     docker:
-      - image: cimg/python:3.12
+    # We can't use our own mechanism to install aws-cli in our preferred version here because
+    # this is the workflow that reads our preferred version and calculates that paramter. So
+    # We use cimg/aws which comes with a somewhat recent version of aws-cli
+      - image: cimg/aws:2026.07
     resource_class: ferrocene/k8s-arm64-small # 1-core
     steps:
-      - aws-cli/install:
-          version: 2.35.11
-          override_installed: true
-
       - ferrocene/aws_oidc_auth
       - ferrocene/git_shallow_clone:
           depth: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,8 @@ jobs:
           override_installed: true
 
       - ferrocene/aws_oidc_auth
-      - ferrocene/checkout
+      - ferrocene/git_shallow_clone:
+          depth: 1
       - ferrocene/setup_uv
 
       - run:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -536,10 +536,10 @@ jobs:
 
   aarch64-linux-rhivos2-test-container:
     executor:
-      ferrocene/facade_testserver:
-        image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
-        test_image: 886866542769.dkr.ecr.us-east-1.amazonaws.com/ci-docker-images:run-id.<< pipeline.parameters.stable-workflow-id >>.rhivos-2.0-test-server
-        target:  aarch64-rhivos2-linux-gnu
+      name: ferrocene/facade_testserver
+      test_image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      testserver_image: 886866542769.dkr.ecr.us-east-1.amazonaws.com/ci-docker-images:run-id.<< pipeline.parameters.stable-workflow-id >>.rhivos-2.0-test-server
+      target:  aarch64-rhivos2-linux-gnu
     parameters:
       tasks:
         type: string

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -977,6 +977,7 @@ jobs:
         type: string
       resource_class:
         description: the resource_class to use (must match the architecture)
+        type: string
       image:
         description: The image that needs to be built
         type: string

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -967,16 +967,16 @@ jobs:
   # Job to build and upload a Docker image defined ferrocene/ci/docker-images.
   # If the image exists in the remote storage and is up to date, the job will
   # early exit without doing any work.
+  #
+  # To build an aarch64 image use an aarch64 resource class, to build an x68_64 image
+  # use an x86_64 resource class
   build-docker:
     description: Job that builds and uploads a Docker image on, if needed.
     docker:
       - image: cimg/base:current
     parameters:
-      architecture:
-        description: The architecture to build for (currently either x86_64 or aarch64)
-        type: string
       resource_class:
-        description: the resource_class to use (must match the architecture)
+        description: the resource_class to use (determines the target architecture)
         type: string
       image:
         description: The image that needs to be built

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -126,7 +126,7 @@ jobs:
   # individual target. If you have a test you don't know where to run it, this
   # is the place for it.
   misc-checks:
-    executor:
+    executor: &executor-x86_64-ubuntu-20
       name: ferrocene/docker
       image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
       registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
@@ -147,10 +147,7 @@ jobs:
 
   # Generate a SBOM for the Ferrocene repository
   sbom-gen:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-small
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -163,10 +160,7 @@ jobs:
   # x86_64-unknown-linux-gnu jobs
 
   x86_64-linux-build:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -177,10 +171,7 @@ jobs:
     steps: [ferrocene-job-build]
 
   x86_64-linux-docs:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-medium
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -199,10 +190,7 @@ jobs:
           restore-from-job: x86_64-linux-build
 
   x86_64-linux-dist:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -214,10 +202,7 @@ jobs:
           restore-from-job: x86_64-linux-build
 
   x86_64-linux-dist-tools:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -229,10 +214,7 @@ jobs:
           restore-from-job: x86_64-linux-build
 
   x86_64-linux-dist-targets:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -245,9 +227,7 @@ jobs:
           restore-from-job: x86_64-linux-build
 
   x86_64-linux-dist-targets-qnx8:
-    executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+    executor: *executor-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -260,10 +240,7 @@ jobs:
           restore-from-job: x86_64-linux-build
 
   x86_64-linux-dist-src:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-medium
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -277,10 +254,7 @@ jobs:
           llvm_subset: false
 
   x86_64-linux-generic-test-container:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-x86_64-ubuntu-20
     parameters:
       job:
         type: string
@@ -302,10 +276,7 @@ jobs:
           restore-from-job: x86_64-linux-build
 
   x86_64-linux-traceability-matrix:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-small
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -323,10 +294,7 @@ jobs:
           destination: reports
 
   x86_64-linux-library-coverage:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -343,10 +311,7 @@ jobs:
       - ferrocene/ci
 
   x86_64-linux-llvm:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -367,10 +332,7 @@ jobs:
           command: echo
 
   x86_64-linux-self-test:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-tiny
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -384,23 +346,20 @@ jobs:
           name: Download dist artifacts and run the self-test tool
           command: ferrocene/ci/scripts/run-self-test.sh
 
-  # x86_64-linux-self-test-qnx8:
-  #   executor:
-  #     name: ferrocene/docker
-  #     image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-  #     registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
-  #   resource_class: ferrocene/k8s-amd64-tiny
-  #   environment:
-  #     FERROCENE_HOST: x86_64-unknown-linux-gnu
-  #     FERROCENE_TARGETS: aarch64-unknown-nto-qnx800,x86_64-pc-nto-qnx800
-  #   steps:
-  #     - ferrocene/git_shallow_clone:
-  #         depth: 1
-  #     - ferrocene/aws_oidc_auth
-  #     - setup-qnx8-toolchain: {}
-  #     - run:
-  #         name: Download dist artifacts and run the self-test tool
-  #         command: ferrocene/ci/scripts/run-self-test.sh
+  x86_64-linux-self-test-qnx8:
+    executor: *executor-x86_64-ubuntu-20
+    resource_class: ferrocene/k8s-amd64-tiny
+    environment:
+      FERROCENE_HOST: x86_64-unknown-linux-gnu
+      FERROCENE_TARGETS: aarch64-unknown-qnx,x86_64-pc-qnx
+    steps:
+      - ferrocene/git_shallow_clone:
+          depth: 1
+      - ferrocene/aws_oidc_auth
+      - setup-qnx8-toolchain: {}
+      - run:
+          name: Download dist artifacts and run the self-test tool
+          command: ferrocene/ci/scripts/run-self-test.sh
 
   x86_64-qnx-generic-test-vm:
     executor: linux-vm
@@ -474,7 +433,7 @@ jobs:
   # aarch64-unknown-linux-gnu jobs
 
   aarch64-linux-llvm:
-    executor:
+    executor: &executor-aarch64-ubuntu-20
       name: ferrocene/docker
       image_tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
       registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
@@ -498,10 +457,7 @@ jobs:
           command: echo
 
   aarch64-linux-build:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-aarch64-ubuntu-20
     resource_class: ferrocene/k8s-arm64-large
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
@@ -514,10 +470,7 @@ jobs:
     steps: [ferrocene-job-build]
 
   aarch64-linux-dist:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-aarch64-ubuntu-20
     resource_class: ferrocene/k8s-arm64-large
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
@@ -529,10 +482,7 @@ jobs:
           restore-from-job: aarch64-linux-build
 
   aarch64-linux-dist-tools:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-aarch64-ubuntu-20
     resource_class: ferrocene/k8s-arm64-large
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
@@ -544,10 +494,7 @@ jobs:
           restore-from-job: aarch64-linux-build
 
   aarch64-linux-generic-test-container:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-aarch64-ubuntu-20
     parameters:
       job:
         type: string
@@ -566,10 +513,7 @@ jobs:
           restore-from-job: aarch64-linux-build
 
   aarch64-linux-self-test:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-aarch64-ubuntu-20
     resource_class: ferrocene/k8s-arm64-small
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
@@ -583,10 +527,7 @@ jobs:
           command: ferrocene/ci/scripts/run-self-test.sh
 
   aarch64-linux-library-coverage:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-aarch64-ubuntu-20
     resource_class: ferrocene/k8s-arm64-large
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
@@ -883,7 +824,7 @@ jobs:
     environment:
       FERROCENE_BUILD_HOST: x86_64-pc-windows-msvc
       FERROCENE_HOST: x86_64-pc-windows-msvc
-      FERROCENE_TARGETS: aarch64-unknown-nto-qnx800,x86_64-pc-nto-qnx800
+      FERROCENE_TARGETS: aarch64-unknown-qnx,x86_64-pc-qnx
     steps:
       - when:
           condition: << pipeline.parameters.full-build-x86_64-pc-windows-msvc-host >>
@@ -1158,10 +1099,7 @@ jobs:
 
   # Misc jobs
   wasm-dist-oxidos:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-medium
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -1173,10 +1111,7 @@ jobs:
           restore-from-job: x86_64-linux-build
 
   finish-build:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-tiny
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -1232,10 +1167,7 @@ jobs:
   # Simple job used to run "something" when no other jobs are supposed to be
   # run. See the `skip` workflow for more information.
   skip:
-    executor:
-      name: ferrocene/docker
-      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+    executor: *executor-x86_64-ubuntu-20
     resource_class: ferrocene/k8s-amd64-tiny
     steps:
       - run:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -119,6 +119,7 @@ parameters:
 orbs:
   aws-cli: circleci/aws-cli@5.4.2
   win: circleci/windows@5.0
+  ferrocene: ferrocene/ferrocene-common@0.0.2
 
 jobs:
   # Container dedicated to running ad-hoc tests that don't depend on an
@@ -126,28 +127,30 @@ jobs:
   # is the place for it.
   misc-checks:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-amd64-small
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       SCRIPT: |
         ./x.py test $(ferrocene/ci/split-tasks.py test:misc-checks)
     steps:
-      - aws-oidc-auth
-      - ferrocene-checkout:
-          llvm-subset: true
+      - ferrocene/aws_oidc_auth
+      - ferrocene/checkout:
+          llvm_subset: true
       - run:
           name: Perform licensing checks
           command: |
             uvx reuse@5.1.1 --include-submodules lint
-      - ferrocene-ci
+      - ferrocene/ci
 
   # Generate a SBOM for the Ferrocene repository
   sbom-gen:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-amd64-small
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -155,14 +158,15 @@ jobs:
         ./x.py dist ferrocene-sbom
     steps:
       - ferrocene-job-dist:
-          llvm-subset: false
+          llvm_subset: false
 
   # x86_64-unknown-linux-gnu jobs
 
   x86_64-linux-build:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -174,8 +178,9 @@ jobs:
 
   x86_64-linux-docs:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-amd64-medium
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -195,8 +200,9 @@ jobs:
 
   x86_64-linux-dist:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -209,8 +215,9 @@ jobs:
 
   x86_64-linux-dist-tools:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -223,8 +230,9 @@ jobs:
 
   x86_64-linux-dist-targets:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -253,8 +261,9 @@ jobs:
 
   x86_64-linux-dist-src:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-amd64-medium
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -265,12 +274,13 @@ jobs:
           restore-from-job: x86_64-linux-build
           # We need the whole LLVM clone to be able to include the full source
           # code into the tarball we ship to customers.
-          llvm-subset: false
+          llvm_subset: false
 
   x86_64-linux-generic-test-container:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     parameters:
       job:
         type: string
@@ -293,8 +303,9 @@ jobs:
 
   x86_64-linux-traceability-matrix:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-amd64-small
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -303,18 +314,19 @@ jobs:
         ferrocene/ci/scripts/fetch-test-outcomes.sh
         ./x.py run ferrocene/tools/traceability-matrix
     steps:
-      - aws-oidc-auth
-      - ferrocene-checkout:
-          llvm-subset: true
-      - ferrocene-ci
+      - ferrocene/aws_oidc_auth
+      - ferrocene/checkout:
+          llvm_subset: true
+      - ferrocene/ci
       - store_artifacts:
           path: build/x86_64-unknown-linux-gnu/ferrocene/traceability-matrix.html
           destination: reports
 
   x86_64-linux-library-coverage:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -322,18 +334,19 @@ jobs:
         ferrocene/ci/scripts/llvm_cache.py download
         ./x.py test --stage=1 --coverage=library library/core library/alloc --tests
     steps:
-      - aws-oidc-auth
-      - ferrocene-checkout:
-          llvm-subset: true
+      - ferrocene/aws_oidc_auth
+      - ferrocene/checkout:
+          llvm_subset: true
       # - run:
       #     name: Restore files from the x86_64-linux-build job
       #     command: ferrocene/ci/scripts/persist-between-jobs.sh restore x86_64-linux-build
-      - ferrocene-ci
+      - ferrocene/ci
 
   x86_64-linux-llvm:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -346,46 +359,48 @@ jobs:
       - when:
           condition: << pipeline.parameters.llvm-rebuild--x86_64-unknown-linux-gnu >>
           steps:
-            - aws-oidc-auth
-            - ferrocene-checkout
-            - ferrocene-ci
+            - ferrocene/aws_oidc_auth
+            - ferrocene/checkout
+            - ferrocene/ci
       - run:
           name: Empty step to make sure the job always has steps
           command: echo
 
   x86_64-linux-self-test:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-amd64-tiny
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       FERROCENE_TARGETS: << pipeline.parameters.targets--x86_64-unknown-linux-gnu--self-test >>
     steps:
-      - ferrocene-git-shallow-clone:
+      - ferrocene/git_shallow_clone:
           depth: 1
-      - aws-oidc-auth
+      - ferrocene/aws_oidc_auth
       - setup-qnx-toolchain: {}
       - run:
           name: Download dist artifacts and run the self-test tool
           command: ferrocene/ci/scripts/run-self-test.sh
 
-  x86_64-linux-self-test-qnx8:
-    executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-    resource_class: ferrocene/k8s-amd64-tiny
-    environment:
-      FERROCENE_HOST: x86_64-unknown-linux-gnu
-      FERROCENE_TARGETS: aarch64-unknown-qnx,x86_64-pc-qnx
-    steps:
-      - ferrocene-git-shallow-clone:
-          depth: 1
-      - aws-oidc-auth
-      - setup-qnx8-toolchain: {}
-      - run:
-          name: Download dist artifacts and run the self-test tool
-          command: ferrocene/ci/scripts/run-self-test.sh
+  # x86_64-linux-self-test-qnx8:
+  #   executor:
+  #     name: ferrocene/docker
+  #     image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+  #     registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
+  #   resource_class: ferrocene/k8s-amd64-tiny
+  #   environment:
+  #     FERROCENE_HOST: x86_64-unknown-linux-gnu
+  #     FERROCENE_TARGETS: aarch64-unknown-nto-qnx800,x86_64-pc-nto-qnx800
+  #   steps:
+  #     - ferrocene/git_shallow_clone:
+  #         depth: 1
+  #     - ferrocene/aws_oidc_auth
+  #     - setup-qnx8-toolchain: {}
+  #     - run:
+  #         name: Download dist artifacts and run the self-test tool
+  #         command: ferrocene/ci/scripts/run-self-test.sh
 
   x86_64-qnx-generic-test-vm:
     executor: linux-vm
@@ -410,9 +425,9 @@ jobs:
       - aws-cli/install:
           version: << pipeline.parameters.awscli-version >>
           override_installed: true
-      - aws-oidc-auth
-      - ferrocene-checkout
-      - setup-uv
+      - ferrocene/aws_oidc_auth
+      - ferrocene/checkout
+      - ferrocene/setup_uv
       - setup-qnx-toolchain:
           source-env-script: false
       - ferrocene-job-test-vm:
@@ -444,9 +459,9 @@ jobs:
       - aws-cli/install:
           version: << pipeline.parameters.awscli-version >>
           override_installed: true
-      - aws-oidc-auth
-      - ferrocene-checkout
-      - setup-uv
+      - ferrocene/aws_oidc_auth
+      - ferrocene/checkout
+      - ferrocene/setup_uv
       - setup-qnx8-toolchain:
           source-env-script: false
       - ferrocene-job-test-vm:
@@ -460,8 +475,9 @@ jobs:
 
   aarch64-linux-llvm:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-arm64-large
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
@@ -474,17 +490,18 @@ jobs:
       - when:
           condition: << pipeline.parameters.llvm-rebuild--aarch64-unknown-linux-gnu >>
           steps:
-            - aws-oidc-auth
-            - ferrocene-checkout
-            - ferrocene-ci
+            - ferrocene/aws_oidc_auth
+            - ferrocene/checkout
+            - ferrocene/ci
       - run:
           name: Empty step to make sure the job always has steps
           command: echo
 
   aarch64-linux-build:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-arm64-large
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
@@ -498,8 +515,9 @@ jobs:
 
   aarch64-linux-dist:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-arm64-large
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
@@ -512,8 +530,9 @@ jobs:
 
   aarch64-linux-dist-tools:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-arm64-large
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
@@ -526,8 +545,9 @@ jobs:
 
   aarch64-linux-generic-test-container:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     parameters:
       job:
         type: string
@@ -547,24 +567,26 @@ jobs:
 
   aarch64-linux-self-test:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-arm64-small
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
       FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-unknown-linux-gnu--self-test >>
     steps:
-      - ferrocene-git-shallow-clone:
+      - ferrocene/git_shallow_clone:
           depth: 1
-      - aws-oidc-auth
+      - ferrocene/aws_oidc_auth
       - run:
           name: Download dist artifacts and run the self-test tool
           command: ferrocene/ci/scripts/run-self-test.sh
 
   aarch64-linux-library-coverage:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-arm64-large
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
@@ -572,10 +594,10 @@ jobs:
         ferrocene/ci/scripts/llvm_cache.py download
         ./x.py test --stage=1 --coverage=library library/core library/alloc --tests
     steps:
-      - aws-oidc-auth
-      - ferrocene-checkout:
-          llvm-subset: true
-      - ferrocene-ci
+      - ferrocene/aws_oidc_auth
+      - ferrocene/checkout:
+          llvm_subset: true
+      - ferrocene/ci
 
   aarch64-linux-rhivos2-test-container:
     executor: docker-aarch64-ubuntu-20-rhivos2-test-server
@@ -620,15 +642,15 @@ jobs:
               - << pipeline.parameters.llvm-rebuild--aarch64-apple-darwin >>
               - << pipeline.parameters.full-build-aarch64-darwin-host >>
           steps:
-            - ferrocene-checkout
+            - ferrocene/checkout
             # Darwin does not come with awscli, setup it before aws steps
             - aws-cli/install:
                 version: << pipeline.parameters.awscli-version >>
                 override_installed: true
-            - aws-oidc-auth
+            - ferrocene/aws_oidc_auth
             - ferrocene-setup-darwin # Darwin does not come with awscli, setup it before aws steps
-            - setup-uv
-            - ferrocene-ci
+            - ferrocene/setup_uv
+            - ferrocene/ci
       - run:
           name: Empty step to make sure the job always has steps
           command: echo
@@ -708,15 +730,15 @@ jobs:
       - when:
           condition: << pipeline.parameters.full-build-aarch64-darwin-host >>
           steps:
-            - ferrocene-git-shallow-clone:
+            - ferrocene/git_shallow_clone:
                 depth: 1
             # Darwin does not come with awscli, setup it before aws steps
             - aws-cli/install:
                 version: << pipeline.parameters.awscli-version >>
                 override_installed: true
-            - aws-oidc-auth
+            - ferrocene/aws_oidc_auth
             - ferrocene-setup-darwin
-            - setup-uv
+            - ferrocene/setup_uv
             - run:
                 name: Download dist artifacts and run the self-test tool
                 command: ferrocene/ci/scripts/run-self-test.sh
@@ -781,12 +803,12 @@ jobs:
               - << pipeline.parameters.llvm-rebuild--x86_64-pc-windows-msvc >>
               - << pipeline.parameters.full-build-x86_64-pc-windows-msvc-host >>
           steps:
-            - aws-oidc-auth
-            - ferrocene-checkout
+            - ferrocene/aws_oidc_auth
+            - ferrocene/checkout
             - ferrocene-setup-windows:
                 llvm_build: true
-            - setup-uv
-            - ferrocene-ci
+            - ferrocene/setup_uv
+            - ferrocene/ci
       - run:
           name: Empty step to make sure the job always has steps
           command: echo
@@ -840,11 +862,11 @@ jobs:
       - when:
           condition: << pipeline.parameters.full-build-x86_64-pc-windows-msvc-host >>
           steps:
-            - ferrocene-git-shallow-clone:
+            - ferrocene/git_shallow_clone:
                 depth: 1
-            - aws-oidc-auth
+            - ferrocene/aws_oidc_auth
             - ferrocene-setup-windows: {}
-            - setup-uv
+            - ferrocene/setup_uv
             - setup-qnx-toolchain: {}
             - run:
                 name: Download dist artifacts and run the self-test tool
@@ -861,16 +883,16 @@ jobs:
     environment:
       FERROCENE_BUILD_HOST: x86_64-pc-windows-msvc
       FERROCENE_HOST: x86_64-pc-windows-msvc
-      FERROCENE_TARGETS: aarch64-unknown-qnx,x86_64-pc-qnx
+      FERROCENE_TARGETS: aarch64-unknown-nto-qnx800,x86_64-pc-nto-qnx800
     steps:
       - when:
           condition: << pipeline.parameters.full-build-x86_64-pc-windows-msvc-host >>
           steps:
-            - ferrocene-git-shallow-clone:
+            - ferrocene/git_shallow_clone:
                 depth: 1
-            - aws-oidc-auth
+            - ferrocene/aws_oidc_auth
             - ferrocene-setup-windows: {}
-            - setup-uv
+            - ferrocene/setup_uv
             - setup-qnx8-toolchain: {}
             - run:
                 name: Download dist artifacts and run the self-test tool
@@ -901,9 +923,9 @@ jobs:
       SCRIPT: |
         sudo update-binfmts --import && sudo update-binfmts --enable << parameters.qemu-arch >> && ./x.py --stage 2 test << parameters.tasks >> --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
     steps:
-      - aws-oidc-auth
-      - ferrocene-checkout
-      - setup-uv
+      - ferrocene/aws_oidc_auth
+      - ferrocene/checkout
+      - ferrocene/setup_uv
       - aws-cli/install:
           version: << pipeline.parameters.awscli-version >>
           override_installed: true
@@ -916,7 +938,7 @@ jobs:
             aws ecr get-login-password --region us-east-1 \
               | docker login -u AWS --password-stdin << pipeline.parameters.docker-repository-url--ci-docker-images >>
             docker pull << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-      - ferrocene-ci:
+      - ferrocene/ci:
           wrapper: |
             docker run \
               --rm \
@@ -950,9 +972,9 @@ jobs:
       SCRIPT: |
         set +u; source ./qnx710-472/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.105:12345 ./x.py --stage 2 test << parameters.tasks >> --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >> << parameters.extra-args >>
     steps:
-      - aws-oidc-auth
-      - ferrocene-checkout
-      - setup-uv
+      - ferrocene/aws_oidc_auth
+      - ferrocene/checkout
+      - ferrocene/setup_uv
       - aws-cli/install:
           version: << pipeline.parameters.awscli-version >>
           override_installed: true
@@ -984,9 +1006,9 @@ jobs:
       SCRIPT: |
         set +u; source ./qnx800-141/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.105:12345 ./x.py --stage 2 test << parameters.tasks >> --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >> << parameters.extra-args >>
     steps:
-      - aws-oidc-auth
-      - ferrocene-checkout
-      - setup-uv
+      - ferrocene/aws_oidc_auth
+      - ferrocene/checkout
+      - ferrocene/setup_uv
       - aws-cli/install:
           version: << pipeline.parameters.awscli-version >>
           override_installed: true
@@ -1026,8 +1048,8 @@ jobs:
             - aws-cli/install:
                 version: << pipeline.parameters.awscli-version >>
                 override_installed: true
-            - aws-oidc-auth
-            - ferrocene-git-shallow-clone:
+            - ferrocene/aws_oidc_auth
+            - ferrocene/git_shallow_clone:
                 depth: 1
             - setup_remote_docker:
                 version: default
@@ -1063,8 +1085,8 @@ jobs:
             - aws-cli/install:
                 version: << pipeline.parameters.awscli-version >>
                 override_installed: true
-            - aws-oidc-auth
-            - ferrocene-git-shallow-clone:
+            - ferrocene/aws_oidc_auth
+            - ferrocene/git_shallow_clone:
                 depth: 1
             - setup_remote_docker:
                 version: default # Only default and edge are supported: https://circleci.com/docs/building-docker-images/#docker-version
@@ -1088,8 +1110,8 @@ jobs:
       - aws-cli/install:
           version: << pipeline.parameters.awscli-version >>
           override_installed: true
-      - aws-oidc-auth
-      - ferrocene-git-shallow-clone:
+      - ferrocene/aws_oidc_auth
+      - ferrocene/git_shallow_clone:
           depth: 1
       - setup_remote_docker:
           version: default # Only default and edge are supported: https://circleci.com/docs/building-docker-images/#docker-version
@@ -1116,8 +1138,8 @@ jobs:
       - aws-cli/install:
           version: << pipeline.parameters.awscli-version >>
           override_installed: true
-      - aws-oidc-auth
-      - ferrocene-git-shallow-clone:
+      - ferrocene/aws_oidc_auth
+      - ferrocene/git_shallow_clone:
           depth: 1
       - setup_remote_docker:
           version: default # Only default and edge are supported: https://circleci.com/docs/building-docker-images/#docker-version
@@ -1137,8 +1159,9 @@ jobs:
   # Misc jobs
   wasm-dist-oxidos:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-amd64-medium
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -1151,8 +1174,9 @@ jobs:
 
   finish-build:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-amd64-tiny
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
@@ -1176,8 +1200,8 @@ jobs:
               - << pipeline.parameters.full-build-x86_64-pc-windows-msvc-host >>
               - << pipeline.parameters.full-build-aarch64-darwin-host >>
           steps:
-            - aws-oidc-auth
-            - ferrocene-git-shallow-clone:
+            - ferrocene/aws_oidc_auth
+            - ferrocene/git_shallow_clone:
                 depth: 1
             - run:
                 name: Restore files from the x86_64-linux-build
@@ -1209,8 +1233,9 @@ jobs:
   # run. See the `skip` workflow for more information.
   skip:
     executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      name: ferrocene/docker
+      image_tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+      registry: << pipeline.parameters.docker-repository-url--ci-docker-images >>
     resource_class: ferrocene/k8s-amd64-tiny
     steps:
       - run:
@@ -1640,8 +1665,8 @@ commands:
         type: string
         default: linux # Or `windows` or `darwin`
     steps:
-      - ferrocene-checkout:
-          llvm-subset: true
+      - ferrocene/checkout:
+          llvm_subset: true
       - when:
           condition:
             equal: [<<parameters.os>>, "darwin"]
@@ -1649,7 +1674,7 @@ commands:
             - aws-cli/install:
                 version: << pipeline.parameters.awscli-version >>
                 override_installed: true
-      - aws-oidc-auth
+      - ferrocene/aws_oidc_auth
       - when:
           condition:
             equal: [<<parameters.os>>, "darwin"]
@@ -1660,8 +1685,8 @@ commands:
             equal: [<<parameters.os>>, "windows"]
           steps:
             - ferrocene-setup-windows: {}
-      - setup-uv
-      - ferrocene-ci
+      - ferrocene/setup_uv
+      - ferrocene/ci
       # Persist the build artifacts so following jobs don't have to start from
       # scratch. The build directory is shrinked beforehand to avoid persisting
       # too much data (slowing down uploads and downloads).
@@ -1681,7 +1706,7 @@ commands:
       restore-from-job:
         type: string
         default: ""
-      llvm-subset:
+      llvm_subset:
         type: boolean
         default: true
       qnx7:
@@ -1691,8 +1716,8 @@ commands:
         type: boolean
         default: false
     steps:
-      - ferrocene-checkout:
-          llvm-subset: << parameters.llvm-subset >>
+      - ferrocene/checkout:
+          llvm_subset: << parameters.llvm_subset >>
       - when:
           condition:
             equal: [<<parameters.os>>, "darwin"]
@@ -1700,7 +1725,7 @@ commands:
             - aws-cli/install:
                 version: << pipeline.parameters.awscli-version >>
                 override_installed: true
-      - aws-oidc-auth
+      - ferrocene/aws_oidc_auth
       - when:
           condition:
             equal: [<<parameters.os>>, "darwin"]
@@ -1711,7 +1736,7 @@ commands:
             equal: [<<parameters.os>>, "windows"]
           steps:
             - ferrocene-setup-windows: {}
-      - setup-uv
+      - ferrocene/setup_uv
       - when:
           condition: <<parameters.restore-from-job>>
           steps:
@@ -1728,7 +1753,7 @@ commands:
             equal: [<<parameters.qnx8>>, true]
           steps:
             - setup-qnx8-toolchain: {}
-      - ferrocene-ci
+      - ferrocene/ci
 
   ferrocene-job-test-container:
     description: Collection of steps for test jobs in containers
@@ -1739,8 +1764,8 @@ commands:
         type: string
         default: linux # Or `windows` or `darwin`
     steps:
-      - ferrocene-checkout:
-          llvm-subset: true
+      - ferrocene/checkout:
+          llvm_subset: true
       - when:
           condition:
             equal: [<<parameters.os>>, "darwin"]
@@ -1748,8 +1773,8 @@ commands:
             - aws-cli/install:
                 version: << pipeline.parameters.awscli-version >>
                 override_installed: true
-      - setup-uv
-      - aws-oidc-auth
+      - ferrocene/setup_uv
+      - ferrocene/aws_oidc_auth
       - when:
           condition:
             equal: [<<parameters.os>>, "darwin"]
@@ -1758,7 +1783,7 @@ commands:
       - run:
           name: Restore files from the << parameters.restore-from-job >> job
           command: ferrocene/ci/scripts/persist-between-jobs.sh restore << parameters.restore-from-job >>
-      - ferrocene-ci
+      - ferrocene/ci
 
   ferrocene-job-test-vm:
     description: Collection of steps for test jobs in VMs
@@ -1780,13 +1805,13 @@ commands:
         type: boolean
         default: true
     steps:
-      - aws-oidc-auth
+      - ferrocene/aws_oidc_auth
       - when:
           condition: << parameters.checkout-source >>
           steps:
-            - ferrocene-checkout:
-                llvm-subset: true
-      - setup-uv
+            - ferrocene/checkout:
+                llvm_subset: true
+      - ferrocene/setup_uv
       - run:
           name: Restore files from the << parameters.restore-from-job >> job
           command: ferrocene/ci/scripts/persist-between-jobs.sh restore << parameters.restore-from-job >>
@@ -1856,7 +1881,7 @@ commands:
                     << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< parameters.run-emulator-docker-image-tag >> \
                     bash -c "<< parameters.emulator-script >>"
 
-      - ferrocene-ci:
+      - ferrocene/ci:
           wrapper: |
             docker run \
               --rm \
@@ -1870,26 +1895,6 @@ commands:
               --interactive \
               --tty \
               << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< parameters.docker-image-tag >> \
-
-  ferrocene-git-shallow-clone:
-    description: Perform a shallow `git clone`
-    parameters:
-      depth:
-        type: integer
-    steps:
-      - run:
-          name: Clone the source code
-          command: |
-            # There is no need to use any deploy key or SSH for CI, as the
-            # Ferrocene repository is public anyway. Also, on Windows the
-            # deploy key doesn't seem to be injected into the VM, so using
-            # HTTPS fixes that problem too.
-            repo_url="$(echo "${CIRCLE_REPOSITORY_URL}" | sed 's#^git@github.com:#https://github.com/#')"
-
-            git init .
-            git remote add origin "${repo_url}"
-            git fetch --depth=<< parameters.depth >> origin "${CIRCLE_SHA1}"
-            git checkout -b "${CIRCLE_BRANCH}" "${CIRCLE_SHA1}"
 
   ferrocene-setup-darwin:
     description: Prepare the Darwin environment
@@ -1915,73 +1920,6 @@ commands:
                 name: Setup LLVM build dependencies
                 command: ferrocene/ci/scripts/setup-windows-llvm.sh
 
-  # This task can be skipped inside docker containers, it's mainly intended for Mac/Windows hosts.
-  setup-uv:
-    description: Setup uv
-    steps:
-      - run:
-          name: Setup uv
-          command: ferrocene/ci/scripts/setup-uv.sh
-
-  ferrocene-checkout:
-    description: Checkout the Ferrocene source code
-    parameters:
-      llvm-subset:
-        type: boolean
-        default: false
-    steps:
-      - ferrocene-git-shallow-clone:
-          depth: 2
-      - when:
-          condition: << parameters.llvm-subset >>
-          steps:
-            - run:
-                name: Clone a subset of the llvm-project monorepo
-                command: ferrocene/ci/scripts/clone-llvm-subset.sh
-      - run:
-          name: Checkout the submodules
-          command: ferrocene/ci/scripts/checkout-submodules.sh
-      - run:
-          name: Unshallow the clone on the beta channel
-          command: ferrocene/ci/scripts/unshallow-on-beta.sh
-      - run:
-          name: Change the files modification time to a consistent date
-          command: ferrocene/ci/scripts/reset-mtime-to-last-commit.sh
-      - run:
-          name: Show the current environment
-          command: ferrocene/ci/scripts/show-environment.sh
-
-  ferrocene-ci:
-    description: Common CI steps for Ferrocene
-    parameters:
-      wrapper:
-        type: string
-        default: ""
-    steps:
-      - run:
-          name: Execute the build
-          no_output_timeout: 20m
-          command: << parameters.wrapper >> ferrocene/ci/run.sh
-
-      - run:
-          name: Generate resource usage report
-          command: |
-            mkdir -p /tmp/metrics
-            ferrocene/ci/scripts/generate-resources-usage-report.py build/metrics.json > /tmp/metrics/report.html
-            cp build/metrics.json /tmp/metrics/raw.json
-
-      - run:
-          name: Upload artifacts to S3
-          command: ferrocene/ci/scripts/upload-dist-artifacts.sh
-          # We want to upload artifacts even when the build is failing, to be
-          # able to retrieve and investigate them. They won't be making into a
-          # release anyway, sine the "finish-build" job will not be executed in
-          # case of a failure.
-          when: always
-
-      - store_artifacts:
-          path: /tmp/metrics
-          destination: metrics
 
   setup-qnx-toolchain:
     description: Setup QNX Toolchain
@@ -2021,53 +1959,7 @@ commands:
                 name: Set PATH to include QNX800 tools
                 command: echo 'source $(pwd)/qnx800-141/qnxsdp-env.sh' >> "$BASH_ENV"
 
-  aws-oidc-auth:
-    description: Authenticate with AWS using OIDC
-    steps:
-      - run:
-          name: Prepare environment for AWS authentication
-          command: |
-            # Load the JWT token into a file
-            touch /tmp/awsjwt
-            chmod 0600 /tmp/awsjwt
-            echo "${CIRCLE_OIDC_TOKEN_V2}" > /tmp/awsjwt
-
-            set_env() {
-              echo "export $1=\"$2\"" >> "${BASH_ENV}"
-            }
-
-            # Set environment variables to authenticate with OIDC
-            set_env AWS_WEB_IDENTITY_TOKEN_FILE /tmp/awsjwt
-            set_env AWS_ROLE_SESSION_NAME circleci
-            set_env AWS_DEFAULT_REGION us-east-1
-
-            # Avoid reaching out to the EC2 metadata server, which just
-            # timeouts outside of EC2.
-            set_env AWS_EC2_METADATA_DISABLED true
-
-            # Some versions of AWS CLI fail if `less` is not installed, so
-            # disable pager support to suppress the error.
-            set_env AWS_PAGER ""
-
-      - run:
-          name: Authenticate with AWS
-          command: aws sts get-caller-identity
-
 executors:
-  # Execute on a docker runner with a custom image
-  docker-custom-image:
-    parameters:
-      registry:
-        type: string
-        default: << pipeline.parameters.docker-repository-url--ci-docker-images >>
-      image-tag:
-        type: string
-    docker:
-      - image: << parameters.registry >>:<< parameters.image-tag >>
-        aws_auth:
-          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
-          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
-
   # This executor spins up a secondary container with the remote testserver running in a RHIVOS2 image
   # The image is built specifically for this run.
   docker-aarch64-ubuntu-20-rhivos2-test-server:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -119,7 +119,7 @@ parameters:
 orbs:
   aws-cli: circleci/aws-cli@5.4.2
   win: circleci/windows@5.0
-  ferrocene: ferrocene/ferrocene-common@0.0.2
+  ferrocene: ferrocene/ferrocene-common@dev:main
 
 jobs:
   # Container dedicated to running ad-hoc tests that don't depend on an
@@ -962,70 +962,6 @@ jobs:
           restore-from-job: x86_64-linux-build
           emulator-script: "set +u; source ./qnx800-141/qnxsdp-env.sh; set -u; ./ferrocene/ci/scripts/emulated-aarch64-qnx8-test-runner.sh"
 
-  # Docker jobs
-
-  # Job to build and upload a Docker image defined ferrocene/ci/docker-images.
-  # If the image exists in the remote storage and is up to date, the job will
-  # early exit without doing any work.
-  #
-  # To build an aarch64 image use an aarch64 resource class, to build an x68_64 image
-  # use an x86_64 resource class
-  build-docker:
-    description: Job that builds and uploads a Docker image on, if needed.
-    docker:
-      - image: cimg/base:current
-    parameters:
-      resource_class:
-        description: the resource_class to use (determines the target architecture)
-        type: string
-      image:
-        description: The image that needs to be built
-        type: string
-      tag:
-        description: The tag of the image that needs to be build
-        type: string
-      restore_from_job:
-        description: Restore build result from a previous job
-        type: string
-        default: ""
-      rebuild:
-        description: Whether the image should be rebuilt or not
-        type: boolean
-      awscli_version:
-        description: The AWS-CLI version to install for auth
-        type: string
-    resource_class: << parameters.resource_class >>
-    steps:
-      - when:
-          condition: << parameters.rebuild >>
-          steps:
-            - aws-cli/install:
-                version: << parameters.awscli_version >>
-                override_installed: true
-            - ferrocene/aws_oidc_auth
-            - ferrocene/git_shallow_clone:
-                depth: 1
-            - setup_remote_docker:
-                version: default # Only default and edge are supported: https://circleci.com/docs/building-docker-images/#docker-version
-            - when:
-                condition: << parameters.restore_from_job >>
-                steps:
-                  - run:
-                      name: Install required packages
-                      command: sudo apt update && sudo apt install zstd
-                  - run:
-                      name: Restore files from the << parameters.restore_from_job>> job
-                      command: ferrocene/ci/scripts/persist-between-jobs.sh restore << parameters.restore_from_job>>
-            - run:
-                name: Build and upload the Docker image, if needed
-                command: ferrocene/ci/scripts/build-and-push-docker-image.sh
-                environment:
-                  IMAGE_NAME: << parameters.image >>
-                  IMAGE_TAG: << parameters.tag >>
-      - run:
-          name: Empty step to make sure the job always has steps
-          command: echo
-
   # Misc jobs
   wasm-dist-oxidos:
     executor: *executor-x86_64-ubuntu-20
@@ -1117,7 +1053,7 @@ workflows:
         - equal: [<< pipeline.git.branch >>, "trying"]
         - equal: [<< pipeline.trigger_source >>, "api"]
     jobs:
-      - build-docker:
+      - ferrocene/build_docker:
           name: build-docker--ubuntu-20--x86_64
           image: ubuntu-20
           tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
@@ -1125,7 +1061,7 @@ workflows:
           resource_class: large.gen2
           awscli_version: << pipeline.parameters.awscli-version >>
 
-      - build-docker:
+      - ferrocene/build_docker:
           name: build-docker--ubuntu-24--x86_64
           image: ubuntu-24
           tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-24 >>
@@ -1133,7 +1069,7 @@ workflows:
           resource_class: large.gen2
           awscli_version: << pipeline.parameters.awscli-version >>
 
-      - build-docker:
+      - ferrocene/build_docker:
           name: build-docker--ubuntu-20--aarch64
           image: ubuntu-20
           tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
@@ -1422,7 +1358,7 @@ workflows:
 
       # RHEL Test Infrastructure
       # The image gets built for every job because it needs to contain build results per job
-      - build-docker:
+      - ferrocene/build_docker:
           name: build-docker-rhel-test-server-aarch64
           image: rhel-10.1-test-server
           tag: run-id.<< pipeline.parameters.stable-workflow-id >>.rhel-10.1-test-server
@@ -1435,7 +1371,7 @@ workflows:
 
       # RHIVOS2 Test Infrastructure
       # The image gets built for every job because it needs to contain build results per job
-      - build-docker:
+      - ferrocene/build_docker:
           name: build-docker-rhivos2-test-server-aarch64
           image: rhivos-2.0-test-server
           tag: run-id.<< pipeline.parameters.stable-workflow-id >>.rhivos-2.0-test-server

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -535,7 +535,11 @@ jobs:
       - ferrocene/ci
 
   aarch64-linux-rhivos2-test-container:
-    executor: docker-aarch64-ubuntu-20-rhivos2-test-server
+    executor:
+      ferrocene/facade_testserver:
+        image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+        test_image: 886866542769.dkr.ecr.us-east-1.amazonaws.com/ci-docker-images:run-id.<< pipeline.parameters.stable-workflow-id >>.rhivos-2.0-test-server
+        target:  aarch64-rhivos2-linux-gnu
     parameters:
       tasks:
         type: string
@@ -1509,9 +1513,8 @@ commands:
       - when:
           condition: <<parameters.restore-from-job>>
           steps:
-            - run:
-                name: Restore files from the << parameters.restore-from-job >> job
-                command: ferrocene/ci/scripts/persist-between-jobs.sh restore << parameters.restore-from-job >>
+            - ferrocene/restore_from_job:
+                from_job: << parameters.restore-from-job>>
       - when:
           condition:
             equal: [<<parameters.qnx7>>, true]
@@ -1538,9 +1541,8 @@ commands:
       - ferrocene/setup:
           awscli_version: << pipeline.parameters.awscli-version >>
           os: <<parameters.os>>
-      - run:
-          name: Restore files from the << parameters.restore-from-job >> job
-          command: ferrocene/ci/scripts/persist-between-jobs.sh restore << parameters.restore-from-job >>
+      - ferrocene/restore_from_job:
+          from_job: << parameters.restore-from-job>>
       - ferrocene/ci
 
   ferrocene-job-test-vm:
@@ -1570,9 +1572,8 @@ commands:
                 llvm_subset: true
       - ferrocene/setup:
           awscli_version: << pipeline.parameters.awscli-version >>
-      - run:
-          name: Restore files from the << parameters.restore-from-job >> job
-          command: ferrocene/ci/scripts/persist-between-jobs.sh restore << parameters.restore-from-job >>
+      - ferrocene/restore_from_job:
+          from_job: << parameters.restore-from-job>>
       - run:
           name: Enable IPv6 for Docker
           command: |
@@ -1693,46 +1694,6 @@ commands:
                 command: echo 'source $(pwd)/qnx800-141/qnxsdp-env.sh' >> "$BASH_ENV"
 
 executors:
-  # This executor spins up a secondary container with the remote testserver running in a RHIVOS2 image
-  # The image is built specifically for this run.
-  docker-aarch64-ubuntu-20-rhivos2-test-server:
-    docker:
-      - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
-        aws_auth:
-          # Self-Hosted Runners can't do OIDC auth at the moment
-          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
-          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
-      - name: rhivos-test-server
-        image: 886866542769.dkr.ecr.us-east-1.amazonaws.com/ci-docker-images:run-id.<< pipeline.parameters.stable-workflow-id >>.rhivos-2.0-test-server
-        command:
-          - "/bin/test-server/aarch64-rhivos2-linux-gnu/remote-test-server"
-          - "-v"
-          - "--bind"
-          - "127.0.0.1:12345"
-        aws_auth:
-          # Self-Hosted Runners can't do OIDC auth at the moment
-          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
-          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
-  # This executor spins up a secondary container with the remote testserver running in a RHEL 10.1 image
-  # The image is built specifically for this run.
-  docker-aarch64-ubuntu-20-rhel-10-1-test-server:
-    docker:
-      - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
-        aws_auth:
-          # Self-Hosted Runners can't do OIDC auth at the moment
-          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
-          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
-      - name: rhel-test-server
-        image: 886866542769.dkr.ecr.us-east-1.amazonaws.com/ci-docker-images:run-id.<< pipeline.parameters.stable-workflow-id >>.rhel-10.1-test-server
-        command:
-          - "/bin/test-server/aarch64-unknown-linux-gnu/remote-test-server"
-          - "-v"
-          - "--bind"
-          - "127.0.0.1:12345"
-        aws_auth:
-          # Self-Hosted Runners can't do OIDC auth at the moment
-          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
-          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
   linux-vm:
     machine:
       image: default

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -381,12 +381,9 @@ jobs:
         # the IP address of the QNX VMs is configured in ferrocene/ci/scripts/qnx-common.sh
         set +u; source ./qnx710-472/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.105:12345 ./x.py --stage 2 test << parameters.tasks >> --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >> << parameters.extra-args >>
     steps:
-      - aws-cli/install:
-          version: << pipeline.parameters.awscli-version >>
-          override_installed: true
-      - ferrocene/aws_oidc_auth
       - ferrocene/checkout
-      - ferrocene/setup_uv
+      - ferrocene/setup:
+          awscli_version: << pipeline.parameters.awscli-version >>
       - setup-qnx-toolchain:
           source-env-script: false
       - ferrocene-job-test-vm:
@@ -415,12 +412,9 @@ jobs:
       SCRIPT: |
         set +u; source ./qnx800-141/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.105:12345 ./x.py --stage 2 test << parameters.tasks >> --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >> << parameters.extra-args >>
     steps:
-      - aws-cli/install:
-          version: << pipeline.parameters.awscli-version >>
-          override_installed: true
-      - ferrocene/aws_oidc_auth
       - ferrocene/checkout
-      - ferrocene/setup_uv
+      - ferrocene/setup:
+          awscli_version: << pipeline.parameters.awscli-version >>
       - setup-qnx8-toolchain:
           source-env-script: false
       - ferrocene-job-test-vm:
@@ -584,13 +578,9 @@ jobs:
               - << pipeline.parameters.full-build-aarch64-darwin-host >>
           steps:
             - ferrocene/checkout
-            # Darwin does not come with awscli, setup it before aws steps
-            - aws-cli/install:
-                version: << pipeline.parameters.awscli-version >>
-                override_installed: true
-            - ferrocene/aws_oidc_auth
-            - ferrocene-setup-darwin # Darwin does not come with awscli, setup it before aws steps
-            - ferrocene/setup_uv
+            - ferrocene/setup:
+                awscli_version: << pipeline.parameters.awscli-version >>
+                os: darwin
             - ferrocene/ci
       - run:
           name: Empty step to make sure the job always has steps
@@ -673,13 +663,9 @@ jobs:
           steps:
             - ferrocene/git_shallow_clone:
                 depth: 1
-            # Darwin does not come with awscli, setup it before aws steps
-            - aws-cli/install:
-                version: << pipeline.parameters.awscli-version >>
-                override_installed: true
-            - ferrocene/aws_oidc_auth
-            - ferrocene-setup-darwin
-            - ferrocene/setup_uv
+            - ferrocene/setup:
+                awscli_version: << pipeline.parameters.awscli-version >>
+                os: darwin
             - run:
                 name: Download dist artifacts and run the self-test tool
                 command: ferrocene/ci/scripts/run-self-test.sh
@@ -744,11 +730,11 @@ jobs:
               - << pipeline.parameters.llvm-rebuild--x86_64-pc-windows-msvc >>
               - << pipeline.parameters.full-build-x86_64-pc-windows-msvc-host >>
           steps:
-            - ferrocene/aws_oidc_auth
             - ferrocene/checkout
-            - ferrocene-setup-windows:
+            - ferrocene/setup:
+                awscli_version: << pipeline.parameters.awscli-version >>
+                os: windows
                 llvm_build: true
-            - ferrocene/setup_uv
             - ferrocene/ci
       - run:
           name: Empty step to make sure the job always has steps
@@ -805,9 +791,9 @@ jobs:
           steps:
             - ferrocene/git_shallow_clone:
                 depth: 1
-            - ferrocene/aws_oidc_auth
-            - ferrocene-setup-windows: {}
-            - ferrocene/setup_uv
+            - ferrocene/setup:
+                awscli_version: << pipeline.parameters.awscli-version >>
+                os: windows
             - setup-qnx-toolchain: {}
             - run:
                 name: Download dist artifacts and run the self-test tool
@@ -831,9 +817,9 @@ jobs:
           steps:
             - ferrocene/git_shallow_clone:
                 depth: 1
-            - ferrocene/aws_oidc_auth
-            - ferrocene-setup-windows: {}
-            - ferrocene/setup_uv
+            - ferrocene/setup:
+                awscli_version: << pipeline.parameters.awscli-version >>
+                os: windows
             - setup-qnx8-toolchain: {}
             - run:
                 name: Download dist artifacts and run the self-test tool
@@ -864,12 +850,9 @@ jobs:
       SCRIPT: |
         sudo update-binfmts --import && sudo update-binfmts --enable << parameters.qemu-arch >> && ./x.py --stage 2 test << parameters.tasks >> --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
     steps:
-      - ferrocene/aws_oidc_auth
       - ferrocene/checkout
-      - ferrocene/setup_uv
-      - aws-cli/install:
-          version: << pipeline.parameters.awscli-version >>
-          override_installed: true
+      - ferrocene/setup:
+          awscli_version: << pipeline.parameters.awscli-version >>
       - run:
           name: Restore files from the x86_64-linux-build job
           command: ferrocene/ci/scripts/persist-between-jobs.sh restore x86_64-linux-build
@@ -913,12 +896,9 @@ jobs:
       SCRIPT: |
         set +u; source ./qnx710-472/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.105:12345 ./x.py --stage 2 test << parameters.tasks >> --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >> << parameters.extra-args >>
     steps:
-      - ferrocene/aws_oidc_auth
       - ferrocene/checkout
-      - ferrocene/setup_uv
-      - aws-cli/install:
-          version: << pipeline.parameters.awscli-version >>
-          override_installed: true
+      - ferrocene/setup:
+          awscli_version: << pipeline.parameters.awscli-version >>
       - setup-qnx-toolchain:
           source-env-script: false
       - ferrocene-job-test-vm:
@@ -947,12 +927,9 @@ jobs:
       SCRIPT: |
         set +u; source ./qnx800-141/qnxsdp-env.sh; set -u; RUST_TEST_THREADS=1 TEST_DEVICE_ADDR=172.31.1.105:12345 ./x.py --stage 2 test << parameters.tasks >> --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >> << parameters.extra-args >>
     steps:
-      - ferrocene/aws_oidc_auth
       - ferrocene/checkout
-      - ferrocene/setup_uv
-      - aws-cli/install:
-          version: << pipeline.parameters.awscli-version >>
-          override_installed: true
+      - ferrocene/setup:
+          awscli_version: << pipeline.parameters.awscli-version >>
       - setup-qnx8-toolchain:
           source-env-script: false
       - ferrocene-job-test-vm:
@@ -1483,28 +1460,16 @@ commands:
       os:
         type: string
         default: linux # Or `windows` or `darwin`
+      llvm_build:
+        type: boolean
+        default: false
     steps:
       - ferrocene/checkout:
           llvm_subset: true
-      - when:
-          condition:
-            equal: [<<parameters.os>>, "darwin"]
-          steps:
-            - aws-cli/install:
-                version: << pipeline.parameters.awscli-version >>
-                override_installed: true
-      - ferrocene/aws_oidc_auth
-      - when:
-          condition:
-            equal: [<<parameters.os>>, "darwin"]
-          steps:
-            - ferrocene-setup-darwin
-      - when:
-          condition:
-            equal: [<<parameters.os>>, "windows"]
-          steps:
-            - ferrocene-setup-windows: {}
-      - ferrocene/setup_uv
+      - ferrocene/setup:
+          awscli_version: << pipeline.parameters.awscli-version >>
+          os: <<parameters.os>>
+          llvm_build: << parameters.llvm_build >>
       - ferrocene/ci
       # Persist the build artifacts so following jobs don't have to start from
       # scratch. The build directory is shrinked beforehand to avoid persisting
@@ -1537,25 +1502,10 @@ commands:
     steps:
       - ferrocene/checkout:
           llvm_subset: << parameters.llvm_subset >>
-      - when:
-          condition:
-            equal: [<<parameters.os>>, "darwin"]
-          steps:
-            - aws-cli/install:
-                version: << pipeline.parameters.awscli-version >>
-                override_installed: true
-      - ferrocene/aws_oidc_auth
-      - when:
-          condition:
-            equal: [<<parameters.os>>, "darwin"]
-          steps:
-            - ferrocene-setup-darwin
-      - when:
-          condition:
-            equal: [<<parameters.os>>, "windows"]
-          steps:
-            - ferrocene-setup-windows: {}
-      - ferrocene/setup_uv
+      - ferrocene/setup:
+          awscli_version: << pipeline.parameters.awscli-version >>
+          os: <<parameters.os>>    parameters:
+          llvm_build: false
       - when:
           condition: <<parameters.restore-from-job>>
           steps:
@@ -1585,20 +1535,9 @@ commands:
     steps:
       - ferrocene/checkout:
           llvm_subset: true
-      - when:
-          condition:
-            equal: [<<parameters.os>>, "darwin"]
-          steps:
-            - aws-cli/install:
-                version: << pipeline.parameters.awscli-version >>
-                override_installed: true
-      - ferrocene/setup_uv
-      - ferrocene/aws_oidc_auth
-      - when:
-          condition:
-            equal: [<<parameters.os>>, "darwin"]
-          steps:
-            - ferrocene-setup-darwin # Darwin does not come with awscli, setup it before aws steps
+      - ferrocene/setup:
+          awscli_version: << pipeline.parameters.awscli-version >>
+          os: <<parameters.os>>
       - run:
           name: Restore files from the << parameters.restore-from-job >> job
           command: ferrocene/ci/scripts/persist-between-jobs.sh restore << parameters.restore-from-job >>
@@ -1624,13 +1563,13 @@ commands:
         type: boolean
         default: true
     steps:
-      - ferrocene/aws_oidc_auth
       - when:
           condition: << parameters.checkout-source >>
           steps:
             - ferrocene/checkout:
                 llvm_subset: true
-      - ferrocene/setup_uv
+      - ferrocene/setup:
+          awscli_version: << pipeline.parameters.awscli-version >>
       - run:
           name: Restore files from the << parameters.restore-from-job >> job
           command: ferrocene/ci/scripts/persist-between-jobs.sh restore << parameters.restore-from-job >>
@@ -1714,31 +1653,6 @@ commands:
               --interactive \
               --tty \
               << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< parameters.docker-image-tag >> \
-
-  ferrocene-setup-darwin:
-    description: Prepare the Darwin environment
-    steps:
-      - run:
-          name: Setup Darwin environment
-          command: ferrocene/ci/scripts/setup-darwin.sh
-
-  ferrocene-setup-windows:
-    description: Prepare the Windows environment
-    parameters:
-      llvm_build:
-        type: boolean
-        default: false
-    steps:
-      - run:
-          name: Setup Windows environment
-          command: ferrocene/ci/scripts/setup-windows.sh
-      - when:
-          condition: << parameters.llvm_build >>
-          steps:
-            - run:
-                name: Setup LLVM build dependencies
-                command: ferrocene/ci/scripts/setup-windows-llvm.sh
-
 
   setup-qnx-toolchain:
     description: Setup QNX Toolchain

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1531,7 +1531,7 @@ commands:
           condition: <<parameters.restore-from-job>>
           steps:
             - ferrocene/restore_from_job:
-                from_job: << parameters.restore-from-job>>
+                from_job: << parameters.restore-from-job >>
       - when:
           condition:
             equal: [<<parameters.qnx7>>, true]
@@ -1559,7 +1559,7 @@ commands:
           awscli_version: << pipeline.parameters.awscli-version >>
           os: <<parameters.os>>
       - ferrocene/restore_from_job:
-          from_job: << parameters.restore-from-job>>
+          from_job: << parameters.restore-from-job >>
       - ferrocene/ci
 
   ferrocene-job-test-vm:
@@ -1590,7 +1590,7 @@ commands:
       - ferrocene/setup:
           awscli_version: << pipeline.parameters.awscli-version >>
       - ferrocene/restore_from_job:
-          from_job: << parameters.restore-from-job>>
+          from_job: << parameters.restore-from-job >>
       - run:
           name: Enable IPv6 for Docker
           command: |

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -119,7 +119,7 @@ parameters:
 orbs:
   aws-cli: circleci/aws-cli@5.4.2
   win: circleci/windows@5.0
-  ferrocene: ferrocene/ferrocene-common@26080.3.0
+  ferrocene: ferrocene/ferrocene-common@26080.3.0 # https://circleci.com/developer/orbs/orb/ferrocene/ferrocene-common?version=26080.3.0#orb-source
 
 jobs:
   # Container dedicated to running ad-hoc tests that don't depend on an

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -983,6 +983,10 @@ jobs:
       tag:
         description: The tag of the image that needs to be build
         type: string
+      restore_from_job:
+        description: Restore build result from a previous job
+        type: string
+        default: ""
       rebuild:
         description: Whether the image should be rebuilt or not
         type: boolean
@@ -1002,6 +1006,15 @@ jobs:
                 depth: 1
             - setup_remote_docker:
                 version: default # Only default and edge are supported: https://circleci.com/docs/building-docker-images/#docker-version
+            - when:
+                condition: << parameters.restore_from_job >>
+                steps:
+                  - run:
+                      name: Install required packages
+                      command: sudo apt update && sudo apt install zstd
+                  - run:
+                      name: Restore files from the << parameters.restore_from_job>> job
+                      command: ferrocene/ci/scripts/persist-between-jobs.sh restore << parameters.restore_from_job>>
             - run:
                 name: Build and upload the Docker image, if needed
                 command: ferrocene/ci/scripts/build-and-push-docker-image.sh
@@ -1011,62 +1024,6 @@ jobs:
       - run:
           name: Empty step to make sure the job always has steps
           command: echo
-
-  # The image gets built for every job because it needs to contain build results per job
-  build-docker-rhivos2-test-server-aarch64:
-    description: Build and upload a Docker image for a rhivos2 container with a remote testserver.
-    docker:
-      - image: cimg/base:current
-    resource_class: arm.medium # 2-core
-    steps:
-      - aws-cli/install:
-          version: << pipeline.parameters.awscli-version >>
-          override_installed: true
-      - ferrocene/aws_oidc_auth
-      - ferrocene/git_shallow_clone:
-          depth: 1
-      - setup_remote_docker:
-          version: default # Only default and edge are supported: https://circleci.com/docs/building-docker-images/#docker-version
-      - run:
-          name: Install required packages
-          command: sudo apt update && sudo apt install zstd
-      - run:
-          name: Restore files from the aarch64-linux-build job
-          command: ferrocene/ci/scripts/persist-between-jobs.sh restore aarch64-linux-build
-      - run:
-          name: Build and upload the Docker image
-          command: ferrocene/ci/scripts/build-and-push-docker-image.sh
-          environment:
-            IMAGE_NAME: rhivos-2.0-test-server
-            IMAGE_TAG: run-id.<< pipeline.parameters.stable-workflow-id >>.rhivos-2.0-test-server
-
-  # The image gets built for every job because it needs to contain build results per job
-  build-docker-rhel-test-server-aarch64:
-    description: Job that builds and uploads a Docker image for a rhel container with a remote testserver.
-    docker:
-      - image: cimg/base:current
-    resource_class: arm.medium # 2-core
-    steps:
-      - aws-cli/install:
-          version: << pipeline.parameters.awscli-version >>
-          override_installed: true
-      - ferrocene/aws_oidc_auth
-      - ferrocene/git_shallow_clone:
-          depth: 1
-      - setup_remote_docker:
-          version: default # Only default and edge are supported: https://circleci.com/docs/building-docker-images/#docker-version
-      - run:
-          name: Install required packages
-          command: sudo apt update && sudo apt install zstd
-      - run:
-          name: Restore files from the aarch64-linux-build job
-          command: ferrocene/ci/scripts/persist-between-jobs.sh restore aarch64-linux-build
-      - run:
-          name: Build and upload the Docker image
-          command: ferrocene/ci/scripts/build-and-push-docker-image.sh
-          environment:
-            IMAGE_NAME: rhel-10.1-test-server
-            IMAGE_TAG: run-id.<< pipeline.parameters.stable-workflow-id >>.rhel-10.1-test-server
 
   # Misc jobs
   wasm-dist-oxidos:
@@ -1463,12 +1420,28 @@ workflows:
             - x86_64-linux-dist
 
       # RHEL Test Infrastructure
-      - build-docker-rhel-test-server-aarch64:
+      # The image gets built for every job because it needs to contain build results per job
+      - build-docker:
+          name: build-docker-rhel-test-server-aarch64
+          image: rhel-10.1-test-server
+          tag: run-id.<< pipeline.parameters.stable-workflow-id >>.rhel-10.1-test-server
+          rebuild: true
+          resource_class: arm.medium
+          awscli_version: << pipeline.parameters.awscli-version >>
+          restore_from_job: aarch64-linux-build
           requires:
             - aarch64-linux-build
 
       # RHIVOS2 Test Infrastructure
-      - build-docker-rhivos2-test-server-aarch64:
+      # The image gets built for every job because it needs to contain build results per job
+      - build-docker:
+          name: build-docker-rhivos2-test-server-aarch64
+          image: rhivos-2.0-test-server
+          tag: run-id.<< pipeline.parameters.stable-workflow-id >>.rhivos-2.0-test-server
+          rebuild: true
+          resource_class: arm.medium
+          awscli_version: << pipeline.parameters.awscli-version >>
+          restore_from_job: aarch64-linux-build
           requires:
             - aarch64-linux-build
       - aarch64-linux-rhivos2-test-container:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -967,12 +967,16 @@ jobs:
   # Job to build and upload a Docker image defined ferrocene/ci/docker-images.
   # If the image exists in the remote storage and is up to date, the job will
   # early exit without doing any work.
-  build-docker-x86_64:
-    description: Job that builds and uploads a Docker image on an x86_64 host, if needed.
+  build-docker:
+    description: Job that builds and uploads a Docker image on, if needed.
     docker:
       - image: cimg/base:current
-    resource_class: large # 4-core
     parameters:
+      architecture:
+        description: The architecture to build for (currently either x86_64 or aarch64)
+        type: string
+      resource_class:
+        description: the resource_class to use (must match the architecture)
       image:
         description: The image that needs to be built
         type: string
@@ -982,49 +986,16 @@ jobs:
       rebuild:
         description: Whether the image should be rebuilt or not
         type: boolean
+      awscli_version:
+        description: The AWS-CLI version to install for auth
+        type: string
+    resource_class: << parameters.resource_class >>
     steps:
       - when:
           condition: << parameters.rebuild >>
           steps:
             - aws-cli/install:
-                version: << pipeline.parameters.awscli-version >>
-                override_installed: true
-            - ferrocene/aws_oidc_auth
-            - ferrocene/git_shallow_clone:
-                depth: 1
-            - setup_remote_docker:
-                version: default
-            - run:
-                name: Build and upload the Docker image, if needed
-                command: ferrocene/ci/scripts/build-and-push-docker-image.sh
-                environment:
-                  IMAGE_NAME: << parameters.image >>
-                  IMAGE_TAG: << parameters.tag >>
-      - run:
-          name: Empty step to make sure the job always has steps
-          command: echo
-
-  build-docker-aarch64:
-    description: Job that builds and uploads a Docker image on an aarch64 host, if needed.
-    docker:
-      - image: cimg/base:current
-    resource_class: arm.medium # 2-core
-    parameters:
-      image:
-        description: The image that needs to be built
-        type: string
-      tag:
-        description: The tag of the image that needs to be build
-        type: string
-      rebuild:
-        description: Whether the image should be rebuilt or not
-        type: boolean
-    steps:
-      - when:
-          condition: << parameters.rebuild >>
-          steps:
-            - aws-cli/install:
-                version: << pipeline.parameters.awscli-version >>
+                version: << parameters.awscli_version >>
                 override_installed: true
             - ferrocene/aws_oidc_auth
             - ferrocene/git_shallow_clone:
@@ -1188,23 +1159,29 @@ workflows:
         - equal: [<< pipeline.git.branch >>, "trying"]
         - equal: [<< pipeline.trigger_source >>, "api"]
     jobs:
-      - build-docker-x86_64:
+      - build-docker:
           name: build-docker--ubuntu-20--x86_64
           image: ubuntu-20
           tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
           rebuild: << pipeline.parameters.docker-image-rebuild--ci-docker-images--x86_64--ubuntu-20 >>
+          resource_class: large.gen2
+          awscli_version: << pipeline.parameters.awscli-version >>
 
-      - build-docker-x86_64:
+      - build-docker:
           name: build-docker--ubuntu-24--x86_64
           image: ubuntu-24
           tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-24 >>
           rebuild: << pipeline.parameters.docker-image-rebuild--ci-docker-images--x86_64--ubuntu-24 >>
+          resource_class: large.gen2
+          awscli_version: << pipeline.parameters.awscli-version >>
 
-      - build-docker-aarch64:
+      - build-docker:
           name: build-docker--ubuntu-20--aarch64
           image: ubuntu-20
           tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
           rebuild: << pipeline.parameters.docker-image-rebuild--ci-docker-images--aarch64--ubuntu-20 >>
+          resource_class: arm.medium
+          awscli_version: << pipeline.parameters.awscli-version >>
 
       - misc-checks:
           requires:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -737,6 +737,7 @@ jobs:
             - ferrocene/checkout
             - ferrocene/setup:
                 awscli_version: << pipeline.parameters.awscli-version >>
+                override_installed: false
                 os: windows
                 llvm_build: true
             - ferrocene/ci
@@ -776,6 +777,7 @@ jobs:
           steps:
             - ferrocene-job-dist:
                 os: windows
+
       - run:
           name: Empty step to make sure the job always has steps
           command: echo
@@ -797,6 +799,7 @@ jobs:
                 depth: 1
             - ferrocene/setup:
                 awscli_version: << pipeline.parameters.awscli-version >>
+                override_installed: false
                 os: windows
             - setup-qnx-toolchain: {}
             - run:
@@ -823,6 +826,7 @@ jobs:
                 depth: 1
             - ferrocene/setup:
                 awscli_version: << pipeline.parameters.awscli-version >>
+                override_installed: false
                 os: windows
             - setup-qnx8-toolchain: {}
             - run:
@@ -1467,11 +1471,18 @@ commands:
       llvm_build:
         type: boolean
         default: false
+      awscli_version:
+        type: string
+        default: << pipeline.parameters.awscli-version >>
+      override_installed:
+        type: boolean
+        default: false
     steps:
       - ferrocene/checkout:
           llvm_subset: true
       - ferrocene/setup:
-          awscli_version: << pipeline.parameters.awscli-version >>
+          awscli_version: << parameters.awscli_version >>
+          override_installed: << parameters.override_installed >>
           os: <<parameters.os>>
           llvm_build: << parameters.llvm_build >>
       - ferrocene/ci
@@ -1491,6 +1502,12 @@ commands:
       os:
         type: string
         default: linux # Or `windows` or `darwin`
+      awscli_version:
+        type: string
+        default: << pipeline.parameters.awscli-version >>
+      override_installed:
+        type: boolean
+        default: false
       restore-from-job:
         type: string
         default: ""
@@ -1507,8 +1524,9 @@ commands:
       - ferrocene/checkout:
           llvm_subset: << parameters.llvm_subset >>
       - ferrocene/setup:
-          awscli_version: << pipeline.parameters.awscli-version >>
-          os: <<parameters.os>>    parameters:
+          awscli_version: << parameters.awscli_version >>
+          override_installed: << parameters.override_installed >>
+          os: <<parameters.os>>
           llvm_build: false
       - when:
           condition: <<parameters.restore-from-job>>

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -119,7 +119,7 @@ parameters:
 orbs:
   aws-cli: circleci/aws-cli@5.4.2
   win: circleci/windows@5.0
-  ferrocene: ferrocene/ferrocene-common@dev:main
+  ferrocene: ferrocene/ferrocene-common@26080.3.0
 
 jobs:
   # Container dedicated to running ad-hoc tests that don't depend on an

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -117,7 +117,6 @@ parameters:
     default: ""
 
 orbs:
-  aws-cli: circleci/aws-cli@5.4.2
   win: circleci/windows@5.0
   ferrocene: ferrocene/ferrocene-common@26080.3.0 # https://circleci.com/developer/orbs/orb/ferrocene/ferrocene-common?version=26080.3.0#orb-source
 

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -537,8 +537,8 @@ jobs:
   aarch64-linux-rhivos2-test-container:
     executor:
       name: ferrocene/facade_testserver
-      test_image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
-      testserver_image: 886866542769.dkr.ecr.us-east-1.amazonaws.com/ci-docker-images:run-id.<< pipeline.parameters.stable-workflow-id >>.rhivos-2.0-test-server
+      test_image: harbor.infra.ferrous-systems.net/ferrocene-ci-ecr-cache/ci-docker-images:<< pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+      testserver_image: harbor.infra.ferrous-systems.net/ferrocene-ci-ecr-cache/ci-docker-images:run-id.<< pipeline.parameters.stable-workflow-id >>.rhivos-2.0-test-server
       target:  aarch64-rhivos2-linux-gnu
     parameters:
       tasks:

--- a/ferrocene/ci/docker-images/common/run-testserver.sh
+++ b/ferrocene/ci/docker-images/common/run-testserver.sh
@@ -3,9 +3,14 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: The Ferrocene Developers
 
+# call as run-testserver.sh <TARGET> <TEST_DEVICE_ADDR> <EMULATED> <QEMU_VERSION> <QEMU_ARCH>
 set -xe
 
-# print our env
+TARGET=$1
+TEST_DEVICE_ADDR=$2
+EMULATED=$3
+QEMU_VERSION=$4
+QEMU_ARCH=$5
 
 env
 

--- a/ferrocene/ci/docker-images/common/run-testserver.sh
+++ b/ferrocene/ci/docker-images/common/run-testserver.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -xe
+
+EMULATOR=""
+if $EMULATED; then EMULATOR=/opt/qemu-ferrocene/${QEMU_VERSION}/bin/${QEMU_ARCH}; fi
+${EMULATOR} \
+/bin/test-server/$1/remote-test-server -v --bind $TEST_DEVICE_ADDR

--- a/ferrocene/ci/docker-images/common/run-testserver.sh
+++ b/ferrocene/ci/docker-images/common/run-testserver.sh
@@ -15,6 +15,8 @@ QEMU_ARCH=$5
 env
 
 EMULATOR=""
-if $EMULATED; then EMULATOR=/opt/qemu-ferrocene/${QEMU_VERSION}/bin/${QEMU_ARCH}; fi
+if [[ "$EMULATED" == "true" ]];
+    then EMULATOR=/opt/qemu-ferrocene/${QEMU_VERSION}/bin/${QEMU_ARCH};
+fi
 ${EMULATOR} \
 /bin/test-server/$1/remote-test-server -v --bind $TEST_DEVICE_ADDR

--- a/ferrocene/ci/docker-images/common/run-testserver.sh
+++ b/ferrocene/ci/docker-images/common/run-testserver.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
 set -xe
 
 EMULATOR=""

--- a/ferrocene/ci/docker-images/common/run-testserver.sh
+++ b/ferrocene/ci/docker-images/common/run-testserver.sh
@@ -5,6 +5,10 @@
 
 set -xe
 
+# print our env
+
+env
+
 EMULATOR=""
 if $EMULATED; then EMULATOR=/opt/qemu-ferrocene/${QEMU_VERSION}/bin/${QEMU_ARCH}; fi
 ${EMULATOR} \

--- a/ferrocene/ci/docker-images/rhel-10.1-test-server/Dockerfile
+++ b/ferrocene/ci/docker-images/rhel-10.1-test-server/Dockerfile
@@ -10,6 +10,8 @@ FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi10:10.1
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
+COPY --chmod=0700 ferrocene/ci/docker-images/common/run-testserver.sh /bin/run-testserver.sh
+
 RUN mkdir -p /bin/test-server/aarch64-unknown-linux-gnu
 RUN mkdir -p /bin/test-server/aarch64-rhivos2-linux-gnu
 COPY build/aarch64-unknown-linux-gnu/stage2-tools/aarch64-unknown-linux-gnu/release/remote-test-server /bin/test-server/aarch64-unknown-linux-gnu/remote-test-server

--- a/ferrocene/ci/docker-images/rhivos-2.0-test-server/Dockerfile
+++ b/ferrocene/ci/docker-images/rhivos-2.0-test-server/Dockerfile
@@ -9,5 +9,6 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 RUN mkdir -p /bin/test-server/aarch64-rhivos2-linux-gnu
+COPY --chmod=0700 ferrocene/ci/docker-images/common/run-testserver.sh /bin/run-testserver.sh
 COPY build/aarch64-unknown-linux-gnu/stage2-tools/aarch64-rhivos2-linux-gnu/release/remote-test-server /bin/test-server/aarch64-rhivos2-linux-gnu/remote-test-server
 CMD [ "sleep", "5000" ]

--- a/ferrocene/ci/docker-images/ubuntu-20/force_rebuild
+++ b/ferrocene/ci/docker-images/ubuntu-20/force_rebuild
@@ -1,0 +1,2 @@
+# increment this to force a rebuild
+GENERATION 1

--- a/ferrocene/ci/docker-images/ubuntu-20/force_rebuild
+++ b/ferrocene/ci/docker-images/ubuntu-20/force_rebuild
@@ -1,2 +1,5 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
 # increment this to force a rebuild
 GENERATION 1

--- a/ferrocene/ci/docker-images/ubuntu-24/force_rebuild
+++ b/ferrocene/ci/docker-images/ubuntu-24/force_rebuild
@@ -1,0 +1,2 @@
+# increment this to force a rebuild
+GENERATION 1

--- a/ferrocene/ci/docker-images/ubuntu-24/force_rebuild
+++ b/ferrocene/ci/docker-images/ubuntu-24/force_rebuild
@@ -1,2 +1,5 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
 # increment this to force a rebuild
 GENERATION 1


### PR DESCRIPTION
This PR moves shared parts of the CI workflow definitions into a circleci orb at https://github.com/ferrocene/circleci-orb-ferrocene-common

While this means that we're suffering from the added friction of having a two-stage development process for changes to these parts, it significantly improves the development process of the shared parts because the orb development process is better organized. Orb are split into multiple files that allow for better separation and visibility, has tooling to lint both shell comands and yaml files and is in general easier to work with. It also allows reusing parts across multiple configuration files.

Most of the extracted parts have essentially been stable for an extended period of time, so I would expect that we don't see much development on the extracted parts.

This PR contains changes to the remote-testserver startup which are not immediately relevant to this change, but will be in future PRs.