### PR TITLE
feat: tag built ci docker images with stable aliases on main

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1029,11 +1029,10 @@ jobs:
           name: Empty step to make sure the job always has steps
           command: echo
 
-  alias-docker-x86_64:
-    description: Specialized version of build-docker-x86_64 for running on main and tagging the image as such
+  alias-docker:
+    description: Specialized version of build-docker-* for running on main and tagging the image as such
     docker:
       - image: cimg/base:current
-    resource_class: large # 4-core
     parameters:
       image:
         description: The image that needs to be built
@@ -1044,6 +1043,10 @@ jobs:
       alias:
         description: The tag of the alias to push
         type: string
+      resource_class:
+        description: Resource class of the runner
+        type: string
+    resource_class: << parameters.resource_class >>
     steps:
       - aws-cli/install:
           version: << pipeline.parameters.awscli-version >>
@@ -1096,37 +1099,6 @@ jobs:
       - run:
           name: Empty step to make sure the job always has steps
           command: echo
-
-  alias-docker-aarch64:
-    description: Specialized version of build-docker-aarch64 for running on main and tagging the image as such
-    docker:
-      - image: cimg/base:current
-    resource_class: arm.medium # 2-core
-    parameters:
-      image:
-        description: The image that needs to be built
-        type: string
-      tag:
-        description: The tag of the image that needs to be built
-        type: string
-      alias:
-        description: The tag of the alias to push
-        type: string
-    steps:
-      - aws-cli/install:
-          version: << pipeline.parameters.awscli-version >>
-          override_installed: true
-      - aws-oidc-auth
-      - ferrocene-git-shallow-clone:
-          depth: 1
-      - setup_remote_docker:
-          version: default
-      - run:
-          name: Maybe build x86_64-<< parameters.image >> and upload
-          environment:
-            ECR_REPOSITORY: ci-docker-images
-            ECR_REGION: us-east-1
-          command: ferrocene/ci/scripts/maybe-build-push-and-alias-docker-images.sh '<< parameters.image >>' '<< parameters.tag >>' '<< parameters.alias >>'
 
   # The image gets built for every job because it needs to contain build results per job
   build-docker-rhivos2-test-server-aarch64:
@@ -1685,20 +1657,23 @@ workflows:
   tag-images:
     jobs:
       # tag built docker images with the `:main` tag
-      - alias-docker-x86_64:
+      - alias-docker:
           filters: pipeline.git.branch == "main"
+          resource_class: large # 4-core
           name: alias-docker-x86_64-ubuntu-20
           image: ubuntu-20
           tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
           alias: x86_64-ubuntu-20
-      - alias-docker-x86_64:
+      - alias-docker:
           filters: pipeline.git.branch == "main"
+          resource_class: large # 4-core
           name: alias-docker-x86_64-ubuntu-24
           image: ubuntu-24
           tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-24 >>
           alias: x86_64-ubuntu-24
-      - alias-docker-aarch64:
+      - alias-docker:
           filters: pipeline.git.branch == "main"
+          resource_class: arm.medium # 2-core
           name: alias-docker-aarch64-ubuntu-20
           image: ubuntu-20
           tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1058,30 +1058,7 @@ jobs:
           environment:
             ECR_REPOSITORY: ci-docker-images
             ECR_REGION: us-east-1
-          command: |
-            account="$(aws sts get-caller-identity --region "${ECR_REGION}" | jq -r .Account)"
-            registry="${account}.dkr.ecr.${ECR_REGION}.amazonaws.com"
-
-            aws ecr get-login-password --region "${ECR_REGION}" \
-              | docker login --username AWS --password-stdin "${registry}"
-
-            manifest="$(aws ecr batch-get-image --repository-name "$ECR_REPOSITORY" --image-ids imageTag='<< parameters.tag >>' --output text --query 'images[].imageManifest')"
-            if [[ "$?" -ne '0' ]]; then
-              echo "image << parameters.tag >> doesn't exist, building..."
-              IMAGE_NAME="<< parameters.image >>" \
-                IMAGE_TAG="<< parameters.tag >>" \
-                ferrocene/ci/scripts/build-and-push-docker-image.sh
-              manifest="$(aws ecr batch-get-image --repository-name "$ECR_REPOSITORY" --image-ids imageTag='<< parameters.tag >>' --output text --query 'images[].imageManifest')"
-            else
-              alias_manifest="$(aws ecr batch-get-image --repository-name "$ECR_REPOSITORY" --image-ids imageTag='<< parameters.alias >>' --output text --query 'images[].imageManifest')"
-              src_digest="$(echo "$manifest" | jq -r .config.digest)"
-              alias_digest="$(echo "$alias_manifest" | jq -r .config.digest)"
-              if [[ "$src_digest" == "$alias_digest" ]]; then
-                echo "alias << parameters.alias >> already points to << parameters.tag >>"
-                exit 0
-              fi
-            fi
-            aws ecr put-image --repository-name "$ECR_REPOSITORY" --image-tag '<< parameters.alias >>' --image-manifest "$manifest"
+          command: ferrocene/ci/scripts/maybe-build-push-and-alias-docker-images.sh '<< parameters.image >>' '<< parameters.tag >>' '<< parameters.alias >>'
 
   build-docker-aarch64:
     description: Job that builds and uploads a Docker image on an aarch64 host, if needed.
@@ -1149,30 +1126,7 @@ jobs:
           environment:
             ECR_REPOSITORY: ci-docker-images
             ECR_REGION: us-east-1
-          command: |
-            account="$(aws sts get-caller-identity --region "${ECR_REGION}" | jq -r .Account)"
-            registry="${account}.dkr.ecr.${ECR_REGION}.amazonaws.com"
-
-            aws ecr get-login-password --region "${ECR_REGION}" \
-              | docker login --username AWS --password-stdin "${registry}"
-
-            manifest="$(aws ecr batch-get-image --repository-name "$ECR_REPOSITORY" --image-ids imageTag='<< parameters.tag >>' --output text --query 'images[].imageManifest')"
-            if [[ "$?" -ne '0' ]]; then
-              echo "image << parameters.tag >> doesn't exist, building..."
-              IMAGE_NAME="<< parameters.image >>" \
-                IMAGE_TAG="<< parameters.tag >>" \
-                ferrocene/ci/scripts/build-and-push-docker-image.sh
-              manifest="$(aws ecr batch-get-image --repository-name "$ECR_REPOSITORY" --image-ids imageTag='<< parameters.tag >>' --output text --query 'images[].imageManifest')"
-            else
-              alias_manifest="$(aws ecr batch-get-image --repository-name "$ECR_REPOSITORY" --image-ids imageTag='<< parameters.alias >>' --output text --query 'images[].imageManifest')"
-              src_digest="$(echo "$manifest" | jq -r .config.digest)"
-              alias_digest="$(echo "$alias_manifest" | jq -r .config.digest)"
-              if [[ "$src_digest" == "$alias_digest" ]]; then
-                echo "alias << parameters.alias >> already points to << parameters.tag >>"
-                exit 0
-              fi
-            fi
-            aws ecr put-image --repository-name "$ECR_REPOSITORY" --image-tag '<< parameters.alias >>' --image-manifest "$manifest"
+          command: ferrocene/ci/scripts/maybe-build-push-and-alias-docker-images.sh '<< parameters.image >>' '<< parameters.tag >>' '<< parameters.alias >>'
 
   # The image gets built for every job because it needs to contain build results per job
   build-docker-rhivos2-test-server-aarch64:
@@ -1728,8 +1682,7 @@ workflows:
     jobs:
       - skip
 
-  # workflow for miscellaneous tasks that don't affect the status of a commit
-  misc:
+  tag-images:
     jobs:
       # tag built docker images with the `:main` tag
       - alias-docker-x86_64:
@@ -1739,14 +1692,14 @@ workflows:
           tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
           alias: x86_64-ubuntu-20
       - alias-docker-x86_64:
-          name: alias-docker-x86_64-ubuntu-24
           filters: pipeline.git.branch == "main"
+          name: alias-docker-x86_64-ubuntu-24
           image: ubuntu-24
           tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-24 >>
           alias: x86_64-ubuntu-24
       - alias-docker-aarch64:
-          name: alias-docker-aarch64-ubuntu-20
           filters: pipeline.git.branch == "main"
+          name: alias-docker-aarch64-ubuntu-20
           image: ubuntu-20
           tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
           alias: aarch64-ubuntu-20

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1029,6 +1029,60 @@ jobs:
           name: Empty step to make sure the job always has steps
           command: echo
 
+  alias-docker-x86_64:
+    description: Specialized version of build-docker-x86_64 for running on main and tagging the image as such
+    docker:
+      - image: cimg/base:current
+    resource_class: large # 4-core
+    parameters:
+      image:
+        description: The image that needs to be built
+        type: string
+      tag:
+        description: The tag of the image that needs to be built
+        type: string
+      alias:
+        description: The tag of the alias to push
+        type: string
+    steps:
+      - aws-cli/install:
+          version: << pipeline.parameters.awscli-version >>
+          override_installed: true
+      - aws-oidc-auth
+      - ferrocene-git-shallow-clone:
+          depth: 1
+      - setup_remote_docker:
+          version: default
+      - run:
+          name: Maybe build x86_64-<< parameters.image >> and upload
+          environment:
+            ECR_REPOSITORY: ci-docker-images
+            ECR_REGION: us-east-1
+          command: |
+            account="$(aws sts get-caller-identity --region "${ECR_REGION}" | jq -r .Account)"
+            registry="${account}.dkr.ecr.${ECR_REGION}.amazonaws.com"
+
+            aws ecr get-login-password --region "${ECR_REGION}" \
+              | docker login --username AWS --password-stdin "${registry}"
+
+            manifest="$(aws ecr batch-get-image --repository-name "$ECR_REPOSITORY" --image-ids imageTag='<< parameters.tag >>' --output text --query 'images[].imageManifest')"
+            if [[ "$?" -ne '0' ]]; then
+              echo "image << parameters.tag >> doesn't exist, building..."
+              IMAGE_NAME="<< parameters.image >>" \
+                IMAGE_TAG="<< parameters.tag >>" \
+                ferrocene/ci/scripts/build-and-push-docker-image.sh
+              manifest="$(aws ecr batch-get-image --repository-name "$ECR_REPOSITORY" --image-ids imageTag='<< parameters.tag >>' --output text --query 'images[].imageManifest')"
+            else
+              alias_manifest="$(aws ecr batch-get-image --repository-name "$ECR_REPOSITORY" --image-ids imageTag='<< parameters.alias >>' --output text --query 'images[].imageManifest')"
+              src_digest="$(echo "$manifest" | jq -r .config.digest)"
+              alias_digest="$(echo "$alias_manifest" | jq -r .config.digest)"
+              if [[ "$src_digest" == "$alias_digest" ]]; then
+                echo "alias << parameters.alias >> already points to << parameters.tag >>"
+                exit 0
+              fi
+            fi
+            aws ecr put-image --repository-name "$ECR_REPOSITORY" --image-tag '<< parameters.alias >>' --image-manifest "$manifest"
+
   build-docker-aarch64:
     description: Job that builds and uploads a Docker image on an aarch64 host, if needed.
     docker:
@@ -1065,6 +1119,60 @@ jobs:
       - run:
           name: Empty step to make sure the job always has steps
           command: echo
+
+  alias-docker-aarch64:
+    description: Specialized version of build-docker-aarch64 for running on main and tagging the image as such
+    docker:
+      - image: cimg/base:current
+    resource_class: arm.medium # 2-core
+    parameters:
+      image:
+        description: The image that needs to be built
+        type: string
+      tag:
+        description: The tag of the image that needs to be built
+        type: string
+      alias:
+        description: The tag of the alias to push
+        type: string
+    steps:
+      - aws-cli/install:
+          version: << pipeline.parameters.awscli-version >>
+          override_installed: true
+      - aws-oidc-auth
+      - ferrocene-git-shallow-clone:
+          depth: 1
+      - setup_remote_docker:
+          version: default
+      - run:
+          name: Maybe build x86_64-<< parameters.image >> and upload
+          environment:
+            ECR_REPOSITORY: ci-docker-images
+            ECR_REGION: us-east-1
+          command: |
+            account="$(aws sts get-caller-identity --region "${ECR_REGION}" | jq -r .Account)"
+            registry="${account}.dkr.ecr.${ECR_REGION}.amazonaws.com"
+
+            aws ecr get-login-password --region "${ECR_REGION}" \
+              | docker login --username AWS --password-stdin "${registry}"
+
+            manifest="$(aws ecr batch-get-image --repository-name "$ECR_REPOSITORY" --image-ids imageTag='<< parameters.tag >>' --output text --query 'images[].imageManifest')"
+            if [[ "$?" -ne '0' ]]; then
+              echo "image << parameters.tag >> doesn't exist, building..."
+              IMAGE_NAME="<< parameters.image >>" \
+                IMAGE_TAG="<< parameters.tag >>" \
+                ferrocene/ci/scripts/build-and-push-docker-image.sh
+              manifest="$(aws ecr batch-get-image --repository-name "$ECR_REPOSITORY" --image-ids imageTag='<< parameters.tag >>' --output text --query 'images[].imageManifest')"
+            else
+              alias_manifest="$(aws ecr batch-get-image --repository-name "$ECR_REPOSITORY" --image-ids imageTag='<< parameters.alias >>' --output text --query 'images[].imageManifest')"
+              src_digest="$(echo "$manifest" | jq -r .config.digest)"
+              alias_digest="$(echo "$alias_manifest" | jq -r .config.digest)"
+              if [[ "$src_digest" == "$alias_digest" ]]; then
+                echo "alias << parameters.alias >> already points to << parameters.tag >>"
+                exit 0
+              fi
+            fi
+            aws ecr put-image --repository-name "$ECR_REPOSITORY" --image-tag '<< parameters.alias >>' --image-manifest "$manifest"
 
   # The image gets built for every job because it needs to contain build results per job
   build-docker-rhivos2-test-server-aarch64:
@@ -1619,6 +1727,29 @@ workflows:
             value: << pipeline.git.branch >>
     jobs:
       - skip
+
+  # workflow for miscellaneous tasks that don't affect the status of a commit
+  misc:
+    jobs:
+      # tag built docker images with the `:main` tag
+      - alias-docker-x86_64:
+          filters: pipeline.git.branch == "main"
+          name: alias-docker-x86_64-ubuntu-20
+          image: ubuntu-20
+          tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+          alias: x86_64-ubuntu-20
+      - alias-docker-x86_64:
+          name: alias-docker-x86_64-ubuntu-24
+          filters: pipeline.git.branch == "main"
+          image: ubuntu-24
+          tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-24 >>
+          alias: x86_64-ubuntu-24
+      - alias-docker-aarch64:
+          name: alias-docker-aarch64-ubuntu-20
+          filters: pipeline.git.branch == "main"
+          image: ubuntu-20
+          tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+          alias: aarch64-ubuntu-20
 
 commands:
   ferrocene-job-build:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1037,8 +1037,8 @@ jobs:
       image:
         description: The image that needs to be built
         type: string
-      tag:
-        description: The tag of the image that needs to be built
+      src:
+        description: The tag of the image that needs to be aliased
         type: string
       alias:
         description: The tag of the alias to push
@@ -1057,11 +1057,11 @@ jobs:
       - setup_remote_docker:
           version: default
       - run:
-          name: Maybe build x86_64-<< parameters.image >> and upload
+          name: alias << parameters.image >> from << parameters.src >> to << parameters.alias >>
           environment:
             ECR_REPOSITORY: ci-docker-images
             ECR_REGION: us-east-1
-          command: ferrocene/ci/scripts/maybe-build-push-and-alias-docker-images.sh '<< parameters.image >>' '<< parameters.tag >>' '<< parameters.alias >>'
+          command: ferrocene/ci/scripts/alias-docker-image-tag.sh '<< parameters.image >>' '<< parameters.src >>' '<< parameters.alias >>'
 
   build-docker-aarch64:
     description: Job that builds and uploads a Docker image on an aarch64 host, if needed.
@@ -1655,28 +1655,52 @@ workflows:
       - skip
 
   tag-images:
+    when:
+      equal: [<< pipeline.git.branch >>, main]
     jobs:
-      # tag built docker images with the `:main` tag
-      - alias-docker:
-          filters: pipeline.git.branch == "main"
-          resource_class: large # 4-core
-          name: alias-docker-x86_64-ubuntu-20
+      - build-docker-x86_64:
+          name: build-docker--ubuntu-20--x86_64
           image: ubuntu-20
           tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-          alias: x86_64-ubuntu-20
+          rebuild: << pipeline.parameters.docker-image-rebuild--ci-docker-images--x86_64--ubuntu-20 >>
+
       - alias-docker:
-          filters: pipeline.git.branch == "main"
+          name: alias-docker-x86_64-ubuntu-20
+          requires:
+            - build-docker--ubuntu-20--x86_64
           resource_class: large # 4-core
-          name: alias-docker-x86_64-ubuntu-24
+          image: ubuntu-20
+          src: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+          alias: x86_64-ubuntu-20
+
+      - build-docker-x86_64:
+          name: build-docker--ubuntu-24--x86_64
           image: ubuntu-24
           tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-24 >>
-          alias: x86_64-ubuntu-24
+          rebuild: << pipeline.parameters.docker-image-rebuild--ci-docker-images--x86_64--ubuntu-24 >>
+
       - alias-docker:
-          filters: pipeline.git.branch == "main"
-          resource_class: arm.medium # 2-core
-          name: alias-docker-aarch64-ubuntu-20
+          name: alias-docker-x86_64-ubuntu-24
+          requires:
+            - build-docker--ubuntu-24--x86_64
+          resource_class: large # 4-core
+          image: ubuntu-24
+          src: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-24 >>
+          alias: x86_64-ubuntu-24
+
+      - build-docker-aarch64:
+          name: build-docker--ubuntu-20--aarch64
           image: ubuntu-20
           tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+          rebuild: << pipeline.parameters.docker-image-rebuild--ci-docker-images--aarch64--ubuntu-20 >>
+
+      - alias-docker:
+          name: alias-docker-aarch64-ubuntu-20
+          requires:
+            - build-docker--ubuntu-20--aarch64
+          resource_class: arm.medium # 2-core
+          image: ubuntu-20
+          src: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
           alias: aarch64-ubuntu-20
 
 commands:

--- a/ferrocene/ci/scripts/alias-docker-image-tag.sh
+++ b/ferrocene/ci/scripts/alias-docker-image-tag.sh
@@ -26,29 +26,29 @@ function get_manifest() {
 }
 
 function get_manifest_digest() {
-    echo "$1" | jq -r .config.digest
+    echo "$1" | jq -er .config.digest
 }
 
 aws ecr get-login-password --region "${ECR_REGION}" \
     | docker login --username AWS --password-stdin "${registry}"
 
-src_manifest="$(get_manifest "$SRC")"
-src_digest="$(get_manifest_digest "$src_manifest")"
-if [[ -n "$src_digest" ]]; then
-    echo "image $SRC exists"
-    alias_manifest="$(get_manifest "$ALIAS")"
-    alias_digest="$(get_manifest_digest "$alias_manifest")"
-    if [[ "$src_digest" == "$alias_digest" ]]; then
-        echo "alias $ALIAS already points to $SRC"
-        exit 0
-    fi
-else
-    echo "image $SRC doesn't exist, building..."
-    IMAGE_NAME="$IMAGE" \
-    IMAGE_TAG="$SRC" \
-    ferrocene/ci/scripts/build-and-push-docker-image.sh
-    src_manifest="$(get_manifest "$SRC")"
+echo "getting source tag manifest..."
+if ! src_manifest="$(get_manifest "$SRC")" \
+    || ! src_digest="$(get_manifest_digest "$src_manifest")" \
+    || [[ -z "$src_digest" ]];
+then
+    echo "image $SRC does not exist"
+    exit 1
 fi
 
-echo "aliasing $ALIAS to $SRC"
+echo "getting alias tag manifest..."
+if alias_manifest="$(get_manifest "$ALIAS")" \
+    && alias_digest="$(get_manifest_digest "$alias_manifest")" \
+    && [[ "$src_digest" == "$alias_digest" ]];
+then
+    echo "alias $ALIAS already points to $SRC"
+    exit 0
+fi
+
+echo "aliasing $ALIAS to $SRC..."
 aws ecr put-image --repository-name "$ECR_REPOSITORY" --image-tag "$ALIAS" --image-manifest "$src_manifest"

--- a/ferrocene/ci/scripts/maybe-build-push-and-alias-docker-images.sh
+++ b/ferrocene/ci/scripts/maybe-build-push-and-alias-docker-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: The Ferrocene Developers
 

--- a/ferrocene/ci/scripts/maybe-build-push-and-alias-docker-images.sh
+++ b/ferrocene/ci/scripts/maybe-build-push-and-alias-docker-images.sh
@@ -29,12 +29,6 @@ aws ecr get-login-password --region "${ECR_REGION}" \
 
 manifest=""
 if manifest="$(get_manifest "$SRC")"; then
-    echo "image $SRC doesn't exist, building..."
-    IMAGE_NAME="$IMAGE" \
-    IMAGE_TAG="$SRC" \
-    ferrocene/ci/scripts/build-and-push-docker-image.sh
-    manifest="$(get_manifest "$SRC")"
-else
     alias_manifest="$(get_manifest "$ALIAS")"
     src_digest="$(echo "$manifest" | get_manifest_digest)"
     alias_digest="$(echo "$alias_manifest" | get_manifest_digest)"
@@ -42,6 +36,12 @@ else
         echo "alias $ALIAS already points to $SRC"
         exit 0
     fi
+else
+    echo "image $SRC doesn't exist, building..."
+    IMAGE_NAME="$IMAGE" \
+    IMAGE_TAG="$SRC" \
+    ferrocene/ci/scripts/build-and-push-docker-image.sh
+    manifest="$(get_manifest "$SRC")"
 fi
 
 aws ecr put-image --repository-name "$ECR_REPOSITORY" --image-tag "$ALIAS" --image-manifest "$manifest"

--- a/ferrocene/ci/scripts/maybe-build-push-and-alias-docker-images.sh
+++ b/ferrocene/ci/scripts/maybe-build-push-and-alias-docker-images.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+set -euo pipefail
+
+IMAGE="${1:-}"
+SRC="${2:-}"
+ALIAS="${3:-}"
+
+if [[ -z "$IMAGE" ]] || [[ -z "$SRC" ]] || [[ -z "$ALIAS" ]]; then
+    echo "USAGE: $0 IMAGE SRC ALIAS"
+    exit 1
+fi
+
+account="$(aws sts get-caller-identity --region "${ECR_REGION}" | jq -r .Account)"
+registry="${account}.dkr.ecr.${ECR_REGION}.amazonaws.com"
+
+function get_manifest() {
+    aws ecr batch-get-image --repository-name "$ECR_REPOSITORY" --image-ids imageTag="$1" --output text --query 'images[].imageManifest'
+}
+
+function get_manifest_digest() {
+    jq -r .config.digest
+}
+
+aws ecr get-login-password --region "${ECR_REGION}" \
+    | docker login --username AWS --password-stdin "${registry}"
+
+manifest=""
+if manifest="$(get_manifest "$SRC")"; then
+    echo "image $SRC doesn't exist, building..."
+    IMAGE_NAME="$IMAGE" \
+    IMAGE_TAG="$SRC" \
+    ferrocene/ci/scripts/build-and-push-docker-image.sh
+    manifest="$(get_manifest "$SRC")"
+else
+    alias_manifest="$(get_manifest "$ALIAS")"
+    src_digest="$(echo "$manifest" | get_manifest_digest)"
+    alias_digest="$(echo "$alias_manifest" | get_manifest_digest)"
+    if [[ "$src_digest" == "$alias_digest" ]]; then
+        echo "alias $ALIAS already points to $SRC"
+        exit 0
+    fi
+fi
+
+aws ecr put-image --repository-name "$ECR_REPOSITORY" --image-tag "$ALIAS" --image-manifest "$manifest"

--- a/ferrocene/ci/scripts/maybe-build-push-and-alias-docker-images.sh
+++ b/ferrocene/ci/scripts/maybe-build-push-and-alias-docker-images.sh
@@ -17,21 +17,27 @@ account="$(aws sts get-caller-identity --region "${ECR_REGION}" | jq -r .Account
 registry="${account}.dkr.ecr.${ECR_REGION}.amazonaws.com"
 
 function get_manifest() {
-    aws ecr batch-get-image --repository-name "$ECR_REPOSITORY" --image-ids imageTag="$1" --output text --query 'images[].imageManifest'
+    aws ecr batch-get-image \
+        --repository-name "$ECR_REPOSITORY" \
+        --image-ids imageTag="$1" \
+        --output text \
+        --query 'images[].imageManifest' \
+        || return 1
 }
 
 function get_manifest_digest() {
-    jq -r .config.digest
+    echo "$1" | jq -r .config.digest
 }
 
 aws ecr get-login-password --region "${ECR_REGION}" \
     | docker login --username AWS --password-stdin "${registry}"
 
-manifest=""
-if manifest="$(get_manifest "$SRC")"; then
+src_manifest="$(get_manifest "$SRC")"
+src_digest="$(get_manifest_digest "$src_manifest")"
+if [[ -n "$src_digest" ]]; then
+    echo "image $SRC exists"
     alias_manifest="$(get_manifest "$ALIAS")"
-    src_digest="$(echo "$manifest" | get_manifest_digest)"
-    alias_digest="$(echo "$alias_manifest" | get_manifest_digest)"
+    alias_digest="$(get_manifest_digest "$alias_manifest")"
     if [[ "$src_digest" == "$alias_digest" ]]; then
         echo "alias $ALIAS already points to $SRC"
         exit 0
@@ -41,7 +47,8 @@ else
     IMAGE_NAME="$IMAGE" \
     IMAGE_TAG="$SRC" \
     ferrocene/ci/scripts/build-and-push-docker-image.sh
-    manifest="$(get_manifest "$SRC")"
+    src_manifest="$(get_manifest "$SRC")"
 fi
 
-aws ecr put-image --repository-name "$ECR_REPOSITORY" --image-tag "$ALIAS" --image-manifest "$manifest"
+echo "aliasing $ALIAS to $SRC"
+aws ecr put-image --repository-name "$ECR_REPOSITORY" --image-tag "$ALIAS" --image-manifest "$src_manifest"


### PR DESCRIPTION
we want to build qemu using the ferrocene ci images, but right now there's no stable identifier that can be used to pull these images from our pull-through cache on harbor

this PR adds a new `misc` workflow for ci actions that aren't part of the main testing workflow.

when a commit hits `main`, pushes an aliased tag (currently the same, without the hash suffix) to the ECR registry for the docker image that was built from the current tag.

<img width="1125" height="324" alt="image" src="https://github.com/user-attachments/assets/d8e3fadf-7caf-4d62-9637-4f8c2e70d34b" />

