### PR TITLE
[1.96] forward-port CI fixes

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -222,6 +222,7 @@ jobs:
         # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
         ./x.py --stage 2 test $(ferrocene/ci/split-tasks.py << parameters.job >>) --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
     steps:
+      - aws-oidc-auth
       - ferrocene-job-test-container:
           restore-from-job: x86_64-linux-build
 
@@ -1639,22 +1640,26 @@ executors:
     docker:
       - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
         aws_auth:
-          oidc_role_arn: $AWS_ROLE_ARN
+          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
+          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
   docker-aarch64-ubuntu-20:
     docker:
       - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
         aws_auth:
-          oidc_role_arn: $AWS_ROLE_ARN
+          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
+          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
   docker-x86_64-ubuntu-24:
     docker:
       - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--x86_64--ubuntu-24 >>
         aws_auth:
-          oidc_role_arn: $AWS_ROLE_ARN
+          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
+          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
   docker-aarch64-ubuntu-24:
     docker:
       - image: << pipeline.parameters.docker-repository-url--ci-docker-images >>:<< pipeline.parameters.docker-image-tag--aarch64--ubuntu-24 >>
         aws_auth:
-          oidc_role_arn: $AWS_ROLE_ARN
+          aws_access_key_id: $ECR_PULL_AWS_ACCESS_KEY
+          aws_secret_access_key: $ECR_PULL_AWS_SECRET_KEY
   linux-vm:
     machine:
       image: default

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -926,7 +926,7 @@ workflows:
       - x86_64-linux-generic-test-container:
           name: x86_64-linux-compiletest
           job: test:compiletest
-          resource-class: xlarge # 8-core
+          resource-class: ferrocene/k8s-amd64-large  # 8-core
           test-variant: "2021"
           requires:
             - x86_64-linux-build

--- a/ferrocene/ci/scripts/reset-mtime-to-last-commit.sh
+++ b/ferrocene/ci/scripts/reset-mtime-to-last-commit.sh
@@ -20,7 +20,10 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-if [[ "${OSTYPE}" =~ ^darwin.* ]]; then
+parent=$(cd $(dirname $0) && pwd)
+source "$parent/../../../src/ci/shared.sh"
+
+if isMacOS; then
     # Darwin's bash does not support RFC2822 on `touch`
     # `%ct` outputs the commit date formatted according UNIX timestamp
     git_log_format="%ct"

--- a/ferrocene/ci/scripts/run-self-test.sh
+++ b/ferrocene/ci/scripts/run-self-test.sh
@@ -13,11 +13,15 @@ PREFIX="ferrocene/dist/${COMMIT}"
 
 TAR="tar"
 FERROCENE_SELF_TEST="ferrocene-self-test"
+
+parent=$(cd $(dirname $0) && pwd)
+source "$parent/../../../src/ci/shared.sh"
+
 # Ensure we use GNU tar on Windows, bsdtar will not handle links well.
 # bsdtar (the default tar.exe) does not handle symlinks properly,
 # and will get 'stuck' in a cycle while unpacking and packing.
 # GNU Tar does not have this issue.
-if [[ "${OSTYPE}" = "msys" ]]; then
+if isWindows; then
     TAR="/c/Program Files/Git/usr/bin/tar.exe"
     FERROCENE_SELF_TEST="ferrocene-self-test.exe"
 fi

--- a/ferrocene/ci/scripts/setup-windows.sh
+++ b/ferrocene/ci/scripts/setup-windows.sh
@@ -20,8 +20,11 @@ setup_python3() {
     fi
 }
 
-if [[ "${OSTYPE}" != "msys" ]]; then
-    echo "error: the script can only run on Windows (under MSYS)"
+parent=$(cd $(dirname $0) && pwd)
+source "$parent/../../../src/ci/shared.sh"
+
+if ! isWindows; then
+    echo "error: the script can only run on Windows (under CYGWIN)"
     exit 1
 fi
 
@@ -41,6 +44,6 @@ choco install -y cmake.portable ninja llvm
 choco install -y zstandard --version=1.5.6 # 1.5.7 was reporting a mismatched SHA
 
 # Followed: https://docs.chocolatey.org/en-us/guides/create/recompile-packages/#how-to-internalizerecompile-an-existing-package-manually
-# From: https://developer.arm.com/-/media/Files/downloads/gnu/15.2.rel1/binrel/arm-gnu-toolchain-15.2.rel1-mingw-w64-x86_64-arm-none-eabi.msi 
+# From: https://developer.arm.com/-/media/Files/downloads/gnu/15.2.rel1/binrel/arm-gnu-toolchain-15.2.rel1-mingw-w64-x86_64-arm-none-eabi.msi
 aws s3 cp s3://ferrocene-ci-mirrors/manual/arm-compiler/gcc-arm-embedded.10.3.1.20251211.nupkg gcc-arm-embedded.10.3.1.20251211.nupkg
 choco install gcc-arm-embedded --version="10.3.1.20251211" --source .

--- a/ferrocene/ci/scripts/show-environment.sh
+++ b/ferrocene/ci/scripts/show-environment.sh
@@ -5,26 +5,32 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+parent=$(cd $(dirname $0) && pwd)
+source "$parent/../../../src/ci/shared.sh"
+
 echo "CPU"
 echo "==="
-if [[ "${OSTYPE}" =~ ^darwin.* ]]; then
+if isMacOS; then
     sysctl -n machdep.cpu.brand_string
-elif [[ "${OSTYPE}" = "msys" ]]; then
+elif isWindows; then
     systeminfo
-else
+elif isLinux; then
     lscpu
+else
+    echo "Unknown OS"
 fi
 
 echo
 echo "System memory"
 echo "============="
-if [[ "${OSTYPE}" =~ ^darwin.* ]]; then
+if isMacOS; then
     vm_stat
-elif [[ "${OSTYPE}" != "msys" ]]; then
+elif isLinux; then
     free -h
 
     echo "Disk"
     echo "===="
     df -h
+else
+    echo "Unknown OS"
 fi
-

--- a/ferrocene/ci/scripts/shrink-build-directory.sh
+++ b/ferrocene/ci/scripts/shrink-build-directory.sh
@@ -8,7 +8,10 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-if [[ "${OSTYPE}" != "msys" ]]; then
+parent=$(cd $(dirname $0) && pwd)
+source "$parent/../../../src/ci/shared.sh"
+
+if ! isWindows; then
     echo "build directory size:"
     du -sh build/*/* | sort -hr
 fi


### PR DESCRIPTION
generated with `GITHUB_TOKEN=$(gh auth token) ferrocene/tools/backport/one.py 2417`; see #2417.