### PR TITLE
Normalize out the extra line printed by qemu when a process aborts

### DIFF
--- a/tests/ui/hygiene/panic-location.rs
+++ b/tests/ui/hygiene/panic-location.rs
@@ -1,11 +1,11 @@
-// Ferrocene addition: QEMU user space emulation outputs an extra message when an abort happens
-//@ ignore-qemu
-
 //@ run-fail
 //@ check-run-results
 //@ exec-env:RUST_BACKTRACE=0
 //@ normalize-stderr: ".rs:\d+:\d+" -> ".rs:LL:CC"
 //@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
+
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
 //
 // Regression test for issue #70963
 // The reported panic location should not be `<::core::macros::panic macros>`.

--- a/tests/ui/intrinsics/const-eval-select-backtrace-std.rs
+++ b/tests/ui/intrinsics/const-eval-select-backtrace-std.rs
@@ -3,8 +3,8 @@
 //@ check-run-results
 //@ exec-env:RUST_BACKTRACE=0
 
-// Ferrocene addition: QEMU user space emulation outputs an extra message when an abort happens
-//@ ignore-qemu
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
 
 fn main() {
     &""[1..];

--- a/tests/ui/intrinsics/const-eval-select-backtrace.rs
+++ b/tests/ui/intrinsics/const-eval-select-backtrace.rs
@@ -4,8 +4,8 @@
 //@ check-run-results
 //@ exec-env:RUST_BACKTRACE=0
 
-// Ferrocene addition: QEMU user space emulation outputs an extra message when an abort happens
-//@ ignore-qemu
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
 
 #[track_caller]
 fn uhoh() {

--- a/tests/ui/lto/issue-105637.rs
+++ b/tests/ui/lto/issue-105637.rs
@@ -13,8 +13,8 @@
 //@ run-fail
 //@ check-run-results
 
-// Ferrocene addition: QEMU user space emulation outputs an extra message when an abort happens
-//@ ignore-qemu
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
 
 extern crate thinlto_dylib;
 

--- a/tests/ui/macros/assert-long-condition.rs
+++ b/tests/ui/macros/assert-long-condition.rs
@@ -3,8 +3,8 @@
 //@ exec-env:RUST_BACKTRACE=0
 // ignore-tidy-linelength
 
-// Ferrocene addition: QEMU user space emulation outputs an extra message when an abort happens
-//@ ignore-qemu
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
 
 fn main() {
     assert!(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15 + 16 + 17 + 18 + 19 + 20 + 21 + 22 + 23 + 24 + 25 == 0);

--- a/tests/ui/panics/fmt-only-once.rs
+++ b/tests/ui/panics/fmt-only-once.rs
@@ -2,8 +2,8 @@
 //@ check-run-results
 //@ exec-env:RUST_BACKTRACE=0
 
-// Ferrocene addition: QEMU user space emulation outputs an extra message when an abort happens
-//@ ignore-qemu
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
 
 // Test that we format the panic message only once.
 // Regression test for https://github.com/rust-lang/rust/issues/110717

--- a/tests/ui/panics/location-detail-panic-no-column.rs
+++ b/tests/ui/panics/location-detail-panic-no-column.rs
@@ -3,8 +3,8 @@
 //@ compile-flags: -Zlocation-detail=line,file
 //@ exec-env:RUST_BACKTRACE=0
 
-// Ferrocene addition: QEMU user space emulation outputs an extra message when an abort happens
-//@ ignore-qemu
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
 
 fn main() {
     panic!("column-redacted");

--- a/tests/ui/panics/location-detail-panic-no-file.rs
+++ b/tests/ui/panics/location-detail-panic-no-file.rs
@@ -3,8 +3,8 @@
 //@ compile-flags: -Zlocation-detail=line,column
 //@ exec-env:RUST_BACKTRACE=0
 
-// Ferrocene addition: QEMU user space emulation outputs an extra message when an abort happens
-//@ ignore-qemu
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
 
 fn main() {
     panic!("file-redacted");

--- a/tests/ui/panics/location-detail-panic-no-line.rs
+++ b/tests/ui/panics/location-detail-panic-no-line.rs
@@ -3,8 +3,8 @@
 //@ compile-flags: -Zlocation-detail=file,column
 //@ exec-env:RUST_BACKTRACE=0
 
-// Ferrocene addition: QEMU user space emulation outputs an extra message when an abort happens
-//@ ignore-qemu
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
 
 fn main() {
     panic!("line-redacted");

--- a/tests/ui/panics/location-detail-panic-no-location-info.rs
+++ b/tests/ui/panics/location-detail-panic-no-location-info.rs
@@ -3,8 +3,8 @@
 //@ compile-flags: -Zlocation-detail=none
 //@ exec-env:RUST_BACKTRACE=0
 
-// Ferrocene addition: QEMU user space emulation outputs an extra message when an abort happens
-//@ ignore-qemu
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
 
 fn main() {
     panic!("no location info");

--- a/tests/ui/panics/location-detail-unwrap-no-file.rs
+++ b/tests/ui/panics/location-detail-unwrap-no-file.rs
@@ -3,8 +3,8 @@
 //@ compile-flags: -Copt-level=0 -Zlocation-detail=line,column
 //@ exec-env:RUST_BACKTRACE=0
 
-// Ferrocene addition: QEMU user space emulation outputs an extra message when an abort happens
-//@ ignore-qemu
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
 
 fn main() {
     let opt: Option<u32> = None;

--- a/tests/ui/panics/panic-in-message-fmt.rs
+++ b/tests/ui/panics/panic-in-message-fmt.rs
@@ -9,8 +9,8 @@
 //@ normalize-stderr: "(core/src/panicking\.rs):[0-9]+:[0-9]+" -> "$1:$$LINE:$$COL"
 //@ ignore-emscripten "RuntimeError" junk in output
 
-// Ferrocene addition: QEMU user space emulation outputs an extra message when an abort happens
-//@ ignore-qemu
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
 
 use std::fmt::{Display, self};
 

--- a/tests/ui/process/println-with-broken-pipe.rs
+++ b/tests/ui/process/println-with-broken-pipe.rs
@@ -14,8 +14,8 @@
 //@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 //@ compile-flags: -Zon-broken-pipe=error
 
-// Ferrocene addition: QEMU user space emulation outputs an extra message when an abort happens
-//@ ignore-qemu
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
 
 // Test what the error message looks like when `println!()` panics because of
 // `std::io::ErrorKind::BrokenPipe`

--- a/tests/ui/test-attrs/test-panic-abort-nocapture.rs
+++ b/tests/ui/test-attrs/test-panic-abort-nocapture.rs
@@ -6,8 +6,8 @@
 //@ exec-env:RUST_BACKTRACE=0
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
-// Ferrocene addition: QEMU user space emulation outputs an extra message when an abort happens
-//@ ignore-qemu
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
 
 //@ needs-subprocess
 

--- a/tests/ui/test-attrs/test-panic-abort.rs
+++ b/tests/ui/test-attrs/test-panic-abort.rs
@@ -6,8 +6,8 @@
 //@ exec-env:RUST_BACKTRACE=0
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
-// Ferrocene addition: QEMU user space emulation outputs an extra message when an abort happens
-//@ ignore-qemu
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
 
 //@ needs-subprocess
 


### PR DESCRIPTION
This allows a bunch of tests to be re-enabled on qemu targets