### PR TITLE
Fix normalize-stderr directives for qemu

### DIFF
--- a/tests/ui/extern/extern-types-field-offset.rs
+++ b/tests/ui/extern/extern-types-field-offset.rs
@@ -4,6 +4,10 @@
 //@ normalize-stderr: "(core/src/panicking\.rs):[0-9]+:[0-9]+" -> "$1:$$LINE:$$COL"
 //@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 //@ ignore-backends: gcc
+
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
+
 #![feature(extern_types)]
 
 extern "C" {

--- a/tests/ui/hygiene/panic-location.rs
+++ b/tests/ui/hygiene/panic-location.rs
@@ -5,7 +5,7 @@
 //@ normalize-stderr: "/rustc(?:-dev)?/[a-z0-9.]+/" -> ""
 
 // Ferrocene addition: Remove extra output line added by qemu
-//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
 //
 // Regression test for issue #70963
 // The reported panic location should not be `<::core::macros::panic macros>`.

--- a/tests/ui/intrinsics/const-eval-select-backtrace-std.rs
+++ b/tests/ui/intrinsics/const-eval-select-backtrace-std.rs
@@ -4,7 +4,7 @@
 //@ exec-env:RUST_BACKTRACE=0
 
 // Ferrocene addition: Remove extra output line added by qemu
-//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
 
 fn main() {
     &""[1..];

--- a/tests/ui/intrinsics/const-eval-select-backtrace.rs
+++ b/tests/ui/intrinsics/const-eval-select-backtrace.rs
@@ -5,7 +5,7 @@
 //@ exec-env:RUST_BACKTRACE=0
 
 // Ferrocene addition: Remove extra output line added by qemu
-//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
 
 #[track_caller]
 fn uhoh() {

--- a/tests/ui/lto/issue-105637.rs
+++ b/tests/ui/lto/issue-105637.rs
@@ -14,7 +14,7 @@
 //@ check-run-results
 
 // Ferrocene addition: Remove extra output line added by qemu
-//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
 
 extern crate thinlto_dylib;
 

--- a/tests/ui/macros/assert-long-condition.rs
+++ b/tests/ui/macros/assert-long-condition.rs
@@ -4,7 +4,7 @@
 // ignore-tidy-linelength
 
 // Ferrocene addition: Remove extra output line added by qemu
-//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
 
 fn main() {
     assert!(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15 + 16 + 17 + 18 + 19 + 20 + 21 + 22 + 23 + 24 + 25 == 0);

--- a/tests/ui/panics/fmt-only-once.rs
+++ b/tests/ui/panics/fmt-only-once.rs
@@ -3,7 +3,7 @@
 //@ exec-env:RUST_BACKTRACE=0
 
 // Ferrocene addition: Remove extra output line added by qemu
-//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
 
 // Test that we format the panic message only once.
 // Regression test for https://github.com/rust-lang/rust/issues/110717

--- a/tests/ui/panics/location-detail-panic-no-column.rs
+++ b/tests/ui/panics/location-detail-panic-no-column.rs
@@ -4,7 +4,7 @@
 //@ exec-env:RUST_BACKTRACE=0
 
 // Ferrocene addition: Remove extra output line added by qemu
-//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
 
 fn main() {
     panic!("column-redacted");

--- a/tests/ui/panics/location-detail-panic-no-file.rs
+++ b/tests/ui/panics/location-detail-panic-no-file.rs
@@ -4,7 +4,7 @@
 //@ exec-env:RUST_BACKTRACE=0
 
 // Ferrocene addition: Remove extra output line added by qemu
-//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
 
 fn main() {
     panic!("file-redacted");

--- a/tests/ui/panics/location-detail-panic-no-line.rs
+++ b/tests/ui/panics/location-detail-panic-no-line.rs
@@ -4,7 +4,7 @@
 //@ exec-env:RUST_BACKTRACE=0
 
 // Ferrocene addition: Remove extra output line added by qemu
-//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
 
 fn main() {
     panic!("line-redacted");

--- a/tests/ui/panics/location-detail-panic-no-location-info.rs
+++ b/tests/ui/panics/location-detail-panic-no-location-info.rs
@@ -4,7 +4,7 @@
 //@ exec-env:RUST_BACKTRACE=0
 
 // Ferrocene addition: Remove extra output line added by qemu
-//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
 
 fn main() {
     panic!("no location info");

--- a/tests/ui/panics/location-detail-unwrap-no-file.rs
+++ b/tests/ui/panics/location-detail-unwrap-no-file.rs
@@ -4,7 +4,7 @@
 //@ exec-env:RUST_BACKTRACE=0
 
 // Ferrocene addition: Remove extra output line added by qemu
-//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
 
 fn main() {
     let opt: Option<u32> = None;

--- a/tests/ui/panics/panic-in-hook.rs
+++ b/tests/ui/panics/panic-in-hook.rs
@@ -6,6 +6,9 @@
 //@ error-pattern: panicked while processing panic
 //@ ignore-emscripten "RuntimeError" junk in output
 
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
+
 use std::panic;
 
 fn main() {

--- a/tests/ui/panics/panic-in-hook.run.stderr
+++ b/tests/ui/panics/panic-in-hook.run.stderr
@@ -1,3 +1,3 @@
-panicked at $DIR/panic-in-hook.rs:12:34:
+panicked at $DIR/panic-in-hook.rs:15:34:
 
 thread panicked while processing panic. aborting.

--- a/tests/ui/panics/panic-in-message-fmt.rs
+++ b/tests/ui/panics/panic-in-message-fmt.rs
@@ -10,7 +10,7 @@
 //@ ignore-emscripten "RuntimeError" junk in output
 
 // Ferrocene addition: Remove extra output line added by qemu
-//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
 
 use std::fmt::{Display, self};
 

--- a/tests/ui/panics/panic-resume_unwind-in-hook.rs
+++ b/tests/ui/panics/panic-resume_unwind-in-hook.rs
@@ -6,6 +6,9 @@
 //@ error-pattern: panicked while processing panic
 //@ ignore-emscripten "RuntimeError" junk in output
 
+// Ferrocene addition: Remove extra output line added by qemu
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
+
 use std::panic;
 
 fn main() {

--- a/tests/ui/process/println-with-broken-pipe.rs
+++ b/tests/ui/process/println-with-broken-pipe.rs
@@ -15,7 +15,7 @@
 //@ compile-flags: -Zon-broken-pipe=error
 
 // Ferrocene addition: Remove extra output line added by qemu
-//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
 
 // Test what the error message looks like when `println!()` panics because of
 // `std::io::ErrorKind::BrokenPipe`

--- a/tests/ui/test-attrs/test-panic-abort-nocapture.rs
+++ b/tests/ui/test-attrs/test-panic-abort-nocapture.rs
@@ -7,7 +7,7 @@
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // Ferrocene addition: Remove extra output line added by qemu
-//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
 
 //@ needs-subprocess
 

--- a/tests/ui/test-attrs/test-panic-abort.rs
+++ b/tests/ui/test-attrs/test-panic-abort.rs
@@ -7,7 +7,7 @@
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // Ferrocene addition: Remove extra output line added by qemu
-//@ normalize-stderr: "qemu: uncaught target signal 6 (Aborted) - core dumped" -> ""
+//@ normalize-stderr: "qemu: uncaught target signal 6 \(Aborted\) - core dumped\n" -> ""
 
 //@ needs-subprocess
 


### PR DESCRIPTION
The syntax of the `normalize-stderr` directives in https://github.com/ferrocene/ferrocene/pull/2445 was wrong. The text to replace is actually a regex, so the brackets need to be escaped. Also we need to remove an extra newline.

Strangely, these tests passed in CI with the previous, apparently broken normalization rule, but failed if the rule was removed entirely. The reason for this is very unclear.

On the other hand, these tests reliably fail for Jonathan without the fully correct regexes. This may be due to a difference in qemu versions between CI and his system.

Fix the syntax in the tests enabled by https://github.com/ferrocene/ferrocene/pull/2445 , and add directives to three more tests which failed for Jonathan (but again, not in CI)