### PR TITLE
[26.08 release] Bump release notes

### DIFF
--- a/ferrocene/doc/release-notes/src/26.08.0.rst
+++ b/ferrocene/doc/release-notes/src/26.08.0.rst
@@ -1,0 +1,32 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+:upcoming-release:
+
+Ferrocene 26.08
+===============
+
+This page contains the changes to be introduced in the upcoming Ferrocene
+release.
+
+New features
+------------
+
+* The ``flip-link`` tool is now quality managed. See the User Manual for documentation.
+* Three new targets are now supported and qualified for safety critical use:
+
+  * :target-with-tuple:`aarch64-unknown-qnx`
+  * :target-with-tuple:`armv7r-none-eabihf`
+  * :target-with-tuple:`x86_64-pc-qnx`
+
+Rust changes
+------------
+
+This release includes the following changes introduced by the upstream Rust
+project. Note that this changelog is maintained by upstream. The target support
+changes described here describe Rust's support levels, and have no correlation
+to the targets and platforms supported by Ferrocene.
+
+.. rust-changelog::
+    :from: 1.96.0
+    :to: 1.97.0

--- a/ferrocene/doc/release-notes/src/index.rst
+++ b/ferrocene/doc/release-notes/src/index.rst
@@ -10,10 +10,16 @@ This document contains the list of new features, changes and bug fixes included
 in Ferrocene releases.
 
 .. toctree::
-   :caption: Ferrocene 26.08 series
+   :caption: Ferrocene 26.11 series
    :maxdepth: 1
 
    next
+
+.. toctree::
+   :caption: Ferrocene 26.08 series
+   :maxdepth: 1
+
+   26.08.0
 
 .. toctree::
    :caption: Ferrocene 26.05 series:

--- a/ferrocene/doc/release-notes/src/next.rst
+++ b/ferrocene/doc/release-notes/src/next.rst
@@ -8,13 +8,3 @@ Next Ferrocene release
 
 This page contains the changes to be introduced in the upcoming Ferrocene
 release.
-
-New features
-------------
-
-* The ``flip-link`` tool is now quality managed. See the User Manual for documentation.
-* Three new targets are now supported and qualified for safety critical use:
-
-  * :target-with-tuple:`aarch64-unknown-qnx`
-  * :target-with-tuple:`armv7r-none-eabihf`
-  * :target-with-tuple:`x86_64-pc-qnx`


### PR DESCRIPTION
Update release notes for 26.08 release.
See https://public-docs.ferrocene.dev/main/qualification/internal-procedures/release/stable.html#version-bump-release-notes.

This PR was created by automation on behalf of `@jyn` (but then i edited it because my draft automation was broken).

Rendered: 
<img width="921" height="805" alt="image" src="https://github.com/user-attachments/assets/14c42142-2240-4cef-889f-64bc7fdb4dba" />

Note that this will be missing release notes for 1.97 until https://github.com/ferrocene/ferrocene/pull/2467 is merged.