### PR TITLE
QNX 8 docs bump & new schema

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -454,7 +454,7 @@ jobs:
           docker-image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
           run-emulator-docker-image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-24 >>
           restore-from-job: x86_64-linux-build
-          emulator-script: "set +u; source ./qnx800-141/qnxsdp-env.sh; set -u; ./ferrocene/ci/scripts/emulated-x86_64-qnx8-test-runner.sh"
+          emulator-script: "set +u; source ./qnx-8.0.5/qnxsdp-env.sh; set -u; ./ferrocene/ci/scripts/emulated-x86_64-qnx8-test-runner.sh"
 
   # aarch64-unknown-linux-gnu jobs
 
@@ -1986,18 +1986,21 @@ commands:
       source-env-script:
         type: boolean
         default: true
+      version:
+        type: string
+        default: "8.0.5"
     steps:
       - run:
-          name: Fetch QNX800 toolchain
+          name: Fetch QNX << parameters.version >> toolchain
           # On Windows, the virtualenv detection seems to struggle at times.
           command: |
-            ferrocene/ci/scripts/cache.py retrieve s3://ferrocene-ci-mirrors/manual/qnx/qnx800-141-deployment.tar.zst .
+            ferrocene/ci/scripts/cache.py retrieve s3://ferrocene-ci-mirrors/manual/qnx/qnx8-<< parameters.version >>.tar.zst .
       - when:
           condition: << parameters.source-env-script >>
           steps:
             - run:
-                name: Set PATH to include QNX800 tools
-                command: echo 'source $(pwd)/qnx800-141/qnxsdp-env.sh' >> "$BASH_ENV"
+                name: Set PATH to include QNX << parameters.version >> tools
+                command: echo 'source $(pwd)/qnx-<< parameters.version >>/qnxsdp-env.sh' >> "$BASH_ENV"
 
   aws-oidc-auth:
     description: Authenticate with AWS using OIDC

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -411,7 +411,7 @@ jobs:
           docker-image-tag: qnx-runner--<< pipeline.parameters.docker-images-hash >>--x86_64
           run-emulator-docker-image-tag: emulator--<< pipeline.parameters.docker-images-hash >>--x86_64
           restore-from-job: x86_64-linux-build
-          emulator-script: "set +u; source ./qnx800-141/qnxsdp-env.sh; set -u; ./ferrocene/ci/scripts/emulated-x86_64-qnx8-test-runner.sh"
+          emulator-script: "set +u; source ./qnx-8.0.5/qnxsdp-env.sh; set -u; ./ferrocene/ci/scripts/emulated-x86_64-qnx8-test-runner.sh"
 
   # aarch64-unknown-linux-gnu jobs
 
@@ -1679,18 +1679,21 @@ commands:
       source-env-script:
         type: boolean
         default: true
+      version:
+        type: string
+        default: "8.0.5"
     steps:
       - run:
-          name: Fetch QNX800 toolchain
+          name: Fetch QNX << parameters.version >> toolchain
           # On Windows, the virtualenv detection seems to struggle at times.
           command: |
-            ferrocene/ci/scripts/cache.py retrieve s3://ferrocene-ci-mirrors/manual/qnx/qnx800-141-deployment.tar.zst .
+            ferrocene/ci/scripts/cache.py retrieve s3://ferrocene-ci-mirrors/manual/qnx/qnx8-<< parameters.version >>.tar.zst .
       - when:
           condition: << parameters.source-env-script >>
           steps:
             - run:
-                name: Set PATH to include QNX800 tools
-                command: echo 'source $(pwd)/qnx800-141/qnxsdp-env.sh' >> "$BASH_ENV"
+                name: Set PATH to include QNX << parameters.version >> tools
+                command: echo 'source $(pwd)/qnx-<< parameters.version >>/qnxsdp-env.sh' >> "$BASH_ENV"
 
 executors:
   linux-vm:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -236,20 +236,20 @@ jobs:
           qnx7: true
           restore-from-job: x86_64-linux-build
 
-  # x86_64-linux-dist-targets-qnx8:
-  #   executor:
-  #     name: docker-custom-image
-  #     image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-  #   resource_class: ferrocene/k8s-amd64-large
-  #   environment:
-  #     FERROCENE_HOST: x86_64-unknown-linux-gnu
-  #     FERROCENE_TARGETS: aarch64-unknown-nto-qnx800,x86_64-pc-nto-qnx800
-  #     SCRIPT: |
-  #       ./x.py --stage 2 dist rust-std
-  #   steps:
-  #     - ferrocene-job-dist:
-  #         qnx8: true
-  #         restore-from-job: x86_64-linux-build
+  x86_64-linux-dist-targets-qnx8:
+    executor:
+      name: docker-custom-image
+      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+    resource_class: ferrocene/k8s-amd64-large
+    environment:
+      FERROCENE_HOST: x86_64-unknown-linux-gnu
+      FERROCENE_TARGETS: aarch64-unknown-nto-qnx800,x86_64-pc-nto-qnx800
+      SCRIPT: |
+        ./x.py --stage 2 dist rust-std
+    steps:
+      - ferrocene-job-dist:
+          qnx8: true
+          restore-from-job: x86_64-linux-build
 
   x86_64-linux-dist-src:
     executor:
@@ -370,22 +370,22 @@ jobs:
           name: Download dist artifacts and run the self-test tool
           command: ferrocene/ci/scripts/run-self-test.sh
 
-  # x86_64-linux-self-test-qnx8:
-  #   executor:
-  #     name: docker-custom-image
-  #     image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
-  #   resource_class: ferrocene/k8s-amd64-tiny
-  #   environment:
-  #     FERROCENE_HOST: x86_64-unknown-linux-gnu
-  #     FERROCENE_TARGETS: aarch64-unknown-nto-qnx800,x86_64-pc-nto-qnx800
-  #   steps:
-  #     - ferrocene-git-shallow-clone:
-  #         depth: 1
-  #     - aws-oidc-auth
-  #     - setup-qnx8-toolchain: {}
-  #     - run:
-  #         name: Download dist artifacts and run the self-test tool
-  #         command: ferrocene/ci/scripts/run-self-test.sh
+  x86_64-linux-self-test-qnx8:
+    executor:
+      name: docker-custom-image
+      image-tag: << pipeline.parameters.docker-image-tag--x86_64--ubuntu-20 >>
+    resource_class: ferrocene/k8s-amd64-tiny
+    environment:
+      FERROCENE_HOST: x86_64-unknown-linux-gnu
+      FERROCENE_TARGETS: aarch64-unknown-nto-qnx800,x86_64-pc-nto-qnx800
+    steps:
+      - ferrocene-git-shallow-clone:
+          depth: 1
+      - aws-oidc-auth
+      - setup-qnx8-toolchain: {}
+      - run:
+          name: Download dist artifacts and run the self-test tool
+          command: ferrocene/ci/scripts/run-self-test.sh
 
   x86_64-qnx-generic-test-vm:
     executor: linux-vm
@@ -841,31 +841,31 @@ jobs:
           name: Empty step to make sure the job always has steps
           command: echo
 
-  # x86_64-windows-self-test-qnx8:
-  #   executor:
-  #     name: win/server-2022
-  #     size: medium # 4-core
-  #     shell: bash.exe -euo pipefail
-  #   environment:
-  #     FERROCENE_BUILD_HOST: x86_64-pc-windows-msvc
-  #     FERROCENE_HOST: x86_64-pc-windows-msvc
-  #     FERROCENE_TARGETS: aarch64-unknown-nto-qnx800,x86_64-pc-nto-qnx800
-  #   steps:
-  #     - when:
-  #         condition: << pipeline.parameters.full-build-x86_64-pc-windows-msvc-host >>
-  #         steps:
-  #           - ferrocene-git-shallow-clone:
-  #               depth: 1
-  #           - aws-oidc-auth
-  #           - ferrocene-setup-windows
-  #           - setup-uv
-  #           - setup-qnx8-toolchain: {}
-  #           - run:
-  #               name: Download dist artifacts and run the self-test tool
-  #               command: ferrocene/ci/scripts/run-self-test.sh
-  #     - run:
-  #         name: Empty step to make sure the job always has steps
-  #         command: echo
+  x86_64-windows-self-test-qnx8:
+    executor:
+      name: win/server-2022
+      size: medium # 4-core
+      shell: bash.exe -euo pipefail
+    environment:
+      FERROCENE_BUILD_HOST: x86_64-pc-windows-msvc
+      FERROCENE_HOST: x86_64-pc-windows-msvc
+      FERROCENE_TARGETS: aarch64-unknown-nto-qnx800,x86_64-pc-nto-qnx800
+    steps:
+      - when:
+          condition: << pipeline.parameters.full-build-x86_64-pc-windows-msvc-host >>
+          steps:
+            - ferrocene-git-shallow-clone:
+                depth: 1
+            - aws-oidc-auth
+            - ferrocene-setup-windows
+            - setup-uv
+            - setup-qnx8-toolchain: {}
+            - run:
+                name: Download dist artifacts and run the self-test tool
+                command: ferrocene/ci/scripts/run-self-test.sh
+      - run:
+          name: Empty step to make sure the job always has steps
+          command: echo
 
   # Test VMs
 
@@ -1258,9 +1258,9 @@ workflows:
             - x86_64-linux-compiletest
             - x86_64-linux-library-coverage
             - x86_64-qnx-test-library-compiletest
-            # - x86_64-qnx8-test-library-compiletest
+            - x86_64-qnx8-test-library-compiletest
             - aarch64-qnx-test-library-compiletest
-            # - aarch64-qnx8-test-library-compiletest
+            - aarch64-qnx8-test-library-compiletest
             - aarch64-none-test-library-compiletest
             - aarch64-none-test-target-cpu-library-compiletest
             - aarch64r82-none-test-library-compiletest
@@ -1286,9 +1286,9 @@ workflows:
       - x86_64-linux-dist-targets:
           requires:
             - x86_64-linux-build
-      # - x86_64-linux-dist-targets-qnx8:
-      #     requires:
-      #       - x86_64-linux-build
+      - x86_64-linux-dist-targets-qnx8:
+          requires:
+            - x86_64-linux-build
       - x86_64-linux-dist-src:
           requires:
             - x86_64-linux-build
@@ -1376,12 +1376,12 @@ workflows:
             - x86_64-linux-dist-targets
             - aarch64-linux-dist
 
-      # - x86_64-linux-self-test-qnx8:
-      #     requires:
-      #       - x86_64-linux-dist
-      #       - x86_64-linux-dist-tools
-      #       - x86_64-linux-dist-targets-qnx8
-      #       - aarch64-linux-dist
+      - x86_64-linux-self-test-qnx8:
+          requires:
+            - x86_64-linux-dist
+            - x86_64-linux-dist-tools
+            - x86_64-linux-dist-targets-qnx8
+            - aarch64-linux-dist
 
       - x86_64-qnx-generic-test-vm:
           name: x86_64-qnx-test-library-compiletest
@@ -1393,15 +1393,15 @@ workflows:
             - x86_64-linux-build
             - build-docker--ubuntu-24--x86_64
 
-      # - x86_64-qnx8-generic-test-vm:
-      #     name: x86_64-qnx8-test-library-compiletest
-      #     tasks: $(ferrocene/ci/split-tasks.py qnx:compiletest-no-only-hosts) $(ferrocene/ci/split-tasks.py test:library)
-      #     test-variant: "2021"
-      #     extra-args: --tests # We do not run cross compiled doctests for this job on this platform, there are segfaults
-      #     resource-class: large # 4-core
-      #     requires:
-      #       - x86_64-linux-build
-      #       - build-docker--ubuntu-24--x86_64
+      - x86_64-qnx8-generic-test-vm:
+          name: x86_64-qnx8-test-library-compiletest
+          tasks: $(ferrocene/ci/split-tasks.py qnx:compiletest-no-only-hosts) $(ferrocene/ci/split-tasks.py test:library)
+          test-variant: "2021"
+          extra-args: --tests # We do not run cross compiled doctests for this job on this platform, there are segfaults
+          resource-class: large # 4-core
+          requires:
+            - x86_64-linux-build
+            - build-docker--ubuntu-24--x86_64
 
       - facade-generic-test:
           name: armv7r-eabihf-test-library-compiletest
@@ -1463,15 +1463,15 @@ workflows:
             - x86_64-linux-build
             - build-docker--ubuntu-24--x86_64
 
-      # - aarch64-qnx8-generic-test-vm:
-      #     name: aarch64-qnx8-test-library-compiletest
-      #     tasks:  $(ferrocene/ci/split-tasks.py qnx:compiletest-no-only-hosts) $(ferrocene/ci/split-tasks.py test:library)
-      #     test-variant: "2021"
-      #     extra-args: --tests # We do not run cross compiled doctests for this job on this platform, there are segfaults
-      #     resource-class: large # 4-core
-      #     requires:
-      #       - x86_64-linux-build
-      #       - build-docker--ubuntu-24--x86_64
+      - aarch64-qnx8-generic-test-vm:
+          name: aarch64-qnx8-test-library-compiletest
+          tasks:  $(ferrocene/ci/split-tasks.py qnx:compiletest-no-only-hosts) $(ferrocene/ci/split-tasks.py test:library)
+          test-variant: "2021"
+          extra-args: --tests # We do not run cross compiled doctests for this job on this platform, there are segfaults
+          resource-class: large # 4-core
+          requires:
+            - x86_64-linux-build
+            - build-docker--ubuntu-24--x86_64
 
       - aarch64-linux-llvm:
           requires:
@@ -1575,10 +1575,10 @@ workflows:
           requires:
             - x86_64-windows-dist
             - x86_64-linux-dist-targets
-      # - x86_64-windows-self-test-qnx8:
-      #     requires:
-      #       - x86_64-windows-dist
-      #       - x86_64-linux-dist-targets-qnx8
+      - x86_64-windows-self-test-qnx8:
+          requires:
+            - x86_64-windows-dist
+            - x86_64-linux-dist-targets-qnx8
 
       - sbom-gen:
           requires:
@@ -1590,9 +1590,9 @@ workflows:
             - x86_64-linux-dist-src
             - x86_64-linux-traceability-matrix
             - x86_64-linux-self-test
-            # - x86_64-linux-self-test-qnx8
+            - x86_64-linux-self-test-qnx8
             - x86_64-windows-self-test
-            # - x86_64-windows-self-test-qnx8
+            - x86_64-windows-self-test-qnx8
             - wasm-dist-oxidos
             - aarch64-linux-self-test
             - aarch64-darwin-self-test

--- a/ferrocene/doc/internal-procedures/src/partners/qnx.rst
+++ b/ferrocene/doc/internal-procedures/src/partners/qnx.rst
@@ -338,52 +338,65 @@ provided by QNX for our CI/CD.
 To create the deployment, first, ensure you are using a myQNX account with a
 **QNX Software Development Platform Subscription - Build Server License** deployed to it.
 
-Create a deployment containing Linux and Windows toolchains:
+Create deployments containing Linux and Windows toolchains:
 
 .. code-block::
 
     LICENSE_KEY="FILL_ME_IN"
     QNX_USER="FILL_ME_IN"
     QNX_PASSWORD="FILL_ME_IN"
-    QNX_VERSION="8.0.0.00141T202311271501L"
-    QNX_WINDOWS_HOST_VERSION="0.0.1.02005T202411230033L"
-    QNX_LINUX_HOST_VERSION="0.0.1.00135T202311191043L"
 
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
         -myqnx.user $QNX_USER -myqnx.password $QNX_PASSWORD \
         -activateLicenseKey $LICENSE_KEY
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
         -mirrorBaseline qnx800 \
-        -destination qnx/qnx800-141
+        -destination qnx/qnx-8.0.0-baseline
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
-            -installBaseline com.qnx.qnx800/$QNX_VERSION \
-            -installPackage com.qnx.qnx800.host.win.x86_64=$QNX_WINDOWS_HOST_VERSION \
-            -installPackage com.qnx.qnx800.host.linux.x86_64=$QNX_LINUX_HOST_VERSION \
-            -installPackage com.qnx.qnx800.target.qemuvirt/0.2.1.00087T202507241124L \
-            -installPackage com.qnx.qnx800.target.driver.virtio.devc/0.1.1.00011T202411230100L \
-            -installPackage com.qnx.qnx800.patchset805/8.0.5.00390T202606231321L \
-            -destination qnx/qnx800-141 \
-            -cleanInstall
+        -installBaseline com.qnx.qnx800/8.0.0.00141T202311271501L \
+        -installPackage com.qnx.qnx800.host.win.x86_64=0.0.1.02005T202411230033L \
+        -installPackage com.qnx.qnx800.host.linux.x86_64=0.0.1.00135T202311191043L \
+        -installPackage com.qnx.qnx800.target.qemuvirt/0.2.1.00087T202507241124L \
+        -installPackage com.qnx.qnx800.target.driver.virtio.devc/0.1.1.00011T202411230100L \
+        -destination qnx/qnx-8.0.0 \
+        -cleanInstall
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
-        -deploySdpInstallation qnx/qnx800-141 \
+        -deploySdpInstallation qnx/qnx-8.0.0 \
         -deployLicense $LICENSE_KEY \
-        -installationDeployAs qnx/qnx800-141-deployment
+        -installationDeployAs qnx/qnx-8.0.0-deployment
 
-Finally, create an archive of the deployment (with dereferenced symlinks) and upload it to the S3 URL which the CI attempts to pull from:
+    qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
+        -installBaseline com.qnx.qnx800/8.0.0.00141T202311271501L \
+        -installPackage com.qnx.qnx800.host.win.x86_64=0.0.1.02005T202411230033L \
+        -installPackage com.qnx.qnx800.host.linux.x86_64=0.0.1.00135T202311191043L \
+        -installPackage com.qnx.qnx800.target.qemuvirt/0.2.1.00087T202507241124L \
+        -installPackage com.qnx.qnx800.target.driver.virtio.devc/0.1.1.00011T202411230100L \
+        -installPackage com.qnx.qnx800.patchset805/8.0.5.00390T202606231321L \
+        -destination qnx/qnx-8.0.5 \
+        -cleanInstall
+    qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
+        -deploySdpInstallation qnx/qnx-8.0.5 \
+        -deployLicense $LICENSE_KEY \
+        -installationDeployAs qnx/qnx-8.0.5-deployment
+
+Finally, create archives of the deployments (with dereferenced symlinks) and upload it to the S3 URL which the CI attempts to pull from:
 
 .. code-block::
 
     cd $HOME
-    tar -cv --dereference -I 'zstd -T0' -f qnx/qnx800-141-deployment.tar.zst -C qnx/qnx800-141-deployment/ qnx800-141
-    aws s3 cp qnx/qnx800-141-deployment.tar.zst s3://ferrocene-ci-mirrors/manual/qnx/qnx800-141-deployment.tar.zst
+    tar -cv --dereference -I 'zstd -T0' -f qnx/qnx-8.0.0.tar.zst -C qnx/qnx-8.0.0-deployment/ qnx-8.0.0
+    aws s3 cp qnx/qnx-8.0.0.tar.zst s3://ferrocene-ci-mirrors/manual/qnx/qnx-8.0.0.tar.zst
+
+    tar -cv --dereference -I 'zstd -T0' -f qnx/qnx-8.0.5.tar.zst -C qnx/qnx-8.0.5-deployment/ qnx-8.0.5
+    aws s3 cp qnx/qnx-8.0.5.tar.zst s3://ferrocene-ci-mirrors/manual/qnx/qnx-8.0.5.tar.zst
 
 On CI/CD hosts we use a Python script to setup the toolchain:
 
 .. code-block::
 
     cd $HOME
-    ferrocene/ci/scripts/cache.py retrieve s3://ferrocene-ci-mirrors/manual/qnx/qnx800-141-deployment.tar.zst .
-    source qnx/qnx800-141/qnxsdp-env.sh
+    ferrocene/ci/scripts/cache.py retrieve s3://ferrocene-ci-mirrors/manual/qnx/qnx-8.0.5.tar.zst .
+    source qnx/qnx-8.0.5/qnxsdp-env.sh
     qcc -v
 
 It's also possible to use ``tar`` directly, but it can be problematic on Windows hosts.
@@ -391,6 +404,6 @@ It's also possible to use ``tar`` directly, but it can be problematic on Windows
 .. code-block::
 
     cd $HOME
-    aws s3 cp s3://ferrocene-ci-mirrors/manual/qnx/qnx800-141-deployment.tar.zst - | tar -x --zstd -f-
-    source qnx/qnx800-141/qnxsdp-env.sh
+    aws s3 cp s3://ferrocene-ci-mirrors/manual/qnx/qnx-8.0.5-deployment.tar.zst - | tar -x --zstd -f-
+    source qnx/qnx-8.0.5/qnxsdp-env.sh
     qcc -v

--- a/ferrocene/doc/internal-procedures/src/partners/qnx.rst
+++ b/ferrocene/doc/internal-procedures/src/partners/qnx.rst
@@ -338,51 +338,65 @@ provided by QNX for our CI/CD.
 To create the deployment, first, ensure you are using a myQNX account with a
 **QNX Software Development Platform Subscription - Build Server License** deployed to it.
 
-Create a deployment containing Linux and Windows toolchains:
+Create deployments containing Linux and Windows toolchains:
 
 .. code-block::
 
     LICENSE_KEY="FILL_ME_IN"
     QNX_USER="FILL_ME_IN"
     QNX_PASSWORD="FILL_ME_IN"
-    QNX_VERSION="8.0.0.00141T202311271501L"
-    QNX_WINDOWS_HOST_VERSION="0.0.1.02005T202411230033L"
-    QNX_LINUX_HOST_VERSION="0.0.1.00135T202311191043L"
 
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
         -myqnx.user $QNX_USER -myqnx.password $QNX_PASSWORD \
         -activateLicenseKey $LICENSE_KEY
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
         -mirrorBaseline qnx800 \
-        -destination qnx/qnx800-141
+        -destination qnx/qnx-8.0.0-baseline
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
-            -installBaseline com.qnx.qnx800/$QNX_VERSION \
-            -installPackage com.qnx.qnx800.host.win.x86_64=$QNX_WINDOWS_HOST_VERSION \
-            -installPackage com.qnx.qnx800.host.linux.x86_64=$QNX_LINUX_HOST_VERSION \
-            -installPackage com.qnx.qnx800.target.qemuvirt/0.2.1.00087T202507241124L \
-            -installPackage com.qnx.qnx800.target.driver.virtio.devc/0.1.1.00011T202411230100L \
-            -destination qnx/qnx800-141 \
-            -cleanInstall
+        -installBaseline com.qnx.qnx800/8.0.0.00141T202311271501L \
+        -installPackage com.qnx.qnx800.host.win.x86_64=0.0.1.02005T202411230033L \
+        -installPackage com.qnx.qnx800.host.linux.x86_64=0.0.1.00135T202311191043L \
+        -installPackage com.qnx.qnx800.target.qemuvirt/0.2.1.00087T202507241124L \
+        -installPackage com.qnx.qnx800.target.driver.virtio.devc/0.1.1.00011T202411230100L \
+        -destination qnx/qnx-8.0.0 \
+        -cleanInstall
     qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
-        -deploySdpInstallation qnx/qnx800-141 \
+        -deploySdpInstallation qnx/qnx-8.0.0 \
         -deployLicense $LICENSE_KEY \
-        -installationDeployAs qnx/qnx800-141-deployment
+        -installationDeployAs qnx/qnx-8.0.0-deployment
 
-Finally, create an archive of the deployment (with dereferenced symlinks) and upload it to the S3 URL which the CI attempts to pull from:
+    qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
+        -installBaseline com.qnx.qnx800/8.0.0.00141T202311271501L \
+        -installPackage com.qnx.qnx800.host.win.x86_64=0.0.1.02005T202411230033L \
+        -installPackage com.qnx.qnx800.host.linux.x86_64=0.0.1.00135T202311191043L \
+        -installPackage com.qnx.qnx800.target.qemuvirt/0.2.1.00087T202507241124L \
+        -installPackage com.qnx.qnx800.target.driver.virtio.devc/0.1.1.00011T202411230100L \
+        -installPackage com.qnx.qnx800.patchset805/8.0.5.00390T202606231321L \
+        -destination qnx/qnx-8.0.5 \
+        -cleanInstall
+    qnx/qnxsoftwarecenter/qnxsoftwarecenter_clt \
+        -deploySdpInstallation qnx/qnx-8.0.5 \
+        -deployLicense $LICENSE_KEY \
+        -installationDeployAs qnx/qnx-8.0.5-deployment
+
+Finally, create archives of the deployments (with dereferenced symlinks) and upload it to the S3 URL which the CI attempts to pull from:
 
 .. code-block::
 
     cd $HOME
-    tar -cv --dereference -I 'zstd -T0' -f qnx/qnx800-141-deployment.tar.zst -C qnx/qnx800-141-deployment/ qnx800-141
-    aws s3 cp qnx/qnx800-141-deployment.tar.zst s3://ferrocene-ci-mirrors/manual/qnx/qnx800-141-deployment.tar.zst
+    tar -cv --dereference -I 'zstd -T0' -f qnx/qnx-8.0.0.tar.zst -C qnx/qnx-8.0.0-deployment/ qnx-8.0.0
+    aws s3 cp qnx/qnx-8.0.0.tar.zst s3://ferrocene-ci-mirrors/manual/qnx/qnx-8.0.0.tar.zst
+
+    tar -cv --dereference -I 'zstd -T0' -f qnx/qnx-8.0.5.tar.zst -C qnx/qnx-8.0.5-deployment/ qnx-8.0.5
+    aws s3 cp qnx/qnx-8.0.5.tar.zst s3://ferrocene-ci-mirrors/manual/qnx/qnx-8.0.5.tar.zst
 
 On CI/CD hosts we use a Python script to setup the toolchain:
 
 .. code-block::
 
     cd $HOME
-    ferrocene/ci/scripts/cache.py retrieve s3://ferrocene-ci-mirrors/manual/qnx/qnx800-141-deployment.tar.zst .
-    source qnx/qnx800-141/qnxsdp-env.sh
+    ferrocene/ci/scripts/cache.py retrieve s3://ferrocene-ci-mirrors/manual/qnx/qnx-8.0.5.tar.zst .
+    source qnx/qnx-8.0.5/qnxsdp-env.sh
     qcc -v
 
 It's also possible to use ``tar`` directly, but it can be problematic on Windows hosts.
@@ -390,6 +404,6 @@ It's also possible to use ``tar`` directly, but it can be problematic on Windows
 .. code-block::
 
     cd $HOME
-    aws s3 cp s3://ferrocene-ci-mirrors/manual/qnx/qnx800-141-deployment.tar.zst - | tar -x --zstd -f-
-    source qnx/qnx800-141/qnxsdp-env.sh
+    aws s3 cp s3://ferrocene-ci-mirrors/manual/qnx/qnx-8.0.5-deployment.tar.zst - | tar -x --zstd -f-
+    source qnx/qnx-8.0.5/qnxsdp-env.sh
     qcc -v

--- a/ferrocene/packages.toml
+++ b/ferrocene/packages.toml
@@ -108,9 +108,9 @@ subset = "default"
 [groups.qnx]
 targets = [
   "aarch64-unknown-nto-qnx710",
-  # "aarch64-unknown-nto-qnx800",
+  "aarch64-unknown-nto-qnx800",
   "x86_64-pc-nto-qnx710",
-  # "x86_64-pc-nto-qnx800",
+  "x86_64-pc-nto-qnx800",
 ]
 
 [[groups.qnx.packages]]


### PR DESCRIPTION
Should be after https://github.com/ferrocene/ferrocene/pull/2454

We're swapping to a new, better scheme for QNX 8 deployments.