### PR TITLE
Add per-platform coverage reports to generated docs

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1262,6 +1262,7 @@ workflows:
             - aarch64-qnx-test-library-compiletest
             # - aarch64-qnx8-test-library-compiletest
             - aarch64-none-test-library-compiletest
+            - aarch64-none-library-coverage
             - aarch64-none-test-target-cpu-library-compiletest
             - aarch64r82-none-test-library-compiletest
             - aarch64v8r-none-test-library-compiletest
@@ -1331,6 +1332,16 @@ workflows:
           test-variant: 2021-cortex-a53
           qemu-arch: qemu-aarch64
           tasks: $(ferrocene/ci/split-tasks.py qnx:compiletest-no-only-hosts) $(ferrocene/ci/split-tasks.py test:library-nostd)
+          resource-class: large # 4-core
+          requires:
+            - x86_64-linux-build
+
+      - facade-generic-test:
+          name: aarch64-none-library-coverage
+          target: aarch64-unknown-ferrocene.facade
+          test-variant: 2021-cortex-a53
+          qemu-arch: qemu-aarch64
+          tasks: --coverage=library library/core library/alloc --tests
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -320,7 +320,7 @@ jobs:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       SCRIPT: |
         ferrocene/ci/scripts/llvm_cache.py download
-        ./x.py test --stage=1 --coverage=library library/core library/alloc --tests
+        ./x.py test --stage=1 --coverage=library $(ferrocene/ci/split-tasks.py test:library-coverage) --tests
     steps:
       - aws-oidc-auth
       - ferrocene-checkout:
@@ -570,7 +570,7 @@ jobs:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
       SCRIPT: |
         ferrocene/ci/scripts/llvm_cache.py download
-        ./x.py test --stage=1 --coverage=library library/core library/alloc --tests
+        ./x.py test --stage=1 --coverage=library $(ferrocene/ci/split-tasks.py test:library-coverage) --tests
     steps:
       - aws-oidc-auth
       - ferrocene-checkout:
@@ -1341,7 +1341,7 @@ workflows:
           target: aarch64-unknown-ferrocene.facade
           test-variant: 2021-cortex-a53
           qemu-arch: qemu-aarch64
-          tasks: --coverage=library library/core library/alloc --tests
+          tasks: --coverage=library $(ferrocene/ci/split-tasks.py test:library-coverage) --tests
           resource-class: large # 4-core
           requires:
             - x86_64-linux-build

--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -139,6 +139,9 @@ JOBS_DEFINITION: JobsDefinition = {
         # This is the library without std, for all targets that have no std.
         "library-nostd": ["library/core", "library/alloc", "library/test"],
 
+        # We currently only generate coverage for a subset of the standard library
+        "library-coverage": ["library/core", "library/alloc"],
+
         # The flip link tests require the `--target thumbv7-none-eabi` flag
         "flip-link": ["flip-link"],
     },

--- a/ferrocene/doc/core-certification/src/safety-report/code-coverage.rst
+++ b/ferrocene/doc/core-certification/src/safety-report/code-coverage.rst
@@ -4,4 +4,4 @@
 Code coverage report
 ====================
 
-`Code coverage report <../../../coverage/index.html>`_  of the certified core library, showing the statement coverage.
+`Code coverage report <../../../coverage/x86_64-linux/index.html>`_  of the certified core library, showing the statement coverage.

--- a/src/bootstrap/src/ferrocene/doc/code_coverage.rs
+++ b/src/bootstrap/src/ferrocene/doc/code_coverage.rs
@@ -6,6 +6,18 @@ use crate::core::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::core::config::{FerroceneCoverageOutcomes, TargetSelection};
 use crate::ferrocene::code_coverage::CoverageOutcomesDir;
 
+struct CoverageTarget {
+    triple: &'static str,
+    doc_name: &'static str,
+}
+
+// List of targets that we generate coverage for in CI
+const COVERAGE_TARGETS: [CoverageTarget; 3] = [
+    CoverageTarget { triple: "x86_64-unknown-linux-gnu", doc_name: "x86_64-linux" },
+    CoverageTarget { triple: "aarch64-unknown-linux-gnu", doc_name: "aarch64-linux" },
+    CoverageTarget { triple: "aarch64-unknown-ferrocene.facade", doc_name: "aarch64-none" },
+];
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub(crate) struct AllCoverageReports {
     pub(crate) target: TargetSelection,
@@ -34,29 +46,26 @@ impl Step for AllCoverageReports {
             panic!("can't generate coverage report with ferrocene.coverage-outcomes=\"disabled\"");
         };
 
-        let mut saw_coverage = false;
-        for entry in builder.read_dir(&outcomes_dir.join(self.target.to_string())) {
-            let name_buf = entry.file_name();
-            let name = name_buf.to_str().expect("only UTF-8 file paths supported");
-            assert!(name.ends_with(".html"), "unrecognized coverage report format");
+        for target in COVERAGE_TARGETS {
+            let src = outcomes_dir.join(target.triple).join("certified-coverage-report.html");
+            let out = builder
+                .doc_out(self.target)
+                .join("coverage")
+                .join(target.doc_name)
+                .join("index.html");
 
-            let out = builder.doc_out(self.target).join("coverage").join("index.html");
-            if out.exists() {
-                builder.remove(&out);
+            if !src.exists() {
+                panic!(
+                    "`x doc ferrocene-coverage` failed: no coverage report present in {} for target {}",
+                    outcomes_dir.display(),
+                    target.triple
+                );
             }
 
             builder.create_dir(out.parent().unwrap());
-            builder.info(&format!("Copying {} to {}", entry.path().display(), out.display()));
-            builder.copy_link(&entry.path(), &out, FileType::Regular);
+            builder.info(&format!("Copying {} to {}", src.display(), out.display()));
+            builder.copy_link(&src, &out, FileType::Regular);
             builder.info(&format!("Generated coverage at {}", out.display()));
-            saw_coverage = true;
-        }
-
-        if !saw_coverage {
-            panic!(
-                "`x doc ferrocene-coverage` failed: no coverage report present in {}",
-                outcomes_dir.display()
-            );
         }
     }
 }


### PR DESCRIPTION
The reports themselves are already generated by the coverage jobs, we just need to copy them over when we generate the documentation