### PR TITLE
[1.97] FLS updates for 26.08 release

### DIFF
--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -23,18 +23,89 @@ Language changes in Rust 1.95.0
 -------------------------------
 
 - `Stabilize if let guards on match arms <https://github.com/rust-lang/rust/pull/141295>`_
+
+  Changed syntax: :s:`MatchArmGuard`
+
+  New syntax:
+
+  - :s:`MatchArmGuardChain`
+  - :s:`MatchArmGuardCondition`
+  - :s:`MatchArmGuardExpression`
+  - :s:`MatchArmGuardLetPattern`
+
+  New paragraphs:
+
+  - :p:`fls_UlxLrpyPlVmv`
+  - :p:`fls_XADcpJBUxSfv`
+  - :p:`fls_gfHe2Cy6WXsK`
+  - :p:`fls_QQep7FKA1EQX`
+  - :p:`fls_Wepy5R7FZQPU`
+  - :p:`fls_imEIc7PUUO1x`
+  - :p:`fls_fs4ZpXjt0Wqt`
+  - :p:`fls_DT4N2rr6wpvZ`
+  - :p:`fls_AAuyKfxLgJ43`
+  - :p:`fls_uCDQMkWx5OMS`
+
+  Removed paragraph: :p:`fls_sbtx1l6n2tp2`
+
 - `irrefutable_let_patterns lint no longer lints on let chains <https://github.com/rust-lang/rust/pull/146832>`_
 
   - Lints are outside the scope of the FLS.
 
 - `Support importing path-segment keywords with renaming <https://github.com/rust-lang/rust/pull/146972>`_
+
+  - New paragraphs:
+
+    - :p:`fls_sUhnfV62HJrb`
+    - :p:`fls_QGdeRTe0H1Uc`
+    - :p:`fls_aam34hsRmKU2`
+    - :p:`fls_LV94x3HlpBWk`
+
 - `Stabilize ppc inline assembly <https://github.com/rust-lang/rust/pull/147996>`_
 
   - The target is outside the scope of the FLS.
 
 - `const-eval: be more consistent in the behavior of padding during typed copies <https://github.com/rust-lang/rust/pull/148967>`_
+
+  New paragraphs:
+
+  - :p:`fls_LmPbrh0Cba8g`
+  - :p:`fls_nwgIMLkvD2Ol`
+  - :p:`fls_hOIImCr1c6IF`
+
 - `Const blocks are no longer evaluated to determine if expressions involving fallible operations can implicitly be constant-promoted <https://github.com/rust-lang/rust/pull/150557>`_
+
+  - This implementation-specifc behavior is outside the scope of the FLS.
+
 - `Make operational semantics of pattern matching independent of crate and module <https://github.com/rust-lang/rust/pull/150681>`_
+
+  Changed paragraphs:
+
+  - :p:`fls_33hfay24hx8u`
+  - :p:`fls_uqy5w9uc8gla`
+
+  New paragraphs, which mostly document behavior that existed before this release:
+
+  - :p:`fls_rdDT7jsaOMbs`
+  - :p:`fls_j9WyKVyOLFon`
+  - :p:`fls_TbfUxVf8PKPs`
+  - :p:`fls_4TESOxGpEY2h`
+  - :p:`fls_eNkZWskzznW6`
+  - :p:`fls_v8IFXHJnXhez`
+  - :p:`fls_gujpU7p5n9Zx`
+  - :p:`fls_t8tFLUg8O83Q`
+  - :p:`fls_RaONmCLH2KGM`
+  - :p:`fls_Vt9C9mKxHOwo`
+  - :p:`fls_Fs12dmznjsMf`
+  - :p:`fls_7EXHdE2eOVek`
+  - :p:`fls_iLH8X2U4ADHb`
+  - :p:`fls_HMJUXHrvOmPl`
+  - :p:`fls_Gj1znNpthHY6`
+  - :p:`fls_IFyJvb6mlFU4`
+  - :p:`fls_7NEEJgKSpQQ8`
+  - :p:`fls_kYFd3p06pWWV`
+  - :p:`fls_fATMTNUOHsfb`
+  - :p:`fls_fITor3jpmgrl`
 
 Language changes in Rust 1.94.0
 -------------------------------

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -19,6 +19,29 @@ with the change that has been applied due to it.
    just the language changes that had an impact to the FLS. See the `release
    notes`_ for a full list of changes.
 
+Language changes in Rust 1.96.0
+-------------------------------
+
+- `Allow passing expr metavariable to cfg <https://github.com/rust-lang/rust/pull/146961>`_
+
+  - Bug fix in the compiler. The FLS already reflects the correct semantics.
+
+- `Always coerce never types in tuple expressions <https://github.com/rust-lang/rust/pull/147834>`_
+
+  - Bug fix in the compiler. The FLS already reflects the correct semantics.
+
+- `Avoid incorrect inference guidance of function arguments in rare cases <https://github.com/rust-lang/rust/pull/150316>`_
+
+  - Bug fix in the compiler without a corresponding language change.
+
+- `Support s390x vector registers in inline assembly <https://github.com/rust-lang/rust/pull/154184>`_
+
+  - The target is outside the scope of the FLS.
+
+- `Allow using constants of type ManuallyDrop as patterns (fixing a regression introduced in 1.94.0) <https://github.com/rust-lang/rust/pull/154891>`_
+
+  - Bug fix in the compiler without a corresponding language change.
+
 Language changes in Rust 1.95.0
 -------------------------------
 

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -103,6 +103,7 @@ Language changes in Rust 1.95.0
     - :p:`fls_sUhnfV62HJrb`
     - :p:`fls_QGdeRTe0H1Uc`
     - :p:`fls_aam34hsRmKU2`
+    - :p:`fls_uSajfdSsbxna`
 
   - Changed paragraphs:
 
@@ -110,6 +111,7 @@ Language changes in Rust 1.95.0
     - :p:`fls_iuzvtr3oax1o`
     - :p:`fls_90hQvSh7Bfyg`
     - :p:`fls_RUiFQ17bmRLt`
+    - :p:`fls_opn5n5t2mo3m`
 
 - `Stabilize ppc inline assembly <https://github.com/rust-lang/rust/pull/147996>`_
 

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -19,6 +19,27 @@ with the change that has been applied due to it.
    just the language changes that had an impact to the FLS. See the `release
    notes`_ for a full list of changes.
 
+Language changes in Rust 1.97.0
+-------------------------------
+
+- `Consider 'Result<T, Uninhabited>' and 'ControlFlow<Uninhabited, T>' to be equivalent to 'T' for must use lint <https://github.com/rust-lang/rust/pull/148214>`_
+
+  - Lints are outside the scope of the FLS.
+
+- `Add allow-by-default 'dead_code_pub_in_binary' lint for unused pub items in binary crates <https://github.com/rust-lang/rust/pull/149509>`_
+
+  - Lints are outside the scope of the FLS.
+
+- `Stabilize the 'div32', 'lam-bh', 'lamcas', 'ld-seq-sa' and 'scq' target features <https://github.com/rust-lang/rust/pull/154510>`_
+
+  - The target is outside the scope of the FLS
+
+- `Stabilize 'cfg(target_has_atomic_primitive_alignment)' <https://github.com/rust-lang/rust/pull/155006>`_
+
+  - Configuration options are environment-specific and not exhaustive
+
+- `Allow trailing 'self' in imports in more cases <https://github.com/rust-lang/rust/pull/155137>`_
+
 Language changes in Rust 1.96.0
 -------------------------------
 

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -104,6 +104,7 @@ Language changes in Rust 1.95.0
     - :p:`fls_QGdeRTe0H1Uc`
     - :p:`fls_aam34hsRmKU2`
     - :p:`fls_uSajfdSsbxna`
+    - :p:`fls_aam34hsRmKU2`
 
   - Changed paragraphs:
 

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -112,6 +112,7 @@ Language changes in Rust 1.95.0
     - :p:`fls_90hQvSh7Bfyg`
     - :p:`fls_RUiFQ17bmRLt`
     - :p:`fls_opn5n5t2mo3m`
+    - :p:`fls_7k88ypcgaoff`
 
   - Removed paragraphs:
 

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -108,6 +108,9 @@ Language changes in Rust 1.95.0
   - Changed paragraphs:
 
     - :p:`fls_2bkcn83smy2y`
+    - :p:`fls_iuzvtr3oax1o`
+    - :p:`fls_90hQvSh7Bfyg`
+    - :p:`fls_RUiFQ17bmRLt`
 
 - `Stabilize ppc inline assembly <https://github.com/rust-lang/rust/pull/147996>`_
 

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -103,7 +103,6 @@ Language changes in Rust 1.95.0
     - :p:`fls_sUhnfV62HJrb`
     - :p:`fls_QGdeRTe0H1Uc`
     - :p:`fls_aam34hsRmKU2`
-    - :p:`fls_LV94x3HlpBWk`
 
   - Changed paragraphs:
 
@@ -157,6 +156,13 @@ Language changes in Rust 1.95.0
   - :p:`fls_kYFd3p06pWWV`
   - :p:`fls_fATMTNUOHsfb`
   - :p:`fls_fITor3jpmgrl`
+
+FLS maintenance
+---------------
+New paragraphs:
+
+- :p:`fls_CSuxTkwR96j9`
+- :p:`fls_LV94x3HlpBWk`
 
 Language changes in Rust 1.94.0
 -------------------------------

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -40,6 +40,17 @@ Language changes in Rust 1.97.0
 
 - `Allow trailing 'self' in imports in more cases <https://github.com/rust-lang/rust/pull/155137>`_
 
+  Changed paragraphs:
+
+  - :p:`fls_uSajfdSsbxna`
+  - :p:`fls_2bkcn83smy2y`
+  - :p:`fls_ar03D5rxjzy0`
+
+FLS maintenance
+---------------
+
+New paragraph: :p:`fls_oRdi3KXFbJcR`
+
 Language changes in Rust 1.96.0
 -------------------------------
 

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -113,6 +113,12 @@ Language changes in Rust 1.95.0
     - :p:`fls_RUiFQ17bmRLt`
     - :p:`fls_opn5n5t2mo3m`
 
+  - Removed paragraphs:
+
+    - :p:`fls_cw006jhlboa`
+    - :p:`fls_hv3xT2CjZuxc`
+    - :p:`fls_Pxc0Ts8Y7pfW`
+
 - `Stabilize ppc inline assembly <https://github.com/rust-lang/rust/pull/147996>`_
 
   - The target is outside the scope of the FLS.

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -105,6 +105,10 @@ Language changes in Rust 1.95.0
     - :p:`fls_aam34hsRmKU2`
     - :p:`fls_LV94x3HlpBWk`
 
+  - Changed paragraphs:
+
+    - :p:`fls_2bkcn83smy2y`
+
 - `Stabilize ppc inline assembly <https://github.com/rust-lang/rust/pull/147996>`_
 
   - The target is outside the scope of the FLS.

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -175,10 +175,7 @@ FLS maintenance
 
 - Changed paragraph: :p:`fls_1941wid94hlg`
 
-- New paragraphs:
-
-  - :p:`fls_CSuxTkwR96j9`
-  - :p:`fls_LV94x3HlpBWk`
+- New paragraph: :p:`fls_LV94x3HlpBWk`
 
 - Replace the term "simple path prefix" with "common path prefix", to improve clarity.
 

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -172,10 +172,15 @@ Language changes in Rust 1.95.0
 
 FLS maintenance
 ---------------
-New paragraphs:
 
-- :p:`fls_CSuxTkwR96j9`
-- :p:`fls_LV94x3HlpBWk`
+- Changed paragraph: :p:`fls_1941wid94hlg`
+
+- New paragraphs:
+
+  - :p:`fls_CSuxTkwR96j9`
+  - :p:`fls_LV94x3HlpBWk`
+
+- Replace the term "simple path prefix" with "common path prefix", to improve clarity.
 
 Language changes in Rust 1.94.0
 -------------------------------

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -114,8 +114,8 @@ Language changes in Rust 1.95.0
     - :p:`fls_RUiFQ17bmRLt`
     - :p:`fls_opn5n5t2mo3m`
     - :p:`fls_7k88ypcgaoff`
-    - :dp:`fls_yY58pFpkig9o`
-    - :dp:`fls_ar03D5rxjzy0`
+    - :p:`fls_yY58pFpkig9o`
+    - :p:`fls_ar03D5rxjzy0`
 
   - Removed paragraphs:
 

--- a/ferrocene/doc/specification/src/changelog.rst
+++ b/ferrocene/doc/specification/src/changelog.rst
@@ -114,12 +114,15 @@ Language changes in Rust 1.95.0
     - :p:`fls_RUiFQ17bmRLt`
     - :p:`fls_opn5n5t2mo3m`
     - :p:`fls_7k88ypcgaoff`
+    - :dp:`fls_yY58pFpkig9o`
+    - :dp:`fls_ar03D5rxjzy0`
 
   - Removed paragraphs:
 
     - :p:`fls_cw006jhlboa`
     - :p:`fls_hv3xT2CjZuxc`
     - :p:`fls_Pxc0Ts8Y7pfW`
+    - :p:`fls_kz2Gij5wHXnl`
 
 - `Stabilize ppc inline assembly <https://github.com/rust-lang/rust/pull/147996>`_
 

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1135,6 +1135,18 @@ same :t:`namespace` but refer to different :t:`entities <entity>` if the
 If two :t:`[glob import]s` import the same :t:`entity` under the same :t:`name`,
 the :t:`visibility` of the :t:`name` is the most permissive one.
 
+:dp:`fls_sUhnfV62HJrb`
+When :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` is used to import the current :t:`crate`, a :t:`renaming` must be used to define the :t:`binding` name.
+
+:dp:`fls_QGdeRTe0H1Uc`
+When :t:`keyword` ``super`` is used to import a parent :t:`module`, a :t:`renaming` must be used to define the :t:`binding` name.
+
+:dp:`fls_aam34hsRmKU2`
+An :t:`external prelude` cannot be imported.
+
+:dp:`fls_LV94x3HlpBWk`
+A :t:`simple import` cannot refer to :t:`[enum variant]s` through a :t:`type alias`.
+
 .. rubric:: Examples
 
 :dp:`fls_5dlnffim6fso`
@@ -1163,8 +1175,6 @@ The following is a selective import. The imported functions are
 
    use outer_module::inner_module
        {crate_visible_function, visible_function}
-
-.. rubric:: Legality Rules
 
 .. _fls_ydmnb7qnmzzq:
 

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1134,10 +1134,10 @@ If two :t:`[glob import]s` import the same :t:`entity` under the same :t:`name`,
 the :t:`visibility` of the :t:`name` is the most permissive one.
 
 :dp:`fls_sUhnfV62HJrb`
-When a :t:`path segment` expressed as :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` is used to import the current :t:`crate`, the :t:`path segment` shall be subject to a :t:`renaming`.
+When a :t:`path segment` expressed as :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` is used to import the current :t:`crate`, the imported :t:`entity` shall be subject to a :t:`renaming`.
 
 :dp:`fls_QGdeRTe0H1Uc`
-When a :t:`path segment` expressed as :t:`keyword` ``super`` is used to import a parent :t:`module`, the :t:`path segment` shall be subject to a :t:`renaming`.
+When a :t:`path segment` expressed as :t:`keyword` ``super`` is used to import a parent :t:`module`, the imported :t:`entity` shall be subject to a :t:`renaming`.
 
 :dp:`fls_aam34hsRmKU2`
 A :t:`simple path` consisting of namespace qualifier ``::`` followed by a :t:`path segment` expressed as :t:`keyword` ``self`` shall not be used.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -330,12 +330,6 @@ If a :t:`simple path` appears in a :t:`use import` and starts with a
 :t:`path` shall be the :t:`simple path prefix` of a :t:`glob import` or a
 :t:`nesting import`, or the :t:`path` of a :t:`simple import`.
 
-:dp:`fls_cw006jhlboa`
-If a :t:`simple path` appears in a :t:`use import` and starts with a
-:t:`path segment` expressed as :t:`keyword` ``self``, then the :t:`path` shall
-be part of the :s:`UseImportContent` of a :t:`nesting import` as long as the
-:t:`path` is a :t:`single segment path`.
-
 :dp:`fls_kv5bpq8rf1j9`
 A :t:`simple path` is subject to :t:`simple path resolution`.
 
@@ -1115,15 +1109,7 @@ A :t:`glob import` outside of a :t:`nesting import` without a :t:`simple path
 prefix` is rejected, but may still be consumed by :t:`[macro]s`.
 
 :dp:`fls_RUiFQ17bmRLt`
-A :t:`simple import` with a single :t:`path segment` of
-keyword ``self`` shall be subject to the following:
-
-* :dp:`fls_hv3xT2CjZuxc`
-  It shall either appear in a :t:`nesting import` with a non-empty
-  :t:`import path prefix`, or
-
-* :dp:`fls_Pxc0Ts8Y7pfW`
-  It shall be subject to a :t:`renaming`.
+A :t:`simple import` with a single :t:`path segment` of :t:`keyword` ``self`` shall be subject to a :t:`renaming`.
 
 :dp:`fls_wB3fVglLOqbZ`
 It is a static error if two :t:`[glob import]s` import the same :t:`name` in the

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1140,7 +1140,7 @@ When a :t:`path segment` expressed as :t:`keyword` ``crate`` or :t:`keyword` ``$
 When a :t:`path segment` expressed as :t:`keyword` ``super`` is used to import a parent :t:`module`, the :t:`path segment` shall be subject to a :t:`renaming`.
 
 :dp:`fls_aam34hsRmKU2`
-A :t:`simple path` consisting of namespace qualifier ``::``, followed by a :t:`path segment` expressed as :t:`keyword` ``self``, shall not be used.
+A :t:`simple path` consisting of namespace qualifier ``::`` followed by a :t:`path segment` expressed as :t:`keyword` ``self`` shall not be used.
 
 :dp:`fls_LV94x3HlpBWk`
 A :t:`simple import` shall not refer to :t:`[enum variant]s` through a :t:`type alias`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1074,16 +1074,11 @@ A :dt:`simple import path` is the :t:`path` constructed by appending the last
 :dp:`fls_wRmvtgQkFA6w`
 A :t:`simple import` brings :t:`[name]s` into :t:`scope` as follows:
 
-* :dp:`fls_kz2Gij5wHXnl`
-  If the :t:`simple path` is keyword ``self`` and:
+* :dp:`fls_yY58pFpkig9o`
+  If the :t:`simple import` appears in a :t:`nesting import`, and the last :t:`path segment` of its :t:`simple path` is expressed as :t:`keyword` ``self``, then bring the :t:`entity` in :t:`type namespace` that the :t:`import path prefix` resolves to into :t:`scope`.
 
-  * :dp:`fls_yY58pFpkig9o`
-    The :t:`simple import` is in a :t:`nesting import`, then bring the
-    :t:`entity` in :t:`type namespace` that the :t:`import path prefix` resolves
-    to into :t:`scope`.
-
-  * :dp:`fls_ar03D5rxjzy0`
-    Otherwise bring the containing :t:`module` into :t:`scope`.
+* :dp:`fls_ar03D5rxjzy0`
+  If the :t:`simple path` is :t:`keyword` ``self``, then bring the containing :t:`module` into :t:`scope`.
 
 * :dp:`fls_ce73bg0BqV1X`
   Otherwise bring all :t:`entities <entity>` that the :t:`simple import path`

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1134,10 +1134,10 @@ If two :t:`[glob import]s` import the same :t:`entity` under the same :t:`name`,
 the :t:`visibility` of the :t:`name` is the most permissive one.
 
 :dp:`fls_sUhnfV62HJrb`
-When :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` is used to import the current :t:`crate`, a :t:`renaming` must be used to define the :t:`binding` name.
+When :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` is used to import the current :t:`crate`, the keyword shall be subject to a :t:`renaming`.
 
 :dp:`fls_QGdeRTe0H1Uc`
-When :t:`keyword` ``super`` is used to import a parent :t:`module`, a :t:`renaming` must be used to define the :t:`binding` name.
+When :t:`keyword` ``super`` is used to import a parent :t:`module`, the keyword shall be subject to a :t:`renaming`.
 
 :dp:`fls_aam34hsRmKU2`
 An :t:`external prelude` cannot be imported.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1134,7 +1134,7 @@ If two :t:`[glob import]s` import the same :t:`entity` under the same :t:`name`,
 the :t:`visibility` of the :t:`name` is the most permissive one.
 
 :dp:`fls_sUhnfV62HJrb`
-When a :t:`path segment` expressed as :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` is used to import the current :t:`crate`, the imported :t:`entity` shall be subject to a :t:`renaming`.
+An import with a single :t:`path segment` of either :t:`keyword` ``crate`` or ``$crate`` shall be subject to a :t:`renaming`.
 
 :dp:`fls_QGdeRTe0H1Uc`
 When a :t:`path segment` expressed as :t:`keyword` ``super`` is used to import a parent :t:`module`, the imported :t:`entity` shall be subject to a :t:`renaming`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1049,9 +1049,7 @@ An :dt:`import path prefix` is the fully constructed :t:`path` prefix of a
    the current :t:`use import`.
 
 :dp:`fls_2bkcn83smy2y`
-A :t:`simple import` is a :t:`use import` that brings all :t:`entities <entity>`
-it refers to into scope, optionally with a different
-:t:`name` than they are declared with by using a :t:`renaming`.
+A :dt:`simple import` is a :t:`use import` that brings a :t:`simple path` into scope, optionally with a :t:`renaming`.
 
 :dp:`fls_v3a6y2ze44v2`
 A :t:`glob import` is a :t:`use import` that brings all :t:`entities <entity>`

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1137,7 +1137,7 @@ the :t:`visibility` of the :t:`name` is the most permissive one.
 When a :t:`path segment` expressed as :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` is used to import the current :t:`crate`, the :t:`path segment` shall be subject to a :t:`renaming`.
 
 :dp:`fls_QGdeRTe0H1Uc`
-When :t:`keyword` ``super`` is used to import a parent :t:`module`, the keyword shall be subject to a :t:`renaming`.
+When a :t:`path segment` expressed as :t:`keyword` ``super`` is used to import a parent :t:`module`, the :t:`path segment` shall be subject to a :t:`renaming`.
 
 :dp:`fls_aam34hsRmKU2`
 A :t:`simple path` consisting of namespace qualifier ``::``, followed by a :t:`path segment` expressed as :t:`keyword` ``self``, shall not be used.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1111,7 +1111,7 @@ If two :t:`[glob import]s` import the same :t:`entity` under the same :t:`name`,
 the :t:`visibility` of the :t:`name` is the most permissive one.
 
 :dp:`fls_RUiFQ17bmRLt`
-A :t:`simple import` with a single :t:`path segment` expressed as :t:`keyword` ``self`` shall be subject to a :t:`renaming`.
+When a :t:`path segment` expressed as :t:`keyword` ``self`` is used to import the current :t:`module`, the imported :t:`entity` shall be subject to a :t:`renaming`.
 
 :dp:`fls_sUhnfV62HJrb`
 A :t:`use import` with a single :t:`path segment` expressed as either :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` shall be subject to a :t:`renaming`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1118,7 +1118,7 @@ If two :t:`[glob import]s` import the same :t:`entity` under the same :t:`name`,
 the :t:`visibility` of the :t:`name` is the most permissive one.
 
 :dp:`fls_RUiFQ17bmRLt`
-A :t:`simple import` with a single :t:`path segment` of :t:`keyword` ``self`` shall be subject to a :t:`renaming`.
+A :t:`simple import` with a single :t:`path segment` expressed as :t:`keyword` ``self`` shall be subject to a :t:`renaming`.
 
 :dp:`fls_sUhnfV62HJrb`
 An :t:`import <use import>` with a single :t:`path segment` of either :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` shall be subject to a :t:`renaming`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -327,7 +327,7 @@ If a :t:`simple path` appears in a :t:`use import` and starts with a
 :t:`path segment` expressed as either :t:`keyword` ``crate``, :t:`keyword`
 ``$crate``, :t:`keyword` ``self``, or :t:`keyword` ``super``, then the
 :t:`path` shall be the :t:`simple path prefix` of a :t:`glob import` or a
-:t:`nesting import`, or the :t:`simple path` of a :t:`simple import`.
+:t:`nesting import`, or the :t:`path` of a :t:`simple import`.
 
 :dp:`fls_cw006jhlboa`
 If a :t:`simple path` appears in a :t:`use import` and starts with a
@@ -1073,7 +1073,7 @@ A :t:`glob import` brings :t:`[name]s` into :t:`scope` as follows:
 
 :dp:`fls_90hQvSh7Bfyg`
 A :dt:`simple import path` is the :t:`path` constructed by appending the last
-:t:`path segment` of a :t:`simple import`'s :t:`simple path` to the
+:t:`path segment` of the :t:`path` of the :t:`simple import` to the
 :t:`import path prefix`.
 
 :dp:`fls_wRmvtgQkFA6w`
@@ -1114,7 +1114,7 @@ A :t:`glob import` outside of a :t:`nesting import` without a :t:`simple path
 prefix` is rejected, but may still be consumed by :t:`[macro]s`.
 
 :dp:`fls_RUiFQ17bmRLt`
-A :t:`simple import` with a :t:`simple path` with a single :t:`path segment` of
+A :t:`simple import` with a single :t:`path segment` of
 keyword ``self`` shall be subject to the following:
 
 * :dp:`fls_hv3xT2CjZuxc`

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1134,7 +1134,7 @@ If two :t:`[glob import]s` import the same :t:`entity` under the same :t:`name`,
 the :t:`visibility` of the :t:`name` is the most permissive one.
 
 :dp:`fls_sUhnfV62HJrb`
-When a :t:`simple path segment` expressed as :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` is used to import the current :t:`crate`, the :t:`simple import` shall be subject to a :t:`renaming`.
+When a :t:`simple path segment` expressed as :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` is used to import the current :t:`crate`, the :t:`path segment` shall be subject to a :t:`renaming`.
 
 :dp:`fls_QGdeRTe0H1Uc`
 When :t:`keyword` ``super`` is used to import a parent :t:`module`, the keyword shall be subject to a :t:`renaming`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1044,7 +1044,7 @@ An :dt:`import path prefix` is the fully constructed :t:`path` prefix of a
    the current :t:`use import`.
 
 :dp:`fls_2bkcn83smy2y`
-A :dt:`simple import` is a :t:`use import` that brings a :t:`simple path` into scope, optionally with a :t:`renaming`.
+A :dt:`simple import` is a :t:`use import` that bring an :t:`entity` selected by its :t:`simple import path`, or by its :t:`import path prefix` when its :t:`simple path` ends in :t:`keyword` ``self`` and it appears in a :t:`nesting import`, into :t:`scope`.
 
 :dp:`fls_v3a6y2ze44v2`
 A :t:`glob import` is a :t:`use import` that brings all :t:`entities <entity>`

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -298,7 +298,7 @@ A :t:`path` is subject to :t:`path resolution`.
 If a :t:`path segment` is expressed as either :t:`keyword` ``crate``, :t:`keyword` ``$crate``, or :t:`keyword` ``Self``, then the :t:`path segment` shall be the first :t:`path segment` of a :t:`path`.
 
 :dp:`fls_uSajfdSsbxna`
-If a :t:`path segment` is expressed as :t:`keyword` ``self``, then the :t:`path segment` shall be the first :t:`path segment` of a :t:`path`, except that it may also be the last :t:`path segment` of a :t:`simple import` that appears in a :t:`nesting import`.
+If a :t:`path segment` is expressed as :t:`keyword` ``self``, then the :t:`path segment` shall be either the first :t:`path segment` of a :t:`path`, or the last :t:`path segment` of a :t:`simple import` that appears in a :t:`nesting import`.
 
 :dp:`fls_774uryecc2sx`
 A :t:`path` that starts with a :t:`path segment` that is expressed as

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1075,7 +1075,7 @@ A :dt:`simple import path` is the :t:`path` constructed by appending the last
 A :t:`simple import` brings :t:`[name]s` into :t:`scope` as follows:
 
 * :dp:`fls_yY58pFpkig9o`
-  If the :t:`simple import` appears in a :t:`nesting import`, and the last :t:`path segment` of its :t:`simple path` is expressed as :t:`keyword` ``self``, then bring the :t:`entity` in :t:`type namespace` that the :t:`import path prefix` resolves to into :t:`scope`.
+  If the :t:`simple import` appears in a :t:`nesting import`, and the last :t:`path segment` of its :t:`simple path` is expressed as :t:`keyword` ``self``, then the :t:`simple import` brings the :t:`entity` that the :t:`import path prefix` resolves to in  :t:`scope` of the :t:`type namespace`.
 
 * :dp:`fls_ar03D5rxjzy0`
   If the :t:`simple path` is :t:`keyword` ``self``, then bring the containing :t:`module` into :t:`scope`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1096,7 +1096,7 @@ A :t:`simple import` brings :t:`[name]s` into :t:`scope` as follows:
   :t:`simple import` into :t:`scope`.
 
 :dp:`fls_FILuR3pfwjw3`
-An :t:`Entity` imported by a :t:`simple import` subject to a
+An :t:`entity` imported by a :t:`simple import` subject to a
 :t:`renaming` with :t:`identifier` is brought into :t:`scope` under the
 :t:`name` declared by the :t:`renaming`.
 

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1078,7 +1078,7 @@ A :t:`simple import` brings :t:`[name]s` into :t:`scope` as follows:
   If the :t:`simple import` appears in a :t:`nesting import`, and the last :t:`path segment` of its :t:`simple path` is expressed as :t:`keyword` ``self``, then the :t:`simple import` brings the :t:`entity` that the :t:`import path prefix` resolves to in :t:`scope` of the :t:`type namespace`.
 
 * :dp:`fls_ar03D5rxjzy0`
-  If the :t:`simple path` is :t:`keyword` ``self``, then bring the containing :t:`module` into :t:`scope`.
+  If the :t:`simple path` is expressed as :t:`keyword` ``self``, then the :t:`simple import` brings the containing :t:`module` into :t:`scope`.
 
 * :dp:`fls_ce73bg0BqV1X`
   Otherwise bring all :t:`entities <entity>` that the :t:`simple import path`

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -311,6 +311,9 @@ If a :t:`path segment` is expressed as :t:`keyword` ``super``, then each :t:`pat
 A :t:`global path` is a :t:`path` that starts with :t:`namespace qualifier`
 ``::``.
 
+:dp:`fls_P6dFw89ZDKv2`
+The first :t:`path segment` of a :t:`global path` shall be expressed as an :t:`identifier` whose :t:`name` matches the :t:`name` of a :t:`candidate external prelude entity`.
+
 :dp:`fls_n77icl6idazp`
 A :t:`simple path` is a :t:`path` whose :t:`[path segment]s` consist of either
 :t:`[identifier]s` or certain :t:`[keyword]s` as defined in the syntax rules
@@ -1124,7 +1127,7 @@ An :t:`import <use import>` with a single :t:`path segment` of either :t:`keywor
 When a :t:`path segment` expressed as :t:`keyword` ``super`` is used to import a parent :t:`module`, the imported :t:`entity` shall be subject to a :t:`renaming`.
 
 :dp:`fls_aam34hsRmKU2`
-A :t:`simple path` consisting of namespace qualifier ``::`` followed by a :t:`path segment` expressed as :t:`keyword` ``self`` shall not be used.
+A :t:`global path` where any of its :t:`[path segment]s` are expressed as any of the :t:`[keyword]s`, ``self``, ``super``, ``crate``, and ``$crate``, shall not be used.
 
 :dp:`fls_LV94x3HlpBWk`
 A :t:`simple import` shall not refer to :t:`[enum variant]s` through a :t:`type alias`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1134,7 +1134,7 @@ If two :t:`[glob import]s` import the same :t:`entity` under the same :t:`name`,
 the :t:`visibility` of the :t:`name` is the most permissive one.
 
 :dp:`fls_sUhnfV62HJrb`
-When :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` is used to import the current :t:`crate`, the keyword shall be subject to a :t:`renaming`.
+When a :t:`simple path segment` expressed as :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` is used to import the current :t:`crate`, the :t:`simple import` shall be subject to a :t:`renaming`.
 
 :dp:`fls_QGdeRTe0H1Uc`
 When :t:`keyword` ``super`` is used to import a parent :t:`module`, the keyword shall be subject to a :t:`renaming`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1145,7 +1145,7 @@ When :t:`keyword` ``super`` is used to import a parent :t:`module`, a :t:`renami
 An :t:`external prelude` cannot be imported.
 
 :dp:`fls_LV94x3HlpBWk`
-A :t:`simple import` cannot refer to :t:`[enum variant]s` through a :t:`type alias`.
+A :t:`simple import` shall not refer to :t:`[enum variant]s` through a :t:`type alias`.
 
 .. rubric:: Examples
 

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1134,7 +1134,7 @@ If two :t:`[glob import]s` import the same :t:`entity` under the same :t:`name`,
 the :t:`visibility` of the :t:`name` is the most permissive one.
 
 :dp:`fls_sUhnfV62HJrb`
-An :t:`import <use import>` with a single :t:`path segment` of either :t:`keyword` ``crate`` or ``$crate`` shall be subject to a :t:`renaming`.
+An :t:`import <use import>` with a single :t:`path segment` of either :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` shall be subject to a :t:`renaming`.
 
 :dp:`fls_QGdeRTe0H1Uc`
 When a :t:`path segment` expressed as :t:`keyword` ``super`` is used to import a parent :t:`module`, the imported :t:`entity` shall be subject to a :t:`renaming`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -327,7 +327,7 @@ A :dt:`path prefix` is a :t:`path` with its last :t:`path segment` and
 If a :t:`simple path` appears in a :t:`use import` and starts with a
 :t:`path segment` expressed as either :t:`keyword` ``crate``, :t:`keyword`
 ``$crate``, :t:`keyword` ``self``, or :t:`keyword` ``super``, then the
-:t:`path` shall be the :t:`simple path prefix` of a :t:`glob import` or a
+:t:`path` shall be the :t:`common path prefix` of a :t:`glob import` or a
 :t:`nesting import`, or the :t:`path` of a :t:`simple import`.
 
 :dp:`fls_kv5bpq8rf1j9`
@@ -991,15 +991,15 @@ Use Imports
      | SimpleImport
 
    GlobImport ::=
-       SimplePathPrefix? $$*$$
+       CommonPathPrefix? $$*$$
 
    NestingImport ::=
-       SimplePathPrefix? $${$$ UseImportContentList? $$}$$
+       CommonPathPrefix? $${$$ UseImportContentList? $$}$$
 
    SimpleImport ::=
        SimplePath Renaming?
 
-   SimplePathPrefix ::=
+   CommonPathPrefix ::=
        SimplePath? $$::$$
 
    UseImportContentList ::=
@@ -1013,7 +1013,7 @@ A :t:`use import` brings :t:`entities <entity>` :t:`in scope` within the
 :t:`use import` resides.
 
 :dp:`fls_sxo1jb25pl8a`
-A :t:`simple path prefix` is the leading :t:`simple path` of a :t:`glob import`
+A :dt:`common path prefix` is the leading :t:`simple path` of a :t:`glob import`
 or a :t:`nesting import`.
 
 :dp:`fls_WAA4WmohGu6T`
@@ -1031,15 +1031,15 @@ An :dt:`import path prefix` is the fully constructed :t:`path` prefix of a
 
    * :dp:`fls_2UyFcB6Our1v`
      If the :t:`use import` is a :t:`glob import` then start with the
-     :t:`[path segment]s` of the :t:`glob import`'s :t:`simple path prefix`.
+     :t:`[path segment]s` of the :t:`glob import`'s :t:`common path prefix`.
 
    * :dp:`fls_irdKqoYzBM0M`
      If the :t:`use import` is a :t:`nesting import` then start with the
-     :t:`[path segment]s` of the :t:`nesting import`'s :t:`simple path prefix`.
+     :t:`[path segment]s` of the :t:`nesting import`'s :t:`common path prefix`.
 
 #. :dp:`fls_gAWsqibl4GLq`
    Then if the current :t:`use import` is the child of a :t:`nesting import`,
-   prepend the :t:`nesting import`'s :t:`simple path prefix` to the
+   prepend the :t:`nesting import`'s :t:`common path prefix` to the
    :t:`import path prefix`. Repeat this step with the :t:`nesting import` as
    the current :t:`use import`.
 
@@ -1095,10 +1095,10 @@ An :t:`entity` imported by a :t:`simple import` subject to a :t:`renaming` with 
 
 :dp:`fls_ldr7tsuqw34s`
 A :t:`nesting import` is a :t:`use import` that provides a common
-:t:`simple path prefix` for its nested :t:`[use import]s`.
+:t:`common path prefix` for its nested :t:`[use import]s`.
 
 :dp:`fls_iNUBX5fJAI1N`
-A :t:`glob import` outside of a :t:`nesting import` without a :t:`simple path
+A :t:`glob import` outside of a :t:`nesting import` without a :t:`common path
 prefix` is rejected, but may still be consumed by :t:`[macro]s`.
 
 :dp:`fls_wB3fVglLOqbZ`

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1134,7 +1134,7 @@ If two :t:`[glob import]s` import the same :t:`entity` under the same :t:`name`,
 the :t:`visibility` of the :t:`name` is the most permissive one.
 
 :dp:`fls_sUhnfV62HJrb`
-When a :t:`simple path segment` expressed as :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` is used to import the current :t:`crate`, the :t:`path segment` shall be subject to a :t:`renaming`.
+When a :t:`path segment` expressed as :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` is used to import the current :t:`crate`, the :t:`path segment` shall be subject to a :t:`renaming`.
 
 :dp:`fls_QGdeRTe0H1Uc`
 When :t:`keyword` ``super`` is used to import a parent :t:`module`, the keyword shall be subject to a :t:`renaming`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -296,8 +296,11 @@ A :t:`path` is subject to :t:`path resolution`.
 
 :dp:`fls_opn5n5t2mo3m`
 If a :t:`path segment` is expressed as either :t:`keyword` ``crate``,
-:t:`keyword` ``$crate``, :t:`keyword` ``self``, or :t:`keyword` ``Self``, then
+:t:`keyword` ``$crate``, or :t:`keyword` ``Self``, then
 the :t:`path segment` shall be the first :t:`path segment` of a :t:`path`.
+
+:dp:`fls_uSajfdSsbxna`
+If a :t:`path segment` is expressed as :t:`keyword` ``self``, then the :t:`path segment` shall be the first :t:`path segment` of a :t:`path`, except that it may also be the last :t:`path segment` of a :t:`simple import` that appears in a :t:`nesting import`.
 
 :dp:`fls_774uryecc2sx`
 A :t:`path` that starts with a :t:`path segment` that is expressed as

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1108,9 +1108,6 @@ A :t:`nesting import` is a :t:`use import` that provides a common
 A :t:`glob import` outside of a :t:`nesting import` without a :t:`simple path
 prefix` is rejected, but may still be consumed by :t:`[macro]s`.
 
-:dp:`fls_RUiFQ17bmRLt`
-A :t:`simple import` with a single :t:`path segment` of :t:`keyword` ``self`` shall be subject to a :t:`renaming`.
-
 :dp:`fls_wB3fVglLOqbZ`
 It is a static error if two :t:`[glob import]s` import the same :t:`name` in the
 same :t:`namespace` but refer to different :t:`entities <entity>` if the
@@ -1119,6 +1116,9 @@ same :t:`namespace` but refer to different :t:`entities <entity>` if the
 :dp:`fls_zmYSBW995kSN`
 If two :t:`[glob import]s` import the same :t:`entity` under the same :t:`name`,
 the :t:`visibility` of the :t:`name` is the most permissive one.
+
+:dp:`fls_RUiFQ17bmRLt`
+A :t:`simple import` with a single :t:`path segment` of :t:`keyword` ``self`` shall be subject to a :t:`renaming`.
 
 :dp:`fls_sUhnfV62HJrb`
 An :t:`import <use import>` with a single :t:`path segment` of either :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` shall be subject to a :t:`renaming`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -305,10 +305,7 @@ A :t:`path` that starts with a :t:`path segment` that is expressed as
 :t:`keyword` ``$crate`` shall appear only within a :t:`macro transcriber`.
 
 :dp:`fls_7k88ypcgaoff`
-If a :t:`path segment` is expressed as :t:`keyword` ``super``, then the
-:t:`path segment` shall either be the first :t:`path segment` of a :t:`path`,
-or the previous :t:`path segment` of the :t:`path` shall also be expressed as
-:t:`keyword` ``super``.
+If a :t:`path segment` is expressed as :t:`keyword` ``super``, then each :t:`path segment` that precedes it in the :t:`path` shall be expressed as :t:`keyword` ``super``, except that the first :t:`path segment` of the :t:`path` may be expressed as :t:`keyword` ``self``.
 
 :dp:`fls_7kb6ltajgiou`
 A :t:`global path` is a :t:`path` that starts with :t:`namespace qualifier`

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1044,7 +1044,7 @@ An :dt:`import path prefix` is the fully constructed :t:`path` prefix of a
    the current :t:`use import`.
 
 :dp:`fls_2bkcn83smy2y`
-A :dt:`simple import` is a :t:`use import` that bring an :t:`entity` selected by its :t:`simple import path`, or by its :t:`import path prefix` when its :t:`simple path` ends in :t:`keyword` ``self`` and it appears in a :t:`nesting import`, into :t:`scope`.
+A :dt:`simple import` is a :t:`use import` that brings into :t:`scope` an :t:`entity` selected by its :t:`simple import path`, or by its :t:`import path prefix` when its :t:`simple path` ends in :t:`keyword` ``self`` and the :t:`simple path` appears in a :t:`nesting import`.
 
 :dp:`fls_v3a6y2ze44v2`
 A :t:`glob import` is a :t:`use import` that brings all :t:`entities <entity>`

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -295,9 +295,7 @@ A :t:`path segment` is an element of a :t:`path`.
 A :t:`path` is subject to :t:`path resolution`.
 
 :dp:`fls_opn5n5t2mo3m`
-If a :t:`path segment` is expressed as either :t:`keyword` ``crate``,
-:t:`keyword` ``$crate``, or :t:`keyword` ``Self``, then
-the :t:`path segment` shall be the first :t:`path segment` of a :t:`path`.
+If a :t:`path segment` is expressed as either :t:`keyword` ``crate``, :t:`keyword` ``$crate``, or :t:`keyword` ``Self``, then the :t:`path segment` shall be the first :t:`path segment` of a :t:`path`.
 
 :dp:`fls_uSajfdSsbxna`
 If a :t:`path segment` is expressed as :t:`keyword` ``self``, then the :t:`path segment` shall be the first :t:`path segment` of a :t:`path`, except that it may also be the last :t:`path segment` of a :t:`simple import` that appears in a :t:`nesting import`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1140,7 +1140,7 @@ When :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` is used to import the cur
 When :t:`keyword` ``super`` is used to import a parent :t:`module`, the keyword shall be subject to a :t:`renaming`.
 
 :dp:`fls_aam34hsRmKU2`
-An :t:`external prelude` cannot be imported.
+A :t:`simple path` consisting of namespace qualifier ``::``, followed by a :t:`path segment` expressed as :t:`keyword` ``self``, shall not be used.
 
 :dp:`fls_LV94x3HlpBWk`
 A :t:`simple import` shall not refer to :t:`[enum variant]s` through a :t:`type alias`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1134,7 +1134,7 @@ If two :t:`[glob import]s` import the same :t:`entity` under the same :t:`name`,
 the :t:`visibility` of the :t:`name` is the most permissive one.
 
 :dp:`fls_sUhnfV62HJrb`
-An import with a single :t:`path segment` of either :t:`keyword` ``crate`` or ``$crate`` shall be subject to a :t:`renaming`.
+An :t:`import <use import>` with a single :t:`path segment` of either :t:`keyword` ``crate`` or ``$crate`` shall be subject to a :t:`renaming`.
 
 :dp:`fls_QGdeRTe0H1Uc`
 When a :t:`path segment` expressed as :t:`keyword` ``super`` is used to import a parent :t:`module`, the imported :t:`entity` shall be subject to a :t:`renaming`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1075,7 +1075,7 @@ A :dt:`simple import path` is the :t:`path` constructed by appending the last
 A :t:`simple import` brings :t:`[name]s` into :t:`scope` as follows:
 
 * :dp:`fls_yY58pFpkig9o`
-  If the :t:`simple import` appears in a :t:`nesting import`, and the last :t:`path segment` of its :t:`simple path` is expressed as :t:`keyword` ``self``, then the :t:`simple import` brings the :t:`entity` that the :t:`import path prefix` resolves to in :t:`scope` of the :t:`type namespace`.
+  If the :t:`simple import` appears in a :t:`nesting import` and the last :t:`path segment` of its :t:`simple path` is expressed as :t:`keyword` ``self``, then the :t:`simple import` brings the :t:`entity` in :t:`type namespace` that the :t:`import path prefix` resolves to into :t:`scope`.
 
 * :dp:`fls_ar03D5rxjzy0`
   If the :t:`simple path` is expressed as :t:`keyword` ``self``, then the :t:`simple import` brings the containing :t:`module` into :t:`scope`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1091,9 +1091,7 @@ An :t:`entity` imported by a :t:`simple import` subject to a
 :t:`name` declared by the :t:`renaming`.
 
 :dp:`fls_iQOgxNihUEr7`
-A :t:`trait` imported by a :t:`simple import` subject to a
-:t:`renaming` with character underscore ``_`` is added into :t:`scope` without
-a :t:`name`.
+An :t:`entity` imported by a :t:`simple import` subject to a :t:`renaming` with character underscore ``_`` is added into :t:`scope` without a :t:`name`.
 
 :dp:`fls_ldr7tsuqw34s`
 A :t:`nesting import` is a :t:`use import` that provides a common

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1120,7 +1120,7 @@ A :t:`use import` with a single :t:`path segment` expressed as either :t:`keywor
 When a :t:`path segment` expressed as :t:`keyword` ``super`` is used to import a parent :t:`module`, the imported :t:`entity` shall be subject to a :t:`renaming`.
 
 :dp:`fls_aam34hsRmKU2`
-A :t:`global path` where any of its :t:`[path segment]s` are expressed as any of the :t:`[keyword]s`, ``self``, ``super``, ``crate``, and ``$crate``, shall not be used.
+A :t:`simple import` whose :t:`import path prefix` consists only of :t:`namespace qualifier` ``::`` and whose :t:`simple path` consists of a single :t:`path segment` expressed as :t:`keyword` ``self`` shall not be used.
 
 :dp:`fls_LV94x3HlpBWk`
 A :t:`simple import` shall not refer to :t:`[enum variant]s` through a :t:`type alias`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1121,7 +1121,7 @@ the :t:`visibility` of the :t:`name` is the most permissive one.
 A :t:`simple import` with a single :t:`path segment` expressed as :t:`keyword` ``self`` shall be subject to a :t:`renaming`.
 
 :dp:`fls_sUhnfV62HJrb`
-An :t:`import <use import>` with a single :t:`path segment` of either :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` shall be subject to a :t:`renaming`.
+A :t:`use import` with a single :t:`path segment` expressed as either :t:`keyword` ``crate`` or :t:`keyword` ``$crate`` shall be subject to a :t:`renaming`.
 
 :dp:`fls_QGdeRTe0H1Uc`
 When a :t:`path segment` expressed as :t:`keyword` ``super`` is used to import a parent :t:`module`, the imported :t:`entity` shall be subject to a :t:`renaming`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -1075,7 +1075,7 @@ A :dt:`simple import path` is the :t:`path` constructed by appending the last
 A :t:`simple import` brings :t:`[name]s` into :t:`scope` as follows:
 
 * :dp:`fls_yY58pFpkig9o`
-  If the :t:`simple import` appears in a :t:`nesting import`, and the last :t:`path segment` of its :t:`simple path` is expressed as :t:`keyword` ``self``, then the :t:`simple import` brings the :t:`entity` that the :t:`import path prefix` resolves to in  :t:`scope` of the :t:`type namespace`.
+  If the :t:`simple import` appears in a :t:`nesting import`, and the last :t:`path segment` of its :t:`simple path` is expressed as :t:`keyword` ``self``, then the :t:`simple import` brings the :t:`entity` that the :t:`import path prefix` resolves to in :t:`scope` of the :t:`type namespace`.
 
 * :dp:`fls_ar03D5rxjzy0`
   If the :t:`simple path` is :t:`keyword` ``self``, then bring the containing :t:`module` into :t:`scope`.

--- a/ferrocene/doc/specification/src/entities-and-resolution.rst
+++ b/ferrocene/doc/specification/src/entities-and-resolution.rst
@@ -298,7 +298,10 @@ A :t:`path` is subject to :t:`path resolution`.
 If a :t:`path segment` is expressed as either :t:`keyword` ``crate``, :t:`keyword` ``$crate``, or :t:`keyword` ``Self``, then the :t:`path segment` shall be the first :t:`path segment` of a :t:`path`.
 
 :dp:`fls_uSajfdSsbxna`
-If a :t:`path segment` is expressed as :t:`keyword` ``self``, then the :t:`path segment` shall be either the first :t:`path segment` of a :t:`path`, or the last :t:`path segment` of a :t:`simple import` that appears in a :t:`nesting import`.
+If a :t:`path segment` is expressed as :t:`keyword` ``self``, then the :t:`path segment` shall either be the first or the last :t:`path segment` of the :t:`path`.
+
+:dp:`fls_oRdi3KXFbJcR`
+If the last :t:`path segment` of a :t:`path` is expressed as :t:`keyword` ``self``, the :t:`entity` brought into :t:`scope` shall be a :t:`module`, an :t:`enum`, or a :t:`trait`.
 
 :dp:`fls_774uryecc2sx`
 A :t:`path` that starts with a :t:`path segment` that is expressed as
@@ -1044,7 +1047,7 @@ An :dt:`import path prefix` is the fully constructed :t:`path` prefix of a
    the current :t:`use import`.
 
 :dp:`fls_2bkcn83smy2y`
-A :dt:`simple import` is a :t:`use import` that brings into :t:`scope` an :t:`entity` selected by its :t:`simple import path`, or by its :t:`import path prefix` when its :t:`simple path` ends in :t:`keyword` ``self`` and the :t:`simple path` appears in a :t:`nesting import`.
+A :dt:`simple import` is a :t:`use import` that brings into :t:`scope` an :t:`entity` selected by its :t:`simple import path`, or by its :t:`import path prefix` when its :t:`simple path` ends in :t:`keyword` ``self``.
 
 :dp:`fls_v3a6y2ze44v2`
 A :t:`glob import` is a :t:`use import` that brings all :t:`entities <entity>`
@@ -1078,7 +1081,7 @@ A :t:`simple import` brings :t:`[name]s` into :t:`scope` as follows:
   If the :t:`simple import` appears in a :t:`nesting import` and the last :t:`path segment` of its :t:`simple path` is expressed as :t:`keyword` ``self``, then the :t:`simple import` brings the :t:`entity` in :t:`type namespace` that the :t:`import path prefix` resolves to into :t:`scope`.
 
 * :dp:`fls_ar03D5rxjzy0`
-  If the :t:`simple path` is expressed as :t:`keyword` ``self``, then the :t:`simple import` brings the containing :t:`module` into :t:`scope`.
+  If the :t:`simple path` is expressed as :t:`keyword` ``self``, then the :t:`simple import` brings the :t:`entity` that its :t:`import path prefix` resolves to into :t:`scope`.
 
 * :dp:`fls_ce73bg0BqV1X`
   Otherwise bring all :t:`entities <entity>` that the :t:`simple import path`

--- a/ferrocene/doc/specification/src/expressions.rst
+++ b/ferrocene/doc/specification/src/expressions.rst
@@ -341,6 +341,11 @@ control reaches the invocation of :t:`macro` :std:`core::panic`.
 It is a static error if the evaluation of a :t:`constant expression` results in
 a :t:`value` that is unaligned.
 
+.. rubric:: Undefined Behavior
+
+:dp:`fls_hOIImCr1c6IF`
+It is undefined behavior to convert a :t:`pointer` that has :t:`provenance` into a non-:t:`pointer type` in a :t:`constant context`.
+
 .. rubric:: Dynamic Semantics
 
 :dp:`fls_tg0kya5125jt`
@@ -4645,7 +4650,35 @@ Match Expressions
        OuterAttributeOrDoc* Pattern MatchArmGuard?
 
    MatchArmGuard ::=
-       $$if$$ Operand
+       $$if$$ (Operand | MatchArmGuardChain)
+
+   MatchArmGuardChain ::=
+       MatchArmGuardCondition ($$&&$$ MatchArmGuardCondition)*
+
+   MatchArmGuardCondition ::=
+       (MatchArmGuardExpression | OuterAttributeOrDoc* MatchArmGuardLetPattern)
+
+   MatchArmGuardLetPattern ::=
+       $$let$$ Pattern $$=$$ MatchArmGuardExpression
+
+   MatchArmGuardExpression ::=
+       Expression
+
+:dp:`fls_UlxLrpyPlVmv`
+A :dt:`match arm guard expression` is any :t:`expression` in category :s:`Expression`, except:
+
+- :dp:`fls_XADcpJBUxSfv`
+  :s:`AssignmentExpression`
+- :dp:`fls_gfHe2Cy6WXsK`
+  :s:`CompoundAssignmentExpression`
+- :dp:`fls_QQep7FKA1EQX`
+  :s:`LazyBooleanExpression`
+- :dp:`fls_Wepy5R7FZQPU`
+  :s:`RangeFromExpression`
+- :dp:`fls_imEIc7PUUO1x`
+  :s:`RangeFromToExpression`
+- :dp:`fls_fs4ZpXjt0Wqt`
+  :s:`RangeInclusiveExpression`
 
 .. rubric:: Legality Rules
 
@@ -4678,6 +4711,9 @@ A :t:`match arm body` is the :t:`operand` of a :t:`match arm`.
 :dp:`fls_hs1rr54hu18w`
 A :t:`match arm guard` is a :t:`construct` that provides additional filtering to
 a :t:`match arm matcher`.
+
+:dp:`fls_DT4N2rr6wpvZ`
+A :dt:`match arm guard chain` is a set of conditions that must each evaluate to ``true`` in the case of :t:`[match arm guard expression]s`, or must each produce a positive match in the case of a :t:`[match arm guard let pattern]s` for the :t:`match arm` to be selected.
 
 :dp:`fls_RPMOAaZ6lflI`
 :t:`[Binding]s` introduced in the :t:`pattern` of a :t:`match arm matcher` are
@@ -4714,6 +4750,12 @@ match the :t:`[subject expression]'s` :t:`type`.
 :dp:`fls_4sh2yrslszvb`
 The :t:`value` of a :t:`match expression` is the :t:`value` of the :t:`operand`
 of the selected :t:`match arm`.
+
+:dp:`fls_AAuyKfxLgJ43`
+A :dt:`match arm guard let pattern` is evaluated when its :t:`match arm guard expression` matches the specified :t:`pattern`.
+
+:dp:`fls_uCDQMkWx5OMS`
+Each :t:`let binding` introduced in a :t:`match arm guard let pattern` is :t:`in scope` for the rest of the :t:`match arm guard` as well as the :t:`match arm body`.
 
 .. rubric:: Dynamic Semantics
 
@@ -4766,11 +4808,6 @@ The :t:`evaluation` of a :t:`match arm matcher` proceeds as follows:
 
 #. :dp:`fls_yk8l9zjh7i0d`
    Otherwise the :t:`match arm matcher` fails.
-
-:dp:`fls_sbtx1l6n2tp2`
-The :t:`evaluation` of a :t:`match arm guard` evaluates its :t:`operand`. A
-:t:`match arm guard` evaluates to ``true`` when its :t:`operand` evaluates to
-``true``, otherwise it evaluates to ``false``.
 
 .. rubric:: Examples
 
@@ -5153,7 +5190,7 @@ within the :t:`capturing expression`, as follows:
    precedence:
 
    #. :dp:`fls_33hfay24hx8u`
-      :t:`By immutable reference capture`.
+      :t:`By immutable reference capture` (lowest precedence).
 
    #. :dp:`fls_wmxsd0i2yemf`
       :t:`By unique immutable reference capture` mode, if the
@@ -5163,11 +5200,76 @@ within the :t:`capturing expression`, as follows:
       :t:`By mutable reference capture` mode.
 
    #. :dp:`fls_uqy5w9uc8gla`
-      :t:`By value capture`.
+      :t:`By value capture` (highest precedence).
 
 :dp:`fls_wvob7114tfat`
 A tool selects the first :t:`capture mode` that is compatible with the use of
 the :t:`capture target`.
+
+.. _fls_G64vdcIyB2Is:
+
+Capture precision
+~~~~~~~~~~~~~~~~~
+
+:dp:`fls_j9WyKVyOLFon`
+A :dt:`place projection` is a :t:`field access expression`, :t:`dereference`, :t:`array` or :t:`slice` :t:`index expression`, or :t:`pattern` destructuring applied to a :t:`variable`.
+
+:dp:`fls_rdDT7jsaOMbs`
+A :dt:`capture path` is a sequence starting with a :t:`variable` from the :t:`capturing environment` followed by zero or more :t:`[place projection]s` from that :t:`variable`.
+
+:dp:`fls_TbfUxVf8PKPs`
+A :t:`closure expression` :t:`[borrow]s` or :t:`moves <by move>` the :t:`capture path`, which may be truncated based on these rules:
+
+- :dp:`fls_4TESOxGpEY2h`
+  When a :t:`capture path` and an ancestor :t:`capture path` are both :t:`captured <capturing>`, the ancestor :t:`capture path` is captured with the highest :t:`capture mode` among the two :t:`[capture path]s`.
+
+- :dp:`fls_eNkZWskzznW6`
+  The :t:`capture path` is truncated at the rightmost :t:`dereference` in the :t:`capture path` if the :t:`dereference` is applied to a :t:`shared reference`.
+
+:dp:`fls_v8IFXHJnXhez`
+A :t:`place` is not captured when an :t:`underscore expression` is used to bind it.
+
+:dp:`fls_gujpU7p5n9Zx`
+A :t:`place` is not captured by destructuring tuples, structs, and single-variant enums.
+
+:dp:`fls_t8tFLUg8O83Q`
+A :t:`place` is not captured by being matched against a :t:`rest pattern`.
+
+:dp:`fls_RaONmCLH2KGM`
+The entire :t:`slice` or :t:`array` is always captured even if used with :t:`underscore expression`, :t:`indexing <index expression>`, or :t:`slicing <slice>`.
+
+:dp:`fls_Vt9C9mKxHOwo`
+A :t:`place` is captured by :t:`immutable borrow` if its :t:`discriminant` is read by :t:`pattern matching`.
+
+:dp:`fls_Fs12dmznjsMf`
+Matching against a variant of an enum that has more than one variant captures the :t:`place` by :t:`immutable borrow`.
+
+:dp:`fls_7EXHdE2eOVek`
+Matching against a variant of an enum that has one variant does not capture the place, unless it is marked with :t:`attribute` ``non_exhaustive``, in which case the place is captured by :t:`immutable borrow`.
+
+:dp:`fls_iLH8X2U4ADHb`
+Matching against a :t:`range pattern` captures the place by :t:`immutable borrow`.
+
+:dp:`fls_HMJUXHrvOmPl`
+Matching a :t:`slice` against a slice :t:`pattern`, other than one with only a single rest pattern ``[..]``, captures the slice by :t:`immutable borrow`.
+
+:dp:`fls_Gj1znNpthHY6`
+Matching an array against a slice pattern does not capture the :t:`place`.
+
+:dp:`fls_IFyJvb6mlFU4`
+Move closures can only capture the prefix of a :t:`capture path` that runs up to, but not including, the first :t:`dereference` of a :t:`reference`.
+
+:dp:`fls_7NEEJgKSpQQ8`
+Closures will only capture the prefix of a :t:`capture path` that runs up to, but not including, the first :t:`dereference` of a :t:`raw pointer`.
+
+:dp:`fls_kYFd3p06pWWV`
+Closures will only capture the prefix of a :t:`capture path` of a :t:`union` that runs up to the union itself.
+
+:dp:`fls_fATMTNUOHsfb`
+Closures will only capture the prefix of the :t:`capture path` that runs up to, but not including, the first :t:`field access expression` into a structure that uses the :t:`attribute` ``packed`` representation, in unaligned :t:`[field]s` in a struct.
+
+:dp:`fls_fITor3jpmgrl`
+Taking the address of an unaligned :t:`field` captures the entire struct.
 
 .. _fls_ZfIBiJMf8qE1:
 

--- a/ferrocene/doc/specification/src/expressions.rst
+++ b/ferrocene/doc/specification/src/expressions.rst
@@ -5227,7 +5227,7 @@ A :t:`closure expression` :t:`[borrow]s` or :t:`moves <by move>` the :t:`capture
   The :t:`capture path` is truncated at the rightmost :t:`dereference` in the :t:`capture path` if the :t:`dereference` is applied to a :t:`shared reference`.
 
 :dp:`fls_v8IFXHJnXhez`
-A :t:`place` is not captured when an :t:`underscore expression` is used to bind it.
+A :t:`place` is not :t:`captured` when an :t:`underscore pattern` is used to bind it.
 
 :dp:`fls_gujpU7p5n9Zx`
 A :t:`place` is not captured by destructuring tuples, structs, and single-variant enums.

--- a/ferrocene/doc/specification/src/glossary.rst
+++ b/ferrocene/doc/specification/src/glossary.rst
@@ -4111,14 +4111,6 @@ A :dt:`simple path` is a :t:`path` whose :t:`[path segment]s` consist of either
 
 See :s:`SimplePath`.
 
-simple path prefix
-^^^^^^^^^^^^^^^^^^
-
-A :dt:`simple path prefix` is the leading :t:`simple path` of a
-:t:`glob import` or a :t:`nesting import`.
-
-See :s:`SimplePathPrefix`.
-
 simple path public modifier
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/ferrocene/doc/specification/src/glossary.rst
+++ b/ferrocene/doc/specification/src/glossary.rst
@@ -4099,8 +4099,7 @@ See :s:`SimpleCStringLiteral`.
 simple import
 ^^^^^^^^^^^^^
 
-A :dt:`simple import` is a :t:`use import` that binds a :t:`simple path` to a
-local :t:`name` by using an optional :t:`renaming`.
+A :dt:`simple import` is a :t:`use import` that brings a :t:`simple path` into scope, optionally with a :t:`renaming`.
 
 See :s:`SimpleImport`.
 

--- a/ferrocene/doc/specification/src/values.rst
+++ b/ferrocene/doc/specification/src/values.rst
@@ -111,6 +111,12 @@ The :t:`expression` of a :t:`constant initializer` shall be a
 The value of a :t:`constant` is determined by evaluating its
 :t:`constant initializer`.
 
+:dp:`fls_LmPbrh0Cba8g`
+The :t:`type representation` of the :t:`value` of a :t:`constant initializer` or :t:`static initializer` must only contain bytes with :t:`provenance` where all bytes of some original :t:`pointer` are in the correct order.
+
+:dp:`fls_nwgIMLkvD2Ol`
+:dt:`Provenance` is the memory that a :t:`pointer` has permission to access, the timespan during which it can acesss that memory, and if it can access the memory for writes.
+
 .. rubric:: Dynamic Semantics
 
 :dp:`fls_xezt9hl069h4`

--- a/ferrocene/doc/specification/version.rst
+++ b/ferrocene/doc/specification/version.rst
@@ -2,4 +2,4 @@
    SPDX-FileCopyrightText: The Ferrocene Developers
    SPDX-FileCopyrightText: The Rust Project Developers
 
-.. |spec_version| replace:: 1.94.0
+.. |spec_version| replace:: 1.95.0

--- a/ferrocene/doc/specification/version.rst
+++ b/ferrocene/doc/specification/version.rst
@@ -2,4 +2,4 @@
    SPDX-FileCopyrightText: The Ferrocene Developers
    SPDX-FileCopyrightText: The Rust Project Developers
 
-.. |spec_version| replace:: 1.95.0
+.. |spec_version| replace:: 1.97.0

--- a/tests/ui/closures/2229_closure_analysis/migrations/precise.fixed
+++ b/tests/ui/closures/2229_closure_analysis/migrations/precise.fixed
@@ -68,3 +68,6 @@ fn main() {
     test_precise_analysis_drop_paths_not_captured_by_move();
     test_precise_analysis_long_path_missing();
 }
+
+// ferrocene-annotations: fls_g64vdciyb2is
+// Capture precision

--- a/tests/ui/closures/2229_closure_analysis/migrations/precise.rs
+++ b/tests/ui/closures/2229_closure_analysis/migrations/precise.rs
@@ -66,3 +66,6 @@ fn main() {
     test_precise_analysis_drop_paths_not_captured_by_move();
     test_precise_analysis_long_path_missing();
 }
+
+// ferrocene-annotations: fls_g64vdciyb2is
+// Capture precision


### PR DESCRIPTION
This is equivalent of https://github.com/ferrocene/ferrocene/pull/2333, and adds more fixes not in that PR, and, finally, updates path-related rules for `self` keyword (in a2884d76750454c061290639065039a7f2a9759a). That commit corresponds to https://github.com/rust-lang/reference/issues/2237 and https://github.com/rust-lang/reference/issues/2221.