### PR TITLE
qual-report: add facade target mapping to ARMv7r target

### DIFF
--- a/ferrocene/doc/qualification-report/src/rustc/armv7r-none-eabihf.rst
+++ b/ferrocene/doc/qualification-report/src/rustc/armv7r-none-eabihf.rst
@@ -4,3 +4,4 @@
 .. render-outcomes-template:: templates/tests.jinja2
    :host: x86_64-unknown-linux-gnu
    :target: armv7r-none-eabihf
+   :bare_metal_test_target: armv7r-ferrocene.facade-eabihf


### PR DESCRIPTION
This is a no-std target so the test outcomes will be associated to a facade target. The outcomes need to be mapped back to the no-std target with the `:bare_metal_test_target:` field