### PR TITLE
make the llvm-builder for windows an xlarge machine

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -754,7 +754,7 @@ jobs:
   x86_64-windows-llvm:
     executor:
       name: win/server-2022
-      size: large # 8-core
+      size: xlarge # 16-core
       shell: bash.exe -euo pipefail
     environment:
       FERROCENE_BUILD_HOST: x86_64-pc-windows-msvc
@@ -767,8 +767,8 @@ jobs:
       #
       # # On Windows, we tune this down because the CircleCI's agent occasionally
       # tries to contact the runner and will time out, killing the build. We set
-      # the LLVM parallelism to 7 to ensure 1 core is always free to respond.
-      LLVM_BUILD_PARALLELISM: 7
+      # the LLVM parallelism to 15 to ensure 1 core is always free to respond.
+      LLVM_BUILD_PARALLELISM: 15
     steps:
       - run:
           name: Make sure git autocrlf is false


### PR DESCRIPTION
this change chops 50 minutes of the llvm build. While the runner is nearly twice as expensive as the large runner, cutting the time in half makes up for the cost increase