### PR TITLE
No RHIVOS in main safety man

### DIFF
--- a/ferrocene/doc/safety-manual/src/scope.rst
+++ b/ferrocene/doc/safety-manual/src/scope.rst
@@ -23,12 +23,6 @@ as well as environments listed in target specific documentation:
      - Uncertified Libraries
      - Qualified Libraries
 
-   * - :target:`aarch64-unknown-linux-gnu`
-     - :target:`aarch64-rhivos2-linux-gnu`
-     - ``core``
-     - ``alloc``
-     -
-
    * - :target:`x86_64-unknown-linux-gnu`
      - :target:`aarch64-unknown-none`
      - ``core``


### PR DESCRIPTION
#2388 touched this so we touch it again. RHIVOS should be in the safety manual for RHIVOS, not main one.
