### PR TITLE
[1.97] edition lift

### DIFF
--- a/src/bootstrap/src/ferrocene/test_variants.rs
+++ b/src/bootstrap/src/ferrocene/test_variants.rs
@@ -58,32 +58,30 @@ pub enum TestVariantName {
 
 impl TestVariantName {
     const fn base(&self) -> TestVariantBase {
-        // FIXME: all of these point to edition 2015 instead of 2021!!!
-
         // The snippet between INTERNAL_PROCEDURES_{START,END}_TEST_VARIANTS is included in our
         // documentation, as the list of test variants currently supported.
 
         match self {
             // INTERNAL_PROCEDURES_START_TEST_VARIANTS
-            Self::Ed2021 => TestVariantBase::new().edition(Edition("2015")),
+            Self::Ed2021 => TestVariantBase::new().edition(Edition("2021")),
             Self::Ed2021CortexA53 => {
-                TestVariantBase::new().edition(Edition("2015")).qemu_cpu(QemuCpu("cortex-a53"))
+                TestVariantBase::new().edition(Edition("2021")).qemu_cpu(QemuCpu("cortex-a53"))
             }
             Self::Ed2021SpecificCortexA53 => TestVariantBase::new()
-                .edition(Edition("2015"))
+                .edition(Edition("2021"))
                 .qemu_cpu(QemuCpu("cortex-a53"))
                 .target_cpu(TargetCpu("cortex-a53")),
             Self::Ed2021NeoverseV1 => {
-                TestVariantBase::new().edition(Edition("2015")).qemu_cpu(QemuCpu("neoverse-v1"))
+                TestVariantBase::new().edition(Edition("2021")).qemu_cpu(QemuCpu("neoverse-v1"))
             }
             Self::Ed2021CortexM4 => {
-                TestVariantBase::new().edition(Edition("2015")).qemu_cpu(QemuCpu("cortex-m4"))
+                TestVariantBase::new().edition(Edition("2021")).qemu_cpu(QemuCpu("cortex-m4"))
             }
             Self::Ed2021CortexR5F => {
-                TestVariantBase::new().edition(Edition("2015")).qemu_cpu(QemuCpu("cortex-r5f"))
+                TestVariantBase::new().edition(Edition("2021")).qemu_cpu(QemuCpu("cortex-r5f"))
             }
             Self::Ed2021SpecificCortexM4 => TestVariantBase::new()
-                .edition(Edition("2015"))
+                .edition(Edition("2021"))
                 .qemu_cpu(QemuCpu("cortex-m4"))
                 .target_cpu(TargetCpu("cortex-m4")),
             // INTERNAL_PROCEDURES_END_TEST_VARIANTS

--- a/tests/codegen-llvm/bounds-checking/gep-issue-133979.rs
+++ b/tests/codegen-llvm/bounds-checking/gep-issue-133979.rs
@@ -2,6 +2,8 @@
 //! Check that bounds checking are eliminated.
 
 //@ compile-flags: -Copt-level=2
+// FIXME(jyn514): this fails to optimize in 2021 edition, report it upstream
+//@ edition: 2015
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/fatptr.rs
+++ b/tests/codegen-llvm/fatptr.rs
@@ -6,7 +6,7 @@ pub trait T {}
 
 // CHECK-LABEL: @copy_fat_ptr
 #[no_mangle]
-pub fn copy_fat_ptr(x: &T) {
+pub fn copy_fat_ptr(x: &dyn T) {
     // CHECK-NOT: extractvalue
     let x2 = x;
 }

--- a/tests/codegen-llvm/reg-struct-return.rs
+++ b/tests/codegen-llvm/reg-struct-return.rs
@@ -90,17 +90,7 @@ pub struct FooFloat3 {
 }
 
 pub mod tests {
-    use Foo;
-    use Foo1;
-    use Foo2;
-    use Foo3;
-    use Foo4;
-    use Foo5;
-    use FooFloat1;
-    use FooFloat2;
-    use FooFloat3;
-    use FooOversize1;
-    use FooOversize2;
+    use super::*;
 
     // ENABLED: i64 @f1()
     // DISABLED: void @f1(ptr {{.*}}sret

--- a/tests/codegen-llvm/vec-into-iter-drops.rs
+++ b/tests/codegen-llvm/vec-into-iter-drops.rs
@@ -1,4 +1,6 @@
 //@ compile-flags: -Copt-level=3
+// FIXME(jyn514): figure out why this fails in 2021 edition
+//@ edition: 2015
 // Test that we can avoid generating an element dropping loop when `vec::IntoIter` is consumed.
 #![crate_type = "lib"]
 

--- a/tests/codegen-units/item-collection/instantiation-through-vtable.rs
+++ b/tests/codegen-units/item-collection/instantiation-through-vtable.rs
@@ -26,14 +26,14 @@ pub fn start(_: isize, _: *const *const u8) -> isize {
 
     //~ MONO_ITEM fn <Struct<u32> as Trait>::foo
     //~ MONO_ITEM fn <Struct<u32> as Trait>::bar
-    let r1 = &s1 as &Trait;
+    let r1 = &s1 as &dyn Trait;
     r1.foo();
     r1.bar();
 
     let s1 = Struct { _a: 0u64 };
     //~ MONO_ITEM fn <Struct<u64> as Trait>::foo
     //~ MONO_ITEM fn <Struct<u64> as Trait>::bar
-    let _ = &s1 as &Trait;
+    let _ = &s1 as &dyn Trait;
 
     0
 }

--- a/tests/codegen-units/item-collection/non-generic-closures.rs
+++ b/tests/codegen-units/item-collection/non-generic-closures.rs
@@ -66,7 +66,7 @@ pub fn start(_: isize, _: *const *const u8) -> isize {
 }
 
 //~ MONO_ITEM fn run_closure @@ non_generic_closures-cgu.0[External]
-fn run_closure(f: &Fn(i32)) {
+fn run_closure(f: &dyn Fn(i32)) {
     f(3);
 }
 

--- a/tests/codegen-units/item-collection/unsizing.rs
+++ b/tests/codegen-units/item-collection/unsizing.rs
@@ -59,22 +59,22 @@ pub fn start(_: isize, _: *const *const u8) -> isize {
     // simple case
     let bool_sized = &true;
     //~ MONO_ITEM fn <bool as Trait>::foo
-    let _bool_unsized = bool_sized as &Trait;
+    let _bool_unsized = bool_sized as &dyn Trait;
 
     let char_sized = &'a';
 
     //~ MONO_ITEM fn <char as Trait>::foo
-    let _char_unsized = char_sized as &Trait;
+    let _char_unsized = char_sized as &dyn Trait;
 
     // struct field
     let struct_sized = &Struct { _a: 1, _b: 2, _c: 3.0f64 };
     //~ MONO_ITEM fn <f64 as Trait>::foo
-    let _struct_unsized = struct_sized as &Struct<Trait>;
+    let _struct_unsized = struct_sized as &Struct<dyn Trait>;
 
     // custom coercion
     let wrapper_sized = Wrapper(&0u32);
     //~ MONO_ITEM fn <u32 as Trait>::foo
-    let _wrapper_sized = wrapper_sized as Wrapper<Trait>;
+    let _wrapper_sized = wrapper_sized as Wrapper<dyn Trait>;
 
     // with drop
     let droppable = &PresentDrop;

--- a/tests/codegen-units/partitioning/vtable-through-const.rs
+++ b/tests/codegen-units/partitioning/vtable-through-const.rs
@@ -40,8 +40,8 @@ mod mod1 {
     }
 
     // These are referenced, so they produce mono-items (see main)
-    pub const TRAIT1_REF: &'static Trait1 = &NeedsDrop as &Trait1;
-    pub const TRAIT1_GEN_REF: &'static Trait1Gen<u8> = &NeedsDrop as &Trait1Gen<u8>;
+    pub const TRAIT1_REF: &'static dyn Trait1 = &NeedsDrop as &dyn Trait1;
+    pub const TRAIT1_GEN_REF: &'static dyn Trait1Gen<u8> = &NeedsDrop as &dyn Trait1Gen<u8>;
     pub const ID_CHAR: fn(char) -> char = id::<char>;
 
     pub trait Trait2 {
@@ -66,8 +66,8 @@ mod mod1 {
     }
 
     // These are not referenced, so they do not produce mono-items
-    pub const TRAIT2_REF: &'static Trait2 = &NeedsDrop as &Trait2;
-    pub const TRAIT2_GEN_REF: &'static Trait2Gen<u8> = &NeedsDrop as &Trait2Gen<u8>;
+    pub const TRAIT2_REF: &'static dyn Trait2 = &NeedsDrop as &dyn Trait2;
+    pub const TRAIT2_GEN_REF: &'static dyn Trait2Gen<u8> = &NeedsDrop as &dyn Trait2Gen<u8>;
     pub const ID_I64: fn(i64) -> i64 = id::<i64>;
 }
 

--- a/tests/crashes/123140.rs
+++ b/tests/crashes/123140.rs
@@ -3,4 +3,4 @@ trait Project {
     const SELF: Self;
 }
 
-fn take1(_: Project<SELF = { loop {} }>) {}
+fn take1(_: dyn Project<SELF = { loop {} }>) {}

--- a/tests/crashes/124189.rs
+++ b/tests/crashes/124189.rs
@@ -7,7 +7,7 @@ impl<T> Trait for T {
     type Type = ();
 }
 
-fn f(_: <&Copy as Trait>::Type) {}
+fn f(_: <&dyn Copy as Trait>::Type) {}
 
 fn main() {
     f(());

--- a/tests/crashes/126667.rs
+++ b/tests/crashes/126667.rs
@@ -1,4 +1,5 @@
 //@ known-bug: rust-lang/rust#126667
+//@ edition: 2015..2018
 #![warn(rust_2021_compatibility)]
 
 trait Static<'a> {}

--- a/tests/crashes/130411.rs
+++ b/tests/crashes/130411.rs
@@ -3,4 +3,4 @@ trait Project {
     const SELF: Self;
 }
 
-fn take1(_: Project<SELF = {}>) {}
+fn take1(_: dyn Project<SELF = {}>) {}

--- a/tests/crashes/132960.rs
+++ b/tests/crashes/132960.rs
@@ -1,4 +1,5 @@
 //@ known-bug: #132960
+//@ edition: 2015
 
 #![feature(adt_const_params, const_ptr_read, generic_const_exprs, unsized_const_params)]
 

--- a/tests/debuginfo/recursive-enum.rs
+++ b/tests/debuginfo/recursive-enum.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ ignore-lldb
 
 //@ compile-flags:-g

--- a/tests/debuginfo/trait-pointers.rs
+++ b/tests/debuginfo/trait-pointers.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ gdb-command:run

--- a/tests/debuginfo/var-captured-in-nested-closure.rs
+++ b/tests/debuginfo/var-captured-in-nested-closure.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/var-captured-in-sendable-closure.rs
+++ b/tests/debuginfo/var-captured-in-sendable-closure.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/var-captured-in-stack-closure.rs
+++ b/tests/debuginfo/var-captured-in-stack-closure.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/incremental/change_add_field/struct_point.rs
+++ b/tests/incremental/change_add_field/struct_point.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Test where we change a type definition by adding a field.  Fns with
 // this type in their signature are recompiled, as are their callers.
 // Fns with that type used only in their body are also recompiled, but

--- a/tests/incremental/change_private_fn/struct_point.rs
+++ b/tests/incremental/change_private_fn/struct_point.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Test where we change the body of a private method in an impl.
 // We then test what sort of functions must be rebuilt as a result.
 

--- a/tests/incremental/change_private_impl_method/struct_point.rs
+++ b/tests/incremental/change_private_impl_method/struct_point.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Test where we change the body of a private method in an impl.
 // We then test what sort of functions must be rebuilt as a result.
 

--- a/tests/incremental/change_pub_inherent_method_body/struct_point.rs
+++ b/tests/incremental/change_pub_inherent_method_body/struct_point.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Test where we change the body of a public, inherent method.
 
 //@ revisions: bpass1 bpass2

--- a/tests/incremental/change_pub_inherent_method_sig/struct_point.rs
+++ b/tests/incremental/change_pub_inherent_method_sig/struct_point.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Test where we change the *signature* of a public, inherent method.
 
 //@ revisions: bpass1 bpass2

--- a/tests/incremental/clean.rs
+++ b/tests/incremental/clean.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ revisions: rpass1 bfail2
 //@ compile-flags: -Z query-dep-graph
 //@ ignore-backends: gcc

--- a/tests/incremental/hello_world.rs
+++ b/tests/incremental/hello_world.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ revisions: rpass1 rpass2
 //@ compile-flags: -Z query-dep-graph
 //@ ignore-backends: gcc

--- a/tests/incremental/ich_method_call_trait_scope.rs
+++ b/tests/incremental/ich_method_call_trait_scope.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Check that the hash for a method call is sensitive to the traits in
 // scope.
 

--- a/tests/incremental/ich_resolve_results.rs
+++ b/tests/incremental/ich_resolve_results.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Check that the hash for `mod3::bar` changes when we change the
 // `use` to something different.
 

--- a/tests/incremental/issue-49595/issue-49595.rs
+++ b/tests/incremental/issue-49595/issue-49595.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ revisions: bpass1 bpass2 bpass3
 //@ compile-flags: -Z query-dep-graph --test
 //@ ignore-backends: gcc

--- a/tests/incremental/lto.rs
+++ b/tests/incremental/lto.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ no-prefer-dynamic
 //@ revisions:rpass1 rpass2
 //@ compile-flags: -C lto

--- a/tests/incremental/spike.rs
+++ b/tests/incremental/spike.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // A first "spike" for incremental compilation: here, we change the
 // content of the `make` function, and we find that we can reuse the
 // `y` module entirely (but not the `x` module).

--- a/tests/incremental/string_constant.rs
+++ b/tests/incremental/string_constant.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ revisions: bpass1 bpass2
 //@ compile-flags: -Z query-dep-graph -Copt-level=0
 // FIXME(#62277): could be check-pass?

--- a/tests/incremental/thinlto/cgu_invalidated_via_import.rs
+++ b/tests/incremental/thinlto/cgu_invalidated_via_import.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // This test checks that the LTO phase is re-done for CGUs that import something
 // via ThinLTO and that imported thing changes while the definition of the CGU
 // stays untouched.

--- a/tests/incremental/thinlto/cgu_keeps_identical_fn.rs
+++ b/tests/incremental/thinlto/cgu_keeps_identical_fn.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // This test is almost identical to `cgu_invalided_via_import`, except that
 // the two versions of `inline_fn` are identical. Neither version of `inlined_fn`
 // ends up with any spans in its LLVM bitecode, so LLVM is able to skip

--- a/tests/incremental/thinlto/independent_cgus_dont_affect_each_other.rs
+++ b/tests/incremental/thinlto/independent_cgus_dont_affect_each_other.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // This test checks that a change in a CGU does not invalidate an unrelated CGU
 // during incremental ThinLTO.
 

--- a/tests/mir-opt/building/issue_101867.main.built.after.mir
+++ b/tests/mir-opt/building/issue_101867.main.built.after.mir
@@ -8,14 +8,13 @@ fn main() -> () {
     let mut _0: ();
     let _1: std::option::Option<u8> as UserTypeProjection { base: UserType(0), projs: [] };
     let mut _2: !;
-    let _3: ();
-    let mut _4: !;
-    let mut _6: isize;
+    let _3: !;
+    let mut _5: isize;
     scope 1 {
         debug x => _1;
-        let _5: u8;
+        let _4: u8;
         scope 2 {
-            debug y => _5;
+            debug y => _4;
         }
     }
 
@@ -25,18 +24,16 @@ fn main() -> () {
         FakeRead(ForLet(None), _1);
         AscribeUserType(_1, o, UserTypeProjection { base: UserType(1), projs: [] });
         PlaceMention(_1);
-        _6 = discriminant(_1);
-        switchInt(move _6) -> [1: bb4, otherwise: bb3];
+        _5 = discriminant(_1);
+        switchInt(move _5) -> [1: bb4, otherwise: bb3];
     }
 
     bb1: {
         StorageLive(_3);
-        StorageLive(_4);
-        _4 = std::rt::begin_panic::<&str>(const "explicit panic") -> bb8;
+        _3 = core::panicking::panic(const "explicit panic") -> bb8;
     }
 
     bb2: {
-        StorageDead(_4);
         StorageDead(_3);
         unreachable;
     }
@@ -54,10 +51,10 @@ fn main() -> () {
     }
 
     bb6: {
-        StorageLive(_5);
-        _5 = copy ((_1 as Some).0: u8);
+        StorageLive(_4);
+        _4 = copy ((_1 as Some).0: u8);
         _0 = const ();
-        StorageDead(_5);
+        StorageDead(_4);
         StorageDead(_1);
         return;
     }

--- a/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-abort.diff
+++ b/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-abort.diff
@@ -10,7 +10,7 @@
       }
   
       bb1: {
-          _1 = std::rt::begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
+          _1 = core::panicking::panic(const "explicit panic") -> unwind unreachable;
       }
   
       bb2: {

--- a/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/control_flow_simplification.hello.GVN.panic-unwind.diff
@@ -10,7 +10,7 @@
       }
   
       bb1: {
-          _1 = std::rt::begin_panic::<&str>(const "explicit panic") -> unwind continue;
+          _1 = core::panicking::panic(const "explicit panic") -> unwind continue;
       }
   
       bb2: {

--- a/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-abort.diff
@@ -32,7 +32,7 @@
   
       bb2: {
           StorageLive(_6);
-          _6 = std::rt::begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
+          _6 = panic(const "explicit panic") -> unwind unreachable;
       }
   
       bb3: {

--- a/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-unwind.diff
@@ -32,7 +32,7 @@
   
       bb2: {
           StorageLive(_6);
-          _6 = std::rt::begin_panic::<&str>(const "explicit panic") -> unwind continue;
+          _6 = panic(const "explicit panic") -> unwind continue;
       }
   
       bb3: {

--- a/tests/mir-opt/inline/inline_diverging.g.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_diverging.g.Inline.panic-abort.diff
@@ -10,7 +10,7 @@
       let mut _5: !;
       let _6: !;
 +     scope 1 (inlined panic) {
-+         let mut _7: !;
++         let _7: !;
 +     }
   
       bb0: {
@@ -36,7 +36,7 @@
           StorageLive(_6);
 -         _6 = panic() -> unwind unreachable;
 +         StorageLive(_7);
-+         _7 = std::rt::begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
++         _7 = core::panicking::panic(const "explicit panic") -> unwind unreachable;
       }
 + }
 + 

--- a/tests/mir-opt/inline/inline_diverging.g.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_diverging.g.Inline.panic-unwind.diff
@@ -10,7 +10,7 @@
       let mut _5: !;
       let _6: !;
 +     scope 1 (inlined panic) {
-+         let mut _7: !;
++         let _7: !;
 +     }
   
       bb0: {
@@ -36,7 +36,7 @@
           StorageLive(_6);
 -         _6 = panic() -> unwind continue;
 +         StorageLive(_7);
-+         _7 = std::rt::begin_panic::<&str>(const "explicit panic") -> unwind continue;
++         _7 = core::panicking::panic(const "explicit panic") -> unwind continue;
       }
 + }
 + 

--- a/tests/mir-opt/issue_41697.rs
+++ b/tests/mir-opt/issue_41697.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ skip-filecheck
 // Regression test for #41697. Using dump-mir was triggering
 // artificial cycles: during type-checking, we had to get the MIR for

--- a/tests/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.mir
+++ b/tests/mir-opt/issue_41697.{impl#0}-{constant#0}.SimplifyCfg-promote-consts.after.mir
@@ -1,6 +1,6 @@
-// MIR for `<impl at $DIR/issue_41697.rs:18:1: 18:25>::{constant#0}` after SimplifyCfg-promote-consts
+// MIR for `<impl at $DIR/issue_41697.rs:19:1: 19:25>::{constant#0}` after SimplifyCfg-promote-consts
 
-<impl at $DIR/issue_41697.rs:18:1: 18:25>::{constant#0}: usize = {
+<impl at $DIR/issue_41697.rs:19:1: 19:25>::{constant#0}: usize = {
     let mut _0: usize;
     let mut _1: (usize, bool);
 

--- a/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-abort.mir
+++ b/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-abort.mir
@@ -24,7 +24,7 @@ fn unwrap(_1: Option<T>) -> T {
 
     bb2: {
         StorageLive(_4);
-        _4 = std::rt::begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
+        _4 = core::panicking::panic(const "explicit panic") -> unwind unreachable;
     }
 
     bb3: {

--- a/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
+++ b/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
@@ -24,7 +24,7 @@ fn unwrap(_1: Option<T>) -> T {
 
     bb2: {
         StorageLive(_4);
-        _4 = std::rt::begin_panic::<&str>(const "explicit panic") -> bb4;
+        _4 = core::panicking::panic(const "explicit panic") -> bb4;
     }
 
     bb3: {

--- a/tests/pretty/asm-operand-order.pp
+++ b/tests/pretty/asm-operand-order.pp
@@ -1,8 +1,7 @@
 #![feature(prelude_import)]
-#![no_std]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-mode:expanded
 //@ pp-exact:asm-operand-order.pp
 //@ only-x86_64

--- a/tests/pretty/asm.pp
+++ b/tests/pretty/asm.pp
@@ -1,8 +1,7 @@
 #![feature(prelude_import)]
-#![no_std]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-mode:expanded
 //@ pp-exact:asm.pp
 //@ only-x86_64

--- a/tests/pretty/autodiff/autodiff_forward.pp
+++ b/tests/pretty/autodiff/autodiff_forward.pp
@@ -1,11 +1,10 @@
 #![feature(prelude_import)]
-#![no_std]
 //@ only-nightly
 
 #![feature(autodiff)]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-mode:expanded
 //@ pretty-compare-only
 //@ pp-exact:autodiff_forward.pp

--- a/tests/pretty/autodiff/autodiff_reverse.pp
+++ b/tests/pretty/autodiff/autodiff_reverse.pp
@@ -1,11 +1,10 @@
 #![feature(prelude_import)]
-#![no_std]
 //@ only-nightly
 
 #![feature(autodiff)]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-mode:expanded
 //@ pretty-compare-only
 //@ pp-exact:autodiff_reverse.pp

--- a/tests/pretty/autodiff/inherent_impl.pp
+++ b/tests/pretty/autodiff/inherent_impl.pp
@@ -1,11 +1,10 @@
 #![feature(prelude_import)]
-#![no_std]
 //@ only-nightly
 
 #![feature(autodiff)]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-mode:expanded
 //@ pretty-compare-only
 //@ pp-exact:inherent_impl.pp

--- a/tests/pretty/block-index-paren.pp
+++ b/tests/pretty/block-index-paren.pp
@@ -1,8 +1,7 @@
 #![feature(prelude_import)]
-#![no_std]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-mode:expanded
 //@ pp-exact:block-index-paren.pp
 

--- a/tests/pretty/cast-lt.pp
+++ b/tests/pretty/cast-lt.pp
@@ -1,8 +1,7 @@
 #![feature(prelude_import)]
-#![no_std]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:cast-lt.pp

--- a/tests/pretty/closure-reform-pretty.rs
+++ b/tests/pretty/closure-reform-pretty.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 

--- a/tests/pretty/delegation-impl-reuse.pp
+++ b/tests/pretty/delegation-impl-reuse.pp
@@ -1,5 +1,4 @@
 #![feature(prelude_import)]
-#![no_std]
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:delegation-impl-reuse.pp
@@ -8,7 +7,7 @@
 #![feature(fn_delegation)]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 
 trait Trait<T> {
     fn foo(&self) {}

--- a/tests/pretty/delegation-inline-attribute.pp
+++ b/tests/pretty/delegation-inline-attribute.pp
@@ -6,7 +6,7 @@
 #![attr = Feature([fn_delegation#0])]
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 
 mod to_reuse {
     fn foo(x: usize) -> usize { x }

--- a/tests/pretty/delegation-self-rename.pp
+++ b/tests/pretty/delegation-self-rename.pp
@@ -1,7 +1,7 @@
 #![attr = Feature([fn_delegation#0])]
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:delegation-self-rename.pp

--- a/tests/pretty/dollar-crate.pp
+++ b/tests/pretty/dollar-crate.pp
@@ -1,8 +1,7 @@
 #![feature(prelude_import)]
-#![no_std]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:dollar-crate.pp

--- a/tests/pretty/expanded-and-path-remap-80832.pp
+++ b/tests/pretty/expanded-and-path-remap-80832.pp
@@ -1,8 +1,7 @@
 #![feature(prelude_import)]
-#![no_std]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 // Test for issue 80832
 //
 //@ pretty-mode:expanded

--- a/tests/pretty/format-args-str-escape.pp
+++ b/tests/pretty/format-args-str-escape.pp
@@ -1,8 +1,7 @@
 #![feature(prelude_import)]
-#![no_std]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:format-args-str-escape.pp

--- a/tests/pretty/hir-delegation.pp
+++ b/tests/pretty/hir-delegation.pp
@@ -6,7 +6,7 @@
 #![attr = Feature([fn_delegation#0])]
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 
 fn b<C>(e: C) { }
 

--- a/tests/pretty/hir-fn-params.pp
+++ b/tests/pretty/hir-fn-params.pp
@@ -1,6 +1,7 @@
 extern crate std;
 #[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
+//@ edition: 2015
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-fn-params.pp

--- a/tests/pretty/hir-fn-params.rs
+++ b/tests/pretty/hir-fn-params.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-fn-params.pp

--- a/tests/pretty/hir-fn-variadic.pp
+++ b/tests/pretty/hir-fn-variadic.pp
@@ -1,7 +1,7 @@
 #![attr = Feature([c_variadic#0])]
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-fn-variadic.pp

--- a/tests/pretty/hir-if-else.pp
+++ b/tests/pretty/hir-if-else.pp
@@ -1,6 +1,6 @@
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-if-else.pp

--- a/tests/pretty/hir-lifetimes.pp
+++ b/tests/pretty/hir-lifetimes.pp
@@ -7,7 +7,7 @@
 #![allow(unused)]
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 
 struct Foo<'a> {
     x: &'a u32,

--- a/tests/pretty/hir-pretty-attr.pp
+++ b/tests/pretty/hir-pretty-attr.pp
@@ -1,6 +1,6 @@
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-pretty-attr.pp

--- a/tests/pretty/hir-pretty-loop.pp
+++ b/tests/pretty/hir-pretty-loop.pp
@@ -1,6 +1,6 @@
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-pretty-loop.pp

--- a/tests/pretty/hir-struct-expr.pp
+++ b/tests/pretty/hir-struct-expr.pp
@@ -1,6 +1,6 @@
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-struct-expr.pp

--- a/tests/pretty/if-else.pp
+++ b/tests/pretty/if-else.pp
@@ -1,8 +1,7 @@
 #![feature(prelude_import)]
-#![no_std]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:if-else.pp

--- a/tests/pretty/issue-12590-c.pp
+++ b/tests/pretty/issue-12590-c.pp
@@ -1,8 +1,7 @@
 #![feature(prelude_import)]
-#![no_std]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:issue-12590-c.pp

--- a/tests/pretty/issue-4264.pp
+++ b/tests/pretty/issue-4264.pp
@@ -1,6 +1,6 @@
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir,typed
 //@ pp-exact:issue-4264.pp

--- a/tests/pretty/issue-85089.pp
+++ b/tests/pretty/issue-85089.pp
@@ -1,6 +1,6 @@
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 // Test to print lifetimes on HIR pretty-printing.
 
 //@ pretty-compare-only

--- a/tests/pretty/macro-fragment-specifier-whitespace.pp
+++ b/tests/pretty/macro-fragment-specifier-whitespace.pp
@@ -1,8 +1,7 @@
 #![feature(prelude_import)]
-#![no_std]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-mode:expanded
 //@ pp-exact:macro-fragment-specifier-whitespace.pp
 

--- a/tests/pretty/never-pattern.pp
+++ b/tests/pretty/never-pattern.pp
@@ -1,5 +1,4 @@
 #![feature(prelude_import)]
-#![no_std]
 //@ pretty-mode:expanded
 //@ pp-exact:never-pattern.pp
 //@ only-x86_64
@@ -9,7 +8,7 @@
 #![feature(never_type)]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 
 fn f(x: Result<u32, !>) { _ = match x { Ok(x) => x, Err(!) , }; }
 

--- a/tests/pretty/or-pattern-paren.pp
+++ b/tests/pretty/or-pattern-paren.pp
@@ -1,9 +1,8 @@
 #![feature(prelude_import)]
-#![no_std]
 #![feature(box_patterns)]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 
 //@ pretty-compare-only
 //@ pretty-mode:expanded

--- a/tests/pretty/path-type-bounds.rs
+++ b/tests/pretty/path-type-bounds.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ pp-exact
 
 

--- a/tests/pretty/pin-ergonomics-hir.pp
+++ b/tests/pretty/pin-ergonomics-hir.pp
@@ -6,7 +6,7 @@
 #![attr = Feature([pin_ergonomics#0])]
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 
 use std::pin::Pin;
 

--- a/tests/pretty/postfix-match/precedence.pp
+++ b/tests/pretty/postfix-match/precedence.pp
@@ -1,9 +1,8 @@
 #![feature(prelude_import)]
-#![no_std]
 #![feature(postfix_match)]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 
 use std::ops::Add;
 

--- a/tests/pretty/shebang-at-top.pp
+++ b/tests/pretty/shebang-at-top.pp
@@ -1,9 +1,8 @@
 #!/usr/bin/env rust
 #![feature(prelude_import)]
-#![no_std]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ pretty-mode:expanded
 //@ pp-exact:shebang-at-top.pp
 //@ pretty-compare-only

--- a/tests/pretty/tests-are-sorted.pp
+++ b/tests/pretty/tests-are-sorted.pp
@@ -1,8 +1,7 @@
 #![feature(prelude_import)]
-#![no_std]
 extern crate std;
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ compile-flags: --crate-type=lib --test --remap-path-prefix={{src-base}}/=/the/src/ --remap-path-prefix={{src-base}}\=/the/src/
 //@ pretty-compare-only
 //@ pretty-mode:expanded

--- a/tests/rustdoc-html/auto/auto-impl-for-trait.rs
+++ b/tests/rustdoc-html/auto/auto-impl-for-trait.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Test for https://github.com/rust-lang/rust/issues/48463 issue.
 
 use std::any::Any;

--- a/tests/rustdoc-html/auto/auto-trait-bounds-where-51236.rs
+++ b/tests/rustdoc-html/auto/auto-trait-bounds-where-51236.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // https://github.com/rust-lang/rust/issues/51236
 #![crate_name="foo"]
 

--- a/tests/rustdoc-html/auxiliary/mod-stackoverflow.rs
+++ b/tests/rustdoc-html/auxiliary/mod-stackoverflow.rs
@@ -1,11 +1,11 @@
 //@ compile-flags: -Cmetadata=aux
 
 pub mod tree {
-    pub use tree;
+    pub use crate::tree;
 }
 
 pub mod tree2 {
     pub mod prelude {
-        pub use tree2;
+        pub use crate::tree2;
     }
 }

--- a/tests/rustdoc-html/constant/assoc-consts.rs
+++ b/tests/rustdoc-html/constant/assoc-consts.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 pub trait Foo {
     //@ has assoc_consts/trait.Foo.html '//pre[@class="rust item-decl"]' \
     //      'const FOO: usize = _;'

--- a/tests/rustdoc-html/impl/auxiliary/rustdoc-default-impl.rs
+++ b/tests/rustdoc-html/impl/auxiliary/rustdoc-default-impl.rs
@@ -9,7 +9,7 @@ pub mod bar {
         fn foo(&self) {}
     }
 
-    impl Foo {
+    impl dyn Foo {
         pub fn test<T: Bar>(&self) {}
     }
 

--- a/tests/rustdoc-html/impl/default-impl.rs
+++ b/tests/rustdoc-html/impl/default-impl.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ aux-build:rustdoc-default-impl.rs
 //@ ignore-cross-compile
 

--- a/tests/rustdoc-html/impl/hidden-impls.rs
+++ b/tests/rustdoc-html/impl/hidden-impls.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 #![crate_name = "foo"]
 
 mod hidden {

--- a/tests/rustdoc-html/impl/impl-trait-43869.rs
+++ b/tests/rustdoc-html/impl/impl-trait-43869.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // https://github.com/rust-lang/rust/issues/43869
 #![crate_name="foo"]
 

--- a/tests/rustdoc-html/inline_cross/auxiliary/issue-29584.rs
+++ b/tests/rustdoc-html/inline_cross/auxiliary/issue-29584.rs
@@ -6,5 +6,5 @@ pub struct Foo;
 mod bar {
     trait Bar {}
 
-    impl Bar for ::Foo {}
+    impl Bar for crate::Foo {}
 }

--- a/tests/rustdoc-html/inline_cross/auxiliary/rustdoc-nonreachable-impls.rs
+++ b/tests/rustdoc-html/inline_cross/auxiliary/rustdoc-nonreachable-impls.rs
@@ -5,30 +5,30 @@ pub trait Bark {}
 
 mod private {
     // should be shown
-    impl ::Woof for ::Foo {}
+    impl crate::Woof for crate::Foo {}
 
     pub trait Bar {}
     pub struct Wibble;
 
     // these should not be shown
-    impl Bar for ::Foo {}
+    impl Bar for crate::Foo {}
     impl Bar for Wibble {}
-    impl ::Bark for Wibble {}
-    impl ::Woof for Wibble {}
+    impl crate::Bark for Wibble {}
+    impl crate::Woof for Wibble {}
 }
 
 #[doc(hidden)]
 pub mod hidden {
     // should be shown
-    impl ::Bark for ::Foo {}
+    impl crate::Bark for crate::Foo {}
 
     pub trait Qux {}
     pub struct Wobble;
 
 
     // these should only be shown if they're re-exported correctly
-    impl Qux for ::Foo {}
+    impl Qux for crate::Foo {}
     impl Qux for Wobble {}
-    impl ::Bark for Wobble {}
-    impl ::Woof for Wobble {}
+    impl crate::Bark for Wobble {}
+    impl crate::Woof for Wobble {}
 }

--- a/tests/rustdoc-html/inline_cross/auxiliary/rustdoc-trait-object-impl.rs
+++ b/tests/rustdoc-html/inline_cross/auxiliary/rustdoc-trait-object-impl.rs
@@ -2,11 +2,11 @@ use std::fmt;
 
 pub trait Bar {}
 
-impl<'a> Bar + 'a {
+impl<'a> dyn Bar + 'a {
     pub fn bar(&self) -> usize { 42 }
 }
 
-impl<'a> fmt::Debug for Bar + 'a {
+impl<'a> fmt::Debug for dyn Bar + 'a {
     fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
         Ok(())
     }

--- a/tests/rustdoc-html/inline_cross/doc-hidden-extern-trait-impl-29584.rs
+++ b/tests/rustdoc-html/inline_cross/doc-hidden-extern-trait-impl-29584.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ aux-build:issue-29584.rs
 //@ ignore-cross-compile
 

--- a/tests/rustdoc-html/inline_cross/doc-reachability-impl-31948-1.rs
+++ b/tests/rustdoc-html/inline_cross/doc-reachability-impl-31948-1.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // https://github.com/rust-lang/rust/issues/31948
 #![crate_name="foobar"]
 

--- a/tests/rustdoc-html/inline_cross/doc-reachability-impl-31948-2.rs
+++ b/tests/rustdoc-html/inline_cross/doc-reachability-impl-31948-2.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // https://github.com/rust-lang/rust/issues/31948
 #![crate_name="foobar"]
 

--- a/tests/rustdoc-html/inline_cross/doc-reachability-impl-31948.rs
+++ b/tests/rustdoc-html/inline_cross/doc-reachability-impl-31948.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // https://github.com/rust-lang/rust/issues/31948
 #![crate_name="foobar"]
 

--- a/tests/rustdoc-html/inline_cross/impl-dyn-trait-32881.rs
+++ b/tests/rustdoc-html/inline_cross/impl-dyn-trait-32881.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // https://github.com/rust-lang/rust/issues/32881
 #![crate_name="foobar"]
 

--- a/tests/rustdoc-html/inline_local/doc-no-inline-32343.rs
+++ b/tests/rustdoc-html/inline_local/doc-no-inline-32343.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // https://github.com/rust-lang/rust/issues/32343
 #![crate_name="foobar"]
 

--- a/tests/rustdoc-html/inline_local/please_inline.rs
+++ b/tests/rustdoc-html/inline_local/please_inline.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 pub mod foo {
     pub struct Foo;
 }

--- a/tests/rustdoc-html/inline_local/staged-inline.rs
+++ b/tests/rustdoc-html/inline_local/staged-inline.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // https://github.com/rust-lang/rust/issues/135078
 #![crate_name = "foo"]
 #![feature(staged_api)]

--- a/tests/rustdoc-html/inline_local/trait-vis.rs
+++ b/tests/rustdoc-html/inline_local/trait-vis.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 pub trait ThisTrait {}
 
 mod asdf {

--- a/tests/rustdoc-html/intra-doc/in-bodies.rs
+++ b/tests/rustdoc-html/intra-doc/in-bodies.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // we need to make sure that intra-doc links on trait impls get resolved in the right scope
 
 #![deny(rustdoc::broken_intra_doc_links)]

--- a/tests/rustdoc-html/jump-to-def/non-local-method.rs
+++ b/tests/rustdoc-html/jump-to-def/non-local-method.rs
@@ -1,4 +1,3 @@
-//@ edition: 2015
 //@ compile-flags: -Zunstable-options --generate-link-to-definition
 
 #![crate_name = "foo"]
@@ -25,7 +24,7 @@ pub fn bar() {
     //@ has - '//a[@href="{{channel}}/alloc/boxed/struct.Box.html"]' 'Box'
     //@ has - '//a[@href="{{channel}}/alloc/boxed/struct.Box.html#method.new"]' 'new'
     let _ = Box::new(0);
-    //@ has - '//a[@href="#49"]' 'local_private'
+    //@ has - '//a[@href="#48"]' 'local_private'
     local_private();
 }
 
@@ -34,10 +33,9 @@ pub fn extern_call() {
     exit(0);
 }
 
-pub fn macro_call() -> Result<(), ()> {
-    //@ has - '//a[@href="{{channel}}/core/macro.try.html"]' 'try!'
-    try!(Err(()));
-    Ok(())
+pub fn macro_call() {
+    //@ has - '//a[@href="{{channel}}/core/macro.todo.html"]' 'todo!'
+    todo!("anything at all");
 }
 
 pub fn variant() {

--- a/tests/rustdoc-html/jump-to-def/non-local-method.rs
+++ b/tests/rustdoc-html/jump-to-def/non-local-method.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ compile-flags: -Zunstable-options --generate-link-to-definition
 
 #![crate_name = "foo"]

--- a/tests/rustdoc-html/macro/decl_macro.rs
+++ b/tests/rustdoc-html/macro/decl_macro.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ compile-flags: --document-private-items
 
 #![feature(decl_macro)]

--- a/tests/rustdoc-html/macro/proc-macro.rs
+++ b/tests/rustdoc-html/macro/proc-macro.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ force-host
 //@ no-prefer-dynamic
 //@ compile-flags: --crate-type proc-macro --document-private-items

--- a/tests/rustdoc-html/mod-stackoverflow.rs
+++ b/tests/rustdoc-html/mod-stackoverflow.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ aux-build:mod-stackoverflow.rs
 //@ ignore-cross-compile
 

--- a/tests/rustdoc-html/nested-modules.rs
+++ b/tests/rustdoc-html/nested-modules.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 #![crate_name = "aCrate"]
 
 mod a_module {

--- a/tests/rustdoc-html/playground-arg.rs
+++ b/tests/rustdoc-html/playground-arg.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ compile-flags: --playground-url=https://example.com/ -Z unstable-options
 
 #![crate_name = "foo"]

--- a/tests/rustdoc-html/playground.rs
+++ b/tests/rustdoc-html/playground.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 #![crate_name = "foo"]
 
 #![doc(html_playground_url = "https://www.example.com/")]

--- a/tests/rustdoc-html/private/private-use.rs
+++ b/tests/rustdoc-html/private/private-use.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Regression test for <https://github.com/rust-lang/rust/pull/113374> to
 // ensure it doesn't panic.
 

--- a/tests/rustdoc-html/redirect.rs
+++ b/tests/rustdoc-html/redirect.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ aux-build:reexp-stripped.rs
 //@ build-aux-docs
 //@ ignore-cross-compile

--- a/tests/rustdoc-html/reexport/pub-reexport-of-pub-reexport-46506.rs
+++ b/tests/rustdoc-html/reexport/pub-reexport-of-pub-reexport-46506.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // This is a regression test for <https://github.com/rust-lang/rust/issues/46506>.
 // This test ensures that if public re-exported is re-exported, it won't be inlined.
 

--- a/tests/rustdoc-html/reexport/reexport-stability-tags-deprecated-and-portability.rs
+++ b/tests/rustdoc-html/reexport/reexport-stability-tags-deprecated-and-portability.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 #![crate_name = "foo"]
 #![feature(doc_cfg)]
 

--- a/tests/rustdoc-html/reexport/reexport-stability-tags-unstable-and-portability.rs
+++ b/tests/rustdoc-html/reexport/reexport-stability-tags-unstable-and-portability.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 #![crate_name = "foo"]
 #![feature(doc_cfg)]
 #![feature(staged_api)]

--- a/tests/rustdoc-html/test-parens.rs
+++ b/tests/rustdoc-html/test-parens.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 #![crate_name = "foo"]
 
 //@ has foo/fn.foo.html

--- a/tests/rustdoc-html/viewpath-rename.rs
+++ b/tests/rustdoc-html/viewpath-rename.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 #![crate_name = "foo"]
 
 pub mod io {

--- a/tests/rustdoc-html/viewpath-self.rs
+++ b/tests/rustdoc-html/viewpath-self.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 #![crate_name = "foo"]
 
 pub mod io {

--- a/tests/rustdoc-html/visibility.rs
+++ b/tests/rustdoc-html/visibility.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ compile-flags: --document-private-items
 
 #![crate_name = "foo"]

--- a/tests/rustdoc-json/generic-args.rs
+++ b/tests/rustdoc-json/generic-args.rs
@@ -1,3 +1,5 @@
+//@ edition: 2015
+
 pub struct MyStruct(u32);
 
 pub trait MyTrait {

--- a/tests/rustdoc-json/glob_import.rs
+++ b/tests/rustdoc-json/glob_import.rs
@@ -1,4 +1,5 @@
 // This is a regression test for <https://github.com/rust-lang/rust/issues/98003>.
+//@ edition: 2015
 
 #![no_std]
 

--- a/tests/rustdoc-ui/ice-blanket-impl-52873.rs
+++ b/tests/rustdoc-ui/ice-blanket-impl-52873.rs
@@ -55,7 +55,7 @@ pub trait PrivatePow<Y, N> {
 }
 pub type PrivatePowOut<A, Y, N> = <A as PrivatePow<Y, N>>::Output;
 
-pub type Add1<A> = <A as Add<::B1>>::Output;
+pub type Add1<A> = <A as Add<B1>>::Output;
 pub type Prod<A, B> = <A as Mul<B>>::Output;
 pub type Square<A> = <A as Mul>::Output;
 pub type Sum<A, B> = <A as Add<B>>::Output;

--- a/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
+++ b/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
@@ -4,10 +4,7 @@ error[E0432]: unresolved import `inner`
 LL |     pub use inner::S;
    |             ^^^^^ use of unresolved module or unlinked crate `inner`
    |
-help: you might be missing a crate named `inner`, add it to your project and import it in your code
-   |
-LL + extern crate inner;
-   |
+   = help: you might be missing a crate named `inner`
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/impl-fn-nesting.rs
+++ b/tests/rustdoc-ui/impl-fn-nesting.rs
@@ -17,7 +17,7 @@ pub fn f<B: UnknownBound>(a: UnknownType, b: B) {
     //~| ERROR cannot find trait `UnknownTrait` in this scope
     impl ValidTrait for UnknownType {}
     //~^ ERROR cannot find type `UnknownType` in this scope
-    impl ValidTrait for ValidType where ValidTrait: UnknownBound {}
+    impl ValidTrait for ValidType where dyn ValidTrait: UnknownBound {}
     //~^ ERROR cannot find trait `UnknownBound` in this scope
 
     /// This impl has documentation

--- a/tests/rustdoc-ui/impl-fn-nesting.stderr
+++ b/tests/rustdoc-ui/impl-fn-nesting.stderr
@@ -41,10 +41,10 @@ LL |     impl ValidTrait for UnknownType {}
    |                         ^^^^^^^^^^^ not found in this scope
 
 error[E0405]: cannot find trait `UnknownBound` in this scope
-  --> $DIR/impl-fn-nesting.rs:20:53
+  --> $DIR/impl-fn-nesting.rs:20:57
    |
-LL |     impl ValidTrait for ValidType where ValidTrait: UnknownBound {}
-   |                                                     ^^^^^^^^^^^^ not found in this scope
+LL |     impl ValidTrait for ValidType where dyn ValidTrait: UnknownBound {}
+   |                                                         ^^^^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `UnknownType` in this scope
   --> $DIR/impl-fn-nesting.rs:25:21

--- a/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.rs
+++ b/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.rs
@@ -1,4 +1,5 @@
 // Regression test for issue #95879.
+//@ edition: 2015
 
 use unresolved_crate::module::Name; //~ ERROR cannot find
 

--- a/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.stderr
+++ b/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.stderr
@@ -1,5 +1,5 @@
 error[E0433]: cannot find module or crate `unresolved_crate` in the crate root
-  --> $DIR/unresolved-import-recovery.rs:3:5
+  --> $DIR/unresolved-import-recovery.rs:4:5
    |
 LL | use unresolved_crate::module::Name;
    |     ^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved_crate`

--- a/tests/rustdoc-ui/issues/ice-generic-type-alias-105742.rs
+++ b/tests/rustdoc-ui/issues/ice-generic-type-alias-105742.rs
@@ -26,7 +26,7 @@ pub trait SVec: Index<
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
-    Output = <Index<<Self as SVec>::Item,
+    Output = <dyn Index<<Self as SVec>::Item,
     //~^ NOTE expected 1 lifetime argument
     //~| NOTE expected 1 generic argument
     //~| ERROR missing generics for associated type `SVec::Item`

--- a/tests/rustdoc-ui/issues/ice-generic-type-alias-105742.stderr
+++ b/tests/rustdoc-ui/issues/ice-generic-type-alias-105742.stderr
@@ -31,10 +31,10 @@ LL |     <Self as SVec>::Item<T>,
    |                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:29:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:41
    |
-LL |     Output = <Index<<Self as SVec>::Item,
-   |                                     ^^^^ expected 1 lifetime argument
+LL |     Output = <dyn Index<<Self as SVec>::Item,
+   |                                         ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
   --> $DIR/ice-generic-type-alias-105742.rs:62:10
@@ -43,14 +43,14 @@ LL |     type Item<'a, T>;
    |          ^^^^ --
 help: add missing lifetime argument
    |
-LL |     Output = <Index<<Self as SVec>::Item<'a>,
-   |                                         ++++
+LL |     Output = <dyn Index<<Self as SVec>::Item<'a>,
+   |                                             ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:29:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:41
    |
-LL |     Output = <Index<<Self as SVec>::Item,
-   |                                     ^^^^ expected 1 generic argument
+LL |     Output = <dyn Index<<Self as SVec>::Item,
+   |                                         ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
   --> $DIR/ice-generic-type-alias-105742.rs:62:10
@@ -59,8 +59,8 @@ LL |     type Item<'a, T>;
    |          ^^^^     -
 help: add missing generic argument
    |
-LL |     Output = <Index<<Self as SVec>::Item<T>,
-   |                                         +++
+LL |     Output = <dyn Index<<Self as SVec>::Item<T>,
+   |                                             +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/ice-generic-type-alias-105742.rs:40:30
@@ -193,10 +193,10 @@ LL |     <Self as SVec>::Item<T>,
    |                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:29:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:41
    |
-LL |     Output = <Index<<Self as SVec>::Item,
-   |                                     ^^^^ expected 1 lifetime argument
+LL |     Output = <dyn Index<<Self as SVec>::Item,
+   |                                         ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
   --> $DIR/ice-generic-type-alias-105742.rs:62:10
@@ -206,14 +206,14 @@ LL |     type Item<'a, T>;
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
-LL |     Output = <Index<<Self as SVec>::Item<'a>,
-   |                                         ++++
+LL |     Output = <dyn Index<<Self as SVec>::Item<'a>,
+   |                                             ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:29:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:41
    |
-LL |     Output = <Index<<Self as SVec>::Item,
-   |                                     ^^^^ expected 1 generic argument
+LL |     Output = <dyn Index<<Self as SVec>::Item,
+   |                                         ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
   --> $DIR/ice-generic-type-alias-105742.rs:62:10
@@ -223,8 +223,8 @@ LL |     type Item<'a, T>;
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing generic argument
    |
-LL |     Output = <Index<<Self as SVec>::Item<T>,
-   |                                         +++
+LL |     Output = <dyn Index<<Self as SVec>::Item<T>,
+   |                                             +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/ice-generic-type-alias-105742.rs:40:30
@@ -310,7 +310,7 @@ LL |    pub trait SVec: Index<
    | |            this trait is not dyn compatible...
 LL | |      <Self as SVec>::Item,
 ...  |
-LL | |/     Output = <Index<<Self as SVec>::Item,
+LL | |/     Output = <dyn Index<<Self as SVec>::Item,
 ...  ||
 LL | ||     Output = <Self as SVec>::Item> as SVec>::Item,
    | ||_________________________________________________^ ...because it uses `Self` as a type parameter
@@ -358,10 +358,10 @@ LL |     <Self as SVec>::Item<T>,
    |                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:29:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:41
    |
-LL |     Output = <Index<<Self as SVec>::Item,
-   |                                     ^^^^ expected 1 lifetime argument
+LL |     Output = <dyn Index<<Self as SVec>::Item,
+   |                                         ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
   --> $DIR/ice-generic-type-alias-105742.rs:62:10
@@ -371,14 +371,14 @@ LL |     type Item<'a, T>;
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
-LL |     Output = <Index<<Self as SVec>::Item<'a>,
-   |                                         ++++
+LL |     Output = <dyn Index<<Self as SVec>::Item<'a>,
+   |                                             ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:29:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:41
    |
-LL |     Output = <Index<<Self as SVec>::Item,
-   |                                     ^^^^ expected 1 generic argument
+LL |     Output = <dyn Index<<Self as SVec>::Item,
+   |                                         ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
   --> $DIR/ice-generic-type-alias-105742.rs:62:10
@@ -388,8 +388,8 @@ LL |     type Item<'a, T>;
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing generic argument
    |
-LL |     Output = <Index<<Self as SVec>::Item<T>,
-   |                                         +++
+LL |     Output = <dyn Index<<Self as SVec>::Item<T>,
+   |                                             +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/ice-generic-type-alias-105742.rs:40:30
@@ -494,10 +494,10 @@ LL |     <Self as SVec>::Item<T>,
    |                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:29:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:41
    |
-LL |     Output = <Index<<Self as SVec>::Item,
-   |                                     ^^^^ expected 1 lifetime argument
+LL |     Output = <dyn Index<<Self as SVec>::Item,
+   |                                         ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
   --> $DIR/ice-generic-type-alias-105742.rs:62:10
@@ -507,14 +507,14 @@ LL |     type Item<'a, T>;
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing lifetime argument
    |
-LL |     Output = <Index<<Self as SVec>::Item<'a>,
-   |                                         ++++
+LL |     Output = <dyn Index<<Self as SVec>::Item<'a>,
+   |                                             ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:29:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:41
    |
-LL |     Output = <Index<<Self as SVec>::Item,
-   |                                     ^^^^ expected 1 generic argument
+LL |     Output = <dyn Index<<Self as SVec>::Item,
+   |                                         ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
   --> $DIR/ice-generic-type-alias-105742.rs:62:10
@@ -524,8 +524,8 @@ LL |     type Item<'a, T>;
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add missing generic argument
    |
-LL |     Output = <Index<<Self as SVec>::Item<T>,
-   |                                         +++
+LL |     Output = <dyn Index<<Self as SVec>::Item<T>,
+   |                                             +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/ice-generic-type-alias-105742.rs:40:30

--- a/tests/rustdoc-ui/issues/issue-61732.rs
+++ b/tests/rustdoc-ui/issues/issue-61732.rs
@@ -1,4 +1,5 @@
 // This previously triggered an ICE.
+//@ edition: 2015
 
 pub(in crate::r#mod) fn main() {}
 //~^ ERROR cannot find module or crate `r#mod` in `crate`

--- a/tests/rustdoc-ui/issues/issue-61732.stderr
+++ b/tests/rustdoc-ui/issues/issue-61732.stderr
@@ -1,5 +1,5 @@
 error[E0433]: cannot find module or crate `r#mod` in `crate`
-  --> $DIR/issue-61732.rs:3:15
+  --> $DIR/issue-61732.rs:4:15
    |
 LL | pub(in crate::r#mod) fn main() {}
    |               ^^^^^ use of unresolved module or unlinked crate `r#mod`

--- a/tests/ui-fulldeps/dropck-tarena-cycle-checked.rs
+++ b/tests/ui-fulldeps/dropck-tarena-cycle-checked.rs
@@ -25,7 +25,7 @@ mod s {
 }
 
 mod id {
-    use s;
+    use crate::s;
     #[derive(Debug)]
     pub struct Id {
         orig_count: usize,

--- a/tests/ui/associated-types/suggest-assoc-type-from-bounds.rs
+++ b/tests/ui/associated-types/suggest-assoc-type-from-bounds.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 pub trait Trait<T> {
     type Assoc;
 }

--- a/tests/ui/associated-types/suggest-assoc-type-from-bounds.stderr
+++ b/tests/ui/associated-types/suggest-assoc-type-from-bounds.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find type `Assoc` in this scope
-  --> $DIR/suggest-assoc-type-from-bounds.rs:6:12
+  --> $DIR/suggest-assoc-type-from-bounds.rs:7:12
    |
 LL |     let _: Assoc = todo!();
    |            ^^^^^
@@ -12,7 +12,7 @@ LL |     let _: <U as Trait<u32>>::Assoc = todo!();
    |            +++++++++++++++++++
 
 error[E0425]: cannot find type `A` in this scope
-  --> $DIR/suggest-assoc-type-from-bounds.rs:20:12
+  --> $DIR/suggest-assoc-type-from-bounds.rs:21:12
    |
 LL |     let _: A = todo!();
    |            ^
@@ -29,7 +29,7 @@ LL | fn g<'a, T: ::Foo<'a> + inner::Foo<'a>, A>() {
    |                                       +++
 
 error[E0425]: cannot find type `Assoc` in this scope
-  --> $DIR/suggest-assoc-type-from-bounds.rs:32:12
+  --> $DIR/suggest-assoc-type-from-bounds.rs:33:12
    |
 LL |     let _: Assoc = todo!();
    |            ^^^^^
@@ -42,7 +42,7 @@ LL |     let _: <T as Second>::Assoc = todo!();
    |            +++++++++++++++
 
 error[E0425]: cannot find type `Assoc` in this scope
-  --> $DIR/suggest-assoc-type-from-bounds.rs:40:12
+  --> $DIR/suggest-assoc-type-from-bounds.rs:41:12
    |
 LL |     let _: Assoc = todo!();
    |            ^^^^^
@@ -54,7 +54,7 @@ LL +     let _: T::Assoc<'_> = todo!();
    |
 
 error[E0425]: cannot find type `Assoc` in this scope
-  --> $DIR/suggest-assoc-type-from-bounds.rs:47:20
+  --> $DIR/suggest-assoc-type-from-bounds.rs:48:20
    |
 LL |             let _: Assoc = todo!();
    |                    ^^^^^
@@ -65,7 +65,7 @@ LL |             let _: U::Assoc = todo!();
    |                    +++
 
 error[E0425]: cannot find type `Assoc` in this scope
-  --> $DIR/suggest-assoc-type-from-bounds.rs:58:20
+  --> $DIR/suggest-assoc-type-from-bounds.rs:59:20
    |
 LL |             let _: Assoc = todo!();
    |                    ^^^^^ not found in this scope

--- a/tests/ui/closures/wrong-closure-arg-suggestion-125325.rs
+++ b/tests/ui/closures/wrong-closure-arg-suggestion-125325.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ aux-build:wrong-closure-arg-suggestion-aux.rs
 
 // Regression test for #125325

--- a/tests/ui/closures/wrong-closure-arg-suggestion-125325.stderr
+++ b/tests/ui/closures/wrong-closure-arg-suggestion-125325.stderr
@@ -1,5 +1,5 @@
 error[E0594]: cannot assign to `x`, as it is a captured variable in a `Fn` closure
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:29:21
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:30:21
    |
 LL |     fn assoc_func(&self, _f: impl Fn()) -> usize {
    |                              --------- change this to accept `FnMut` instead of `Fn`
@@ -14,7 +14,7 @@ LL |     s.assoc_func(|| x = ());
    |       expects `Fn` instead of `FnMut`
 
 error[E0594]: cannot assign to `x`, as it is a captured variable in a `Fn` closure
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:31:13
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:32:13
    |
 LL | fn func(_f: impl Fn()) -> usize {
    |             --------- change this to accept `FnMut` instead of `Fn`
@@ -29,7 +29,7 @@ LL |     func(|| x = ())
    |     expects `Fn` instead of `FnMut`
 
 error[E0594]: cannot assign to `self.counter`, as `Fn` closures cannot mutate their captured variables
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:46:28
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:47:28
    |
 LL |         take(|_| to_fn(|_| self.counter += 1));
    |                  ----- --- ^^^^^^^^^^^^^^^^^ cannot assign
@@ -38,18 +38,18 @@ LL |         take(|_| to_fn(|_| self.counter += 1));
    |                  expects `Fn` instead of `FnMut`
 
 error: lifetime may not live long enough
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:46:18
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:47:18
    |
 LL |         take(|_| to_fn(|_| self.counter += 1));
    |              --- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
    |              | |
-   |              | return type of closure `aux::Map<{closure@$DIR/wrong-closure-arg-suggestion-125325.rs:46:24: 46:27}>` contains a lifetime `'2`
+   |              | return type of closure `aux::Map<{closure@$DIR/wrong-closure-arg-suggestion-125325.rs:47:24: 47:27}>` contains a lifetime `'2`
    |              lifetime `'1` represents this closure's body
    |
    = note: closure implements `Fn`, so references to captured variables can't escape the closure
 
 error[E0596]: cannot borrow `self` as mutable, as it is a captured variable in a `Fn` closure
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:46:24
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:47:24
    |
 LL |         take(|_| to_fn(|_| self.counter += 1));
    |         ---- ---       ^^^ ------------ mutable borrow occurs due to use of `self` in closure
@@ -62,7 +62,7 @@ LL | fn take<F, U>(_: F)
    |                  - change this to accept `FnMut` instead of `Fn`
 
 error[E0594]: cannot assign to `self.counter`, as `Fn` closures cannot mutate their captured variables
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:54:34
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:55:34
    |
 LL |         P.flat_map(|_| P.map(|_| self.counter += 1));
    |                          --------^^^^^^^^^^^^^^^^^-
@@ -72,12 +72,12 @@ LL |         P.flat_map(|_| P.map(|_| self.counter += 1));
    |                          expects `Fn` instead of `FnMut`
 
 error: lifetime may not live long enough
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:54:24
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:55:24
    |
 LL |         P.flat_map(|_| P.map(|_| self.counter += 1));
    |                    --- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
    |                    | |
-   |                    | return type of closure `aux::Map<{closure@$DIR/wrong-closure-arg-suggestion-125325.rs:54:30: 54:33}>` contains a lifetime `'2`
+   |                    | return type of closure `aux::Map<{closure@$DIR/wrong-closure-arg-suggestion-125325.rs:55:30: 55:33}>` contains a lifetime `'2`
    |                    lifetime `'1` represents this closure's body
    |
    = note: closure implements `Fn`, so references to captured variables can't escape the closure
@@ -87,7 +87,7 @@ LL |         P.flat_map(|_| P.map(move |_| self.counter += 1));
    |                              ++++
 
 error[E0596]: cannot borrow `self` as mutable, as it is a captured variable in a `Fn` closure
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:54:30
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:55:30
    |
 LL |         P.flat_map(|_| P.map(|_| self.counter += 1));
    |           -------------------^^^--------------------

--- a/tests/ui/const-generics/mgca/adt_expr_arg_simple.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_simple.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 #![feature(min_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 

--- a/tests/ui/const-generics/mgca/adt_expr_arg_simple.stderr
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_simple.stderr
@@ -1,11 +1,11 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/adt_expr_arg_simple.rs:29:30
+  --> $DIR/adt_expr_arg_simple.rs:30:30
    |
 LL |     foo::<{ Some::<u32> { 0: N + 1 } }>();
    |                              ^^^^^
 
 error: generic parameters may not be used in const operations
-  --> $DIR/adt_expr_arg_simple.rs:34:38
+  --> $DIR/adt_expr_arg_simple.rs:35:38
    |
 LL |     foo::<{ Some::<u32> { 0: const { N + 1 } } }>();
    |                                      ^

--- a/tests/ui/consts/const-block-items/hir.stdout
+++ b/tests/ui/consts/const-block-items/hir.stdout
@@ -1,7 +1,7 @@
 #![attr = Feature([const_block_items#0])]
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ build-pass
 //@ compile-flags: -Zunpretty=hir
 

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155125.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155125.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `foo` is defined multiple times
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:12:17
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:13:17
    |
 LL |                 fn foo() {}
    |                 -------- previous definition of the value `foo` here
@@ -9,7 +9,7 @@ LL |                 reuse foo;
    = note: `foo` must be defined only once in the value namespace of this block
 
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:10:13
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:11:13
    |
 LL | /             {
 LL | |                 fn foo() {}

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155127.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155127.stderr
@@ -1,5 +1,5 @@
 error: `#[deprecated]` attribute cannot be used on delegations
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:26:9
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:27:9
    |
 LL |         #[deprecated]
    |         ^^^^^^^^^^^^^

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155128.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155128.stderr
@@ -1,5 +1,5 @@
 error[E0061]: this function takes 0 arguments but 1 argument was supplied
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:36:11
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:37:11
    |
 LL |       reuse a as b {
    |  ___________^______-
@@ -9,7 +9,7 @@ LL | |     }
    | |_____- unexpected argument of type `fn() {foo::<_>}`
    |
 note: function defined here
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:34:8
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:35:8
    |
 LL |     fn a() {}
    |        ^

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155164.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155164.stderr
@@ -1,5 +1,5 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:46:13
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:47:13
    |
 LL | /             {
 LL | |

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155202.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155202.stderr
@@ -1,11 +1,11 @@
 error[E0425]: cannot find value `async` in this scope
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:65:13
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:66:13
    |
 LL |             async || {};
    |             ^^^^^ not found in this scope
 
 error[E0308]: mismatched types
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:65:22
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:66:22
    |
 LL |             async || {};
    |                      ^^ expected `bool`, found `()`

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.rs
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ revisions: ice_155125 ice_155127 ice_155128 ice_155164 ice_155202
 
 #![feature(min_generic_const_args, fn_delegation)]

--- a/tests/ui/delegation/impl-reuse-pass.rs
+++ b/tests/ui/delegation/impl-reuse-pass.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 
 #![feature(fn_delegation)]

--- a/tests/ui/delegation/recursive-delegation-ice-150152.stderr
+++ b/tests/ui/delegation/recursive-delegation-ice-150152.stderr
@@ -10,7 +10,7 @@ error[E0425]: cannot find type `S` in this scope
 LL |     impl Trait for S {
    |                    ^ not found in this scope
    |
-note: struct `first_example::S` exists but is inaccessible
+note: struct `crate::first_example::S` exists but is inaccessible
   --> $DIR/recursive-delegation-ice-150152.rs:5:5
    |
 LL |     struct S< S >;
@@ -26,10 +26,10 @@ note: these functions exist but are inaccessible
   --> $DIR/recursive-delegation-ice-150152.rs:4:20
    |
 LL |     mod to_reuse { pub fn foo() {} }
-   |                    ^^^^^^^^^^^^ `first_example::to_reuse::foo`: not accessible
+   |                    ^^^^^^^^^^^^ `crate::first_example::to_reuse::foo`: not accessible
 ...
 LL |         fn foo() {}
-   |         ^^^^^^^^ `second_example::to_reuse::foo`: not accessible
+   |         ^^^^^^^^ `crate::second_example::to_reuse::foo`: not accessible
 
 error[E0603]: function `foo` is private
   --> $DIR/recursive-delegation-ice-150152.rs:17:25

--- a/tests/ui/diagnostic_namespace/on_unknown/this_format_argument.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/this_format_argument.stderr
@@ -42,10 +42,7 @@ LL | pub use doesnt_exist::*;
    |         ^^^^^^^^^^^^ use of unresolved module or unlinked crate `doesnt_exist`
    |
    = note: the name of this is: `doesnt_exist`
-help: you might be missing a crate named `doesnt_exist`, add it to your project and import it in your code
-   |
-LL + extern crate doesnt_exist;
-   |
+   = help: you might be missing a crate named `doesnt_exist`
 
 error[E0432]: unresolved import `foo::Foo`
   --> $DIR/this_format_argument.rs:42:5

--- a/tests/ui/impl-restriction/restriction_resolution_errors.stderr
+++ b/tests/ui/impl-restriction/restriction_resolution_errors.stderr
@@ -83,7 +83,7 @@ LL +         pub impl(in c::b) trait T1 {}
    |
 help: consider importing this module
    |
-LL +         use a;
+LL +         use crate::a;
    |
 
 error[E0433]: cannot find module `c` in the crate root

--- a/tests/ui/imports/issue-114682-3.stderr
+++ b/tests/ui/imports/issue-114682-3.stderr
@@ -10,7 +10,7 @@ LL |     a.ext();
    = help: items from traits can only be used if the trait is in scope
 help: trait `SettingsExt` which provides `ext` is implemented but not in scope; perhaps you want to import it
    |
-LL + use auto::SettingsExt;
+LL + use crate::auto::SettingsExt;
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/imports/nested-import-root-symbol-150103.rs
+++ b/tests/ui/imports/nested-import-root-symbol-150103.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Issue: https://github.com/rust-lang/rust/issues/150103
 // ICE when using `::` at start of nested imports
 // caused by `{{root}}` appearing in diagnostic suggestions

--- a/tests/ui/imports/nested-import-root-symbol-150103.stderr
+++ b/tests/ui/imports/nested-import-root-symbol-150103.stderr
@@ -1,5 +1,5 @@
 error[E0433]: cannot find module or crate `Iuse` in the crate root
-  --> $DIR/nested-import-root-symbol-150103.rs:6:9
+  --> $DIR/nested-import-root-symbol-150103.rs:7:9
    |
 LL |     use Iuse::{ ::Fish };
    |         ^^^^ use of unresolved module or unlinked crate `Iuse`
@@ -10,7 +10,7 @@ LL + extern crate Iuse;
    |
 
 error[E0433]: the crate root in paths can only be used in start position
-  --> $DIR/nested-import-root-symbol-150103.rs:10:13
+  --> $DIR/nested-import-root-symbol-150103.rs:11:13
    |
 LL |     use A::{::Fish};
    |             ^ can only be used in path start position

--- a/tests/ui/imports/no-ambiguous-trait-lint-on-redundant-import.rs
+++ b/tests/ui/imports/no-ambiguous-trait-lint-on-redundant-import.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 // The AMBIGUOUS_GLOB_IMPORTED_TRAITS lint is reported on uses of traits that are
 // ambiguously glob imported. This test checks that we don't report this lint

--- a/tests/ui/imports/private-from-decl-macro.fail.stderr
+++ b/tests/ui/imports/private-from-decl-macro.fail.stderr
@@ -26,7 +26,7 @@ LL |     pub struct S {}
 LL |         let s = S;
    |                 ^
    |
-note: constant `m::S` exists but is inaccessible
+note: constant `crate::m::S` exists but is inaccessible
   --> $DIR/private-from-decl-macro.rs:10:5
    |
 LL |     const S: u8 = 0;

--- a/tests/ui/lint/unused/unused_assignment.rs
+++ b/tests/ui/lint/unused/unused_assignment.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Unused assignments to an unused variable should trigger only the `unused_variables` lint and not
 // also the `unused_assignments` lint.  This test covers the situation where the span of the unused
 // variable identifier comes from a different scope to the binding pattern - here, from a proc

--- a/tests/ui/lint/unused/unused_assignment.stderr
+++ b/tests/ui/lint/unused/unused_assignment.stderr
@@ -1,11 +1,11 @@
 warning: unused variable: `a`
-  --> $DIR/unused_assignment.rs:18:5
+  --> $DIR/unused_assignment.rs:19:5
    |
 LL |     a: (),
    |     ^ help: try ignoring the field: `a: _`
    |
 note: the lint level is defined here
-  --> $DIR/unused_assignment.rs:11:9
+  --> $DIR/unused_assignment.rs:12:9
    |
 LL | #![warn(unused)]
    |         ^^^^^^

--- a/tests/ui/mir/gvn-opt-138225.rs
+++ b/tests/ui/mir/gvn-opt-138225.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //! Regression test for <https://github.com/rust-lang/rust/issues/138225>
 
 pub struct A {

--- a/tests/ui/mir/gvn-opt-138225.stderr
+++ b/tests/ui/mir/gvn-opt-138225.stderr
@@ -1,5 +1,5 @@
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/gvn-opt-138225.rs:9:9
+  --> $DIR/gvn-opt-138225.rs:10:9
    |
 LL |     pub async fn func1() -> &'static A {
    |         ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -8,7 +8,7 @@ LL |     pub async fn func1() -> &'static A {
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0425]: cannot find type `NestedOption` in this scope
-  --> $DIR/gvn-opt-138225.rs:4:11
+  --> $DIR/gvn-opt-138225.rs:5:11
    |
 LL |     name: NestedOption<Option<String>>,
    |           ^^^^^^^^^^^^ not found in this scope

--- a/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.rs
+++ b/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Test for #142064, internal error: entered unreachable code
 //
 //@ compile-flags: -Zthreads=2

--- a/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.stderr
+++ b/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.stderr
@@ -1,7 +1,7 @@
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:23
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:14:23
    |
-LL | trait A { fn foo() -> A; }
+LL | trait B { fn foo() -> A; }
    |                       ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
@@ -9,38 +9,24 @@ LL | trait A { fn foo() -> A; }
    = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
-LL | trait A { fn foo() -> dyn A; }
-   |                       +++
-
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:13:23
-   |
-LL | trait B { fn foo() -> A; }
-   |                       ^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is a dyn-compatible trait, use `dyn`
-   |
 LL | trait B { fn foo() -> dyn A; }
    |                       +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:23
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:8:23
    |
 LL | trait A { fn foo() -> A; }
    |                       ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait A { fn foo() -> dyn A; }
    |                       +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:13:23
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:14:23
    |
 LL | trait B { fn foo() -> A; }
    |                       ^
@@ -53,43 +39,29 @@ help: if this is a dyn-compatible trait, use `dyn`
 LL | trait B { fn foo() -> dyn A; }
    |                       +++
 
-error[E0038]: the trait `A` is not dyn compatible
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:23
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:8:23
    |
 LL | trait A { fn foo() -> A; }
-   |                       ^ `A` is not dyn compatible
+   |                       ^
    |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:14
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: if this is a dyn-compatible trait, use `dyn`
    |
-LL | trait A { fn foo() -> A; }
-   |       -      ^^^ ...because associated function `foo` has no `self` parameter
-   |       |
-   |       this trait is not dyn compatible...
-help: consider turning `foo` into a method by giving it a `&self` argument
-   |
-LL | trait A { fn foo(&self) -> A; }
-   |                  +++++
-help: alternatively, consider constraining `foo` so it does not apply to trait objects
-   |
-LL | trait A { fn foo() -> A where Self: Sized; }
-   |                         +++++++++++++++++
-help: you might have meant to use `Self` to refer to the implementing type
-   |
-LL - trait A { fn foo() -> A; }
-LL + trait A { fn foo() -> Self; }
-   |
+LL | trait A { fn foo() -> dyn A; }
+   |                       +++
 
 error[E0038]: the trait `A` is not dyn compatible
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:13:23
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:14:23
    |
 LL | trait B { fn foo() -> A; }
    |                       ^ `A` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:14
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:8:14
    |
 LL | trait A { fn foo() -> A; }
    |       -      ^^^ ...because associated function `foo` has no `self` parameter
@@ -107,6 +79,34 @@ help: you might have meant to use `Self` to refer to the implementing type
    |
 LL - trait B { fn foo() -> A; }
 LL + trait B { fn foo() -> Self; }
+   |
+
+error[E0038]: the trait `A` is not dyn compatible
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:8:23
+   |
+LL | trait A { fn foo() -> A; }
+   |                       ^ `A` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:8:14
+   |
+LL | trait A { fn foo() -> A; }
+   |       -      ^^^ ...because associated function `foo` has no `self` parameter
+   |       |
+   |       this trait is not dyn compatible...
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL | trait A { fn foo(&self) -> A; }
+   |                  +++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL | trait A { fn foo() -> A where Self: Sized; }
+   |                         +++++++++++++++++
+help: you might have meant to use `Self` to refer to the implementing type
+   |
+LL - trait A { fn foo() -> A; }
+LL + trait A { fn foo() -> Self; }
    |
 
 error: aborting due to 2 previous errors; 4 warnings emitted

--- a/tests/ui/proc-macro/dollar-crate-issue-62325.stdout
+++ b/tests/ui/proc-macro/dollar-crate-issue-62325.stdout
@@ -57,54 +57,54 @@ PRINT-ATTR INPUT (DISPLAY): struct B(identity! ($crate :: S));
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:5: 21:11 (#12),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:5: 21:11 (#11),
     },
     Ident {
         ident: "B",
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:12: 21:13 (#12),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:12: 21:13 (#11),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "identity",
-                span: $DIR/auxiliary/dollar-crate-external.rs:21:14: 21:22 (#12),
+                span: $DIR/auxiliary/dollar-crate-external.rs:21:14: 21:22 (#11),
             },
             Punct {
                 ch: '!',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:21:22: 21:23 (#12),
+                span: $DIR/auxiliary/dollar-crate-external.rs:21:22: 21:23 (#11),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         ident: "$crate",
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:24: 21:30 (#12),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:24: 21:30 (#11),
                     },
                     Punct {
                         ch: ':',
                         spacing: Joint,
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:30: 21:31 (#12),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:30: 21:31 (#11),
                     },
                     Punct {
                         ch: ':',
                         spacing: Alone,
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:31: 21:32 (#12),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:31: 21:32 (#11),
                     },
                     Ident {
                         ident: "S",
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:32: 21:33 (#12),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:32: 21:33 (#11),
                     },
                 ],
-                span: $DIR/auxiliary/dollar-crate-external.rs:21:23: 21:34 (#12),
+                span: $DIR/auxiliary/dollar-crate-external.rs:21:23: 21:34 (#11),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:13: 21:35 (#12),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:13: 21:35 (#11),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:35: 21:36 (#12),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:35: 21:36 (#11),
     },
 ]

--- a/tests/ui/proc-macro/dollar-crate.stdout
+++ b/tests/ui/proc-macro/dollar-crate.stdout
@@ -122,119 +122,119 @@ PRINT-BANG INPUT (DISPLAY): struct M($crate :: S);
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:13: 7:19 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:13: 7:19 (#14),
     },
     Ident {
         ident: "M",
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:20: 7:21 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:20: 7:21 (#14),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:22: 7:28 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:22: 7:28 (#14),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:28: 7:29 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:28: 7:29 (#14),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:29: 7:30 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:29: 7:30 (#14),
             },
             Ident {
                 ident: "S",
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:30: 7:31 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:30: 7:31 (#14),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:21: 7:32 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:21: 7:32 (#14),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:32: 7:33 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:32: 7:33 (#14),
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct A($crate :: S);
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:9: 11:15 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:9: 11:15 (#14),
     },
     Ident {
         ident: "A",
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:16: 11:17 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:16: 11:17 (#14),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:18: 11:24 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:18: 11:24 (#14),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:24: 11:25 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:24: 11:25 (#14),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:25: 11:26 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:25: 11:26 (#14),
             },
             Ident {
                 ident: "S",
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:26: 11:27 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:26: 11:27 (#14),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:17: 11:28 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:17: 11:28 (#14),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:28: 11:29 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:28: 11:29 (#14),
     },
 ]
 PRINT-DERIVE INPUT (DISPLAY): struct D($crate :: S);
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:9: 14:15 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:9: 14:15 (#14),
     },
     Ident {
         ident: "D",
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:16: 14:17 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:16: 14:17 (#14),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:18: 14:24 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:18: 14:24 (#14),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:24: 14:25 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:24: 14:25 (#14),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:25: 14:26 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:25: 14:26 (#14),
             },
             Ident {
                 ident: "S",
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:26: 14:27 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:26: 14:27 (#14),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:17: 14:28 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:17: 14:28 (#14),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:28: 14:29 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:28: 14:29 (#14),
     },
 ]

--- a/tests/ui/proc-macro/nested-macro-rules.stdout
+++ b/tests/ui/proc-macro/nested-macro-rules.stdout
@@ -2,45 +2,45 @@ PRINT-BANG INPUT (DISPLAY): FirstStruct
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "FirstStruct",
-        span: $DIR/auxiliary/nested-macro-rules.rs:16:14: 16:25 (#7),
+        span: $DIR/auxiliary/nested-macro-rules.rs:16:14: 16:25 (#6),
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct FirstAttrStruct {}
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/nested-macro-rules.rs:10:32: 10:38 (#6),
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:32: 10:38 (#5),
     },
     Ident {
         ident: "FirstAttrStruct",
-        span: $DIR/auxiliary/nested-macro-rules.rs:16:27: 16:42 (#7),
+        span: $DIR/auxiliary/nested-macro-rules.rs:16:27: 16:42 (#6),
     },
     Group {
         delimiter: Brace,
         stream: TokenStream [],
-        span: $DIR/auxiliary/nested-macro-rules.rs:10:57: 10:59 (#6),
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:57: 10:59 (#5),
     },
 ]
 PRINT-BANG INPUT (DISPLAY): SecondStruct
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "SecondStruct",
-        span: $DIR/nested-macro-rules.rs:23:38: 23:50 (#16),
+        span: $DIR/nested-macro-rules.rs:23:38: 23:50 (#15),
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct SecondAttrStruct {}
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/nested-macro-rules.rs:10:32: 10:38 (#15),
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:32: 10:38 (#14),
     },
     Ident {
         ident: "SecondAttrStruct",
-        span: $DIR/nested-macro-rules.rs:23:52: 23:68 (#16),
+        span: $DIR/nested-macro-rules.rs:23:52: 23:68 (#15),
     },
     Group {
         delimiter: Brace,
         stream: TokenStream [],
-        span: $DIR/auxiliary/nested-macro-rules.rs:10:57: 10:59 (#15),
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:57: 10:59 (#14),
     },
 ]

--- a/tests/ui/resolve/path-suggestion-duplicated-crate-keyword.stderr
+++ b/tests/ui/resolve/path-suggestion-duplicated-crate-keyword.stderr
@@ -10,7 +10,7 @@ LL |                 let _x = crate::unix::linux::system::Y;
    |                                 ++++++
 help: consider importing this module
    |
-LL +             use unix::linux::system;
+LL +             use crate::unix::linux::system;
    |
 help: if you import `system`, refer to it directly
    |

--- a/tests/ui/shadowed/shadowed-use-visibility.stderr
+++ b/tests/ui/shadowed/shadowed-use-visibility.stderr
@@ -17,7 +17,7 @@ LL | mod foo {
 help: consider importing this function instead
    |
 LL -     use crate::foo::bar::f as g;
-LL +     use foo::f as g;
+LL +     use crate::foo::f as g;
    |
 
 error[E0603]: module import `f` is private

--- a/tests/ui/suggestions/suggest-collect.stderr
+++ b/tests/ui/suggestions/suggest-collect.stderr
@@ -32,12 +32,12 @@ error[E0308]: mismatched types
   --> $DIR/suggest-collect.rs:10:36
    |
 LL |     let res: Result<Vec<i32>, _> = ["1", "2"].into_iter().map(|s| s.parse::<i32>());
-   |              -------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<Vec<i32>, _>`, found `Map<Iter<'_, &str>, {closure@...}>`
+   |              -------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<Vec<i32>, _>`, found `Map<IntoIter<&str, 2>, {closure@...}>`
    |              |
    |              expected due to this
    |
    = note: expected enum `Result<Vec<i32>, _>`
-            found struct `Map<std::slice::Iter<'_, &str>, {closure@$DIR/suggest-collect.rs:10:63: 10:66}>`
+            found struct `Map<std::array::IntoIter<&str, 2>, {closure@$DIR/suggest-collect.rs:10:63: 10:66}>`
 help: consider using `.collect()` to convert the `Iterator` into a `Result<Vec<i32>, _>`
    |
 LL |     let res: Result<Vec<i32>, _> = ["1", "2"].into_iter().map(|s| s.parse::<i32>()).collect();

--- a/tests/ui/type-alias-impl-trait/tait-normalize.rs
+++ b/tests/ui/type-alias-impl-trait/tait-normalize.rs
@@ -1,6 +1,7 @@
 //@ revisions: current next
 //@ [next] compile-flags: -Znext-solver
 //@ check-pass
+//@ edition: 2015..2018
 
 #![feature(type_alias_impl_trait)]
 

--- a/tests/ui/type-alias-impl-trait/tait-normalize.rs
+++ b/tests/ui/type-alias-impl-trait/tait-normalize.rs
@@ -3,6 +3,9 @@
 //@ check-pass
 //@ edition: 2015..2018
 
+// this fails in edition 2021; see tests/crashes/119786-1.rs
+//@ edition: 2015..2018
+
 #![feature(type_alias_impl_trait)]
 
 fn enum_upvar() {

--- a/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.stdout
+++ b/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.stdout
@@ -6,7 +6,7 @@
 #![attr = Feature([min_generic_const_args#0, adt_const_params#0])]
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 
 use std::marker::ConstParamTy;
 

--- a/tests/ui/use/use-mod/use-mod-4.stderr
+++ b/tests/ui/use/use-mod/use-mod-4.stderr
@@ -2,12 +2,7 @@ error[E0432]: unresolved import `crate::foo`
   --> $DIR/use-mod-4.rs:1:12
    |
 LL | use crate::foo::self;
-   |            ^^^ use of unresolved module or unlinked crate `foo`
-   |
-help: you might be missing a crate named `foo`, add it to your project and import it in your code
-   |
-LL + extern crate foo;
-   |
+   |            ^^^ could not find `foo` in the crate root
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/use/use-self-at-end.e2015.stderr
+++ b/tests/ui/use/use-self-at-end.e2015.stderr
@@ -1,5 +1,5 @@
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:14:24
+  --> $DIR/use-self-at-end.rs:15:24
    |
 LL |         pub use crate::self;
    |                        ^^^^
@@ -10,7 +10,7 @@ LL |         pub use crate::self as name;
    |                             +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:16:25
+  --> $DIR/use-self-at-end.rs:17:25
    |
 LL |         pub use crate::{self};
    |                         ^^^^
@@ -21,7 +21,7 @@ LL |         pub use crate::{self as name};
    |                              +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:20:17
+  --> $DIR/use-self-at-end.rs:21:17
    |
 LL |         pub use self;
    |                 ^^^^
@@ -32,7 +32,7 @@ LL |         pub use self as name;
    |                      +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:22:18
+  --> $DIR/use-self-at-end.rs:23:18
    |
 LL |         pub use {self};
    |                  ^^^^
@@ -43,7 +43,7 @@ LL |         pub use {self as name};
    |                       +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:26:23
+  --> $DIR/use-self-at-end.rs:27:23
    |
 LL |         pub use self::self;
    |                       ^^^^
@@ -54,7 +54,7 @@ LL |         pub use self::self as name;
    |                            +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:29:24
+  --> $DIR/use-self-at-end.rs:30:24
    |
 LL |         pub use self::{self};
    |                        ^^^^
@@ -65,7 +65,7 @@ LL |         pub use self::{self as name};
    |                             +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:33:24
+  --> $DIR/use-self-at-end.rs:34:24
    |
 LL |         pub use super::self;
    |                        ^^^^
@@ -76,7 +76,7 @@ LL |         pub use super::self as name;
    |                             +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:36:25
+  --> $DIR/use-self-at-end.rs:37:25
    |
 LL |         pub use super::{self};
    |                         ^^^^
@@ -87,7 +87,7 @@ LL |         pub use super::{self as name};
    |                              +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:48:19
+  --> $DIR/use-self-at-end.rs:50:19
    |
 LL |         pub use ::self;
    |                   ^^^^
@@ -98,7 +98,7 @@ LL |         pub use ::self as name;
    |                        +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:52:20
+  --> $DIR/use-self-at-end.rs:56:20
    |
 LL |         pub use ::{self};
    |                    ^^^^
@@ -109,31 +109,31 @@ LL |         pub use ::{self as name};
    |                         +++++++
 
 error: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:57:20
+  --> $DIR/use-self-at-end.rs:63:20
    |
 LL |         pub use z::self::self;
    |                    ^^^^
 
 error: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:58:20
+  --> $DIR/use-self-at-end.rs:64:20
    |
 LL |         pub use z::self::self as z1;
    |                    ^^^^
 
 error: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:59:21
+  --> $DIR/use-self-at-end.rs:65:21
    |
 LL |         pub use z::{self::{self}};
    |                     ^^^^
 
 error: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:60:21
+  --> $DIR/use-self-at-end.rs:66:21
    |
 LL |         pub use z::{self::{self as z2}};
    |                     ^^^^
 
 error[E0252]: the name `x` is defined multiple times
-  --> $DIR/use-self-at-end.rs:42:28
+  --> $DIR/use-self-at-end.rs:43:28
    |
 LL |         pub use crate::x::self;
    |                 -------------- previous import of the module `x` here
@@ -147,7 +147,7 @@ LL |         pub use crate::x::{self};
    = note: `x` must be defined only once in the type namespace of this module
 
 error[E0252]: the name `Enum` is defined multiple times
-  --> $DIR/use-self-at-end.rs:71:31
+  --> $DIR/use-self-at-end.rs:77:31
    |
 LL |         pub use super::Enum::self;
    |                 ----------------- previous import of the type `Enum` here
@@ -161,7 +161,7 @@ LL |         pub use super::Enum::{self};
    = note: `Enum` must be defined only once in the type namespace of this module
 
 error[E0252]: the name `Trait` is defined multiple times
-  --> $DIR/use-self-at-end.rs:79:32
+  --> $DIR/use-self-at-end.rs:88:32
    |
 LL |         pub use super::Trait::self;
    |                 ------------------ previous import of the trait `Trait` here
@@ -175,103 +175,103 @@ LL |         pub use super::Trait::{self};
    = note: `Trait` must be defined only once in the type namespace of this module
 
 error[E0432]: unresolved import `super::Struct`
-  --> $DIR/use-self-at-end.rs:63:24
+  --> $DIR/use-self-at-end.rs:69:24
    |
 LL |         pub use super::Struct::self;
    |                        ^^^^^^ `Struct` is a struct, not a module
 
 error[E0432]: unresolved import `super::Struct`
-  --> $DIR/use-self-at-end.rs:64:24
+  --> $DIR/use-self-at-end.rs:70:24
    |
 LL |         pub use super::Struct::self as Struct1;
    |                        ^^^^^^ `Struct` is a struct, not a module
 
 error[E0432]: unresolved import `super::Struct`
-  --> $DIR/use-self-at-end.rs:65:24
+  --> $DIR/use-self-at-end.rs:71:24
    |
 LL |         pub use super::Struct::{self};
    |                        ^^^^^^ `Struct` is a struct, not a module
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:83:24
+  --> $DIR/use-self-at-end.rs:92:24
    |
 LL |         pub use super::self::y::z;
    |                        ^^^^ can only be used in path start position or last position
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:84:24
+  --> $DIR/use-self-at-end.rs:93:24
    |
 LL |         pub use super::self::y::z as z3;
    |                        ^^^^ can only be used in path start position or last position
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:85:24
+  --> $DIR/use-self-at-end.rs:94:24
    |
 LL |         pub use super::self::y::{z};
    |                        ^^^^ can only be used in path start position or last position
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:86:24
+  --> $DIR/use-self-at-end.rs:95:24
    |
 LL |         pub use super::self::y::{z as z4};
    |                        ^^^^ can only be used in path start position or last position
 
 error[E0432]: unresolved import `super::Struct`
-  --> $DIR/use-self-at-end.rs:66:24
+  --> $DIR/use-self-at-end.rs:72:24
    |
 LL |         pub use super::Struct::{self as Struct2};
    |                        ^^^^^^ `Struct` is a struct, not a module
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:56:21
+  --> $DIR/use-self-at-end.rs:62:21
    |
 LL |         type G = z::self::self;
    |                     ^^^^ can only be used in path start position or last position
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:82:25
+  --> $DIR/use-self-at-end.rs:91:25
    |
 LL |         type K = super::self::y::z;
    |                         ^^^^ can only be used in path start position or last position
 
 error[E0573]: expected type, found module `crate::self`
-  --> $DIR/use-self-at-end.rs:13:18
+  --> $DIR/use-self-at-end.rs:14:18
    |
 LL |         type A = crate::self;
    |                  ^^^^^^^^^^^ not a type
 
 error[E0573]: expected type, found module `self`
-  --> $DIR/use-self-at-end.rs:19:18
+  --> $DIR/use-self-at-end.rs:20:18
    |
 LL |         type B = self;
    |                  ^^^^ not a type
 
 error[E0573]: expected type, found module `self::self`
-  --> $DIR/use-self-at-end.rs:25:18
+  --> $DIR/use-self-at-end.rs:26:18
    |
 LL |         type C = self::self;
    |                  ^^^^^^^^^^ not a type
 
 error[E0573]: expected type, found module `super::self`
-  --> $DIR/use-self-at-end.rs:32:18
+  --> $DIR/use-self-at-end.rs:33:18
    |
 LL |         type D = super::self;
    |                  ^^^^^^^^^^^ not a type
 
 error[E0573]: expected type, found module `crate::x::self`
-  --> $DIR/use-self-at-end.rs:39:18
+  --> $DIR/use-self-at-end.rs:40:18
    |
 LL |         type E = crate::x::self;
    |                  ^^^^^^^^^^^^^^ not a type
 
 error[E0573]: expected type, found module `::self`
-  --> $DIR/use-self-at-end.rs:45:18
+  --> $DIR/use-self-at-end.rs:46:18
    |
 LL |         type F = ::self;
    |                  ^^^^^^ not a type
 
 error[E0223]: ambiguous associated type
-  --> $DIR/use-self-at-end.rs:62:18
+  --> $DIR/use-self-at-end.rs:68:18
    |
 LL |         type H = super::Struct::self;
    |                  ^^^^^^^^^^^^^^^^^^^
@@ -283,7 +283,7 @@ LL +         type H = <x::Struct as Example>::self;
    |
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/use-self-at-end.rs:74:18
+  --> $DIR/use-self-at-end.rs:80:18
    |
 LL |         type J = super::Trait::self;
    |                  ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/use/use-self-at-end.e2021.stderr
+++ b/tests/ui/use/use-self-at-end.e2021.stderr
@@ -284,21 +284,18 @@ LL -         type H = super::Struct::self;
 LL +         type H = <x::Struct as Example>::self;
    |
 
-warning: trait objects without an explicit `dyn` are deprecated
+error[E0782]: expected a type, found a trait
   --> $DIR/use-self-at-end.rs:80:18
    |
 LL |         type J = super::Trait::self;
    |                  ^^^^^^^^^^^^^^^^^^
    |
-   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
-help: if this is a dyn-compatible trait, use `dyn`
+help: you can add the `dyn` keyword if you want a trait object
    |
 LL |         type J = dyn super::Trait::self;
    |                  +++
 
-error: aborting due to 36 previous errors; 1 warning emitted
+error: aborting due to 37 previous errors
 
-Some errors have detailed explanations: E0223, E0252, E0425, E0432, E0433, E0573.
+Some errors have detailed explanations: E0223, E0252, E0425, E0432, E0433, E0573, E0782.
 For more information about an error, try `rustc --explain E0223`.

--- a/tests/ui/use/use-self-at-end.rs
+++ b/tests/ui/use/use-self-at-end.rs
@@ -1,6 +1,7 @@
-//@ revisions: e2015 e2018
+//@ revisions: e2015 e2018 e2021
 //@ [e2015] edition: 2015
-//@ [e2018] edition: 2018..
+//@ [e2018] edition: 2018
+//@ [e2021] edition: 2021..
 
 pub mod x {
     pub struct Struct;
@@ -45,13 +46,18 @@ pub mod x {
         type F = ::self;
         //[e2015]~^ ERROR expected type, found module `::self`
         //[e2018]~^^ ERROR cannot find crate `self` in the list of imported crates
+        //[e2021]~^^^ ERROR cannot find crate `self` in the list of imported crates
         pub use ::self;
         //[e2015]~^ ERROR imports need to be explicitly named
         //[e2018]~^^ ERROR extern prelude cannot be imported
+        //[e2021]~^^^ ERROR extern prelude cannot be imported
         pub use ::self as crate4; //[e2018]~ ERROR extern prelude cannot be imported
+        //[e2021]~^ ERROR extern prelude cannot be imported
         pub use ::{self}; //[e2018]~ ERROR extern prelude cannot be imported
         //[e2015]~^ ERROR imports need to be explicitly named
+        //[e2021]~^^ ERROR extern prelude cannot be imported
         pub use ::{self as crate5}; //[e2018]~ ERROR extern prelude cannot be imported
+        //[e2021]~^ ERROR extern prelude cannot be imported
 
         type G = z::self::self; //~ ERROR `self` in paths can only be used in start position
         pub use z::self::self; //~ ERROR `self` in paths can only be used in start position or last position
@@ -72,8 +78,11 @@ pub mod x {
         pub use super::Enum::{self as Enum2};
 
         type J = super::Trait::self;
-        //~^ WARN trait objects without an explicit `dyn` are deprecated
-        //~^^ WARN this is accepted in the current edition
+        //[e2015]~^ WARN trait objects without an explicit `dyn` are deprecated
+        //[e2015]~^^ WARN this is accepted in the current edition
+        //[e2018]~^^^ WARN trait objects without an explicit `dyn` are deprecated
+        //[e2018]~^^^^ WARN this is accepted in the current edition
+        //[e2021]~^^^^^ ERROR expected a type, found a trait
         pub use super::Trait::self;
         pub use super::Trait::self as Trait1;
         pub use super::Trait::{self}; //~ ERROR the name `Trait` is defined multiple times


### PR DESCRIPTION
first and last commit are hand-written, middle commit is auto-generated by edition-lift.py. i'll be making PRs to main and upstream shortly but let's get the release ready for the assessor first.

the tait-normalize.rs change shouldn't have been necessary, but rustc crashes on it in 2021 edition: https://github.com/rust-lang/rust/issues/159324