### PR TITLE
fix `--test-variants=2021` to actually use 2021 edition

### DIFF
--- a/src/bootstrap/src/ferrocene/test_variants.rs
+++ b/src/bootstrap/src/ferrocene/test_variants.rs
@@ -58,32 +58,30 @@ pub enum TestVariantName {
 
 impl TestVariantName {
     const fn base(&self) -> TestVariantBase {
-        // FIXME: all of these point to edition 2015 instead of 2021!!!
-
         // The snippet between INTERNAL_PROCEDURES_{START,END}_TEST_VARIANTS is included in our
         // documentation, as the list of test variants currently supported.
 
         match self {
             // INTERNAL_PROCEDURES_START_TEST_VARIANTS
-            Self::Ed2021 => TestVariantBase::new().edition(Edition("2015")),
+            Self::Ed2021 => TestVariantBase::new().edition(Edition("2021")),
             Self::Ed2021CortexA53 => {
-                TestVariantBase::new().edition(Edition("2015")).qemu_cpu(QemuCpu("cortex-a53"))
+                TestVariantBase::new().edition(Edition("2021")).qemu_cpu(QemuCpu("cortex-a53"))
             }
             Self::Ed2021SpecificCortexA53 => TestVariantBase::new()
-                .edition(Edition("2015"))
+                .edition(Edition("2021"))
                 .qemu_cpu(QemuCpu("cortex-a53"))
                 .target_cpu(TargetCpu("cortex-a53")),
             Self::Ed2021NeoverseV1 => {
-                TestVariantBase::new().edition(Edition("2015")).qemu_cpu(QemuCpu("neoverse-v1"))
+                TestVariantBase::new().edition(Edition("2021")).qemu_cpu(QemuCpu("neoverse-v1"))
             }
             Self::Ed2021CortexM4 => {
-                TestVariantBase::new().edition(Edition("2015")).qemu_cpu(QemuCpu("cortex-m4"))
+                TestVariantBase::new().edition(Edition("2021")).qemu_cpu(QemuCpu("cortex-m4"))
             }
             Self::Ed2021CortexR5F => {
-                TestVariantBase::new().edition(Edition("2015")).qemu_cpu(QemuCpu("cortex-r5f"))
+                TestVariantBase::new().edition(Edition("2021")).qemu_cpu(QemuCpu("cortex-r5f"))
             }
             Self::Ed2021SpecificCortexM4 => TestVariantBase::new()
-                .edition(Edition("2015"))
+                .edition(Edition("2021"))
                 .qemu_cpu(QemuCpu("cortex-m4"))
                 .target_cpu(TargetCpu("cortex-m4")),
             // INTERNAL_PROCEDURES_END_TEST_VARIANTS

--- a/tests/ui/associated-types/suggest-assoc-type-from-bounds.rs
+++ b/tests/ui/associated-types/suggest-assoc-type-from-bounds.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 pub trait Trait<T> {
     type Assoc;
 }

--- a/tests/ui/associated-types/suggest-assoc-type-from-bounds.stderr
+++ b/tests/ui/associated-types/suggest-assoc-type-from-bounds.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find type `Assoc` in this scope
-  --> $DIR/suggest-assoc-type-from-bounds.rs:6:12
+  --> $DIR/suggest-assoc-type-from-bounds.rs:7:12
    |
 LL |     let _: Assoc = todo!();
    |            ^^^^^
@@ -12,7 +12,7 @@ LL |     let _: <U as Trait<u32>>::Assoc = todo!();
    |            +++++++++++++++++++
 
 error[E0425]: cannot find type `A` in this scope
-  --> $DIR/suggest-assoc-type-from-bounds.rs:20:12
+  --> $DIR/suggest-assoc-type-from-bounds.rs:21:12
    |
 LL |     let _: A = todo!();
    |            ^
@@ -29,7 +29,7 @@ LL | fn g<'a, T: ::Foo<'a> + inner::Foo<'a>, A>() {
    |                                       +++
 
 error[E0425]: cannot find type `Assoc` in this scope
-  --> $DIR/suggest-assoc-type-from-bounds.rs:32:12
+  --> $DIR/suggest-assoc-type-from-bounds.rs:33:12
    |
 LL |     let _: Assoc = todo!();
    |            ^^^^^
@@ -42,7 +42,7 @@ LL |     let _: <T as Second>::Assoc = todo!();
    |            +++++++++++++++
 
 error[E0425]: cannot find type `Assoc` in this scope
-  --> $DIR/suggest-assoc-type-from-bounds.rs:40:12
+  --> $DIR/suggest-assoc-type-from-bounds.rs:41:12
    |
 LL |     let _: Assoc = todo!();
    |            ^^^^^
@@ -54,7 +54,7 @@ LL +     let _: T::Assoc<'_> = todo!();
    |
 
 error[E0425]: cannot find type `Assoc` in this scope
-  --> $DIR/suggest-assoc-type-from-bounds.rs:47:20
+  --> $DIR/suggest-assoc-type-from-bounds.rs:48:20
    |
 LL |             let _: Assoc = todo!();
    |                    ^^^^^
@@ -65,7 +65,7 @@ LL |             let _: U::Assoc = todo!();
    |                    +++
 
 error[E0425]: cannot find type `Assoc` in this scope
-  --> $DIR/suggest-assoc-type-from-bounds.rs:58:20
+  --> $DIR/suggest-assoc-type-from-bounds.rs:59:20
    |
 LL |             let _: Assoc = todo!();
    |                    ^^^^^ not found in this scope

--- a/tests/ui/closures/wrong-closure-arg-suggestion-125325.rs
+++ b/tests/ui/closures/wrong-closure-arg-suggestion-125325.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ aux-build:wrong-closure-arg-suggestion-aux.rs
 
 // Regression test for #125325

--- a/tests/ui/closures/wrong-closure-arg-suggestion-125325.stderr
+++ b/tests/ui/closures/wrong-closure-arg-suggestion-125325.stderr
@@ -1,5 +1,5 @@
 error[E0594]: cannot assign to `x`, as it is a captured variable in a `Fn` closure
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:29:21
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:30:21
    |
 LL |     fn assoc_func(&self, _f: impl Fn()) -> usize {
    |                              --------- change this to accept `FnMut` instead of `Fn`
@@ -14,7 +14,7 @@ LL |     s.assoc_func(|| x = ());
    |       expects `Fn` instead of `FnMut`
 
 error[E0594]: cannot assign to `x`, as it is a captured variable in a `Fn` closure
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:31:13
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:32:13
    |
 LL | fn func(_f: impl Fn()) -> usize {
    |             --------- change this to accept `FnMut` instead of `Fn`
@@ -29,7 +29,7 @@ LL |     func(|| x = ())
    |     expects `Fn` instead of `FnMut`
 
 error[E0594]: cannot assign to `self.counter`, as `Fn` closures cannot mutate their captured variables
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:46:28
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:47:28
    |
 LL |         take(|_| to_fn(|_| self.counter += 1));
    |                  ----- --- ^^^^^^^^^^^^^^^^^ cannot assign
@@ -38,18 +38,18 @@ LL |         take(|_| to_fn(|_| self.counter += 1));
    |                  expects `Fn` instead of `FnMut`
 
 error: lifetime may not live long enough
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:46:18
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:47:18
    |
 LL |         take(|_| to_fn(|_| self.counter += 1));
    |              --- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
    |              | |
-   |              | return type of closure `aux::Map<{closure@$DIR/wrong-closure-arg-suggestion-125325.rs:46:24: 46:27}>` contains a lifetime `'2`
+   |              | return type of closure `aux::Map<{closure@$DIR/wrong-closure-arg-suggestion-125325.rs:47:24: 47:27}>` contains a lifetime `'2`
    |              lifetime `'1` represents this closure's body
    |
    = note: closure implements `Fn`, so references to captured variables can't escape the closure
 
 error[E0596]: cannot borrow `self` as mutable, as it is a captured variable in a `Fn` closure
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:46:24
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:47:24
    |
 LL |         take(|_| to_fn(|_| self.counter += 1));
    |         ---- ---       ^^^ ------------ mutable borrow occurs due to use of `self` in closure
@@ -62,7 +62,7 @@ LL | fn take<F, U>(_: F)
    |                  - change this to accept `FnMut` instead of `Fn`
 
 error[E0594]: cannot assign to `self.counter`, as `Fn` closures cannot mutate their captured variables
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:54:34
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:55:34
    |
 LL |         P.flat_map(|_| P.map(|_| self.counter += 1));
    |                          --------^^^^^^^^^^^^^^^^^-
@@ -72,12 +72,12 @@ LL |         P.flat_map(|_| P.map(|_| self.counter += 1));
    |                          expects `Fn` instead of `FnMut`
 
 error: lifetime may not live long enough
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:54:24
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:55:24
    |
 LL |         P.flat_map(|_| P.map(|_| self.counter += 1));
    |                    --- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
    |                    | |
-   |                    | return type of closure `aux::Map<{closure@$DIR/wrong-closure-arg-suggestion-125325.rs:54:30: 54:33}>` contains a lifetime `'2`
+   |                    | return type of closure `aux::Map<{closure@$DIR/wrong-closure-arg-suggestion-125325.rs:55:30: 55:33}>` contains a lifetime `'2`
    |                    lifetime `'1` represents this closure's body
    |
    = note: closure implements `Fn`, so references to captured variables can't escape the closure
@@ -87,7 +87,7 @@ LL |         P.flat_map(|_| P.map(move |_| self.counter += 1));
    |                              ++++
 
 error[E0596]: cannot borrow `self` as mutable, as it is a captured variable in a `Fn` closure
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:54:30
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:55:30
    |
 LL |         P.flat_map(|_| P.map(|_| self.counter += 1));
    |           -------------------^^^--------------------

--- a/tests/ui/const-generics/mgca/adt_expr_arg_simple.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_simple.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 #![feature(min_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 

--- a/tests/ui/const-generics/mgca/adt_expr_arg_simple.stderr
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_simple.stderr
@@ -1,11 +1,11 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/adt_expr_arg_simple.rs:29:30
+  --> $DIR/adt_expr_arg_simple.rs:30:30
    |
 LL |     foo::<{ Some::<u32> { 0: N + 1 } }>();
    |                              ^^^^^
 
 error: generic parameters may not be used in const operations
-  --> $DIR/adt_expr_arg_simple.rs:34:38
+  --> $DIR/adt_expr_arg_simple.rs:35:38
    |
 LL |     foo::<{ Some::<u32> { 0: const { N + 1 } } }>();
    |                                      ^

--- a/tests/ui/consts/const-block-items/hir.stdout
+++ b/tests/ui/consts/const-block-items/hir.stdout
@@ -1,7 +1,7 @@
 #![attr = Feature([const_block_items#0])]
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 //@ build-pass
 //@ compile-flags: -Zunpretty=hir
 

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155125.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155125.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `foo` is defined multiple times
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:12:17
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:13:17
    |
 LL |                 fn foo() {}
    |                 -------- previous definition of the value `foo` here
@@ -9,7 +9,7 @@ LL |                 reuse foo;
    = note: `foo` must be defined only once in the value namespace of this block
 
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:10:13
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:11:13
    |
 LL | /             {
 LL | |                 fn foo() {}

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155127.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155127.stderr
@@ -1,5 +1,5 @@
 error: `#[deprecated]` attribute cannot be used on delegations
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:26:9
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:27:9
    |
 LL |         #[deprecated]
    |         ^^^^^^^^^^^^^

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155128.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155128.stderr
@@ -10,7 +10,7 @@ LL | |     }
    | |_____^
 
 error[E0061]: this function takes 0 arguments but 1 argument was supplied
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:36:11
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:37:11
    |
 LL |       reuse a as b {
    |  ___________^______-
@@ -21,7 +21,7 @@ LL | |     }
    | |_____- unexpected argument of type `fn() {foo::<_>}`
    |
 note: function defined here
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:34:8
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:35:8
    |
 LL |     fn a() {}
    |        ^

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.rs
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ revisions: ice_155125 ice_155127 ice_155128 ice_155164 ice_155202
 
 #![feature(min_generic_const_args, fn_delegation)]

--- a/tests/ui/delegation/impl-reuse-pass.rs
+++ b/tests/ui/delegation/impl-reuse-pass.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 
 #![feature(fn_delegation)]

--- a/tests/ui/delegation/recursive-delegation-ice-150152.stderr
+++ b/tests/ui/delegation/recursive-delegation-ice-150152.stderr
@@ -10,7 +10,7 @@ error[E0425]: cannot find type `S` in this scope
 LL |     impl Trait for S {
    |                    ^ not found in this scope
    |
-note: struct `first_example::S` exists but is inaccessible
+note: struct `crate::first_example::S` exists but is inaccessible
   --> $DIR/recursive-delegation-ice-150152.rs:5:5
    |
 LL |     struct S< S >;
@@ -26,10 +26,10 @@ note: these functions exist but are inaccessible
   --> $DIR/recursive-delegation-ice-150152.rs:4:20
    |
 LL |     mod to_reuse { pub fn foo() {} }
-   |                    ^^^^^^^^^^^^ `first_example::to_reuse::foo`: not accessible
+   |                    ^^^^^^^^^^^^ `crate::first_example::to_reuse::foo`: not accessible
 ...
 LL |         fn foo() {}
-   |         ^^^^^^^^ `second_example::to_reuse::foo`: not accessible
+   |         ^^^^^^^^ `crate::second_example::to_reuse::foo`: not accessible
 
 error[E0603]: function `foo` is private
   --> $DIR/recursive-delegation-ice-150152.rs:17:25

--- a/tests/ui/diagnostic_namespace/on_unknown/this_format_argument.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/this_format_argument.stderr
@@ -44,10 +44,7 @@ LL | pub use doesnt_exist::*;
    |         ^^^^^^^^^^^^ use of unresolved module or unlinked crate `doesnt_exist`
    |
    = note: the name of this is: `doesnt_exist`
-help: you might be missing a crate named `doesnt_exist`, add it to your project and import it in your code
-   |
-LL + extern crate doesnt_exist;
-   |
+   = help: you might be missing a crate named `doesnt_exist`
 
 error[E0432]: unresolved import `foo::Foo`
   --> $DIR/this_format_argument.rs:42:5

--- a/tests/ui/impl-restriction/restriction_resolution_errors.stderr
+++ b/tests/ui/impl-restriction/restriction_resolution_errors.stderr
@@ -83,7 +83,7 @@ LL +         pub impl(in c::b) trait T1 {}
    |
 help: consider importing this module
    |
-LL +         use a;
+LL +         use crate::a;
    |
 
 error[E0433]: cannot find module `c` in the crate root

--- a/tests/ui/imports/issue-114682-3.stderr
+++ b/tests/ui/imports/issue-114682-3.stderr
@@ -10,7 +10,7 @@ LL |     a.ext();
    = help: items from traits can only be used if the trait is in scope
 help: trait `SettingsExt` which provides `ext` is implemented but not in scope; perhaps you want to import it
    |
-LL + use auto::SettingsExt;
+LL + use crate::auto::SettingsExt;
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/imports/nested-import-root-symbol-150103.rs
+++ b/tests/ui/imports/nested-import-root-symbol-150103.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Issue: https://github.com/rust-lang/rust/issues/150103
 // ICE when using `::` at start of nested imports
 // caused by `{{root}}` appearing in diagnostic suggestions

--- a/tests/ui/imports/nested-import-root-symbol-150103.stderr
+++ b/tests/ui/imports/nested-import-root-symbol-150103.stderr
@@ -1,5 +1,5 @@
 error[E0433]: cannot find module or crate `Iuse` in the crate root
-  --> $DIR/nested-import-root-symbol-150103.rs:6:9
+  --> $DIR/nested-import-root-symbol-150103.rs:7:9
    |
 LL |     use Iuse::{ ::Fish };
    |         ^^^^ use of unresolved module or unlinked crate `Iuse`
@@ -10,7 +10,7 @@ LL + extern crate Iuse;
    |
 
 error[E0433]: the crate root in paths can only be used in start position
-  --> $DIR/nested-import-root-symbol-150103.rs:10:13
+  --> $DIR/nested-import-root-symbol-150103.rs:11:13
    |
 LL |     use A::{::Fish};
    |             ^ can only be used in path start position

--- a/tests/ui/imports/no-ambiguous-trait-lint-on-redundant-import.rs
+++ b/tests/ui/imports/no-ambiguous-trait-lint-on-redundant-import.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 // The AMBIGUOUS_GLOB_IMPORTED_TRAITS lint is reported on uses of traits that are
 // ambiguously glob imported. This test checks that we don't report this lint

--- a/tests/ui/imports/private-from-decl-macro.fail.stderr
+++ b/tests/ui/imports/private-from-decl-macro.fail.stderr
@@ -26,7 +26,7 @@ LL |     pub struct S {}
 LL |         let s = S;
    |                 ^
    |
-note: constant `m::S` exists but is inaccessible
+note: constant `crate::m::S` exists but is inaccessible
   --> $DIR/private-from-decl-macro.rs:10:5
    |
 LL |     const S: u8 = 0;

--- a/tests/ui/lint/unused/unused_assignment.rs
+++ b/tests/ui/lint/unused/unused_assignment.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Unused assignments to an unused variable should trigger only the `unused_variables` lint and not
 // also the `unused_assignments` lint.  This test covers the situation where the span of the unused
 // variable identifier comes from a different scope to the binding pattern - here, from a proc

--- a/tests/ui/lint/unused/unused_assignment.stderr
+++ b/tests/ui/lint/unused/unused_assignment.stderr
@@ -1,11 +1,11 @@
 warning: unused variable: `a`
-  --> $DIR/unused_assignment.rs:18:5
+  --> $DIR/unused_assignment.rs:19:5
    |
 LL |     a: (),
    |     ^ help: try ignoring the field: `a: _`
    |
 note: the lint level is defined here
-  --> $DIR/unused_assignment.rs:11:9
+  --> $DIR/unused_assignment.rs:12:9
    |
 LL | #![warn(unused)]
    |         ^^^^^^

--- a/tests/ui/mir/gvn-opt-138225.rs
+++ b/tests/ui/mir/gvn-opt-138225.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //! Regression test for <https://github.com/rust-lang/rust/issues/138225>
 
 pub struct A {

--- a/tests/ui/mir/gvn-opt-138225.stderr
+++ b/tests/ui/mir/gvn-opt-138225.stderr
@@ -1,5 +1,5 @@
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/gvn-opt-138225.rs:9:9
+  --> $DIR/gvn-opt-138225.rs:10:9
    |
 LL |     pub async fn func1() -> &'static A {
    |         ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -8,7 +8,7 @@ LL |     pub async fn func1() -> &'static A {
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0425]: cannot find type `NestedOption` in this scope
-  --> $DIR/gvn-opt-138225.rs:4:11
+  --> $DIR/gvn-opt-138225.rs:5:11
    |
 LL |     name: NestedOption<Option<String>>,
    |           ^^^^^^^^^^^^ not found in this scope

--- a/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.rs
+++ b/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 // Test for #142064, internal error: entered unreachable code
 //
 //@ compile-flags: -Zthreads=2

--- a/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.stderr
+++ b/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.stderr
@@ -1,5 +1,5 @@
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:23
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:8:23
    |
 LL | trait A { fn foo() -> A; }
    |                       ^
@@ -13,7 +13,20 @@ LL | trait A { fn foo() -> dyn A; }
    |                       +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:23
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:14:23
+   |
+LL | trait B { fn foo() -> A; }
+   |                       ^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: if this is a dyn-compatible trait, use `dyn`
+   |
+LL | trait B { fn foo() -> dyn A; }
+   |                       +++
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:8:23
    |
 LL | trait A { fn foo() -> A; }
    |                       ^
@@ -27,20 +40,7 @@ LL | trait A { fn foo() -> dyn A; }
    |                       +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:13:23
-   |
-LL | trait B { fn foo() -> A; }
-   |                       ^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is a dyn-compatible trait, use `dyn`
-   |
-LL | trait B { fn foo() -> dyn A; }
-   |                       +++
-
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:13:23
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:14:23
    |
 LL | trait B { fn foo() -> A; }
    |                       ^
@@ -54,14 +54,14 @@ LL | trait B { fn foo() -> dyn A; }
    |                       +++
 
 error[E0038]: the trait `A` is not dyn compatible
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:23
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:8:23
    |
 LL | trait A { fn foo() -> A; }
    |                       ^ `A` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:14
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:8:14
    |
 LL | trait A { fn foo() -> A; }
    |       -      ^^^ ...because associated function `foo` has no `self` parameter
@@ -82,14 +82,14 @@ LL + trait A { fn foo() -> Self; }
    |
 
 error[E0038]: the trait `A` is not dyn compatible
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:13:23
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:14:23
    |
 LL | trait B { fn foo() -> A; }
    |                       ^ `A` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:14
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:8:14
    |
 LL | trait A { fn foo() -> A; }
    |       -      ^^^ ...because associated function `foo` has no `self` parameter

--- a/tests/ui/proc-macro/dollar-crate-issue-62325.stdout
+++ b/tests/ui/proc-macro/dollar-crate-issue-62325.stdout
@@ -57,54 +57,54 @@ PRINT-ATTR INPUT (DISPLAY): struct B(identity! ($crate :: S));
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:5: 21:11 (#12),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:5: 21:11 (#11),
     },
     Ident {
         ident: "B",
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:12: 21:13 (#12),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:12: 21:13 (#11),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "identity",
-                span: $DIR/auxiliary/dollar-crate-external.rs:21:14: 21:22 (#12),
+                span: $DIR/auxiliary/dollar-crate-external.rs:21:14: 21:22 (#11),
             },
             Punct {
                 ch: '!',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:21:22: 21:23 (#12),
+                span: $DIR/auxiliary/dollar-crate-external.rs:21:22: 21:23 (#11),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         ident: "$crate",
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:24: 21:30 (#12),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:24: 21:30 (#11),
                     },
                     Punct {
                         ch: ':',
                         spacing: Joint,
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:30: 21:31 (#12),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:30: 21:31 (#11),
                     },
                     Punct {
                         ch: ':',
                         spacing: Alone,
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:31: 21:32 (#12),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:31: 21:32 (#11),
                     },
                     Ident {
                         ident: "S",
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:32: 21:33 (#12),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:32: 21:33 (#11),
                     },
                 ],
-                span: $DIR/auxiliary/dollar-crate-external.rs:21:23: 21:34 (#12),
+                span: $DIR/auxiliary/dollar-crate-external.rs:21:23: 21:34 (#11),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:13: 21:35 (#12),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:13: 21:35 (#11),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:35: 21:36 (#12),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:35: 21:36 (#11),
     },
 ]

--- a/tests/ui/proc-macro/dollar-crate.stdout
+++ b/tests/ui/proc-macro/dollar-crate.stdout
@@ -122,119 +122,119 @@ PRINT-BANG INPUT (DISPLAY): struct M($crate :: S);
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:13: 7:19 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:13: 7:19 (#14),
     },
     Ident {
         ident: "M",
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:20: 7:21 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:20: 7:21 (#14),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:22: 7:28 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:22: 7:28 (#14),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:28: 7:29 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:28: 7:29 (#14),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:29: 7:30 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:29: 7:30 (#14),
             },
             Ident {
                 ident: "S",
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:30: 7:31 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:30: 7:31 (#14),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:21: 7:32 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:21: 7:32 (#14),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:32: 7:33 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:32: 7:33 (#14),
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct A($crate :: S);
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:9: 11:15 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:9: 11:15 (#14),
     },
     Ident {
         ident: "A",
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:16: 11:17 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:16: 11:17 (#14),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:18: 11:24 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:18: 11:24 (#14),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:24: 11:25 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:24: 11:25 (#14),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:25: 11:26 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:25: 11:26 (#14),
             },
             Ident {
                 ident: "S",
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:26: 11:27 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:26: 11:27 (#14),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:17: 11:28 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:17: 11:28 (#14),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:28: 11:29 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:28: 11:29 (#14),
     },
 ]
 PRINT-DERIVE INPUT (DISPLAY): struct D($crate :: S);
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:9: 14:15 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:9: 14:15 (#14),
     },
     Ident {
         ident: "D",
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:16: 14:17 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:16: 14:17 (#14),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:18: 14:24 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:18: 14:24 (#14),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:24: 14:25 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:24: 14:25 (#14),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:25: 14:26 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:25: 14:26 (#14),
             },
             Ident {
                 ident: "S",
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:26: 14:27 (#15),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:26: 14:27 (#14),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:17: 14:28 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:17: 14:28 (#14),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:28: 14:29 (#15),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:28: 14:29 (#14),
     },
 ]

--- a/tests/ui/proc-macro/nested-macro-rules.stdout
+++ b/tests/ui/proc-macro/nested-macro-rules.stdout
@@ -2,45 +2,45 @@ PRINT-BANG INPUT (DISPLAY): FirstStruct
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "FirstStruct",
-        span: $DIR/auxiliary/nested-macro-rules.rs:16:14: 16:25 (#7),
+        span: $DIR/auxiliary/nested-macro-rules.rs:16:14: 16:25 (#6),
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct FirstAttrStruct {}
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/nested-macro-rules.rs:10:32: 10:38 (#6),
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:32: 10:38 (#5),
     },
     Ident {
         ident: "FirstAttrStruct",
-        span: $DIR/auxiliary/nested-macro-rules.rs:16:27: 16:42 (#7),
+        span: $DIR/auxiliary/nested-macro-rules.rs:16:27: 16:42 (#6),
     },
     Group {
         delimiter: Brace,
         stream: TokenStream [],
-        span: $DIR/auxiliary/nested-macro-rules.rs:10:57: 10:59 (#6),
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:57: 10:59 (#5),
     },
 ]
 PRINT-BANG INPUT (DISPLAY): SecondStruct
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "SecondStruct",
-        span: $DIR/nested-macro-rules.rs:23:38: 23:50 (#16),
+        span: $DIR/nested-macro-rules.rs:23:38: 23:50 (#15),
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct SecondAttrStruct {}
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/nested-macro-rules.rs:10:32: 10:38 (#15),
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:32: 10:38 (#14),
     },
     Ident {
         ident: "SecondAttrStruct",
-        span: $DIR/nested-macro-rules.rs:23:52: 23:68 (#16),
+        span: $DIR/nested-macro-rules.rs:23:52: 23:68 (#15),
     },
     Group {
         delimiter: Brace,
         stream: TokenStream [],
-        span: $DIR/auxiliary/nested-macro-rules.rs:10:57: 10:59 (#15),
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:57: 10:59 (#14),
     },
 ]

--- a/tests/ui/resolve/path-suggestion-duplicated-crate-keyword.stderr
+++ b/tests/ui/resolve/path-suggestion-duplicated-crate-keyword.stderr
@@ -10,7 +10,7 @@ LL |                 let _x = crate::unix::linux::system::Y;
    |                                 ++++++
 help: consider importing this module
    |
-LL +             use unix::linux::system;
+LL +             use crate::unix::linux::system;
    |
 help: if you import `system`, refer to it directly
    |

--- a/tests/ui/shadowed/shadowed-use-visibility.stderr
+++ b/tests/ui/shadowed/shadowed-use-visibility.stderr
@@ -17,7 +17,7 @@ LL | mod foo {
 help: consider importing this function instead
    |
 LL -     use crate::foo::bar::f as g;
-LL +     use foo::f as g;
+LL +     use crate::foo::f as g;
    |
 
 error[E0603]: module import `f` is private

--- a/tests/ui/suggestions/suggest-collect.stderr
+++ b/tests/ui/suggestions/suggest-collect.stderr
@@ -32,12 +32,12 @@ error[E0308]: mismatched types
   --> $DIR/suggest-collect.rs:10:36
    |
 LL |     let res: Result<Vec<i32>, _> = ["1", "2"].into_iter().map(|s| s.parse::<i32>());
-   |              -------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<Vec<i32>, _>`, found `Map<Iter<'_, &str>, {closure@...}>`
+   |              -------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<Vec<i32>, _>`, found `Map<IntoIter<&str, 2>, {closure@...}>`
    |              |
    |              expected due to this
    |
    = note: expected enum `Result<Vec<i32>, _>`
-            found struct `Map<std::slice::Iter<'_, &str>, {closure@$DIR/suggest-collect.rs:10:63: 10:66}>`
+            found struct `Map<std::array::IntoIter<&str, 2>, {closure@$DIR/suggest-collect.rs:10:63: 10:66}>`
 help: consider using `.collect()` to convert the `Iterator` into a `Result<Vec<i32>, _>`
    |
 LL |     let res: Result<Vec<i32>, _> = ["1", "2"].into_iter().map(|s| s.parse::<i32>()).collect();

--- a/tests/ui/type-alias-impl-trait/tait-normalize.rs
+++ b/tests/ui/type-alias-impl-trait/tait-normalize.rs
@@ -1,6 +1,7 @@
 //@ revisions: current next
 //@ [next] compile-flags: -Znext-solver
 //@ check-pass
+//@ edition: 2015..2018
 
 #![feature(type_alias_impl_trait)]
 

--- a/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.stdout
+++ b/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.stdout
@@ -6,7 +6,7 @@
 #![attr = Feature([min_generic_const_args#0, adt_const_params#0])]
 extern crate std;
 #[attr = PreludeImport]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2021::*;
 
 use std::marker::ConstParamTy;
 

--- a/tests/ui/use/use-mod/use-mod-4.stderr
+++ b/tests/ui/use/use-mod/use-mod-4.stderr
@@ -2,12 +2,7 @@ error[E0432]: unresolved import `crate::foo`
   --> $DIR/use-mod-4.rs:1:12
    |
 LL | use crate::foo::self;
-   |            ^^^ use of unresolved module or unlinked crate `foo`
-   |
-help: you might be missing a crate named `foo`, add it to your project and import it in your code
-   |
-LL + extern crate foo;
-   |
+   |            ^^^ could not find `foo` in the crate root
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/use/use-self-at-end.e2015.stderr
+++ b/tests/ui/use/use-self-at-end.e2015.stderr
@@ -1,5 +1,5 @@
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:14:24
+  --> $DIR/use-self-at-end.rs:15:24
    |
 LL |         pub use crate::self;
    |                        ^^^^
@@ -10,7 +10,7 @@ LL |         pub use crate::self as name;
    |                             +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:16:25
+  --> $DIR/use-self-at-end.rs:17:25
    |
 LL |         pub use crate::{self};
    |                         ^^^^
@@ -21,7 +21,7 @@ LL |         pub use crate::{self as name};
    |                              +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:20:17
+  --> $DIR/use-self-at-end.rs:21:17
    |
 LL |         pub use self;
    |                 ^^^^
@@ -32,7 +32,7 @@ LL |         pub use self as name;
    |                      +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:22:18
+  --> $DIR/use-self-at-end.rs:23:18
    |
 LL |         pub use {self};
    |                  ^^^^
@@ -43,7 +43,7 @@ LL |         pub use {self as name};
    |                       +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:26:23
+  --> $DIR/use-self-at-end.rs:27:23
    |
 LL |         pub use self::self;
    |                       ^^^^
@@ -54,7 +54,7 @@ LL |         pub use self::self as name;
    |                            +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:29:24
+  --> $DIR/use-self-at-end.rs:30:24
    |
 LL |         pub use self::{self};
    |                        ^^^^
@@ -65,7 +65,7 @@ LL |         pub use self::{self as name};
    |                             +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:33:24
+  --> $DIR/use-self-at-end.rs:34:24
    |
 LL |         pub use super::self;
    |                        ^^^^
@@ -76,7 +76,7 @@ LL |         pub use super::self as name;
    |                             +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:36:25
+  --> $DIR/use-self-at-end.rs:37:25
    |
 LL |         pub use super::{self};
    |                         ^^^^
@@ -87,7 +87,7 @@ LL |         pub use super::{self as name};
    |                              +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:48:19
+  --> $DIR/use-self-at-end.rs:50:19
    |
 LL |         pub use ::self;
    |                   ^^^^
@@ -98,7 +98,7 @@ LL |         pub use ::self as name;
    |                        +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:52:20
+  --> $DIR/use-self-at-end.rs:56:20
    |
 LL |         pub use ::{self};
    |                    ^^^^
@@ -109,31 +109,31 @@ LL |         pub use ::{self as name};
    |                         +++++++
 
 error: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:57:20
+  --> $DIR/use-self-at-end.rs:63:20
    |
 LL |         pub use z::self::self;
    |                    ^^^^
 
 error: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:58:20
+  --> $DIR/use-self-at-end.rs:64:20
    |
 LL |         pub use z::self::self as z1;
    |                    ^^^^
 
 error: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:59:21
+  --> $DIR/use-self-at-end.rs:65:21
    |
 LL |         pub use z::{self::{self}};
    |                     ^^^^
 
 error: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:60:21
+  --> $DIR/use-self-at-end.rs:66:21
    |
 LL |         pub use z::{self::{self as z2}};
    |                     ^^^^
 
 error[E0252]: the name `x` is defined multiple times
-  --> $DIR/use-self-at-end.rs:42:28
+  --> $DIR/use-self-at-end.rs:43:28
    |
 LL |         pub use crate::x::self;
    |                 -------------- previous import of the module `x` here
@@ -147,7 +147,7 @@ LL |         pub use crate::x::{self};
    = note: `x` must be defined only once in the type namespace of this module
 
 error[E0252]: the name `Enum` is defined multiple times
-  --> $DIR/use-self-at-end.rs:71:31
+  --> $DIR/use-self-at-end.rs:77:31
    |
 LL |         pub use super::Enum::self;
    |                 ----------------- previous import of the type `Enum` here
@@ -161,7 +161,7 @@ LL |         pub use super::Enum::{self};
    = note: `Enum` must be defined only once in the type namespace of this module
 
 error[E0252]: the name `Trait` is defined multiple times
-  --> $DIR/use-self-at-end.rs:79:32
+  --> $DIR/use-self-at-end.rs:88:32
    |
 LL |         pub use super::Trait::self;
    |                 ------------------ previous import of the trait `Trait` here
@@ -175,103 +175,103 @@ LL |         pub use super::Trait::{self};
    = note: `Trait` must be defined only once in the type namespace of this module
 
 error[E0432]: unresolved import `super::Struct`
-  --> $DIR/use-self-at-end.rs:63:24
+  --> $DIR/use-self-at-end.rs:69:24
    |
 LL |         pub use super::Struct::self;
    |                        ^^^^^^ `Struct` is a struct, not a module
 
 error[E0432]: unresolved import `super::Struct`
-  --> $DIR/use-self-at-end.rs:64:24
+  --> $DIR/use-self-at-end.rs:70:24
    |
 LL |         pub use super::Struct::self as Struct1;
    |                        ^^^^^^ `Struct` is a struct, not a module
 
 error[E0432]: unresolved import `super::Struct`
-  --> $DIR/use-self-at-end.rs:65:24
+  --> $DIR/use-self-at-end.rs:71:24
    |
 LL |         pub use super::Struct::{self};
    |                        ^^^^^^ `Struct` is a struct, not a module
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:83:24
+  --> $DIR/use-self-at-end.rs:92:24
    |
 LL |         pub use super::self::y::z;
    |                        ^^^^ can only be used in path start position or last position
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:84:24
+  --> $DIR/use-self-at-end.rs:93:24
    |
 LL |         pub use super::self::y::z as z3;
    |                        ^^^^ can only be used in path start position or last position
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:85:24
+  --> $DIR/use-self-at-end.rs:94:24
    |
 LL |         pub use super::self::y::{z};
    |                        ^^^^ can only be used in path start position or last position
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:86:24
+  --> $DIR/use-self-at-end.rs:95:24
    |
 LL |         pub use super::self::y::{z as z4};
    |                        ^^^^ can only be used in path start position or last position
 
 error[E0432]: unresolved import `super::Struct`
-  --> $DIR/use-self-at-end.rs:66:24
+  --> $DIR/use-self-at-end.rs:72:24
    |
 LL |         pub use super::Struct::{self as Struct2};
    |                        ^^^^^^ `Struct` is a struct, not a module
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:56:21
+  --> $DIR/use-self-at-end.rs:62:21
    |
 LL |         type G = z::self::self;
    |                     ^^^^ can only be used in path start position or last position
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:82:25
+  --> $DIR/use-self-at-end.rs:91:25
    |
 LL |         type K = super::self::y::z;
    |                         ^^^^ can only be used in path start position or last position
 
 error[E0573]: expected type, found module `crate::self`
-  --> $DIR/use-self-at-end.rs:13:18
+  --> $DIR/use-self-at-end.rs:14:18
    |
 LL |         type A = crate::self;
    |                  ^^^^^^^^^^^ not a type
 
 error[E0573]: expected type, found module `self`
-  --> $DIR/use-self-at-end.rs:19:18
+  --> $DIR/use-self-at-end.rs:20:18
    |
 LL |         type B = self;
    |                  ^^^^ not a type
 
 error[E0573]: expected type, found module `self::self`
-  --> $DIR/use-self-at-end.rs:25:18
+  --> $DIR/use-self-at-end.rs:26:18
    |
 LL |         type C = self::self;
    |                  ^^^^^^^^^^ not a type
 
 error[E0573]: expected type, found module `super::self`
-  --> $DIR/use-self-at-end.rs:32:18
+  --> $DIR/use-self-at-end.rs:33:18
    |
 LL |         type D = super::self;
    |                  ^^^^^^^^^^^ not a type
 
 error[E0573]: expected type, found module `crate::x::self`
-  --> $DIR/use-self-at-end.rs:39:18
+  --> $DIR/use-self-at-end.rs:40:18
    |
 LL |         type E = crate::x::self;
    |                  ^^^^^^^^^^^^^^ not a type
 
 error[E0573]: expected type, found module `::self`
-  --> $DIR/use-self-at-end.rs:45:18
+  --> $DIR/use-self-at-end.rs:46:18
    |
 LL |         type F = ::self;
    |                  ^^^^^^ not a type
 
 error[E0223]: ambiguous associated type
-  --> $DIR/use-self-at-end.rs:62:18
+  --> $DIR/use-self-at-end.rs:68:18
    |
 LL |         type H = super::Struct::self;
    |                  ^^^^^^^^^^^^^^^^^^^
@@ -283,7 +283,7 @@ LL +         type H = <x::Struct as Example>::self;
    |
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/use-self-at-end.rs:74:18
+  --> $DIR/use-self-at-end.rs:80:18
    |
 LL |         type J = super::Trait::self;
    |                  ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/use/use-self-at-end.e2021.stderr
+++ b/tests/ui/use/use-self-at-end.e2021.stderr
@@ -284,21 +284,18 @@ LL -         type H = super::Struct::self;
 LL +         type H = <x::Struct as Example>::self;
    |
 
-warning: trait objects without an explicit `dyn` are deprecated
+error[E0782]: expected a type, found a trait
   --> $DIR/use-self-at-end.rs:80:18
    |
 LL |         type J = super::Trait::self;
    |                  ^^^^^^^^^^^^^^^^^^
    |
-   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
-help: if this is a dyn-compatible trait, use `dyn`
+help: you can add the `dyn` keyword if you want a trait object
    |
 LL |         type J = dyn super::Trait::self;
    |                  +++
 
-error: aborting due to 36 previous errors; 1 warning emitted
+error: aborting due to 37 previous errors
 
-Some errors have detailed explanations: E0223, E0252, E0425, E0432, E0433, E0573.
+Some errors have detailed explanations: E0223, E0252, E0425, E0432, E0433, E0573, E0782.
 For more information about an error, try `rustc --explain E0223`.

--- a/tests/ui/use/use-self-at-end.rs
+++ b/tests/ui/use/use-self-at-end.rs
@@ -1,6 +1,7 @@
-//@ revisions: e2015 e2018
+//@ revisions: e2015 e2018 e2021
 //@ [e2015] edition: 2015
-//@ [e2018] edition: 2018..
+//@ [e2018] edition: 2018
+//@ [e2021] edition: 2021..
 
 pub mod x {
     pub struct Struct;
@@ -45,13 +46,18 @@ pub mod x {
         type F = ::self;
         //[e2015]~^ ERROR expected type, found module `::self`
         //[e2018]~^^ ERROR cannot find crate `self` in the list of imported crates
+        //[e2021]~^^^ ERROR cannot find crate `self` in the list of imported crates
         pub use ::self;
         //[e2015]~^ ERROR imports need to be explicitly named
         //[e2018]~^^ ERROR extern prelude cannot be imported
+        //[e2021]~^^^ ERROR extern prelude cannot be imported
         pub use ::self as crate4; //[e2018]~ ERROR extern prelude cannot be imported
+        //[e2021]~^ ERROR extern prelude cannot be imported
         pub use ::{self}; //[e2018]~ ERROR extern prelude cannot be imported
         //[e2015]~^ ERROR imports need to be explicitly named
+        //[e2021]~^^ ERROR extern prelude cannot be imported
         pub use ::{self as crate5}; //[e2018]~ ERROR extern prelude cannot be imported
+        //[e2021]~^ ERROR extern prelude cannot be imported
 
         type G = z::self::self; //~ ERROR `self` in paths can only be used in start position
         pub use z::self::self; //~ ERROR `self` in paths can only be used in start position or last position
@@ -72,8 +78,11 @@ pub mod x {
         pub use super::Enum::{self as Enum2};
 
         type J = super::Trait::self;
-        //~^ WARN trait objects without an explicit `dyn` are deprecated
-        //~^^ WARN this is accepted in the current edition
+        //[e2015]~^ WARN trait objects without an explicit `dyn` are deprecated
+        //[e2015]~^^ WARN this is accepted in the current edition
+        //[e2018]~^^^ WARN trait objects without an explicit `dyn` are deprecated
+        //[e2018]~^^^^ WARN this is accepted in the current edition
+        //[e2021]~^^^^^ ERROR expected a type, found a trait
         pub use super::Trait::self;
         pub use super::Trait::self as Trait1;
         pub use super::Trait::{self}; //~ ERROR the name `Trait` is defined multiple times


### PR DESCRIPTION
previously, we did this weird thing called an "edition lift" where we would bless all the tests as a one-off. the conflicts are relatively minor (mostly; the major ones are landing in https://github.com/rust-lang/rust/pull/159330), so let's just accept the merge conflicts in exchange for not having to add more steps to the release process.

this is a direct forward port of https://github.com/ferrocene/ferrocene/pull/2481.