### PR TITLE
CI optimization tests

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -561,21 +561,21 @@ jobs:
           name: Download dist artifacts and run the self-test tool
           command: ferrocene/ci/scripts/run-self-test.sh
 
-  aarch64-linux-library-coverage:
-    executor:
-      name: docker-custom-image
-      image-tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
-    resource_class: ferrocene/k8s-arm64-large
-    environment:
-      FERROCENE_HOST: aarch64-unknown-linux-gnu
-      SCRIPT: |
-        ferrocene/ci/scripts/llvm_cache.py download
-        ./x.py test --stage=1 --coverage=library library/core library/alloc --tests
-    steps:
-      - aws-oidc-auth
-      - ferrocene-checkout:
-          llvm-subset: true
-      - ferrocene-ci
+#  aarch64-linux-library-coverage:
+#    executor:
+#      name: docker-custom-image
+#      image-tag: << pipeline.parameters.docker-image-tag--aarch64--ubuntu-20 >>
+#    resource_class: ferrocene/k8s-arm64-large
+#    environment:
+#      FERROCENE_HOST: aarch64-unknown-linux-gnu
+#      SCRIPT: |
+#        ferrocene/ci/scripts/llvm_cache.py download
+#        ./x.py test --stage=1 --coverage=library library/core library/alloc --tests
+#    steps:
+#      - aws-oidc-auth
+#      - ferrocene-checkout:
+#          llvm-subset: true
+#      - ferrocene-ci
 
   aarch64-linux-rhivos2-test-container:
     executor: docker-aarch64-ubuntu-20-rhivos2-test-server
@@ -1273,7 +1273,7 @@ workflows:
             - aarch64-linux-test
             - aarch64-linux-test-library
             - aarch64-linux-compiletest
-            - aarch64-linux-library-coverage
+            #- aarch64-linux-library-coverage
             - aarch64-linux-rhivos2-test-library-compiletest
       - x86_64-linux-traceability-matrix:
           requires: *test-outcomes-dependencies
@@ -1506,9 +1506,9 @@ workflows:
           test-variant: "2021"
           requires:
             - aarch64-linux-build
-      - aarch64-linux-library-coverage:
-          requires:
-            - aarch64-linux-build
+      #- aarch64-linux-library-coverage:
+      #    requires:
+      #      - aarch64-linux-build
       - aarch64-linux-self-test:
           requires:
             - aarch64-linux-dist

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -169,7 +169,8 @@ jobs:
       FERROCENE_TARGETS: aarch64-unknown-linux-gnu
       SCRIPT: |
         ferrocene/ci/scripts/llvm_cache.py download
-        ./x.py --stage 2 build library src/tools/rustdoc
+        ./x.py --stage 2 build cargo library src/tools/rustdoc symbol-report
+        ./x.py --stage 1 build compiletest coverage-dump src/tools/rustdoc src/tools/run-make-support
     steps: [ferrocene-job-build]
 
   x86_64-linux-docs:
@@ -491,8 +492,8 @@ jobs:
       FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-unknown-linux-gnu--build >>
       SCRIPT: |
         ferrocene/ci/scripts/llvm_cache.py download
-        ./x.py --stage 2 build library src/tools/rustdoc
-        ./x.py --stage 1 build src/tools/rustdoc
+        ./x.py --stage 2 build cargo library src/tools/rustdoc symbol-report
+        ./x.py --stage 1 build compiletest coverage-dump src/tools/rustdoc src/tools/run-make-support
         ./x build src/tools/remote-test-server --target "aarch64-unknown-linux-gnu,aarch64-rhivos2-linux-gnu" --stage "2"
     steps: [ferrocene-job-build]
 
@@ -642,8 +643,8 @@ jobs:
       FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-apple-darwin--build >>
       SCRIPT: |
         ferrocene/ci/scripts/llvm_cache.py download
-        ./x.py --stage 2 build library src/tools/rustdoc
-        ./x.py --stage 1 build src/tools/rustdoc
+        ./x.py --stage 2 build cargo library src/tools/rustdoc symbol-report
+        ./x.py --stage 1 build compiletest coverage-dump src/tools/rustdoc src/tools/run-make-support
     steps:
       - when:
           condition: << pipeline.parameters.full-build-aarch64-darwin-host >>

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -166,7 +166,7 @@ jobs:
     resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
-      FERROCENE_TARGETS: aarch64-unknown-linux-gnu
+      FERROCENE_TARGETS: << pipeline.parameters.targets--x86_64-unknown-linux-gnu--build >>
       SCRIPT: |
         ferrocene/ci/scripts/llvm_cache.py download
         ./x.py --stage 2 build cargo library src/tools/rustdoc symbol-report

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -890,7 +890,8 @@ jobs:
         sudo update-binfmts --import && sudo update-binfmts --enable << parameters.qemu-arch >> && ./x.py --stage 2 test << parameters.tasks >> --ferrocene-test-one-crate-per-cargo-call --test-variant << parameters.test-variant >>
     steps:
       - aws-oidc-auth
-      - ferrocene-checkout
+      - ferrocene-checkout:
+          llvm-subset: true
       - setup-uv
       - aws-cli/install:
           version: << pipeline.parameters.awscli-version >>

--- a/ferrocene/ci/split-tasks.py
+++ b/ferrocene/ci/split-tasks.py
@@ -163,6 +163,7 @@ JOBS_DEFINITION: JobsDefinition = {
                 "coverage-run-rustdoc",
                 "pretty",
                 "rustdoc",
+                "rustdoc-html",
                 "rustdoc-js",
                 "rustdoc-js-std",
                 "rustdoc-json",

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -824,7 +824,8 @@ impl<'a> Builder<'a> {
                 tool::LlvmBitcodeLinker,
                 tool::RustcPerf,
                 tool::WasmComponentLd,
-                tool::LldWrapper
+                tool::LldWrapper,
+                tool::RunMakeSupport,
             ),
             Kind::Clippy => describe!(
                 clippy::Std,


### PR DESCRIPTION
I ran the following experiments to see if we can remove some redundant work from our CI workflow:

1) Disable aarch64-linux-library-coverage: Currently this job is run every CI run, but its results are not used. This can be re-enabled when we merge https://github.com/ferrocene/ferrocene/pull/2459 . Saves about 20 machine-minutes per run.

2) Use a partial checkout of LLVM for facade-generic-test jobs: Saves 25s * 9 jobs = 3.75 machine-minutes per run.

3) Add tests/rustdoc-html to the list of host-only tests which should not be run when testing with target != host: Saves about 80 machine-minutes per run across 13 jobs

4) Disable profiling for non-coverage runs: Did not save an appreciable amount of time

5) Combine test jobs for different variants of the same target: Saves about 3 * 15 minutes = 45 machine-minutes per run. The combined runs are still shorter than the QNX tests, so do not increase the critical path length. However, we decided against this in its current form to avoid potential interference between the two test sets.

6) On looking at (5) more closely, it turns out that the test jobs need a lot of host tools which were not being built by the {x86_64-linux, aarch64-linux, aarch64-darwin}-build jobs. So these were rebuilt per test job, causing a lot of redundant work. Moving these into the build jobs makes those jobs take 5-6 minutes longer each, but is more than compensated by time savings on the corresponding host=target test jobs. It also saves 9 * 12 minutes on the facade-generic-test jobs and 4 * 15 minutes on the qnx test jobs (relative to changes 1+2+3), for a saving of another 2.5 machine-hours or so.



This patch applies changes 1+2+3+6, with a total savings north of 4 machine-hours per CI run. It also shortens the critical path length (which goes through the qnx test jobs) by ~20 minutes, bringing it close to even with the path through the aarch64-linux jobs.