### PR TITLE
feat: enable ci runs for rust-bors branches

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1229,6 +1229,8 @@ workflows:
       or:
         - equal: [<< pipeline.git.branch >>, "staging"]
         - equal: [<< pipeline.git.branch >>, "trying"]
+        - equal: [<< pipeline.git.branch >>, "automation/bors/auto"]
+        - equal: [<< pipeline.git.branch >>, "automation/bors/try"]
         - equal: [<< pipeline.trigger_source >>, "api"]
     jobs:
       - build-docker-x86_64:


### PR DESCRIPTION
i'd also like to add parameters and consequently update `calculate_parameters` to allow filtering out jobs eg to support `@bors try jobs=...`

this would require discussion to determine how the `job=...` lines in the merge commit message would affect job runs. note bors has no way to check if a `job=...` line is valid