### PR TITLE
[1.97] annotate const_panic

### DIFF
--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -164,6 +164,9 @@ pub macro const_panic {
         #[inline(always)] // inline the wrapper
         #[track_caller]
         #[ferrocene::prevalidated]
+        #[ferrocene::annotation = "Due to a tooling bug, this shows as uncovered.
+            There is no logic to test here: `const_eval_select` is a compiler intrinsic,
+            not part of the certified standard library. `core::panic!` is already extensively tested."]
         const fn do_panic($($arg: $ty),*) -> ! {
             $crate::intrinsics::const_eval_select!(
                 @capture { $($arg: $ty = $arg),* } -> !:


### PR DESCRIPTION
this is the last remaining "partially tested" function on https://docs.ferrocene.dev/beta-26.08/coverage/index.html.

i keep getting "Error: missing section: CoverageFunctions" when i try to generate coverage locally, so this is untested other than verifying core compiles.