### PR TITLE
Fix channel name displayed by rustc --version

### DIFF
--- a/src/bootstrap/src/ferrocene/dist.rs
+++ b/src/bootstrap/src/ferrocene/dist.rs
@@ -497,7 +497,11 @@ impl Step for GenerateBuildMetadata {
             );
         }
 
-        let channel = crate::ferrocene::ferrocene_channel(builder, ferrocene_version);
+        let channel = crate::ferrocene::ferrocene_release_channel(
+            &*builder.config.channel,
+            ferrocene_channel,
+            ferrocene_version,
+        );
 
         // Whenever the contents of this JSON file change, even just adding new fields,
         // make sure to increase the metadata version number and update publish-release

--- a/src/bootstrap/src/ferrocene/mod.rs
+++ b/src/bootstrap/src/ferrocene/mod.rs
@@ -76,8 +76,12 @@ pub(crate) fn download_from_local_filesystem(path: &str, dest: &Path, help_on_er
     }
 }
 
-fn ferrocene_channel(builder: &Builder<'_>, ferrocene_version: &str) -> String {
-    match (&*builder.config.channel, &*builder.config.ferrocene_raw_channel) {
+pub(crate) fn ferrocene_release_channel(
+    upstream_channel: &str,
+    ferrocene_channel: &str,
+    ferrocene_version: &str,
+) -> String {
+    match (upstream_channel, ferrocene_channel) {
         ("nightly" | "dev", "rolling") => "nightly".to_owned(),
         ("beta", "rolling") => "pre-rolling".to_owned(),
         ("stable", "rolling") => "rolling".to_owned(),

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -1714,8 +1714,13 @@ impl Build {
             version.push_str(" (");
 
             // Ferrocene addition
+            let channel = crate::ferrocene::ferrocene_release_channel(
+                &self.config.channel,
+                &self.config.ferrocene_raw_channel,
+                &self.ferrocene_version,
+            );
             version.push_str("Ferrocene ");
-            version.push_str(&self.ferrocene_version);
+            version.push_str(&channel);
             version.push(' ');
 
             version.push_str(s);
@@ -1723,7 +1728,12 @@ impl Build {
         } else {
             // Ferrocene addition
             use std::fmt::Write;
-            let _ = write!(version, " (Ferrocene {})", self.ferrocene_version);
+            let channel = crate::ferrocene::ferrocene_release_channel(
+                &self.config.channel,
+                &self.config.ferrocene_raw_channel,
+                &self.ferrocene_version,
+            );
+            let _ = write!(version, " (Ferrocene {})", channel);
         }
         version
     }

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -42,6 +42,10 @@ mod core;
 mod ferrocene;
 mod utils;
 
+// Ferrocene addition
+#[cfg(test)]
+mod tests;
+
 #[cfg(feature = "tracing")]
 pub use core::builder::STEP_SPAN_TARGET;
 pub use core::builder::{PathSet, StepStack};

--- a/src/bootstrap/src/tests.rs
+++ b/src/bootstrap/src/tests.rs
@@ -1,0 +1,48 @@
+// This entire file is a Ferrocene addition
+use crate::Build;
+use crate::utils::tests::{ConfigBuilder, TestCtx};
+
+#[test]
+fn test_ferrocene_version_string() {
+    // Check that the Rust and Ferrocene parts of the version string (displayed by
+    // `rustc --version` etc.) remain in sync
+
+    let config = TestCtx::new().config("test").create_config();
+    let build = Build::new(config);
+
+    let version_string = build.rust_version();
+
+    let rust_channel = build.config.channel;
+    let rust_version = build.version;
+    let ferrocene_channel = build.config.ferrocene_raw_channel;
+    let ferrocene_version = build.ferrocene_version;
+
+    eprintln!("Rust channel: {rust_channel}");
+    eprintln!("Rust version: {rust_version}");
+    eprintln!("Ferrocene channel: {ferrocene_channel}");
+    eprintln!("Ferrocene version: {ferrocene_version}");
+    eprintln!("");
+
+    let (expected_rust_part, expected_ferrocene_part) = match (
+        &rust_channel[..],
+        &ferrocene_channel[..],
+    ) {
+        ("dev", "rolling") => (format!("{rust_version}-dev"), "Ferrocene nightly".to_owned()),
+        ("nightly", "rolling") => {
+            (format!("{rust_version}-nightly"), "Ferrocene nightly".to_owned())
+        }
+        ("beta", "rolling") => (format!("{rust_version}-beta"), "Ferrocene pre-rolling".to_owned()),
+        ("stable", "rolling") => (rust_version.to_owned(), "Ferrocene rolling".to_owned()),
+        ("stable", _) => (rust_version.to_owned(), format!("Ferrocene {}", ferrocene_version)),
+        _ => panic!(
+            "error: unsupported channel configuration: rust '{rust_channel}' and ferrocene '{ferrocene_channel}'"
+        ),
+    };
+
+    eprintln!("Expected Rust part of version string: {expected_rust_part}");
+    eprintln!("Expected Ferrocene part of version string: {expected_ferrocene_part}");
+    eprintln!("Actual version string: {version_string}");
+
+    assert!(version_string.starts_with(&expected_rust_part));
+    assert!(version_string.contains(&expected_ferrocene_part));
+}


### PR DESCRIPTION
Before (displaying the content of `ferrocene/version`):
```
$ ./x install && ../ferrocene-install/bin/rustc --version
rustc 1.99.0-dev (Ferrocene rolling)
```

After (displaying the combined release channel):
```
$ ./x install && ../ferrocene-install/bin/rustc --version
rustc 1.99.0-dev (Ferrocene nightly)
```