### PR TITLE
Validate `impl<T: Hash, const N: usize> Hash for [T; N]`

### DIFF
--- a/ferrocene/doc/symbol-report.csv
+++ b/ferrocene/doc/symbol-report.csv
@@ -5692,6 +5692,7 @@ core::array::<impl core::convert::TryFrom<&'a mut [T]> for &'a mut [T; N]>::try_
 core::array::<impl core::convert::TryFrom<&[T]> for [T; N]>::try_from
 core::array::<impl core::convert::TryFrom<&mut [T]> for [T; N]>::try_from
 core::array::<impl core::fmt::Debug for [T; N]>::fmt
+core::array::<impl core::hash::Hash for [T; N]>::hash
 core::array::<impl core::iter::traits::collect::IntoIterator for &'a [T; N]>::into_iter
 core::array::<impl core::iter::traits::collect::IntoIterator for &'a mut [T; N]>::into_iter
 core::array::<impl core::ops::index::Index<I> for [T; N]>::index

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -357,6 +357,7 @@ impl<'a, T, const N: usize> const TryFrom<&'a mut [T]> for &'a mut [T; N] {
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Hash, const N: usize> Hash for [T; N] {
+    #[ferrocene::prevalidated]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         Hash::hash(&self[..], state)
     }


### PR DESCRIPTION
I ran coverage locally to check that this function is covered. I had to remove the annotation in https://github.com/ferrocene/ferrocene/commit/3c6997c045065a6bb4852e01fa68ae06953f4c90 in order to get blanket to generate a coverage report.