### PR TITLE
`ferrocene::prevalidated`: Treat all non-generic annotated functions as mono roots

### DIFF
--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1668,32 +1668,26 @@ impl<'v> RootCollector<'_, 'v> {
     }
 
     fn is_root(&self, def_id: LocalDefId) -> bool {
-        // Ferrocene addition: reuse same strategy as Lazy collector
-        // closure so that we don't slow down incremental by calling queries we don't use
-        let is_reachable_lazy = || {
-            self.entry_fn.and_then(|(id, _)| id.as_local()) == Some(def_id)
-                || self.tcx.is_reachable_non_generic(def_id)
-                || {
-                    let flags = self.tcx.codegen_fn_attrs(def_id).flags;
-                    flags.intersects(
-                        CodegenFnAttrFlags::RUSTC_STD_INTERNAL_SYMBOL
-                            | CodegenFnAttrFlags::EXTERNALLY_IMPLEMENTABLE_ITEM,
-                    )
-                }
-        };
-
         !self.tcx.generics_of(def_id).requires_monomorphization(self.tcx)
             && match self.strategy {
                 MonoItemCollectionStrategy::Eager => {
                     !matches!(self.tcx.codegen_fn_attrs(def_id).inline, InlineAttr::Force { .. })
                 }
-                MonoItemCollectionStrategy::Lazy => is_reachable_lazy(),
+                MonoItemCollectionStrategy::Lazy => {
+                    self.entry_fn.and_then(|(id, _)| id.as_local()) == Some(def_id)
+                        || self.tcx.is_reachable_non_generic(def_id)
+                        || {
+                            let flags = self.tcx.codegen_fn_attrs(def_id).flags;
+                            flags.intersects(
+                                CodegenFnAttrFlags::RUSTC_STD_INTERNAL_SYMBOL
+                                    | CodegenFnAttrFlags::EXTERNALLY_IMPLEMENTABLE_ITEM,
+                            )
+                        }
+                }
                 // Ferrocene addition
                 MonoItemCollectionStrategy::Validated => {
-                    let entrypoint = is_reachable_lazy();
                     // Explicit match is intentional, please update this if you add new fields.
-                    entrypoint
-                        && matches!(self.tcx.codegen_fn_attrs(def_id).validated, Some(Validated {}))
+                    matches!(self.tcx.codegen_fn_attrs(def_id).validated, Some(Validated {}))
                 }
             }
     }

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1684,7 +1684,8 @@ impl<'v> RootCollector<'_, 'v> {
                             )
                         }
                 }
-                // Ferrocene addition
+                // Ferrocene addition: mark all non-generic functions as annotated, even if they're private.
+                // This catches errors sooner when `cargo build`-ing a library.
                 MonoItemCollectionStrategy::Validated => {
                     // Explicit match is intentional, please update this if you add new fields.
                     matches!(self.tcx.codegen_fn_attrs(def_id).validated, Some(Validated {}))

--- a/ferrocene/doc/symbol-report.csv
+++ b/ferrocene/doc/symbol-report.csv
@@ -6332,55 +6332,6 @@ core::convert::num::ptr_try_from_impls::<impl core::convert::TryFrom<usize> for 
 core::convert::num::ptr_try_from_impls::<impl core::convert::TryFrom<usize> for u32>::try_from
 core::convert::num::ptr_try_from_impls::<impl core::convert::TryFrom<usize> for u64>::try_from
 core::convert::num::ptr_try_from_impls::<impl core::convert::TryFrom<usize> for u8>::try_from
-core::core_arch::x86::__m128::as_f32x4
-core::core_arch::x86::__m128bh::as_i16x8
-core::core_arch::x86::__m128bh::as_i32x4
-core::core_arch::x86::__m128bh::as_u16x8
-core::core_arch::x86::__m128bh::as_u32x4
-core::core_arch::x86::__m128d::as_f64x2
-core::core_arch::x86::__m128h::as_f16x8
-core::core_arch::x86::__m128i::as_i16x8
-core::core_arch::x86::__m128i::as_i32x4
-core::core_arch::x86::__m128i::as_i64x2
-core::core_arch::x86::__m128i::as_i8x16
-core::core_arch::x86::__m128i::as_u16x8
-core::core_arch::x86::__m128i::as_u32x4
-core::core_arch::x86::__m128i::as_u64x2
-core::core_arch::x86::__m128i::as_u8x16
-core::core_arch::x86::__m256::as_f32x8
-core::core_arch::x86::__m256bh::as_i16x16
-core::core_arch::x86::__m256bh::as_i32x8
-core::core_arch::x86::__m256bh::as_u16x16
-core::core_arch::x86::__m256bh::as_u32x8
-core::core_arch::x86::__m256d::as_f64x4
-core::core_arch::x86::__m256h::as_f16x16
-core::core_arch::x86::__m256i::as_i16x16
-core::core_arch::x86::__m256i::as_i32x8
-core::core_arch::x86::__m256i::as_i64x4
-core::core_arch::x86::__m256i::as_i8x32
-core::core_arch::x86::__m256i::as_u16x16
-core::core_arch::x86::__m256i::as_u32x8
-core::core_arch::x86::__m256i::as_u64x4
-core::core_arch::x86::__m256i::as_u8x32
-core::core_arch::x86::__m512::as_f32x16
-core::core_arch::x86::__m512bh::as_i16x32
-core::core_arch::x86::__m512bh::as_i32x16
-core::core_arch::x86::__m512bh::as_u16x32
-core::core_arch::x86::__m512bh::as_u32x16
-core::core_arch::x86::__m512d::as_f64x8
-core::core_arch::x86::__m512h::as_f16x32
-core::core_arch::x86::__m512i::as_i16x32
-core::core_arch::x86::__m512i::as_i32x16
-core::core_arch::x86::__m512i::as_i64x8
-core::core_arch::x86::__m512i::as_i8x64
-core::core_arch::x86::__m512i::as_u16x32
-core::core_arch::x86::__m512i::as_u32x16
-core::core_arch::x86::__m512i::as_u64x8
-core::core_arch::x86::__m512i::as_u8x64
-core::core_arch::x86::sse2::_mm_loadu_si128
-core::core_arch::x86::sse2::_mm_movemask_epi8
-core::core_arch::x86::sse2::_mm_or_si128
-core::core_arch::x86::sse2::_mm_undefined_si128
 core::escape::EscapeIterInner::<N, ESCAPING>::advance_by
 core::escape::EscapeIterInner::<N, ESCAPING>::ascii
 core::escape::EscapeIterInner::<N, ESCAPING>::backslash

--- a/ferrocene/doc/symbol-report.csv
+++ b/ferrocene/doc/symbol-report.csv
@@ -3,6 +3,7 @@
 <&'b str as core::str::pattern::Pattern>::into_searcher
 <&'b str as core::str::pattern::Pattern>::is_prefix_of
 <&'b str as core::str::pattern::Pattern>::is_suffix_of
+<&'b str as core::str::pattern::Pattern>::strip_suffix_of
 <&T as core::borrow::Borrow<T>>::borrow
 <&T as core::convert::AsRef<U>>::as_ref
 <&T as core::fmt::Binary>::fmt
@@ -1398,6 +1399,7 @@
 <*mut T as core::fmt::Pointer>::fmt
 <A as core::iter::traits::iterator::SpecIterEq<B>>::spec_iter_eq
 <A as core::iter::traits::iterator::SpecIterEq<B>>::spec_iter_eq
+<A as core::slice::cmp::SliceOrd>::compare
 <A as core::slice::cmp::SlicePartialEq<B>>::equal_same_length
 <A as core::slice::cmp::SlicePartialEq<B>>::equal_same_length
 <I as core::iter::adapters::filter::SpecAssumeCount>::assume_count_le_upper_bound
@@ -1455,6 +1457,7 @@
 <char as core::str::pattern::Pattern>::into_searcher
 <char as core::str::pattern::Pattern>::is_prefix_of
 <char as core::str::pattern::Pattern>::is_suffix_of
+<char as core::str::pattern::Pattern>::strip_suffix_of
 <core::alloc::layout::Layout as core::clone::Clone>::clone
 <core::alloc::layout::Layout as core::cmp::Eq>::assert_fields_are_eq
 <core::alloc::layout::Layout as core::cmp::PartialEq>::eq
@@ -3353,6 +3356,7 @@
 <core::ops::index_range::IndexRange as core::iter::traits::double_ended::DoubleEndedIterator>::next_back
 <core::ops::index_range::IndexRange as core::iter::traits::double_ended::DoubleEndedIterator>::rfold
 <core::ops::index_range::IndexRange as core::iter::traits::double_ended::DoubleEndedIterator>::try_rfold
+<core::ops::index_range::IndexRange as core::iter::traits::exact_size::ExactSizeIterator>::len
 <core::ops::index_range::IndexRange as core::iter::traits::iterator::Iterator>::advance_by
 <core::ops::index_range::IndexRange as core::iter::traits::iterator::Iterator>::fold
 <core::ops::index_range::IndexRange as core::iter::traits::iterator::Iterator>::next
@@ -6328,6 +6332,55 @@ core::convert::num::ptr_try_from_impls::<impl core::convert::TryFrom<usize> for 
 core::convert::num::ptr_try_from_impls::<impl core::convert::TryFrom<usize> for u32>::try_from
 core::convert::num::ptr_try_from_impls::<impl core::convert::TryFrom<usize> for u64>::try_from
 core::convert::num::ptr_try_from_impls::<impl core::convert::TryFrom<usize> for u8>::try_from
+core::core_arch::x86::__m128::as_f32x4
+core::core_arch::x86::__m128bh::as_i16x8
+core::core_arch::x86::__m128bh::as_i32x4
+core::core_arch::x86::__m128bh::as_u16x8
+core::core_arch::x86::__m128bh::as_u32x4
+core::core_arch::x86::__m128d::as_f64x2
+core::core_arch::x86::__m128h::as_f16x8
+core::core_arch::x86::__m128i::as_i16x8
+core::core_arch::x86::__m128i::as_i32x4
+core::core_arch::x86::__m128i::as_i64x2
+core::core_arch::x86::__m128i::as_i8x16
+core::core_arch::x86::__m128i::as_u16x8
+core::core_arch::x86::__m128i::as_u32x4
+core::core_arch::x86::__m128i::as_u64x2
+core::core_arch::x86::__m128i::as_u8x16
+core::core_arch::x86::__m256::as_f32x8
+core::core_arch::x86::__m256bh::as_i16x16
+core::core_arch::x86::__m256bh::as_i32x8
+core::core_arch::x86::__m256bh::as_u16x16
+core::core_arch::x86::__m256bh::as_u32x8
+core::core_arch::x86::__m256d::as_f64x4
+core::core_arch::x86::__m256h::as_f16x16
+core::core_arch::x86::__m256i::as_i16x16
+core::core_arch::x86::__m256i::as_i32x8
+core::core_arch::x86::__m256i::as_i64x4
+core::core_arch::x86::__m256i::as_i8x32
+core::core_arch::x86::__m256i::as_u16x16
+core::core_arch::x86::__m256i::as_u32x8
+core::core_arch::x86::__m256i::as_u64x4
+core::core_arch::x86::__m256i::as_u8x32
+core::core_arch::x86::__m512::as_f32x16
+core::core_arch::x86::__m512bh::as_i16x32
+core::core_arch::x86::__m512bh::as_i32x16
+core::core_arch::x86::__m512bh::as_u16x32
+core::core_arch::x86::__m512bh::as_u32x16
+core::core_arch::x86::__m512d::as_f64x8
+core::core_arch::x86::__m512h::as_f16x32
+core::core_arch::x86::__m512i::as_i16x32
+core::core_arch::x86::__m512i::as_i32x16
+core::core_arch::x86::__m512i::as_i64x8
+core::core_arch::x86::__m512i::as_i8x64
+core::core_arch::x86::__m512i::as_u16x32
+core::core_arch::x86::__m512i::as_u32x16
+core::core_arch::x86::__m512i::as_u64x8
+core::core_arch::x86::__m512i::as_u8x64
+core::core_arch::x86::sse2::_mm_loadu_si128
+core::core_arch::x86::sse2::_mm_movemask_epi8
+core::core_arch::x86::sse2::_mm_or_si128
+core::core_arch::x86::sse2::_mm_undefined_si128
 core::escape::EscapeIterInner::<N, ESCAPING>::advance_by
 core::escape::EscapeIterInner::<N, ESCAPING>::ascii
 core::escape::EscapeIterInner::<N, ESCAPING>::backslash
@@ -6349,6 +6402,7 @@ core::escape::verbatim
 core::f128::<impl f128>::clamp::do_panic
 core::f128::<impl f128>::clamp::do_panic::compiletime
 core::f128::<impl f128>::clamp::do_panic::runtime
+core::f128::<impl f128>::to_bits
 core::f16::<impl f16>::abs
 core::f16::<impl f16>::clamp::do_panic
 core::f16::<impl f16>::clamp::do_panic::compiletime
@@ -6504,6 +6558,7 @@ core::fmt::builders::debug_set_new
 core::fmt::builders::debug_struct_new
 core::fmt::builders::debug_tuple_new
 core::fmt::builders::from_fn
+core::fmt::float::<impl core::fmt::Debug for f128>::fmt
 core::fmt::float::<impl core::fmt::Debug for f16>::fmt
 core::fmt::float::<impl core::fmt::Debug for f32>::fmt
 core::fmt::float::<impl core::fmt::Debug for f64>::fmt
@@ -8342,7 +8397,10 @@ core::slice::ascii::is_ascii
 core::slice::ascii::is_ascii::compiletime
 core::slice::ascii::is_ascii::runtime
 core::slice::ascii::is_ascii_simple
+core::slice::ascii::is_ascii_sse2
+core::slice::cmp::<impl core::cmp::Ord for [T]>::cmp
 core::slice::cmp::<impl core::cmp::PartialEq<[U]> for [T]>::eq
+core::slice::cmp::chaining_impl
 core::slice::copy_from_slice_impl
 core::slice::copy_from_slice_impl::len_mismatch_fail
 core::slice::copy_from_slice_impl::len_mismatch_fail::do_panic

--- a/ferrocene/tools/symbol-report/src/main.rs
+++ b/ferrocene/tools/symbol-report/src/main.rs
@@ -178,9 +178,13 @@ fn get_qualified_name(tcx: TyCtxt<'_>, def: LocalDefId) -> String {
 
 /// Filter out functions that are marked prevalidated for internal use only
 fn should_filter_out(qualified_name: &str) -> bool {
-    const FILTER_LIST: &[&str] = &["<core::ferrocene_test::", "core::ferrocene_test::"];
+    const FILTER_LIST: &[&str] = &["core::ferrocene_test", "core::core_arch"];
 
-    FILTER_LIST.iter().any(|filter| qualified_name.starts_with(filter))
+    FILTER_LIST
+        .iter()
+        // Some symbols start with `<`, some without
+        .flat_map(|s| [s.to_string(), format!("<{s}")])
+        .any(|filter| qualified_name.starts_with(&filter))
 }
 
 fn get_span(tcx: TyCtxt<'_>, vis: &mut Vis<'_>, def: LocalDefId) -> (String, usize, usize) {

--- a/library/core/src/fmt/float.rs
+++ b/library/core/src/fmt/float.rs
@@ -294,6 +294,7 @@ impl UpperExp for f16 {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Debug for f128 {
+    #[ferrocene::prevalidated]
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{:#034x}", self.to_bits())

--- a/library/core/src/fmt/nofloat.rs
+++ b/library/core/src/fmt/nofloat.rs
@@ -5,6 +5,7 @@ macro_rules! floating {
         $(
             #[stable(feature = "rust1", since = "1.0.0")]
             impl Debug for $ty {
+                #[ferrocene::prevalidated]
                 #[inline]
                 fn fmt(&self, _fmt: &mut Formatter<'_>) -> Result {
                     panic!("floating point fmt support is turned off");

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -1046,6 +1046,7 @@ impl f128 {
     /// assert_eq!((12.5f128).to_bits(), 0x40029000000000000000000000000000);
     /// # }
     /// ```
+    #[ferrocene::prevalidated]
     #[inline]
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "this returns the result of the operation, without modifying the original"]

--- a/library/core/src/ops/index_range.rs
+++ b/library/core/src/ops/index_range.rs
@@ -236,6 +236,7 @@ impl DoubleEndedIterator for IndexRange {
 }
 
 impl ExactSizeIterator for IndexRange {
+    #[ferrocene::prevalidated]
     #[inline]
     fn len(&self) -> usize {
         self.len()

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -572,6 +572,7 @@ const fn is_ascii(s: &[u8]) -> bool {
 #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
 const SSE2_CHUNK_SIZE: usize = 64;
 
+#[ferrocene::prevalidated]
 #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
 #[inline]
 fn is_ascii_sse2(bytes: &[u8]) -> bool {

--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -37,6 +37,7 @@ const impl<T: [const] Eq> Eq for [T] {}
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
 const impl<T: [const] Ord> Ord for [T] {
+    #[ferrocene::prevalidated]
     fn cmp(&self, other: &[T]) -> Ordering {
         SliceOrd::compare(self, other)
     }
@@ -212,6 +213,7 @@ const impl<A: [const] PartialOrd> SliceChain for A {
     }
 }
 
+#[ferrocene::prevalidated]
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
 #[inline]
 const fn chaining_impl<'l, 'r, A: PartialOrd, B, C>(
@@ -286,6 +288,7 @@ const trait SliceOrd: Sized {
 
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
 const impl<A: [const] Ord> SliceOrd for A {
+    #[ferrocene::prevalidated]
     default fn compare(left: &[Self], right: &[Self]) -> Ordering {
         let elem_chain = const |a, b| match Ord::cmp(a, b) {
             Ordering::Equal => ControlFlow::Continue(()),

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -634,6 +634,7 @@ impl Pattern for char {
         self.encode_utf8(&mut [0u8; 4]).is_suffix_of(haystack)
     }
 
+    #[ferrocene::prevalidated]
     #[inline]
     fn strip_suffix_of<'a>(self, haystack: &'a str) -> Option<&'a str>
     where
@@ -1063,6 +1064,7 @@ impl<'b> Pattern for &'b str {
     }
 
     /// Removes the pattern from the back of haystack, if it matches.
+    #[ferrocene::prevalidated]
     #[inline]
     fn strip_suffix_of<'a>(self, haystack: &'a str) -> Option<&'a str>
     where

--- a/library/stdarch/crates/core_arch/src/x86/mod.rs
+++ b/library/stdarch/crates/core_arch/src/x86/mod.rs
@@ -519,6 +519,7 @@ pub use self::test::*;
 macro_rules! as_transmute {
     ($from:ty => $as_from:ident, $($as_to:ident -> $to:ident),* $(,)?) => {
         impl $from {$(
+            #[ferrocene::prevalidated]
             #[inline]
             pub(crate) const fn $as_to(self) -> crate::core_arch::simd::$to {
                 unsafe { transmute(self) }

--- a/library/stdarch/crates/core_arch/src/x86/sse2.rs
+++ b/library/stdarch/crates/core_arch/src/x86/sse2.rs
@@ -886,6 +886,7 @@ pub const fn _mm_andnot_si128(a: __m128i, b: __m128i) -> __m128i {
 /// `b`.
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_or_si128)
+#[ferrocene::prevalidated]
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(orps))]
@@ -1331,6 +1332,7 @@ pub const unsafe fn _mm_load_si128(mem_addr: *const __m128i) -> __m128i {
 /// `mem_addr` does not need to be aligned on any particular boundary.
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_loadu_si128)
+#[ferrocene::prevalidated]
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movups))]
@@ -1609,6 +1611,7 @@ pub const fn _mm_insert_epi16<const IMM8: i32>(a: __m128i, i: i32) -> __m128i {
 /// Returns a mask of the most significant bit of each element in `a`.
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_movemask_epi8)
+#[ferrocene::prevalidated]
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pmovmskb))]
@@ -3201,6 +3204,7 @@ pub const fn _mm_undefined_pd() -> __m128d {
 /// In practice, this is typically equivalent to [`mem::zeroed`].
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_undefined_si128)
+#[ferrocene::prevalidated]
 #[inline]
 #[target_feature(enable = "sse2")]
 #[stable(feature = "simd_x86", since = "1.27.0")]

--- a/tests/ui/ferrocene/lint-prevalidated/lint-levels.rs
+++ b/tests/ui/ferrocene/lint-prevalidated/lint-levels.rs
@@ -9,6 +9,7 @@
 
 fn unvalidated() {}
 //~^ NOTE unvalidated
+//~^^ NOTE unvalidated
 
 struct Unvalidated;
 impl Drop for Unvalidated {
@@ -44,8 +45,11 @@ pub fn reachable() { //~ NOTE validated
 }
 
 #[ferrocene::prevalidated] //~ NOTE marked
+//~^ NOTE marked
 fn unreachable() { //~ NOTE is validated
+    //~^ NOTE is validated
     #[warn(ferrocene::unvalidated)] //~ NOTE lint level
     unvalidated();
     //~^ WARN calls
+    //~^^ WARN calls
 }

--- a/tests/ui/ferrocene/lint-prevalidated/lint-levels.stderr
+++ b/tests/ui/ferrocene/lint-prevalidated/lint-levels.stderr
@@ -1,5 +1,5 @@
 warning: validated function calls an unvalidated function
-  --> $DIR/lint-levels.rs:49:5
+  --> $DIR/lint-levels.rs:52:5
    |
 LL | fn unvalidated() {}
    |    ----------- `unvalidated` is unvalidated
@@ -8,14 +8,15 @@ LL |     unvalidated();
    |     ^^^^^^^^^^^
    |
 note: `unreachable` is validated
-  --> $DIR/lint-levels.rs:47:4
+  --> $DIR/lint-levels.rs:49:4
    |
 LL | #[ferrocene::prevalidated]
    | -------------------------- marked as validated here
+LL |
 LL | fn unreachable() {
    |    ^^^^^^^^^^^
 note: the lint level is defined here
-  --> $DIR/lint-levels.rs:48:12
+  --> $DIR/lint-levels.rs:51:12
    |
 LL |     #[warn(ferrocene::unvalidated)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
@@ -23,13 +24,13 @@ LL |     #[warn(ferrocene::unvalidated)]
 warning: validated function calls an unvalidated method
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
    |
-  ::: $DIR/lint-levels.rs:15:8
+  ::: $DIR/lint-levels.rs:16:8
    |
 LL |     fn drop(&mut self) {}
    |        ---- `<Unvalidated as Drop>::drop` is unvalidated
    |
 note: `reachable` is validated
-  --> $DIR/lint-levels.rs:36:8
+  --> $DIR/lint-levels.rs:37:8
    |
 LL | fn uninstantiated_generic_indirect<T>(val: T) {}
    |                                                - `Unvalidated` dropped here, in `uninstantiated_generic_indirect::<Unvalidated>`
@@ -39,13 +40,13 @@ LL | #[ferrocene::prevalidated]
 LL | pub fn reachable() {
    |        ^^^^^^^^^
 note: the lint level is defined here
-  --> $DIR/lint-levels.rs:23:8
+  --> $DIR/lint-levels.rs:24:8
    |
 LL | #[warn(ferrocene::unvalidated)]
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: validated function calls an unvalidated method
-  --> $DIR/lint-levels.rs:29:5
+  --> $DIR/lint-levels.rs:30:5
    |
 LL |     fn clone(&self) -> Self { Unvalidated }
    |        ----- `<Unvalidated as Clone>::clone` is unvalidated
@@ -54,15 +55,33 @@ LL |     val.clone();
    |     ^^^^^^^^^^^
    |
 note: generic function `uninstantiated_generic_direct` instantiated by `reachable`, which is called from a validated entrypoint
-  --> $DIR/lint-levels.rs:39:5
+  --> $DIR/lint-levels.rs:40:5
    |
 LL |     uninstantiated_generic_direct(Unvalidated);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: the lint level is defined here
-  --> $DIR/lint-levels.rs:28:12
+  --> $DIR/lint-levels.rs:29:12
    |
 LL |     #[warn(ferrocene::unvalidated)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: 3 warnings emitted
+warning: validated function calls an unvalidated function
+  --> $DIR/lint-levels.rs:52:5
+   |
+LL | fn unvalidated() {}
+   |    ----------- `unvalidated` is unvalidated
+...
+LL |     unvalidated();
+   |     ^^^^^^^^^^^^^
+   |
+note: `unreachable` is validated
+  --> $DIR/lint-levels.rs:49:4
+   |
+LL | #[ferrocene::prevalidated]
+   | -------------------------- marked as validated here
+LL |
+LL | fn unreachable() {
+   |    ^^^^^^^^^^^
+
+warning: 4 warnings emitted
 

--- a/tests/ui/ferrocene/lint-prevalidated/post-mono.dedup.stderr
+++ b/tests/ui/ferrocene/lint-prevalidated/post-mono.dedup.stderr
@@ -7,15 +7,15 @@ LL |     fn clone(&self) -> Self { Unvalidated }
 LL |     x.clone();
    |     ^^^^^^^^^
    |
-note: `instantiation_reachable` is validated
-  --> $DIR/post-mono.rs:69:8
+note: `instantiation_unreachable` is validated
+  --> $DIR/post-mono.rs:80:4
    |
 LL | #[ferrocene::prevalidated]
    | -------------------------- marked as validated here
-LL | pub fn instantiation_reachable() {
-   |        ^^^^^^^^^^^^^^^^^^^^^^^
-LL |     uninstantiated_generic(Unvalidated);
-   |     ----------------------------------- generic function `uninstantiated_generic` instantiated by `instantiation_reachable`
+LL | fn instantiation_unreachable() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     uninstantiated_generic(Unvalidated); // ok
+   |     ----------------------------------- generic function `uninstantiated_generic` instantiated by `instantiation_unreachable`
 note: the lint level is defined here
   --> $DIR/post-mono.rs:1:9
    |
@@ -31,10 +31,10 @@ LL |     fn default() -> Self { Unvalidated }
 LL |     let mut y = fn_type();
    |                 ^^^^^^^^^
    |
-note: generic function `uninstantiated_generic` instantiated by `instantiation_reachable`, which is called from a validated entrypoint
-  --> $DIR/post-mono.rs:70:5
+note: generic function `uninstantiated_generic` instantiated by `instantiation_unreachable`, which is called from a validated entrypoint
+  --> $DIR/post-mono.rs:81:5
    |
-LL |     uninstantiated_generic(Unvalidated);
+LL |     uninstantiated_generic(Unvalidated); // ok
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: validated function possibly calls an unvalidated method

--- a/tests/ui/ferrocene/lint-prevalidated/post-mono.dedup.stderr
+++ b/tests/ui/ferrocene/lint-prevalidated/post-mono.dedup.stderr
@@ -8,7 +8,7 @@ LL |     x.clone();
    |     ^^^^^^^^^
    |
 note: `instantiation_unreachable` is validated
-  --> $DIR/post-mono.rs:80:4
+  --> $DIR/post-mono.rs:75:4
    |
 LL | #[ferrocene::prevalidated]
    | -------------------------- marked as validated here
@@ -32,7 +32,7 @@ LL |     let mut y = fn_type();
    |                 ^^^^^^^^^
    |
 note: generic function `uninstantiated_generic` instantiated by `instantiation_unreachable`, which is called from a validated entrypoint
-  --> $DIR/post-mono.rs:81:5
+  --> $DIR/post-mono.rs:76:5
    |
 LL |     uninstantiated_generic(Unvalidated); // ok
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/ferrocene/lint-prevalidated/post-mono.no-dedup.stderr
+++ b/tests/ui/ferrocene/lint-prevalidated/post-mono.no-dedup.stderr
@@ -7,15 +7,15 @@ LL |     fn clone(&self) -> Self { Unvalidated }
 LL |     x.clone();
    |     ^^^^^^^^^
    |
-note: `instantiation_reachable` is validated
-  --> $DIR/post-mono.rs:69:8
+note: `instantiation_unreachable` is validated
+  --> $DIR/post-mono.rs:80:4
    |
 LL | #[ferrocene::prevalidated]
    | -------------------------- marked as validated here
-LL | pub fn instantiation_reachable() {
-   |        ^^^^^^^^^^^^^^^^^^^^^^^
-LL |     uninstantiated_generic(Unvalidated);
-   |     ----------------------------------- generic function `uninstantiated_generic` instantiated by `instantiation_reachable`
+LL | fn instantiation_unreachable() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     uninstantiated_generic(Unvalidated); // ok
+   |     ----------------------------------- generic function `uninstantiated_generic` instantiated by `instantiation_unreachable`
 note: the lint level is defined here
   --> $DIR/post-mono.rs:1:9
    |
@@ -31,10 +31,10 @@ LL |     fn default() -> Self { Unvalidated }
 LL |     let mut y = fn_type();
    |                 ^^^^^^^^^
    |
-note: generic function `uninstantiated_generic` instantiated by `instantiation_reachable`, which is called from a validated entrypoint
-  --> $DIR/post-mono.rs:70:5
+note: generic function `uninstantiated_generic` instantiated by `instantiation_unreachable`, which is called from a validated entrypoint
+  --> $DIR/post-mono.rs:81:5
    |
-LL |     uninstantiated_generic(Unvalidated);
+LL |     uninstantiated_generic(Unvalidated); // ok
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: validated function possibly calls an unvalidated method

--- a/tests/ui/ferrocene/lint-prevalidated/post-mono.no-dedup.stderr
+++ b/tests/ui/ferrocene/lint-prevalidated/post-mono.no-dedup.stderr
@@ -8,7 +8,7 @@ LL |     x.clone();
    |     ^^^^^^^^^
    |
 note: `instantiation_unreachable` is validated
-  --> $DIR/post-mono.rs:80:4
+  --> $DIR/post-mono.rs:75:4
    |
 LL | #[ferrocene::prevalidated]
    | -------------------------- marked as validated here
@@ -32,7 +32,7 @@ LL |     let mut y = fn_type();
    |                 ^^^^^^^^^
    |
 note: generic function `uninstantiated_generic` instantiated by `instantiation_unreachable`, which is called from a validated entrypoint
-  --> $DIR/post-mono.rs:81:5
+  --> $DIR/post-mono.rs:76:5
    |
 LL |     uninstantiated_generic(Unvalidated); // ok
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/ferrocene/lint-prevalidated/post-mono.rs
+++ b/tests/ui/ferrocene/lint-prevalidated/post-mono.rs
@@ -65,11 +65,9 @@ fn reachable_unvalidated() {
     only_instantiated_by_unvalidated(());
 }
 
-#[ferrocene::prevalidated] //~ NOTE marked
-pub fn instantiation_reachable() { //~ NOTE is validated
+#[ferrocene::prevalidated]
+pub fn instantiation_reachable() {
     uninstantiated_generic(Unvalidated);
-    //~^ NOTE instantiated by
-    //~^^ NOTE validated entrypoint
     uninstantiated_generic(Validated); // ok
 }
 
@@ -78,8 +76,10 @@ pub fn instantiation_reachable() { //~ NOTE is validated
 // `SimplifyCfg-initial` MIR passes, if that's something we want. I think we would also have to
 // modify our RootCollector to use the Eager collection strategy.
 // But right now we just ban our customers from having dead code, lol.
-#[ferrocene::prevalidated]
-fn instantiation_unreachable() {
+#[ferrocene::prevalidated] //~ NOTE marked
+fn instantiation_unreachable() { //~ NOTE is validated
     uninstantiated_generic(Unvalidated); // ok
+    //~^ NOTE instantiated by
+    //~^^ NOTE validated entrypoint
     uninstantiated_generic(Validated); // ok
 }

--- a/tests/ui/ferrocene/lint-prevalidated/post-mono.rs
+++ b/tests/ui/ferrocene/lint-prevalidated/post-mono.rs
@@ -71,11 +71,6 @@ pub fn instantiation_reachable() {
     uninstantiated_generic(Validated); // ok
 }
 
-// Currently *not* checked.
-// Nadrierel says it should be possible to lift this restriction by not running the
-// `SimplifyCfg-initial` MIR passes, if that's something we want. I think we would also have to
-// modify our RootCollector to use the Eager collection strategy.
-// But right now we just ban our customers from having dead code, lol.
 #[ferrocene::prevalidated] //~ NOTE marked
 fn instantiation_unreachable() { //~ NOTE is validated
     uninstantiated_generic(Unvalidated); // ok


### PR DESCRIPTION
Before only the `main` function and non-generic public functions that are marked with the prevalidated attribute were considered an entry point for the prevalidated analysis. With this change also non-generic private functions are considered entrypoints for the analysis!