### PR TITLE
add qemu to ubuntu-24 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ parameters:
     default: true
 
 orbs:
-  ferrocene: ferrocene/ferrocene-common@26080.3.0 # https://circleci.com/developer/orbs/orb/ferrocene/ferrocene-common?version=26080.3.0#orb-source
+  ferrocene: ferrocene/ferrocene-common@dev:docker_build-docker_arguments # https://circleci.com/developer/orbs/orb/ferrocene/ferrocene-common?version=26080.3.0#orb-source
   continuation: circleci/continuation@0.2.0
 
 jobs:
@@ -61,4 +61,5 @@ workflows:
         - equal: [<< pipeline.git.branch >>, "staging"]
         - equal: [<< pipeline.git.branch >>, "trying"]
         - equal: [<< pipeline.trigger_source >>, "api"]
+        - equal: [<< pipeline.git.branch >>, carmen/ubuntu-24-qemu]
     jobs: [setup]

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -968,6 +968,9 @@ workflows:
           rebuild: << pipeline.parameters.docker-image-rebuild--ci-docker-images--x86_64--ubuntu-24 >>
           resource_class: large.gen2
           awscli_version: << pipeline.parameters.awscli-version >>
+          docker_arguments: |
+            --build-arg
+            QEMUVERSION=<< pipeline.parameters.qemu-version >>
 
       - ferrocene/build_docker:
           name: build-docker--ubuntu-20--aarch64

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -123,7 +123,7 @@ parameters:
 
 orbs:
   win: circleci/windows@5.0
-  ferrocene: ferrocene/ferrocene-common@26080.3.0 # https://circleci.com/developer/orbs/orb/ferrocene/ferrocene-common?version=26080.3.0#orb-source
+  ferrocene: ferrocene/ferrocene-common@dev:docker_build-docker_arguments # https://circleci.com/developer/orbs/orb/ferrocene/ferrocene-common?version=26080.3.0#orb-source
 
 jobs:
   # Container dedicated to running ad-hoc tests that don't depend on an
@@ -952,6 +952,7 @@ workflows:
         - equal: [<< pipeline.git.branch >>, "staging"]
         - equal: [<< pipeline.git.branch >>, "trying"]
         - equal: [<< pipeline.trigger_source >>, "api"]
+        - equal: [<< pipeline.git.branch >>, carmen/ubuntu-24-qemu]
     jobs:
       - ferrocene/build_docker:
           name: build-docker--ubuntu-20--x86_64

--- a/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
@@ -7,11 +7,15 @@
 # From the root of this repository, build with
 # `docker build --tag ubuntu-24 --file ferrocene/ci/docker-images/ubuntu-24/Dockerfile .`
 
+FROM --platform=$TARGETPLATFORM harbor.infra.ferrous-systems.net/ferrocene-images/qemu-arm-patched:11.0.1 AS qemu
+
 FROM --platform=$TARGETPLATFORM ubuntu:24.04
 
 # As a multiplatform container we support all these: https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
+
+COPY --from=qemu / /opt/qemu-ferrocene/11.0.1/
 
 RUN <<-EOF
     set -xe

--- a/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
+++ b/ferrocene/ci/docker-images/ubuntu-24/Dockerfile
@@ -7,7 +7,9 @@
 # From the root of this repository, build with
 # `docker build --tag ubuntu-24 --file ferrocene/ci/docker-images/ubuntu-24/Dockerfile .`
 
-FROM --platform=$TARGETPLATFORM harbor.infra.ferrous-systems.net/ferrocene-images/qemu-arm-patched:11.0.1 AS qemu
+ARG QEMUVERSION
+
+FROM --platform=$TARGETPLATFORM harbor.infra.ferrous-systems.net/ferrocene-images/qemu-arm-patched:$QEMUVERSION AS qemu
 
 FROM --platform=$TARGETPLATFORM ubuntu:24.04
 
@@ -15,7 +17,7 @@ FROM --platform=$TARGETPLATFORM ubuntu:24.04
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
-COPY --from=qemu / /opt/qemu-ferrocene/11.0.1/
+COPY --from=qemu / /opt/qemu-ferrocene/$QEMUVERSION/
 
 RUN <<-EOF
     set -xe

--- a/ferrocene/ci/scripts/build-and-push-docker-image.sh
+++ b/ferrocene/ci/scripts/build-and-push-docker-image.sh
@@ -28,5 +28,6 @@ aws ecr get-login-password --region "${ECR_REGION}" \
 ferrocene/ci/scripts/ensure-ubuntu-20-packages.sh
 
 # Build and push the image
-docker build --progress=plain -t "${image}" --build-arg BASE_IMAGE=${BASE_IMAGE:-""} -f "ferrocene/ci/docker-images/${IMAGE_NAME}/Dockerfile" .
+args=( $DOCKER_ARGS )
+docker build --progress=plain -t "${image}" --build-arg BASE_IMAGE=${BASE_IMAGE:-""} -f "ferrocene/ci/docker-images/${IMAGE_NAME}/Dockerfile" "${args[@]}" .
 docker push "${image}"


### PR DESCRIPTION
currently #2446 fails in CI with this message in :

```
/bin/run-testserver.sh: line 39: /opt/qemu-ferrocene/11.0.1/bin/qemu-arm: No such file or directory
```

this PR adds the built docker image data from https://github.com/ferrocene/qemu/tree/ferrocene/release/11.0.1-patched (served as harbor.infra.ferrous-systems.net/ferrocene/images/qemu-arm-patched:11.0.1) to the `ubuntu-24` image.