### PR TITLE
document the release process

### DIFF
--- a/ferrocene/doc/internal-procedures/src/index.rst
+++ b/ferrocene/doc/internal-procedures/src/index.rst
@@ -48,6 +48,7 @@ based on software engineering best practices.
 
    release/index
    release/stable
+   release/publish
    release/during-outages
 
 .. toctree::

--- a/ferrocene/doc/internal-procedures/src/release/index.rst
+++ b/ferrocene/doc/internal-procedures/src/release/index.rst
@@ -47,3 +47,80 @@ This way, as long as we set ``ferrocene/ci/channel`` to "rolling" on the main
 branch, we don't need to make any change ourselves to promote a branch from
 "nightly" to "pre-rolling" to "rolling", as upstream does that for us when they
 change ``src/ci/channel``.
+
+.. _release-checklist:
+
+Release Checklist
+-----------------
+
+This checklist is targeted towards release managers who are running a release.
+
+12 weeks before release
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* :ref:`Determine which upstream version will be branched <determine-baseline>`
+
+6 weeks before release
+~~~~~~~~~~~~~~~~~~~~~~
+
+In any order:
+
+* [release/1.NN] :ref:`Feature freeze and backports <handling-backports>`.
+  If there are any remaining ``backport:manual`` PRs, backport them now.
+  After this point, the ``release/1.NN`` branch is in **feature freeze**: no new PRs can be backported unless approved by a release manager.
+
+* :ref:`Validate the documentation <documentation-validation>`.
+
+Simultaneously, do the following *in order*:
+
+#. [release/1.NN] :ref:`Branch beta <branch-beta>`.
+#. [KPs repo] :ref:`Add the new version to the Known Problems database <add-known-problems>`.
+#. :ref:`release-note-bump`.
+
+   #. [main] Update the version in the release notes.
+   #. [release/1.NN] Backport the release notes update, and remove `:upcoming-release:` from beta's release notes.
+   #. [main] Create a release note named ``next.rst``.
+
+5 weeks before release
+~~~~~~~~~~~~~~~~~~~~~~
+
+In order:
+
+#. Perform another :ref:`documentation-validation`.
+#. Create a :ref:`semantic-diff`.
+#. [release/1.NN] Instruct the :ref:`Safety Manager <qualification-plan:leadership-roles>` to
+   :ref:`sign the release branch <internal-procedures:signing-all-documents>`.
+
+#. :ref:`Deliver the documentation to the assessor <deliver-docs>`.
+
+At this point, the branch is in **documentation freeze**:
+no new PRs can be merged unless they do not affect the documentation signatures.
+In practice, only changes to CI are allowed from this point forward.
+
+.. note::
+
+   If you do make a documentation change after this point,
+   you MUST re-sign the docs and re-send them to the assessor.
+
+When technical reports are received from the assessor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#. :ref:`Upload the technical reports <release-technical-reports>`
+#. [release/1.NN] :ref:`Publish a dev release <promote-stable>`.
+#. :ref:`Perform release validation <release-validation>`.
+
+At this point, the branch is in **commit freeze**:
+No commits at all can be made until the release is published.
+
+Day of the release
+~~~~~~~~~~~~~~~~~~
+
+* :ref:`Publish a manual release <manual-release>` in the ``prod`` environment.
+
+After the release
+~~~~~~~~~~~~~~~~~
+
+* [release/1.NN] :ref:`prepare-patch-release`.
+* [main] :ref:`remove-upcoming`.
+* [main] :ref:`forward-ports`.
+* [main] Update the release docs to reflect current reality.

--- a/ferrocene/doc/internal-procedures/src/release/index.rst
+++ b/ferrocene/doc/internal-procedures/src/release/index.rst
@@ -10,60 +10,6 @@ release process is present :doc:`in the qualification plan
 <qualification-plan:release>`. Make sure to read the overview before diving
 into this section.
 
-Release tooling
----------------
-
-Ferrocene is developed using a custom tool, `publish-release`_, which is
-responsible for all of the release steps. The tool is written in Rust and
-developed in the ``ferrocene/publish-release`` repository, and it's executed on
-GitHub Actions in the ``ferrocene/ferrocene`` repository.
-
-When GitHub Actions invokes the release tool, the
-`calculate-release-job-matrix.py`_ script is used to determine which commit(s)
-to instruct the release process to release. The script does little when
-starting a manual release, but it's fully responsible for determining which
-scheduled releases to run.
-
-.. _manual-release:
-
-Publishing a manual release
----------------------------
-
-Our release tooling also allows to manually start the release process. This can
-be useful to start releases that are not on a schedule, to restart a scheduled
-release that failed, or for testing (in the ``dev`` environment). Only starting
-the release is manual, meaning all the rest of steps are fully automated.
-
-To manually start a release, go to the `release workflow page`_ and click the
-"Run workflow" button. You need to input the git reference you want to release
-(it can be a branch name, a short commit hash, or a full commit hash), and the
-environment to release in. Note that anyone can publish a release in the
-``dev`` environment, while approval from a :ref:`release manager
-<qualification-plan:organization:Release Managers>` is required for the
-``prod`` environment.
-
-.. note::
-
-   The git reference needs to be a merge commit authored by bors.
-
-   This is because the Release workflow does not actually build anything, but
-   just copies the release artifacts to the appropriate storage location.
-
-It's also possible to override some of the startup checks the release process
-performs, and to treat the git reference as verbatim instead of trying to
-resolve it. The latter option is useful if you need to release a commit which
-is not present in the ``ferrocene/ferrocene`` repository.
-
-Once you click the green "Run workflow" button, a new job will be queued.
-
-If the release targets the prod environment, an approval from a release manager
-will be required. The release manager will need to approve the release in the
-GitHub UI before the release can proceed. Once it's done, the release process
-will start automatically.
-
-If there is a service outage preventing you from manually starting a release,
-follow the instructions in :doc:`internal-procedures:release/during-outages`.
-
 Channel names
 -------------
 
@@ -101,7 +47,3 @@ This way, as long as we set ``ferrocene/ci/channel`` to "rolling" on the main
 branch, we don't need to make any change ourselves to promote a branch from
 "nightly" to "pre-rolling" to "rolling", as upstream does that for us when they
 change ``src/ci/channel``.
-
-.. _publish-release: https://github.com/ferrocene/publish-release
-.. _calculate-release-job-matrix.py: https://github.com/ferrocene/ferrocene/blob/main/ferrocene/ci/scripts/calculate-release-job-matrix.py
-.. _release workflow page: https://github.com/ferrocene/ferrocene/actions/workflows/release.yml

--- a/ferrocene/doc/internal-procedures/src/release/publish.rst
+++ b/ferrocene/doc/internal-procedures/src/release/publish.rst
@@ -1,0 +1,66 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Ferrocene Developers
+
+Publishing a stable release
+===========================
+
+This section describes how to take a branch marked as a `stable` channel and upload its artifacts to our S3 bucket for distribution.
+For prior steps before a branch is marked `stable`, see :doc:`internal-procedures:release/stable`.
+
+Release tooling
+---------------
+
+Ferrocene is developed using a custom tool, `publish-release`_, which is
+responsible for all of the release steps. The tool is written in Rust and
+developed in the ``ferrocene/publish-release`` repository, and it's executed on
+GitHub Actions in the ``ferrocene/ferrocene`` repository.
+
+When GitHub Actions invokes the release tool, the
+`calculate-release-job-matrix.py`_ script is used to determine which commit(s)
+to instruct the release process to release. The script does little when
+starting a manual release, but it's fully responsible for determining which
+scheduled releases to run.
+
+.. _manual-release:
+
+Publishing a manual release
+---------------------------
+
+Our release tooling also allows to manually start the release process. This can
+be useful to start releases that are not on a schedule, to restart a scheduled
+release that failed, or for testing (in the ``dev`` environment). Only starting
+the release is manual, meaning all the rest of steps are fully automated.
+
+To manually start a release, go to the `release workflow page`_ and click the
+"Run workflow" button. You need to input the git reference you want to release
+(it can be a branch name, a short commit hash, or a full commit hash), and the
+environment to release in. Note that anyone can publish a release in the
+``dev`` environment, while approval from a :ref:`release manager
+<qualification-plan:organization:Release Managers>` is required for the
+``prod`` environment.
+
+.. note::
+
+   The git reference needs to be a merge commit authored by bors.
+
+   This is because the Release workflow does not actually build anything, but
+   just copies the release artifacts to the appropriate storage location.
+
+It's also possible to override some of the startup checks the release process
+performs, and to treat the git reference as verbatim instead of trying to
+resolve it. The latter option is useful if you need to release a commit which
+is not present in the ``ferrocene/ferrocene`` repository.
+
+Once you click the green "Run workflow" button, a new job will be queued.
+
+If the release targets the prod environment, an approval from a release manager
+will be required. The release manager will need to approve the release in the
+GitHub UI before the release can proceed. Once it's done, the release process
+will start automatically.
+
+If there is a service outage preventing you from manually starting a release,
+follow the instructions in :doc:`internal-procedures:release/during-outages`.
+
+.. _publish-release: https://github.com/ferrocene/publish-release
+.. _calculate-release-job-matrix.py: https://github.com/ferrocene/ferrocene/blob/main/ferrocene/ci/scripts/calculate-release-job-matrix.py
+.. _release workflow page: https://github.com/ferrocene/ferrocene/actions/workflows/release.yml

--- a/ferrocene/doc/internal-procedures/src/release/publish.rst
+++ b/ferrocene/doc/internal-procedures/src/release/publish.rst
@@ -34,10 +34,7 @@ the release is manual, meaning all the rest of steps are fully automated.
 To manually start a release, go to the `release workflow page`_ and click the
 "Run workflow" button. You need to input the git reference you want to release
 (it can be a branch name, a short commit hash, or a full commit hash), and the
-environment to release in. Note that anyone can publish a release in the
-``dev`` environment, while approval from a :ref:`release manager
-<qualification-plan:organization:Release Managers>` is required for the
-``prod`` environment.
+environment to release in.
 
 .. note::
 

--- a/ferrocene/doc/internal-procedures/src/release/stable.rst
+++ b/ferrocene/doc/internal-procedures/src/release/stable.rst
@@ -7,6 +7,12 @@ Stable release process
 This page details the steps required to publish a new stable release of
 Ferrocene, from branching off a rolling branch to publishing point releases.
 
+This is a *reference*, not a *checklist*.
+It is only vaguely ordered.
+For a canonical ordering, see :ref:`release-checklist`.
+
+.. _determine-baseline:
+
 Determine the baseline Rust version
 -----------------------------------
 
@@ -50,6 +56,8 @@ as the release's version number.
 For any following point release, keep the same year and month as the previous
 release, and increment the previous point release number.
 
+.. _branch-beta:
+
 Branching from rolling into beta
 --------------------------------
 
@@ -65,6 +73,8 @@ the latest commit on that branch into the ``beta-${major_version}`` channel
 every night. You can continue landing changes into the branch until you
 are ready to release it as a stable release.
 
+.. _add-known-problems:
+
 Add version to Known Problems
 -----------------------------
 
@@ -75,6 +85,8 @@ the instructions in ``README.rst``.
 Validate that the locally built site now has the version, and that known problems are tracked for it.
 Make a pull request, ensure it gets merged, then validate the new version shows up on the
 `Known Problems page <https://problems.ferrocene.dev/>`_.
+
+.. _release-note-bump:
 
 Version Bump Release Notes
 --------------------------
@@ -100,16 +112,8 @@ Create a new ``ferrocene/doc/release-notes/src/next.rst`` on the `main` branch w
    release.
 
 
-Precautionary validation
-------------------------
+.. _semantic-diff:
 
-Perform :ref:`qualification-plan:release-validation` on the ``release/1.NN`` branch before signing.
-
-Signing
--------
-
-Request the :ref:`Safety Manager <qualification-plan:leadership-roles>` to perform the
-:ref:`documentation signatures <internal-procedures:signing-all-documents>`.
 Semantic diff
 -------------
 
@@ -174,28 +178,30 @@ The reviewer of this change has to check the following:
 
 2. Check that the configuration is correctly set in ``ferrocene/ci/configure.sh``.
 
-.. _publish-stable:
+.. _promote-stable:
 
-Publishing a stable release
----------------------------
+Promoting beta to stable
+------------------------
 
 To publish a stable release, you need to first open a PR targeting the
 ``release/1.NN`` branch, changing the contents of ``ferrocene/ci/channel`` to
 ``stable``.
 
-Once the PR is merged, you need to grab the commit hash of the merge commit,
-:ref:`start a manual release <manual-release>` on the ``dev`` environment, and
-perform the :ref:`qualification-plan:release-validation`.
+Once the PR is merged, you need to grab the commit hash of the merge commit and
+:ref:`start a manual release <manual-release>` on the ``dev`` environment.
 
-Once the release validation succeeded, :ref:`start a manual release
-<manual-release>` on the ``prod`` environment. The release will require
-approval from the release managers.
+.. _prepare-patch-release:
 
-Finally, you need to send another PR targeting the ``release/1.NN`` branch,
+Prepare for patch releases
+--------------------------
+
+Once you've released to ``prod``, you need to send another PR targeting the ``release/1.NN`` branch,
 changing ``ferrocene/ci/channel`` back to ``beta`` and incrementing the point
 release version in ``ferrocene/version`` by 1. Note that you will need to
 remove digital signatures, because they will be invalidated by the version
 change. The CI also ensures that the signatures remain valid.
+
+.. _remove-upcoming:
 
 Remove upcoming notes in the ``main`` branch
 --------------------------------------------
@@ -207,6 +213,8 @@ After publishing the stable release, send a PR to the ``main`` branch to:
 
 * Remove all mentions of ``:upcoming:`YY.MM``` in the documentation, where
   ``YY.MM`` is the current version number.
+
+.. _forward-ports:
 
 Identify any forward ports
 --------------------------

--- a/ferrocene/doc/internal-procedures/src/release/stable.rst
+++ b/ferrocene/doc/internal-procedures/src/release/stable.rst
@@ -110,13 +110,33 @@ Signing
 
 Request the :ref:`Safety Manager <qualification-plan:leadership-roles>` to perform the
 :ref:`documentation signatures <internal-procedures:signing-all-documents>`.
+Semantic diff
+-------------
+
+To avoid unnecessary work for the safety assessor and safety manager,
+create a high-level overview of what has changed since the last release.
+This should include at least:
+
+* Changes to ``ferrocene/doc``
+* Changes to the symbol report
+* Anything mentioned in the release notes
+
+.. note::
+
+   You can see a list of doc changes since the last release like so:
+
+.. code-block::
+
+    git diff release/1.95 release/1.97 --ignore-all-space --ignore-blank-lines 'ferrocene/doc' ':!*/signature.toml'
+
+.. _deliver-docs:
 
 Delivering the documentation package
 ------------------------------------
 
 Wait for the nightly beta, or manually cut a beta release onto production. Over email,
 send the assessor direct links to the ``ferrocene-docs`` and ``ferrocene-docs-signatures``
-packages, as well as a *semantic diff* of what changed since the last release.
+packages, as well as the semantic diff.
 
 .. _release-technical-reports:
 

--- a/ferrocene/doc/internal-procedures/src/release/stable.rst
+++ b/ferrocene/doc/internal-procedures/src/release/stable.rst
@@ -10,14 +10,20 @@ Ferrocene, from branching off a rolling branch to publishing point releases.
 Determine the baseline Rust version
 -----------------------------------
 
-Each major version of Ferrocene is based off a Rust version, usually the latest
-one available at the point the release was branched off the rolling branches.
-Once the baseline is chosen, it will be possible to upgrade to newer patch
-releases of Rust, but not to new minor or major Rust versions.
+Each major version of Ferrocene is based off a Rust version.
+Choose the Rust version such that the Ferrocene release is the based off the
+latest stable Rust *at the time that docs are sent to the assessor*.
+Consult `Rust Forge <https://forge.rust-lang.org/>`_ for a list of Rust release dates.
 
-The decision of the baseline Rust version for a new Ferrocene major version
-is made within the team. Once chosen, all development work will be done in the
+.. note::
+
+    For example, Ferrocene 26.08 released in August 2028, and sent docs in the last week of July,
+    so it was based off of Rust 1.97 (released July 9), **not** 1.98 (released August 20).
+
+Once a version is chosen, all development work will be done in the
 ``release/1.NN`` branch, where ``NN`` is the minor Rust version number.
+Release branches can upgrade to newer patch releases of Rust, but not to new
+minor or major Rust versions.
 
 Determine the Ferrocene version number
 --------------------------------------

--- a/ferrocene/doc/qualification-plan/src/release.rst
+++ b/ferrocene/doc/qualification-plan/src/release.rst
@@ -104,18 +104,13 @@ environment:
 
 * *None so far.*
 
-The following releases are currently published on a schedule in the **prod**
-environment:
+The following releases are currently published in the **prod**
+environment every day at 3:15 AM UTC:
 
-* Everyday at 00:00 UTC, the tip of the ``main`` branch is released on the
-  nightly channel.
-* Everyday at 00:00 UTC, the tip of the branch with the Rust channel of
-  ``beta`` is released on the pre-rolling channel.
-* Everyday at 00:00 UTC, the tip of the most recent branch with the Rust
-  channel of ``stable`` is released on the rolling channel.
-* Everyday at 00:00 UTC, the tip of every branch with the Ferrocene channel of
-  ``beta`` is released on the beta-${version} channel.
-
+* the tip of the ``main`` branch is released on the nightly channel.
+* the tip of the branch with the Rust channel of ``beta`` is released on the pre-rolling channel.
+* the tip of the most recent branch with the Rust channel of ``stable`` is released on the rolling channel.
+* the tip of every branch with the Ferrocene channel of ``beta`` is released on the beta-${version} channel.
 
 Manually-started Releases
 -------------------------

--- a/ferrocene/doc/qualification-plan/src/release.rst
+++ b/ferrocene/doc/qualification-plan/src/release.rst
@@ -118,23 +118,13 @@ Manually-started Releases
 The Ferrocene release tooling also allows Ferrocene developers to manually
 initiate the release process to prepare releases that are not currently
 scheduled, to restart a scheduled release that failed, or for testing (only for
-**dev** environment). Only the initiation of the release process is manual in
-this case; all the other steps are fully automated.
-
-To manually start a release, go to
-`this page <https://github.com/ferrocene/ferrocene/actions/workflows/release.yml>`_
-and click the "Run workflow" button.
-You will need to choose which git ref you want to release
-(a branch name, a tag name, a short commit hash, a long commit hash, etc...)
-and which environment in which to run the release.
-You will also be able to tweak how the release is run with the available options.
-Once you click the green "Run workflow" button, a new job will be queued.
+**dev** environment).
 
 If the release targets the **prod** environment, an approval from a Release
 Manager is required. A :ref:`release manager <organization:Release Managers>`
 needs to approve the release in the GitHub UI before the release can proceed.
-Once approved, the release process will start automatically.
 
+For more detail, see :doc:`the internal procedures <internal-procedures:release/publish>`.
 
 Backporting Changes
 -------------------

--- a/ferrocene/doc/qualification-plan/src/release.rst
+++ b/ferrocene/doc/qualification-plan/src/release.rst
@@ -115,14 +115,8 @@ environment every day at 3:15 AM UTC:
 Manually-started Releases
 -------------------------
 
-The Ferrocene release tooling also allows Ferrocene developers to manually
-initiate the release process to prepare releases that are not currently
-scheduled, to restart a scheduled release that failed, or for testing (only for
-**dev** environment).
-
-If the release targets the **prod** environment, an approval from a Release
-Manager is required. A :ref:`release manager <organization:Release Managers>`
-needs to approve the release in the GitHub UI before the release can proceed.
+If a manual release targets the **prod** environment, an approval from a
+:ref:`release manager <organization:Release Managers>` is needed.
 
 For more detail, see :doc:`the internal procedures <internal-procedures:release/publish>`.
 

--- a/ferrocene/doc/qualification-plan/src/validation.rst
+++ b/ferrocene/doc/qualification-plan/src/validation.rst
@@ -80,6 +80,7 @@ Quick checks should always include ensuring:
 
 * :ref:`qualification-report:requirements-traceability` is still satisfied
 * :ref:`qualification-report:test-results-overview` shows expected counts
+* :ref:`core-certification:safety-report/code-coverage-overview` shows 100% coverage with "count annotated lines as tested" checked
 * The Specification documents the right version
 * :ref:`release-notes:index`
 

--- a/ferrocene/doc/qualification-plan/src/validation.rst
+++ b/ferrocene/doc/qualification-plan/src/validation.rst
@@ -80,7 +80,7 @@ Quick checks should always include ensuring:
 
 * :ref:`qualification-report:requirements-traceability` is still satisfied
 * :ref:`qualification-report:test-results-overview` shows expected counts
-* :ref:`core-certification:safety-report/code-coverage-overview` shows 100% coverage with "count annotated lines as tested" checked
+* :doc:`core-certification:safety-report/code-coverage` shows 100% coverage with "count annotated lines as tested" checked
 * The Specification documents the right version
 * :ref:`release-notes:index`
 
@@ -111,7 +111,7 @@ functionality guarantees in the other release channels as they are not
 production environments.
 
 This section assumes that you have already
-:ref:`published a stable release <internal-procedures:publish-stable>` to the ``dev`` environment.
+:ref:`published a stable release <internal-procedures:manual-release>` to the ``dev`` environment.
 
 Verify that:
 

--- a/ferrocene/doc/qualification-plan/src/validation.rst
+++ b/ferrocene/doc/qualification-plan/src/validation.rst
@@ -110,10 +110,10 @@ channel. As indicated in :doc:`release`, there are no stability or
 functionality guarantees in the other release channels as they are not
 production environments.
 
-To validate a release, the release manager must first publish the release on
-the ``dev`` environment (as described :ref:`in the internal procedures
-<internal-procedures:publish-stable>`), and once published there they must
-manually verify that:
+This section assumes that you have already
+:ref:`published a stable release <internal-procedures:publish-stable>` to the ``dev`` environment.
+
+Verify that:
 
 * All the expected files are present in the release.
 
@@ -122,5 +122,3 @@ manually verify that:
 * The :ref:`documentation-validation` has been performed.
 
 If any of the checks are not satisfactory, the release must be delayed until resolved.
-
-Once all checks are passed, the safety manager digitally signs the release and the release can be published in the production environment.


### PR DESCRIPTION
the previous docs were dense, contradictory, and bounced you rapidly between different sections of the manuals, especially around signing.

this has a bunch of small cleanups, but the real change is that there is now a canonical checklist for release managers to look at when running a release.

i strongly suggest reviewing this commit-by-commit.