### PR TITLE
Use 3-way conflict markers for merge conflicts in subtree pulls

### DIFF
--- a/ferrocene/tools/pull-subtrees/pull.py
+++ b/ferrocene/tools/pull-subtrees/pull.py
@@ -282,6 +282,8 @@ def update_subtree(repo_root, subtree):
             run(
                 [
                     "git",
+                    "-c",
+                    "merge.conflictstyle=diff3",
                     "subtree",
                     "merge",
                     "--prefix",

--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -214,6 +214,10 @@ git checkout "${current_commit}"
 #   remaining, we will want to resolve those using mergiraf -- but it currently
 #   only supports resolving conflicts in the diff3 format, so we set that here.
 #   See https://codeberg.org/mergiraf/mergiraf/issues/593
+#
+#   3-way conflict markers are also useful when manually fixing merge conflicts,
+#   as they make it much easier to see what we had changed vs. the old upstream
+#   and what changed upstream.
 export GIT_COMMITTER_NAME=$(git config --get user.name)
 export GIT_COMMITTER_EMAIL=$(git config --get user.email)
 if ! HOME= XDG_CONFIG_HOME= git -c merge.conflictstyle=diff3 \


### PR DESCRIPTION
We already do this for pulls from rust-lang/rust, just not from the other repositories we use as subtrees. Three-way conflict markers make it much easier to identify the conflicting changes when fixing things by hand.