### PR TITLE
fix: check for Mergiraf resolutions at an appropriate time

### DIFF
--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -342,13 +342,13 @@ then
                 mergiraf solve --keep-backup=false "$file" || true
             done
 
-            # If mergiraf wasn't able to make any progress on the conflict, or if it
-            # encountered an error during the resolution, it will leave the input
-            # file unchanged. Therefore, everything that was changed is good to add.
-            git add .
-
             # Only commit if mergiraf has resolved anything
             if git status --porcelain=v1 | grep "^ M " >/dev/null; then
+                # If mergiraf wasn't able to make any progress on the conflict, or if it
+                # encountered an error during the resolution, it will leave the input
+                # file unchanged. Therefore, everything that was changed is good to add.
+                git add .
+
                 git commit -F- <<EOF
 resolve conflicts using mergiraf
 

--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -425,7 +425,7 @@ echo "pull-upstream: trying to fix ferrocene/doc/symbol-report.csv"
 if ./x.py test ferrocene/doc/symbol-report.csv --stage 1 --bless --set rust.debug-assertions-std=true; then
     commit_if_modified ferrocene/doc/symbol-report.csv "update symbol report"
 else
-    automation_warning "Couldn't regenerate the symbol report. Please run './x test ferrocene/doc/symbol-report.csv --bless' after fixing the conflicts."
+    automation_warning "Couldn't regenerate the symbol report. Please run \`./x test ferrocene/doc/symbol-report.csv --bless\` after fixing the conflicts."
 fi
 
 git branch -D "${TEMP_BRANCH}"


### PR DESCRIPTION
Turns out my fix in https://github.com/ferrocene/ferrocene/pull/2367 was plain wrong...

Previously, if Mergiraf resolved some conflicts, we would stage them, and _then_ run the `status | grep` thing. However, the latter would never match anything: `^ M ` matches files modified in the work tree, and would therefore not see our modified files, which would already be in the staging area.

An alternative fix would be to change the regex to `^M  `, as that one matches precisely the staged modified files; but I figured we could save a tiny bit of work by not `add`ing when there's nothing to `add`.