### PR TITLE
Post 1.95 release follow ups

### DIFF
--- a/ferrocene/doc/release-notes/src/26.05.0.rst
+++ b/ferrocene/doc/release-notes/src/26.05.0.rst
@@ -1,8 +1,6 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
 
-:upcoming-release:
-
 Ferrocene 26.05.0
 =================
 

--- a/ferrocene/doc/release-notes/src/26.05.0.rst
+++ b/ferrocene/doc/release-notes/src/26.05.0.rst
@@ -80,5 +80,5 @@ changes described here describe Rust's support levels, and have no correlation
 to the targets and platforms supported by Ferrocene.
 
 .. rust-changelog::
-    :from: 1.92.0
+    :from: 1.93.0
     :to: 1.95.0


### PR DESCRIPTION
Post release follow up from https://public-docs.ferrocene.dev/main/qualification/internal-procedures/release/stable.html#remove-upcoming-notes-in-the-main-branch

Also a tiny forward port.