### PR TITLE
Pessimistic line coverage

### DIFF
--- a/ferrocene/tools/blanket/src/main.rs
+++ b/ferrocene/tools/blanket/src/main.rs
@@ -259,10 +259,17 @@ fn get_coverage(
     let mut covered = vec![];
 
     for line in source_lines {
+        let lower_hit_bound = func_coverage
+            .hits
+            .iter()
+            .filter(|(location, _)| location.line_start <= line && location.line_end >= line)
+            .map(|(_, hit_count)| *hit_count)
+            .reduce(usize::min);
         // one more thing to do: within a function, some lines will always be uncovered (e.g. }
         // closing braces). so we do have to trust the coverage tool to report those accurately.
-        let status = match func_coverage.hits_for_line(line) {
+        let status = match lower_hit_bound {
             None => LineCoverageStatus::Ignored,
+            // At least one of the code regions within this line has no hits
             Some(0) => LineCoverageStatus::Untested,
             Some(_) => LineCoverageStatus::Tested,
         };


### PR DESCRIPTION
`llvm_profparser` looks for all regions within line and if one of them has been hit it would count the whole line as hit.

We only want to count lines that have *all* their regions covered.

Note that the `hits` map does *not* record a region kind, so technically if there's a region with some kind other than `Code` and it has hits we will still count it.