### PR TITLE
fixes in qualification docs

### DIFF
--- a/ferrocene/doc/qnx8-manual/src/targets/index.rst
+++ b/ferrocene/doc/qnx8-manual/src/targets/index.rst
@@ -25,17 +25,17 @@ Qualified QNX8 targets
      - Standard library
      - Notes
 
-   * - :target:`x86_64-unknown-linux-gnu`
-     - :target:`aarch64-unknown-qnx`
-     - ``core``
-     - ``alloc``, ``std``, ``test``
-     - ``proc_macro``
+   * - :ref:`aarch64-unknown-qnx`
+     - ``aarch64-unknown-qnx``
+     - Cross-compilation
+     - Full
+     - Only qualified when cross-compiled from :ref:`x86_64-unknown-linux-gnu`.
 
-   * - :target:`x86_64-unknown-linux-gnu`
-     - :target:`x86_64-pc-qnx`
-     - ``core``
-     - ``alloc``, ``std``, ``test``
-     - ``proc_macro``
+   * - :ref:`x86_64-pc-qnx`
+     - ``x86_64-pc-qnx``
+     - Cross-compilation
+     - Full
+     - Only qualified when cross-compiled from :ref:`x86_64-unknown-linux-gnu`.
 
 
 Unsupported targets

--- a/ferrocene/doc/rhivos-manual/src/scope.rst
+++ b/ferrocene/doc/rhivos-manual/src/scope.rst
@@ -25,5 +25,5 @@ This qualification is restricted to the following environment:
    * - :target:`aarch64-unknown-linux-gnu`
      - :target:`aarch64-rhivos2-linux-gnu`
      - ``core``
-     - ``alloc``
-     -
+     - ``alloc``, ``std``, ``test``
+     - ``proc_macro``


### PR DESCRIPTION
- in QNX8, the contents of the target overview were incorrectly copy pasted from the qualification scope page
- the qualification scope of the RHIVOS manual indicated that the target was bare metal but it actually has a full standard library