### PR TITLE
fix llvm rebuild

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,9 @@ jobs:
           command: |
             ferrocene/ci/scripts/calculate_parameters.py > /tmp/continue-parameters.json
             cat /tmp/continue-parameters.json
+          environment:
+            FULL_BUILD_X86_64_WINDOWS_MSVC: << pipeline.parameters.full-build-x86_64-pc-windows-msvc-host >>
+            FULL_BUILD_AARCH64_DARWIN: << pipeline.parameters.full-build-aarch64-darwin-host >>
 
       - continuation/continue:
           configuration_path: .circleci/workflows.yml

--- a/ferrocene/ci/docker-images/common/setup-awscli.sh
+++ b/ferrocene/ci/docker-images/common/setup-awscli.sh
@@ -1,10 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: The Ferrocene Developers
 
 rm -rf /tmp/awscli /tmp/awscli.zip
 set -xe
+set -o pipefail
 
 mkdir /tmp/awscli && cd /tmp/awscli
 
@@ -59,7 +60,7 @@ VERSION=$(cat /tmp/awscli-version)
 PACKAGE_URL="https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}-${VERSION}.zip"
 
 curl -Lo awscliv2.sig "${PACKAGE_URL}.sig"
-curl -Lo "awscliv2.zip" $PACKAGE_URL
+curl -Lo "awscliv2.zip" "$PACKAGE_URL"
 gpg --verify awscliv2.sig awscliv2.zip
 
 unzip -q -d /tmp/awscli awscliv2.zip
@@ -68,6 +69,6 @@ unzip -q -d /tmp/awscli awscliv2.zip
 rm -rf /tmp/awscli awscliv2.zip awscliv2.sig
 
 # some of our environments record all downloaded packages here
-if [ test -x "/ferrocene/packages" ]; then
+if [ -x "/ferrocene/packages" ]; then
     echo "$SHA $PACKAGE_URL" >> /ferrocene/packages/downloads
 fi

--- a/ferrocene/ci/scripts/calculate_parameters.py
+++ b/ferrocene/ci/scripts/calculate_parameters.py
@@ -123,6 +123,11 @@ ecr = boto3.client("ecr", region_name=ECR_REGION)
 with open(CIRCLECI_CONFIGURATION) as f:
     config: dict[str, dict[str, str]] = yaml.safe_load(f)
 
+full_build: dict[str, bool] = {
+    "x86_64-pc-windows-msvc": os.environ["FULL_BUILD_X86_64_WINDOWS_MSVC"] == "true",
+    "aarch64-apple-darwin": os.environ["FULL_BUILD_AARCH64_DARWIN"] == "true",
+}
+
 
 def calculate_docker_repository_url(repo: str) -> str:
     """
@@ -139,16 +144,23 @@ def calculate_llvm_rebuild(*dummy: str):
     """
     Calculates the value of parameters starting with `llvm-rebuild--`
     """
+    not_found = 0
     for jobname in config["jobs"]:
         target = jobname.removeprefix("llvm--")
-        if jobname is not target:
+        if jobname != target and (
+            target not in full_build or full_build[target] is True
+        ):
             url: urllib.parse.ParseResult = llvm_cache.get_s3_url(target)
             assert url.scheme == "s3"
             try:
                 s3.head_object(Bucket=url.netloc, Key=url.path.removeprefix("/"))
             except s3.exceptions.ClientError:
-                return True
-    return False
+                print(
+                    f"missing llvm artifact for {target}: {url.geturl()}",
+                    file=sys.stderr,
+                )
+                not_found += 1
+    return not_found > 0
 
 
 def calculate_targets(host_plus_stage: str):

--- a/ferrocene/ci/scripts/utils/src/utils/docker_images.py
+++ b/ferrocene/ci/scripts/utils/src/utils/docker_images.py
@@ -34,11 +34,9 @@ def calculate_hash() -> str:
     # hashes even though the two directories are equal.
     hash = hashlib.sha256()
     for file in sorted(all_files):
+        filename = file.encode("utf-8")
+        hash.update(f"{len(filename)}|{filename}".encode())
         with open(file, "rb") as f:
-            filename = file.encode("utf-8")
-            hash.update(f"{len(filename)}|".encode())
-            hash.update(filename)
-
             contents = f.read()
             hash.update(f"{len(contents)}|".encode())
             hash.update(contents)

--- a/ferrocene/ci/scripts/utils/src/utils/llvm_cache.py
+++ b/ferrocene/ci/scripts/utils/src/utils/llvm_cache.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: The Ferrocene Developers
 
+import functools
 import hashlib
 import subprocess
 import urllib.parse
@@ -18,6 +19,7 @@ def get_s3_url(ferrocene_host):
     return urllib.parse.urlparse(s3_url)
 
 
+@functools.cache
 def get_llvm_cache_hash():
     """
     Calculate a hash of the LLVM source code and all the files that could impact
@@ -33,17 +35,18 @@ def get_llvm_cache_hash():
         "src/version",
     ]
 
-    ls_files_cmd = ["git", "ls-files", "src/bootstrap", "ferrocene/ci/docker-images"]
+    ls_files_cmd = ["git", "ls-files", "src/bootstrap"]
     ls_files = subprocess.run(ls_files_cmd, check=True, capture_output=True, text=True)
     files += ls_files.stdout.split()
 
     files.sort()
     for file in files:
-        # hashlib.file_digest added in 3.11
-        f = open(file, mode="rb")
-        buf = f.read()
-        shasum = hashlib.sha256(buf)
-        m.update(str.encode(shasum.hexdigest()))
+        filename = file.encode("utf-8")
+        m.update(f"{len(filename)}|{filename}".encode())
+        with open(file, "rb") as f:
+            buf = f.read()
+            m.update(f"{len(buf)}|".encode())
+            m.update(buf)
 
     # Hashing all of the LLVM source code takes time. Instead we can simply get
     # the hash of the tree from git, saving time and achieving the same effect.


### PR DESCRIPTION
since #2518 landed, we've been rebuilding LLVM artifacts more often.

The problem is due to not checking for the existence of only the LLVM targets that will be used in the current workflow. assuming LLVM needs to be built for a given git hash, but we're only testing linux targets:
- `llvm-rebuild` will be rightfully `true` on the first run. LLVM needs to be rebuilt for the linux targets
- on the second run, `llvm-rebuild` will be erroneously `false`, since `calculate_parameters.py` checked for the existence of windows and darwin LLVM as well, even though the linux LLVM (the only one we need) is already built

subsequent runs will have the same results as the second.

this PR updates `calculate_parameters.py` to accept `FULL_BUILD_*` environment variables that are used to determine whether to check for the existence of the corresponding llvm artifact.

this PR also sneaks in a few extra changes that should speed up the `calculate_parameters.py` script a slight bit:
- `llvm_cache.get_llvm_cache_hash()` is now memoized, so the script no longer has to hash the contents of all the files used to calculate the llvm cache hash
- `llvm_cache.get_llvm_cache_hash()` also now avoids re-hashing the `ferrocene/ci/docker-images` directory
- `llvm_cache.get_llvm_cache_hash()` also now follows the same pattern for opening/closing files as from `docker_images.py`
- `setup-awscli.sh` had a syntax error, but none of the invocations resulted in a process failure. the syntax failure has been fixed, and the script was changed to bash (over posix sh) so `set -o pipefail` could be added

additionally, `calculate_llvm_rebuild` now informs via stderr which llvm artifacts are missing, for better debugging in the future.