### PR TITLE
fix llvm cache again

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -28,6 +28,9 @@ parameters:
   llvm-rebuild:
     type: boolean
     default: false
+  llvm-hash:
+    type: string
+    default: ""
   targets--x86_64-unknown-linux-gnu--build:
     type: string
     default: ""
@@ -139,7 +142,7 @@ jobs:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       FERROCENE_TARGETS: << pipeline.parameters.targets--x86_64-unknown-linux-gnu--build >>
       SCRIPT: |
-        ferrocene/ci/scripts/llvm_cache.py download
+        ferrocene/ci/scripts/llvm_cache.py --override-hash << pipeline.parameters.llvm-hash >> download
         ./x.py --stage 2 build cargo library src/tools/rustdoc symbol-report
         ./x.py --stage 1 build compiletest coverage-dump src/tools/rustdoc src/tools/run-make-support
     steps: [ferrocene-job-build]
@@ -279,7 +282,7 @@ jobs:
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
       SCRIPT: |
-        ferrocene/ci/scripts/llvm_cache.py download
+        ferrocene/ci/scripts/llvm_cache.py --override-hash << pipeline.parameters.llvm-hash >> download
         ./x.py test --stage=1 --coverage=library library/core library/alloc --tests
     steps:
       - ferrocene/aws_oidc_auth
@@ -295,7 +298,7 @@ jobs:
     resource_class: ferrocene/k8s-amd64-large
     environment:
       FERROCENE_HOST: x86_64-unknown-linux-gnu
-      SCRIPT: ferrocene/ci/scripts/llvm_cache.py prepare
+      SCRIPT: ferrocene/ci/scripts/llvm_cache.py --override-hash << pipeline.parameters.llvm-hash >> prepare
       # This tries to strike a balance between the highest concurrency possible
       # and not running out of memory during a build. If building LLVM fails
       # due to the OOM killer killing the build, decrease this number.
@@ -414,7 +417,7 @@ jobs:
     resource_class: ferrocene/k8s-arm64-large
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
-      SCRIPT: ferrocene/ci/scripts/llvm_cache.py prepare
+      SCRIPT: ferrocene/ci/scripts/llvm_cache.py --override-hash << pipeline.parameters.llvm-hash >> prepare
       # This tries to strike a balance between the highest concurrency possible
       # and not running out of memory during a build. If building LLVM fails
       # due to the OOM killer killing the build, decrease this number.
@@ -437,7 +440,7 @@ jobs:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
       FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-unknown-linux-gnu--build >>
       SCRIPT: |
-        ferrocene/ci/scripts/llvm_cache.py download
+        ferrocene/ci/scripts/llvm_cache.py --override-hash << pipeline.parameters.llvm-hash >> download
         ./x.py --stage 2 build cargo library src/tools/rustdoc symbol-report
         ./x.py --stage 1 build compiletest coverage-dump src/tools/rustdoc src/tools/run-make-support
         ./x build src/tools/remote-test-server --target "aarch64-unknown-linux-gnu,aarch64-rhivos2-linux-gnu" --stage "2"
@@ -487,7 +490,7 @@ jobs:
     environment:
       FERROCENE_HOST: aarch64-unknown-linux-gnu
       SCRIPT: |
-        ferrocene/ci/scripts/llvm_cache.py download
+        ferrocene/ci/scripts/llvm_cache.py --override-hash << pipeline.parameters.llvm-hash >> download
         ./x.py test --stage=1 --coverage=library library/core library/alloc --tests
     steps:
       - ferrocene/aws_oidc_auth
@@ -504,7 +507,7 @@ jobs:
     environment:
       FERROCENE_HOST: aarch64-apple-darwin
       FERROCENE_TARGETS: aarch64-apple-darwin
-      SCRIPT: ferrocene/ci/scripts/llvm_cache.py prepare
+      SCRIPT: ferrocene/ci/scripts/llvm_cache.py --override-hash << pipeline.parameters.llvm-hash >> prepare
       # This tries to strike a balance between the highest concurrency possible
       # and not running out of memory during a build. If building LLVM fails
       # due to using too much memory, decrease this number.
@@ -533,7 +536,7 @@ jobs:
       FERROCENE_HOST: aarch64-apple-darwin
       FERROCENE_TARGETS: << pipeline.parameters.targets--aarch64-apple-darwin--build >>
       SCRIPT: |
-        ferrocene/ci/scripts/llvm_cache.py download
+        ferrocene/ci/scripts/llvm_cache.py --override-hash << pipeline.parameters.llvm-hash >> download
         ./x.py --stage 2 build cargo library src/tools/rustdoc symbol-report
         ./x.py --stage 1 build compiletest coverage-dump src/tools/rustdoc src/tools/run-make-support
     steps:
@@ -650,7 +653,7 @@ jobs:
       FERROCENE_BUILD_HOST: x86_64-pc-windows-msvc
       FERROCENE_HOST: x86_64-pc-windows-msvc
       SCRIPT: |
-        ferrocene/ci/scripts/llvm_cache.py prepare
+        ferrocene/ci/scripts/llvm_cache.py --override-hash << pipeline.parameters.llvm-hash >> prepare
       # This tries to strike a balance between the highest concurrency possible
       # and not running out of memory during a build. If building LLVM fails
       # due to the OOM killer killing the build, decrease this number.
@@ -701,7 +704,7 @@ jobs:
       # time of windows hosts are faster, then the script `ferrocene/ci/scripts/build_cache.py` will
       # be helpful to build/restore the cache.
       SCRIPT: |
-        ferrocene/ci/scripts/llvm_cache.py download
+        ferrocene/ci/scripts/llvm_cache.py --override-hash << pipeline.parameters.llvm-hash >> download
         # See ferrocene/ci/split-tasks.py for a list of tasks executed by this.
         ./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist)
         ./x.py --stage 2 dist $(ferrocene/ci/split-tasks.py dist:tools)

--- a/ferrocene/ci/scripts/calculate_parameters.py
+++ b/ferrocene/ci/scripts/calculate_parameters.py
@@ -128,7 +128,7 @@ FULL_BUILD_TARGET_ENVS = {
     "aarch64-apple-darwin": "FULL_BUILD_AARCH64_DARWIN",
 }
 full_build: dict[str, bool] = {}
-for target, envname in FULL_BUILD_TARGET_ENVS:
+for target, envname in FULL_BUILD_TARGET_ENVS.items():
     try:
         val = os.environ[envname]
         print(f"-> {envname}={val}", file=sys.stderr)

--- a/ferrocene/ci/scripts/calculate_parameters.py
+++ b/ferrocene/ci/scripts/calculate_parameters.py
@@ -123,10 +123,30 @@ ecr = boto3.client("ecr", region_name=ECR_REGION)
 with open(CIRCLECI_CONFIGURATION) as f:
     config: dict[str, dict[str, str]] = yaml.safe_load(f)
 
+try:
+    FULL_BUILD_X86_64_WINDOWS_MSVC = os.environ["FULL_BUILD_X86_64_WINDOWS_MSVC"]
+    print(
+        f"-> FULL_BUILD_X86_64_WINDOWS_MSVC={FULL_BUILD_X86_64_WINDOWS_MSVC}",
+        file=sys.stderr,
+    )
+except KeyError:
+    FULL_BUILD_X86_64_WINDOWS_MSVC = "TRUE"
+
+try:
+    FULL_BUILD_AARCH64_DARWIN = os.environ["FULL_BUILD_AARCH64_DARWIN"]
+    print(
+        f"-> FULL_BUILD_AARCH64_DARWIN={FULL_BUILD_AARCH64_DARWIN}",
+        file=sys.stderr,
+    )
+except KeyError:
+    FULL_BUILD_AARCH64_DARWIN = "TRUE"
+
+TRUTHY = ["1", "TRUE", "True", "true", "YES", "Yes", "yes", "Y", "y"]
 full_build: dict[str, bool] = {
-    "x86_64-pc-windows-msvc": os.environ["FULL_BUILD_X86_64_WINDOWS_MSVC"] == "true",
-    "aarch64-apple-darwin": os.environ["FULL_BUILD_AARCH64_DARWIN"] == "true",
+    "x86_64-pc-windows-msvc": FULL_BUILD_X86_64_WINDOWS_MSVC in TRUTHY,
+    "aarch64-apple-darwin": FULL_BUILD_AARCH64_DARWIN in TRUTHY,
 }
+print(f"-> full_build: {full_build}", file = sys.stderr)
 
 
 def calculate_docker_repository_url(repo: str) -> str:

--- a/ferrocene/ci/scripts/calculate_parameters.py
+++ b/ferrocene/ci/scripts/calculate_parameters.py
@@ -183,6 +183,13 @@ def calculate_llvm_rebuild(*dummy: str):
     return not_found > 0
 
 
+def calculate_llvm_hash(*dummy: str) -> str:
+    """
+    Calculates the value of the `llvm-hash` parameter
+    """
+    return llvm_cache.get_llvm_cache_hash()
+
+
 def calculate_targets(host_plus_stage: str):
     """
     Calculates the list of targets to pass.
@@ -256,6 +263,7 @@ def prepare_parameters():
         "docker-images-hash": lambda _: docker_images.calculate_hash(),
         "docker-repository-url--": calculate_docker_repository_url,
         "llvm-rebuild": calculate_llvm_rebuild,
+        "llvm-hash": calculate_llvm_hash,
         "targets--": calculate_targets,
         "stable-workflow-id": workflow_id,
         "awscli-version": awscli_version,

--- a/ferrocene/ci/scripts/calculate_parameters.py
+++ b/ferrocene/ci/scripts/calculate_parameters.py
@@ -131,13 +131,23 @@ full_build: dict[str, bool] = {}
 for target, envname in FULL_BUILD_TARGET_ENVS:
     try:
         val = os.environ[envname]
-        print(f"-> {envname}={val}", file = sys.stderr)
+        print(f"-> {envname}={val}", file=sys.stderr)
     except KeyError:
-        print(f"-> {envname} unset, defaulting to '1'", file = sys.stderr)
+        print(f"-> {envname} unset, defaulting to '1'", file=sys.stderr)
         val = "1"
-    full_build[target] = val in ("1", "TRUE", "True", "true", "YES", "Yes", "yes", "Y", "y")
+    full_build[target] = val in (
+        "1",
+        "TRUE",
+        "True",
+        "true",
+        "YES",
+        "Yes",
+        "yes",
+        "Y",
+        "y",
+    )
 
-print(f"-> full_build: {full_build}", file = sys.stderr)
+print(f"-> full_build: {full_build}", file=sys.stderr)
 
 
 def calculate_docker_repository_url(repo: str) -> str:

--- a/ferrocene/ci/scripts/calculate_parameters.py
+++ b/ferrocene/ci/scripts/calculate_parameters.py
@@ -123,29 +123,20 @@ ecr = boto3.client("ecr", region_name=ECR_REGION)
 with open(CIRCLECI_CONFIGURATION) as f:
     config: dict[str, dict[str, str]] = yaml.safe_load(f)
 
-try:
-    FULL_BUILD_X86_64_WINDOWS_MSVC = os.environ["FULL_BUILD_X86_64_WINDOWS_MSVC"]
-    print(
-        f"-> FULL_BUILD_X86_64_WINDOWS_MSVC={FULL_BUILD_X86_64_WINDOWS_MSVC}",
-        file=sys.stderr,
-    )
-except KeyError:
-    FULL_BUILD_X86_64_WINDOWS_MSVC = "TRUE"
-
-try:
-    FULL_BUILD_AARCH64_DARWIN = os.environ["FULL_BUILD_AARCH64_DARWIN"]
-    print(
-        f"-> FULL_BUILD_AARCH64_DARWIN={FULL_BUILD_AARCH64_DARWIN}",
-        file=sys.stderr,
-    )
-except KeyError:
-    FULL_BUILD_AARCH64_DARWIN = "TRUE"
-
-TRUTHY = ["1", "TRUE", "True", "true", "YES", "Yes", "yes", "Y", "y"]
-full_build: dict[str, bool] = {
-    "x86_64-pc-windows-msvc": FULL_BUILD_X86_64_WINDOWS_MSVC in TRUTHY,
-    "aarch64-apple-darwin": FULL_BUILD_AARCH64_DARWIN in TRUTHY,
+FULL_BUILD_TARGET_ENVS = {
+    "x86_64-pc-windows-msvc": "FULL_BUILD_X86_64_WINDOWS_MSVC",
+    "aarch64-apple-darwin": "FULL_BUILD_AARCH64_DARWIN",
 }
+full_build: dict[str, bool] = {}
+for target, envname in FULL_BUILD_TARGET_ENVS:
+    try:
+        val = os.environ[envname]
+        print(f"-> {envname}={val}", file = sys.stderr)
+    except KeyError:
+        print(f"-> {envname} unset, defaulting to '1'", file = sys.stderr)
+        val = "1"
+    full_build[target] = val in ("1", "TRUE", "True", "true", "YES", "Yes", "yes", "Y", "y")
+
 print(f"-> full_build: {full_build}", file = sys.stderr)
 
 

--- a/ferrocene/ci/scripts/llvm_cache.py
+++ b/ferrocene/ci/scripts/llvm_cache.py
@@ -67,6 +67,7 @@ def arguments():
         description="Report various data about LLVM caches",
     )
     parser.add_argument("-v", "--verbose", action="count", default=0)
+    parser.add_argument("--override-hash", required=False, default=None)
     subparsers = parser.add_subparsers(dest="subcommand", help="sub-command help")
 
     prepare_parser = subparsers.add_parser("prepare", help="Build and cache LLVM")
@@ -110,32 +111,32 @@ def main():
 
     # match added in 3.10
     if args.subcommand == "s3-url":
-        subcommand_s3_url(ferrocene_host)
+        subcommand_s3_url(ferrocene_host, args.override_hash)
     elif args.subcommand == "download":
-        subcommand_download(ferrocene_host, args.url)
+        subcommand_download(ferrocene_host, args.url, args.override_hash)
     elif args.subcommand == "prepare":
-        subcommand_prepare(ferrocene_host, args.url)
+        subcommand_prepare(ferrocene_host, args.url, args.override_hash)
     else:
         print(f"Unknown command {args.subcommand}")
 
 
-def subcommand_download(ferrocene_host, url):
+def subcommand_download(ferrocene_host, url, override_hash: str|None):
     if url is None:
-        url = llvm_cache.get_s3_url(ferrocene_host).geturl()
+        url = llvm_cache.get_s3_url(ferrocene_host, override_hash).geturl()
 
     cache.retrieve(url, ".")
 
 
-def subcommand_prepare(ferrocene_host, url):
+def subcommand_prepare(ferrocene_host, url, override_hash: str|None):
     if url is None:
-        url = llvm_cache.get_s3_url(ferrocene_host).geturl()
+        url = llvm_cache.get_s3_url(ferrocene_host, override_hash).geturl()
 
     tarball = prepare_llvm_build(ferrocene_host)
     cache.store(url, tarball)
 
 
-def subcommand_s3_url(ferrocene_host):
-    s3_url = llvm_cache.get_s3_url(ferrocene_host)
+def subcommand_s3_url(ferrocene_host, override_hash: str|None):
+    s3_url = llvm_cache.get_s3_url(ferrocene_host, override_hash)
     print(s3_url.geturl())
 
 

--- a/ferrocene/ci/scripts/llvm_cache.py
+++ b/ferrocene/ci/scripts/llvm_cache.py
@@ -120,14 +120,14 @@ def main():
         print(f"Unknown command {args.subcommand}")
 
 
-def subcommand_download(ferrocene_host, url, override_hash: str|None):
+def subcommand_download(ferrocene_host, url, override_hash: str | None):
     if url is None:
         url = llvm_cache.get_s3_url(ferrocene_host, override_hash).geturl()
 
     cache.retrieve(url, ".")
 
 
-def subcommand_prepare(ferrocene_host, url, override_hash: str|None):
+def subcommand_prepare(ferrocene_host, url, override_hash: str | None):
     if url is None:
         url = llvm_cache.get_s3_url(ferrocene_host, override_hash).geturl()
 
@@ -135,7 +135,7 @@ def subcommand_prepare(ferrocene_host, url, override_hash: str|None):
     cache.store(url, tarball)
 
 
-def subcommand_s3_url(ferrocene_host, override_hash: str|None):
+def subcommand_s3_url(ferrocene_host, override_hash: str | None):
     s3_url = llvm_cache.get_s3_url(ferrocene_host, override_hash)
     print(s3_url.geturl())
 

--- a/ferrocene/ci/scripts/utils/src/utils/llvm_cache.py
+++ b/ferrocene/ci/scripts/utils/src/utils/llvm_cache.py
@@ -12,8 +12,8 @@ CACHE_BUCKET = "ferrocene-ci-caches"
 CACHE_PREFIX = "prebuilt-llvm"
 
 
-def get_s3_url(ferrocene_host):
-    cache_hash = get_llvm_cache_hash()
+def get_s3_url(ferrocene_host, override_hash: str|None = None):
+    cache_hash = override_hash or get_llvm_cache_hash()
     cache_file = f"{CACHE_PREFIX}/{ferrocene_host}-{cache_hash}.tar.zst"
     s3_url = f"s3://{CACHE_BUCKET}/{cache_file}"
     return urllib.parse.urlparse(s3_url)

--- a/ferrocene/ci/scripts/utils/src/utils/llvm_cache.py
+++ b/ferrocene/ci/scripts/utils/src/utils/llvm_cache.py
@@ -12,7 +12,7 @@ CACHE_BUCKET = "ferrocene-ci-caches"
 CACHE_PREFIX = "prebuilt-llvm"
 
 
-def get_s3_url(ferrocene_host, override_hash: str|None = None):
+def get_s3_url(ferrocene_host, override_hash: str | None = None):
     cache_hash = override_hash or get_llvm_cache_hash()
     cache_file = f"{CACHE_PREFIX}/{ferrocene_host}-{cache_hash}.tar.zst"
     s3_url = f"s3://{CACHE_BUCKET}/{cache_file}"


### PR DESCRIPTION
i admittedly didn't test enough the detection of `FULL_BUILD_*` environment variables in `calculate_parameters.py` from #2528 

~~apparently, when you set an environment variable to the boolean `true` value in yaml, circleci sets the environment variable to `1` (and `false` becomes `0`).~~ (update: the env var can be any of `"true", "false", "1", "0"`) i'd only been checking for the string `true`, which means that the script was only ever checking for linux artifacts, never windows or darwin

this PR changes the logic that checks the `FULL_BUILD_*` environment variables in `calculate_parameters.py` to check the variables for well-known truthy values instead (to be extra absolutely completely safe)

tests:
1. needs rebuild, only builds linux
   - workflow: https://app.circleci.com/pipelines/github/ferrocene/ferrocene/20080
   - commit: https://github.com/ferrocene/ferrocene/commit/b49487c99472e52e5585ca6b2ad9c695037f6d5f
2. linux is built, macos+windows need rebuilding
   - workflow: https://app.circleci.com/pipelines/github/ferrocene/ferrocene/20086
   - commit: https://github.com/ferrocene/ferrocene/commit/8f8c9b9cf6beef2e5a7a3aaa09f0373327687bd7
3. all are built, rebuild not needed
   - workflow: https://app.circleci.com/pipelines/github/ferrocene/ferrocene/20099
   - commit: https://github.com/ferrocene/ferrocene/commit/a8e8a1fa8adc258bb97c856fb76a300f7cc98f40 (but it's identical to https://github.com/ferrocene/ferrocene/commit/8f8c9b9cf6beef2e5a7a3aaa09f0373327687bd7)