### PR TITLE
Link the `rustc-docs` from the Ferrocene documentation index page

### DIFF
--- a/ferrocene/doc/index/index.html
+++ b/ferrocene/doc/index/index.html
@@ -182,8 +182,12 @@
                         <p>Documentation about all the editions of Rust, and the changes included in each edition.</p>
                     </a>
                     <a href="rustc/index.html">
-                        <h3>rustc documentation</h3>
-                        <p>Documentation about the Rust compiler itself, and the rustc binary.</p>
+                        <h3>The rustc book</h3>
+                        <p>Documentation about the Rust compiler itself, and the <code>rustc</code> binary.</p>
+                    </a>
+                    <a href="rustc-docs/index.html">
+                        <h3>rustc docs</h3>
+                        <p>Documentation about the <code>rustc_*</code> crates the `rustc` compiler consists of.</p>
                     </a>
                     <a href="cargo/index.html">
                         <h3>Cargo documentation</h3>

--- a/src/bootstrap/src/ferrocene/doc/mod.rs
+++ b/src/bootstrap/src/ferrocene/doc/mod.rs
@@ -971,6 +971,15 @@ impl CommandLineStep for Index {
         copy_breadcrumbs_assets(builder, &out);
         builder.create_dir(&assets_out);
         builder.cp_link_r(&index_dir.join("index-assets"), &assets_out);
+
+        // Create a placeholder `rustc-docs/index.html`
+        let rustc_docs_path = out.join("rustc-docs/");
+        builder.create_dir(&rustc_docs_path);
+        std::fs::write(
+            rustc_docs_path.join("index.html"),
+            "Placeholder, will be replaced by rustc when calling <code>./x dist ferrocene-docs</code>.",
+        )
+        .expect("failed to write rustc-docs/index.html");
     }
 }
 


### PR DESCRIPTION
Follow up to https://github.com/ferrocene/ferrocene/pull/2411 which added the rustc docs to the `ferrocene-docs` tarball.

The docs are already available here: https://public-docs.ferrocene.dev/main/rustc-docs/index.html.

# Re: placeholder page

I modified `./x doc ferrocene/doc/index` to generate a placeholder at the path the rustc docs will be in the `ferrocene-docs` tarball. The reason is that `./x doc compiler` places the documentation of the `rustc_*` crates at `../compiler-doc/` relative to the Ferrocene index page. But they are placed at `./rustc-docs/` when building with `./x dist ferrocene-docs`. Placing the compiler docs at `../compiler-doc/` inside the `ferrocene-docs` tarball is not really an option, since this would be outside of `share/doc/ferrocene/html`.

# How to test

Execute both `./x doc ferrocene/doc/index` and `./x dist ferroce-docs` and check that in the first you see the placeholder and in the second you see the actual docs when clicking the link in the index page.