### PR TITLE
Backport ferrocene/ferrocene#2539

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1169,7 +1169,7 @@ workflows:
           tasks: $(ferrocene/ci/split-tasks.py qnx:compiletest-no-only-hosts) $(ferrocene/ci/split-tasks.py test:library)
           test-variant: "2021"
           extra-args: --tests # We do not run cross compiled doctests for this job on this platform, there are segfaults
-          resource-class: large # 4-core
+          resource-class: large.gen3 # 4-core
           requires:
             - x86_64-linux-build
             - build-docker--emulator--x86_64
@@ -1179,7 +1179,7 @@ workflows:
           tasks: $(ferrocene/ci/split-tasks.py qnx:compiletest-no-only-hosts) $(ferrocene/ci/split-tasks.py test:library)
           test-variant: "2021"
           extra-args: --tests # We do not run cross compiled doctests for this job on this platform, there are segfaults
-          resource-class: large # 4-core
+          resource-class: large.gen3 # 4-core
           requires:
             - x86_64-linux-build
             - build-docker--emulator--x86_64
@@ -1271,7 +1271,7 @@ workflows:
           tasks: $(ferrocene/ci/split-tasks.py qnx:compiletest-no-only-hosts) $(ferrocene/ci/split-tasks.py test:library)
           test-variant: "2021"
           extra-args: --tests # We do not run cross compiled doctests for this job on this platform, there are segfaults
-          resource-class: large # 4-core
+          resource-class: large.gen3 # 4-core
           requires:
             - x86_64-linux-build
             - build-docker--emulator--x86_64
@@ -1281,7 +1281,7 @@ workflows:
           tasks:  $(ferrocene/ci/split-tasks.py qnx:compiletest-no-only-hosts) $(ferrocene/ci/split-tasks.py test:library)
           test-variant: "2021"
           extra-args: --tests # We do not run cross compiled doctests for this job on this platform, there are segfaults
-          resource-class: large # 4-core
+          resource-class: large.gen3 # 4-core
           requires:
             - x86_64-linux-build
             - build-docker--emulator--x86_64
@@ -1593,7 +1593,7 @@ commands:
           steps:
             - run:
                 name: Create emulator directory
-                command: mkdir /tmp/emulator
+                command: mkdir -p $HOME/tmp/emulator
 
             - run:
                 name: Prepare emulator
@@ -1604,7 +1604,7 @@ commands:
                     -e SCRIPT="<< parameters.emulator-script >> prepare" \
                     --workdir /project \
                     --volume $(pwd):/project \
-                    --volume /tmp/emulator:/tmp/emulator \
+                    --volume $HOME/tmp/emulator:/tmp/emulator \
                     --volume /tmp/awsjwt:/tmp/awsjwt \
                     --user $(id -u):$(id -g) \
                     --network host \
@@ -1624,7 +1624,7 @@ commands:
                     $(uv run python3 -c "import os; print(' '.join('--env ' + var for var in os.environ if var not in ['HOME', 'LANG', 'SUDO_USER', 'PATH', 'VIRTUAL_ENV']))") \
                     --workdir /project \
                     --volume $(pwd):/project \
-                    --volume /tmp/emulator:/tmp/emulator \
+                    --volume $HOME/tmp/emulator:/tmp/emulator \
                     --volume /tmp/awsjwt:/tmp/awsjwt \
                     --user $(id -u):$(id -g) \
                     --network host \
@@ -1641,7 +1641,7 @@ commands:
               $(uv run python3 -c "import os; print(' '.join('--env ' + var for var in os.environ if var not in ['HOME', 'LANG', 'SUDO_USER', 'PATH', 'VIRTUAL_ENV']))") \
               --workdir /project \
               --volume $(pwd):/project \
-              --volume /tmp/emulator:/tmp/emulator \
+              --volume $HOME/tmp/emulator:/tmp/emulator \
               --volume /tmp/ferrocene:/tmp/ferrocene \
               --user $(id -u):$(id -g) \
               --network host \
@@ -1690,4 +1690,4 @@ commands:
 executors:
   linux-vm:
     machine:
-      image: default
+      image: ubuntu-2604:current


### PR DESCRIPTION
Use newer gen runners for QNX tests

They're faster, cutting the time for a QNX run down to one hour from ~2.

Ferrocene-backport-of: ferrocene/ferrocene#2539
Ferrocene-backported-commits: 538360e98ac7aa6333d65bdc41c82e41e36f4ebd b6624fb64ae8609a2531fa8dd861182174c0bf3c b632517658219e5128d8fcda093f6614bf6bc63a