### PR TITLE
remove ec2_runners config from rust-bors.toml

### DIFF
--- a/rust-bors.toml
+++ b/rust-bors.toml
@@ -78,12 +78,13 @@ auto_build_failed = [
     "-S-waiting-on-team",
 ]
 
-[ec2_runners]
-runner_group_id = 8
-label_prefix = "ec2"
-region = "us-east-2"
-images = {
-    "ubuntu26.04" = "/aws/service/canonical/ubuntu/server/26.04/stable/current/amd64/hvm/ebs-gp3/ami-id"
-}
-jit_runner = "organization"
-allowed_instances = ["c8a.12xlarge"]
+# Remove for ferrocene
+# [ec2_runners]
+# runner_group_id = 8
+# label_prefix = "ec2"
+# region = "us-east-2"
+# images = {
+#     "ubuntu26.04" = "/aws/service/canonical/ubuntu/server/26.04/stable/current/amd64/hvm/ebs-gp3/ami-id"
+# }
+# jit_runner = "organization"
+# allowed_instances = ["c8a.12xlarge"]


### PR DESCRIPTION
this isnt currently handled by our handlebors instance, and in fact breaks it

it's config that only applies to rust-lang/rust anyways...