### PR TITLE
Test: Fix upcoming `std::fs::set_permissions_nofollow` changes for QNX

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3449,10 +3449,9 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// # Platform-specific behavior
 ///
 /// This function currently corresponds to the following underlying operations:
-/// * Linux: `fchmodat` with `AT_SYMLINK_NOFOLLOW` with a fallback behavior to use
-/// `open` with `O_NOFOLLOW` followed by behavior denoted in [`fs::set_permissions`] when
-/// the former `fchmodat` call errors with `ENOTSUP`[^1].
-/// * BSD-based platforms, Android: `fchmodat` with `AT_SYMLINK_NOFOLLOW`
+/// * Linux, BSD-based platforms, Android, QNX: `fchmodat` with `AT_SYMLINK_NOFOLLOW`
+/// with a fallback behavior to use `open` with `O_NOFOLLOW` followed by behavior
+/// denoted in [`fs::set_permissions`] when the former `fchmodat` call errors with `ENOTSUP`[^1].
 /// * Other Unix-based platforms with symlinks: `open` with `O_NOFOLLOW` followed by behavior
 ///   denoted in [`fs::set_permissions`].
 /// * Other Unix-based platforms without symlinks: `open` followed by behavior
@@ -3463,7 +3462,7 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// Note that, this [may change in the future][changes].
 ///
 /// [^1]: Ubuntu 20.04, for example, makes `fchmodat` with `AT_SYMLINK_NOFOLLOW` return `ENOTSUP`
-/// on both symlinks and non-symlinks
+/// on both symlinks and non-symlinks.
 ///
 /// [changes]: io#platform-specific-behavior
 ///
@@ -3477,10 +3476,8 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// * `path` does not exist.
 /// * The user lacks the permission to change attributes of the file.
 ///
-/// Note: On Linux, this will result in an [`Unsupported`] error
-/// if the final element is a symlink. On other Unix-based platforms
-/// with symlinks (non-BSD-based), this will result in a [`FilesystemLoop`]
-/// error.
+/// Note: On Linux and other Unix-based platforms with symlinks (non-BSD-based),
+/// this will result in an [`Unsupported`] error if the final element is a symlink.
 ///
 /// [`Unsupported`]: crate::io::ErrorKind::Unsupported
 /// [`FilesystemLoop`]: crate::io::ErrorKind::FilesystemLoop

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3449,17 +3449,24 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// # Platform-specific behavior
 ///
 /// This function currently corresponds to the following underlying operations:
-/// * Linux, BSD-based platforms, Android: `fchmodat` with `AT_SYMLINK_NOFOLLOW`.
+/// * Linux: `fchmodat` with `AT_SYMLINK_NOFOLLOW` with a fallback behavior to use
+/// `open` with `O_NOFOLLOW` followed by behavior denoted in [`fs::set_permissions`] when
+/// the former `fchmodat` call errors with `ENOTSUP`[^1].
+/// * BSD-based platforms, Android: `fchmodat` with `AT_SYMLINK_NOFOLLOW`
 /// * Other Unix-based platforms with symlinks: `open` with `O_NOFOLLOW` followed by behavior
 ///   denoted in [`fs::set_permissions`].
-/// * Other Unix-based platforms without symlinks: `open` with followed by behavior
+/// * Other Unix-based platforms without symlinks: `open` followed by behavior
 ///   denoted in [`fs::set_permissions`].
 /// * Windows: `CreateFileW` with `FILE_FLAG_OPEN_REPARSE_POINT` followed
 ///   by `SetFileInformationByHandle`.
 ///
 /// Note that, this [may change in the future][changes].
 ///
+/// [^1]: Ubuntu 20.04, for example, makes `fchmodat` with `AT_SYMLINK_NOFOLLOW` return `ENOTSUP`
+/// on both symlinks and non-symlinks
+///
 /// [changes]: io#platform-specific-behavior
+///
 /// [`fs::set_permissions`]: crate::fs::set_permissions
 ///
 /// # Errors
@@ -3472,11 +3479,11 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 ///
 /// Note: On Linux, this will result in an [`Unsupported`] error
 /// if the final element is a symlink. On other Unix-based platforms
-/// with symlinks (non-BSD-based), this will result in an [`InvalidInput`]
+/// with symlinks (non-BSD-based), this will result in a [`FilesystemLoop`]
 /// error.
 ///
 /// [`Unsupported`]: crate::io::ErrorKind::Unsupported
-/// [`InvalidInput`]: crate::io::ErrorKind::InvalidInput
+/// [`FilesystemLoop`]: crate::io::ErrorKind::FilesystemLoop
 ///
 /// # Examples
 ///

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3449,15 +3449,18 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// # Platform-specific behavior
 ///
 /// This function currently corresponds to the following underlying operations:
-/// * WASI: `open` with `O_NOFOLLOW` followed by `fchmod`.
-/// * Unix: `fchmodat` with `AT_SYMLINK_NOFOLLOW` (or no flag is set if `AT_SYMLINK_NOFOLLOW` does
-///   not exist on a specific Unix-based platform)
+/// * Linux, BSD-based platforms, Android: `fchmodat` with `AT_SYMLINK_NOFOLLOW`.
+/// * Other Unix-based platforms with symlinks: `open` with `O_NOFOLLOW` followed by behavior
+///   denoted in [`fs::set_permissions`].
+/// * Other Unix-based platforms without symlinks: `open` with followed by behavior
+///   denoted in [`fs::set_permissions`].
 /// * Windows: `CreateFileW` with `FILE_FLAG_OPEN_REPARSE_POINT` followed
 ///   by `SetFileInformationByHandle`.
 ///
 /// Note that, this [may change in the future][changes].
 ///
 /// [changes]: io#platform-specific-behavior
+/// [`fs::set_permissions`]: crate::fs::set_permissions
 ///
 /// # Errors
 ///
@@ -3467,12 +3470,13 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// * `path` does not exist.
 /// * The user lacks the permission to change attributes of the file.
 ///
-/// Note: On Linux, this will result in a [`Unsupported`] error
-/// if the final element is a symlink. On BSD-based systems, the
-/// behavior in this case can vary: the operation may have no effect at all
-/// or it may change the permission bits of the symlink itself.
+/// Note: On Linux, this will result in an [`Unsupported`] error
+/// if the final element is a symlink. On other Unix-based platforms
+/// with symlinks (non-BSD-based), this will result in an [`InvalidInput`]
+/// error.
 ///
 /// [`Unsupported`]: crate::io::ErrorKind::Unsupported
+/// [`InvalidInput`]: crate::io::ErrorKind::InvalidInput
 ///
 /// # Examples
 ///
@@ -3483,9 +3487,8 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// fn main() -> std::io::Result<()> {
 ///     let mut perms = fs::symlink_metadata("foo.txt")?.permissions();
 ///     perms.set_readonly(true);
-///     // This should result in an error on certain platforms,
-///     // succeed in modifying the permissions of a symlink,
-///     // or do nothing at all.
+///     // This should result in an error on certain platforms or
+///     // succeed in modifying the permissions of a symlink
 ///     fs::set_permissions_nofollow("foo.txt", perms)?;
 ///     Ok(())
 /// }

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3448,17 +3448,12 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 ///
 /// # Platform-specific behavior
 ///
-/// This function currently corresponds to:
-/// * `open` with `O_NOFOLLOW` flag enabled + `fchmod` on WASI
-/// * `fchmodat` function with the flag `AT_SYMLINK_NOFOLLOW` enabled
-///   on Unix platforms
-/// * The flag `FILE_FLAG_OPEN_REPARSE_POINT` is enabled and then the
-///   permissions of the file is set through `SetFileInformationByHandle`
-///   on Windows.
-/// * On all other platforms, the behavior remains the same with
-/// [`fs::set_permissions`].
-///
-/// [`fs::set_permissions`]: crate::fs::set_permissions
+/// This function currently corresponds to the following underlying operations:
+/// * WASI: `open` with `O_NOFOLLOW` followed by `fchmod`.
+/// * Unix: `fchmodat` with `AT_SYMLINK_NOFOLLOW` (or no flag is set if `AT_SYMLINK_NOFOLLOW` does
+///   not exist on a specific Unix-based platform)
+/// * Windows: `CreateFileW` with `FILE_FLAG_OPEN_REPARSE_POINT` followed
+///   by `SetFileInformationByHandle`.
 ///
 /// Note that, this [may change in the future][changes].
 ///
@@ -3474,8 +3469,8 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 ///
 /// Note: On Linux, this will result in a [`Unsupported`] error
 /// if the final element is a symlink. On BSD-based systems, the
-/// behavior can vary from symlink permission bits changing or
-/// there being no effects on symlinks
+/// behavior in this case can vary: the operation may have no effect at all
+/// or it may change the permission bits of the symlink itself.
 ///
 /// [`Unsupported`]: crate::io::ErrorKind::Unsupported
 ///
@@ -3488,8 +3483,9 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// fn main() -> std::io::Result<()> {
 ///     let mut perms = fs::symlink_metadata("foo.txt")?.permissions();
 ///     perms.set_readonly(true);
-///     // This should result in an error on certain platforms
-///     // or succeed in modifying the permissions of a symlink
+///     // This should result in an error on certain platforms,
+///     // succeed in modifying the permissions of a symlink,
+///     // or do nothing at all.
 ///     fs::set_permissions_nofollow("foo.txt", perms)?;
 ///     Ok(())
 /// }

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -671,7 +671,7 @@ fn set_get_permissions_nofollows_symlink() {
     let result = fs::set_permissions_nofollow(&symlink_name, permission_bits);
 
     cfg_select! {
-        any(windows, target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly") => {
+        any(windows, target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "nto", target_os = "qnx") => {
             assert_eq!(result.unwrap(), ());
             let metadata0 = check!(fs::symlink_metadata(&symlink_name));
             // On these systems, it's confirmed the symlink itself is marked readonly

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -673,14 +673,9 @@ fn set_get_permissions_nofollows_symlink() {
               target_os = "nto", target_os = "qnx") => {
             assert_eq!(result.unwrap(), ());
             let metadata0 = check!(fs::symlink_metadata(&symlink_name));
-            // So seems like BSD-based systems trying to set permissions
-            // on symlinks could lead to no effect, so we should expect
-            // there being no change to BSD-based systems.
+            // On these systems, it's confirmed the symlink itself is marked readonly
             // https://superuser.com/questions/1099634/change-permissions-symbolic-link-mac-os
-            #[cfg(windows)]
             assert!(metadata0.permissions().readonly());
-            #[cfg(not(windows))]
-            assert!(!metadata0.permissions().readonly());
 
             // Reset the read-only bit under Windows 7: avoids the
             // `TempDir::drop` from crashing on a permission denial when

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -649,7 +649,10 @@ fn set_get_permissions_nofollows() {
 
 // Only Windows and Unix support `fs::set_permissions_nofollow`
 #[test]
-#[cfg(all(any(windows, unix), not(any(target_os = "espidf", target_os = "horizon"))))]
+#[cfg(all(
+    any(windows, unix),
+    not(any(target_os = "espidf", target_os = "horizon", target_os = "wasi"))
+))]
 fn set_get_permissions_nofollows_symlink() {
     #[cfg(not(windows))]
     use crate::os::unix::fs::symlink as symlink_dir;
@@ -668,9 +671,7 @@ fn set_get_permissions_nofollows_symlink() {
     let result = fs::set_permissions_nofollow(&symlink_name, permission_bits);
 
     cfg_select! {
-        any(windows, target_os = "android", target_os = "macos", target_os = "freebsd",
-              target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly",
-              target_os = "nto", target_os = "qnx") => {
+        any(windows, target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly") => {
             assert_eq!(result.unwrap(), ());
             let metadata0 = check!(fs::symlink_metadata(&symlink_name));
             // On these systems, it's confirmed the symlink itself is marked readonly

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2377,7 +2377,7 @@ pub struct NormalizeError;
 impl Path {
     // The following (private!) function allows construction of a path from a u8
     // slice, which is only safe when it is known to follow the OsStr encoding.
-    unsafe fn from_u8_slice(s: &[u8]) -> &Path {
+    pub(crate) unsafe fn from_u8_slice(s: &[u8]) -> &Path {
         unsafe { Path::new(OsStr::from_encoded_bytes_unchecked(s)) }
     }
     // The following (private!) function reveals the byte encoding used for OsStr.

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2036,77 +2036,76 @@ pub fn set_perm(p: &CStr, perm: FilePermissions) -> io::Result<()> {
 }
 
 pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
-    cfg_select! {
-        target_os = "linux" => {
-            let res = cvt_r(|| unsafe {
-                libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
-            })
-            .map(|_| ());
+    #[inline]
+    /// Helper function for fallback open with `O_NOFOLLOW` + `fchmod` behavior
+    fn open_and_set_permissions(p: &CStr, perm: FilePermissions) -> io::Result<()> {
+        use crate::fs::{OpenOptions, Permissions};
 
-            match res {
-                Ok(_) => return Ok(()),
-                Err(err) => {
-                    if err.kind() == crate::io::ErrorKind::Unsupported {
-                        use crate::fs::OpenOptions;
-                        use crate::fs::Permissions;
-                        use crate::os::unix::ffi::OsStrExt;
-                        use crate::os::unix::fs::OpenOptionsExt;
+        let mut options = OpenOptions::new();
 
-                        let mut options = OpenOptions::new();
-                        options.read(true).custom_flags(libc::O_NOFOLLOW);
+        // ESP-IDF and Horizon do not support O_NOFOLLOW, so we skip setting it.
+        // Their filesystems do not have symbolic links, so no special handling is required.
+        #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
+        {
+            #[cfg(not(target_os = "wasi"))]
+            use crate::os::unix::fs::OpenOptionsExt;
+            #[cfg(target_os = "wasi")]
+            use crate::os::wasi::fs::OpenOptionsExt;
+            options.read(true).custom_flags(libc::O_NOFOLLOW);
+        }
 
-                        let os_str = OsStr::from_bytes(p.to_bytes());
-                        let path = Path::new(os_str);
-                        match options.open(path) {
-                            Ok(file) => {
-                                return file.set_permissions(Permissions::from_inner(perm));
-                            },
-                            Err(e) => {
-                                if e.kind() == crate::io::ErrorKind::FilesystemLoop {
-                                    // When O_NOFOLLOW flag is enabled, if the trailing component of
-                                    // a path is a symbolic link, open should fail with ELOOP error
-                                    // For consistency with other Linux distributions, we return
-                                    // `ErrorKind::Unsupported`.
-                                    return Err(err);
-                                }
-                                return Err(e);
-                            }
+        #[cfg(not(target_os = "wasi"))]
+        use crate::os::unix::ffi::OsStrExt;
+        #[cfg(target_os = "wasi")]
+        use crate::os::wasi::ffi::OsStrExt;
+
+        let os_str = OsStr::from_bytes(p.to_bytes());
+        options.open(Path::new(os_str))?.set_permissions(Permissions::from_inner(perm))
+    }
+
+    let mut _res: Result<(), core::io::Error> = Err(crate::io::ErrorKind::Unsupported.into());
+
+    // These platforms support `fchmodat`, so utilize this syscall over `open` + `fchmod`
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+        target_os = "android",
+        target_os = "qnx"
+    ))]
+    {
+        _res = cvt_r(|| unsafe {
+            libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
+        })
+        .map(|_| ());
+    }
+
+    // If fchmodat fails with `ErrorKind::Unsupported` fallback to using open + fchmod. This is just in case
+    // for older systems like Ubuntu 20.04 where fchmodat fails with EOPNOTSUPP on both regular files and
+    // symlinks when AT_SYMLINK_NOFOLLOW is passed in.
+    match _res {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            if err.kind() == crate::io::ErrorKind::Unsupported {
+                match open_and_set_permissions(p, perm) {
+                    Ok(_) => return Ok(()),
+                    Err(e) => {
+                        if e.kind() == crate::io::ErrorKind::FilesystemLoop {
+                            // When O_NOFOLLOW flag is enabled, if the trailing component of
+                            // a path is a symbolic link, open should fail with ELOOP error.
+                            // For consistency with other Linux distributions, we return
+                            // `ErrorKind::Unsupported`.
+                            return Err(err);
                         }
+                        return Err(e);
                     }
-
-                    return Err(err);
                 }
             }
-        }
-        any(target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "android") => {
-            cvt_r(|| unsafe {
-                libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
-            })
-            .map(|_| ())
-        },
-        // Not all targets support fchmodat, so we fall back to
-        // open + fchmod.
-        _ => {
-            use crate::fs::OpenOptions;
-            use crate::fs::Permissions;
-            let mut options = OpenOptions::new();
-            // ESP-IDF and Horizon do not support O_NOFOLLOW, so we skip setting it.
-            // Their filesystems do not have symbolic links, so no special handling is required.
-            #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
-            {
-                #[cfg(target_os = "wasi")]
-                use crate::os::wasi::fs::OpenOptionsExt;
-                #[cfg(not(target_os = "wasi"))]
-                use crate::os::unix::fs::OpenOptionsExt;
-                options.read(true).custom_flags(libc::O_NOFOLLOW);
-            }
 
-            // SAFETY: Since this function is called with `with_native_path`
-            // and that successfully converted the `&Path` to a `CString`, it
-            // should be safe to slice away the nul byte from `&CStr` and convert
-            // it back to a `&Path`.
-            let path = unsafe { Path::from_u8_slice(p.to_bytes()) };
-            options.open(path)?.set_permissions(Permissions::from_inner(perm))
+            Err(err)
         }
     }
 }

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2037,7 +2037,48 @@ pub fn set_perm(p: &CStr, perm: FilePermissions) -> io::Result<()> {
 
 pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
     cfg_select! {
-        any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "android") => {
+        target_os = "linux" => {
+            let res = cvt_r(|| unsafe {
+                libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
+            })
+            .map(|_| ());
+
+            match res {
+                Ok(_) => return Ok(()),
+                Err(err) => {
+                    if err.kind() == crate::io::ErrorKind::Unsupported {
+                        use crate::fs::OpenOptions;
+                        use crate::fs::Permissions;
+                        use crate::os::unix::ffi::OsStrExt;
+                        use crate::os::unix::fs::OpenOptionsExt;
+
+                        let mut options = OpenOptions::new();
+                        options.read(true).custom_flags(libc::O_NOFOLLOW);
+
+                        let os_str = OsStr::from_bytes(p.to_bytes());
+                        let path = Path::new(os_str);
+                        match options.open(path) {
+                            Ok(file) => {
+                                return file.set_permissions(Permissions::from_inner(perm));
+                            },
+                            Err(e) => {
+                                if e.kind() == crate::io::ErrorKind::FilesystemLoop {
+                                    // When O_NOFOLLOW flag is enabled, if the trailing component of
+                                    // a path is a symbolic link, open should fail with ELOOP error
+                                    // For consistency with other Linux distributions, we return
+                                    // `ErrorKind::Unsupported`.
+                                    return Err(err);
+                                }
+                                return Err(e);
+                            }
+                        }
+                    }
+
+                    return Err(err);
+                }
+            }
+        }
+        any(target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "android") => {
             cvt_r(|| unsafe {
                 libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
             })
@@ -2057,7 +2098,7 @@ pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
                 use crate::os::wasi::fs::OpenOptionsExt;
                 #[cfg(not(target_os = "wasi"))]
                 use crate::os::unix::fs::OpenOptionsExt;
-                options.custom_flags(libc::O_NOFOLLOW);
+                options.read(true).custom_flags(libc::O_NOFOLLOW);
             }
 
             // SAFETY: Since this function is called with `with_native_path`

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -450,6 +450,27 @@ pub struct DirEntry {
     name: crate::ffi::CString,
 }
 
+#[cfg(not(any(
+    target_os = "aix",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "hurd",
+    target_os = "illumos",
+    target_os = "linux",
+    target_os = "nto",
+    target_os = "qnx",
+    target_os = "redox",
+    target_os = "solaris",
+    target_os = "vita",
+    target_os = "wasi",
+)))]
+pub struct DirEntry {
+    dir: Arc<InnerReadDir>,
+    // The full entry includes a fixed-length `d_name`.
+    entry: dirent64,
+}
+
 // Define a minimal subset of fields we need from `dirent64`, especially since
 // we're not using the immediate `d_name` on these targets. Keeping this as an
 // `entry` field in `DirEntry` helps reduce the `cfg` boilerplate elsewhere.
@@ -479,27 +500,6 @@ struct dirent64_min {
         target_os = "vita",
     )))]
     d_type: u8,
-}
-
-#[cfg(not(any(
-    target_os = "aix",
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "hurd",
-    target_os = "illumos",
-    target_os = "linux",
-    target_os = "nto",
-    target_os = "qnx",
-    target_os = "redox",
-    target_os = "solaris",
-    target_os = "vita",
-    target_os = "wasi",
-)))]
-pub struct DirEntry {
-    dir: Arc<InnerReadDir>,
-    // The full entry includes a fixed-length `d_name`.
-    entry: dirent64,
 }
 
 #[derive(Clone)]
@@ -2036,38 +2036,36 @@ pub fn set_perm(p: &CStr, perm: FilePermissions) -> io::Result<()> {
 }
 
 pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
-    // ESP-IDF and Horizon do not support O_NOFOLLOW, so we skip setting it.
-    // Their filesystems do not have symbolic links, so no special handling is required.
     cfg_select! {
-        // wasm32-wasip1 targets do not support fchmodat, so we fall down to
-        // open + fchmod
-        target_os = "wasi" => {
-            use crate::fs::OpenOptions;
-            use crate::fs::Permissions;
-            use crate::os::wasi::ffi::OsStrExt;
-            use crate::os::wasi::fs::OpenOptionsExt;
-
-            let mut options = OpenOptions::new();
-            options.custom_flags(libc::O_NOFOLLOW);
-
-            let bytes = p.to_bytes();
-            let os_str = OsStr::from_bytes(bytes);
-            options.open(Path::new(os_str))?.set_permissions(Permissions::from_inner(perm))
-        }
-
-        all(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "android"), not(any(target_os = "espidf", target_os = "horizon"))) => {
+        any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "android") => {
             cvt_r(|| unsafe {
                 libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
             })
             .map(|_| ())
         },
+        // Not all targets support fchmodat, so we fall back to
+        // open + fchmod.
         _ => {
-            // These platforms do not have `AT_SYMLINK_NOFOLLOW` but support fchmodat,
-            // so no flag is set for fchmodat.
-            cvt_r(|| unsafe {
-                libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, 0)
-            })
-            .map(|_| ())
+            use crate::fs::OpenOptions;
+            use crate::fs::Permissions;
+            let mut options = OpenOptions::new();
+            // ESP-IDF and Horizon do not support O_NOFOLLOW, so we skip setting it.
+            // Their filesystems do not have symbolic links, so no special handling is required.
+            #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
+            {
+                #[cfg(target_os = "wasi")]
+                use crate::os::wasi::fs::OpenOptionsExt;
+                #[cfg(not(target_os = "wasi"))]
+                use crate::os::unix::fs::OpenOptionsExt;
+                options.custom_flags(libc::O_NOFOLLOW);
+            }
+
+            // SAFETY: Since this function is called with `with_native_path`
+            // and that successfully converted the `&Path` to a `CString`, it
+            // should be safe to slice away the nul byte from `&CStr` and convert
+            // it back to a `&Path`.
+            let path = unsafe { Path::from_u8_slice(p.to_bytes()) };
+            options.open(path)?.set_permissions(Permissions::from_inner(perm))
         }
     }
 }

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2054,38 +2054,16 @@ pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
             let os_str = OsStr::from_bytes(bytes);
             options.open(Path::new(os_str))?.set_permissions(Permissions::from_inner(perm))
         }
-        all(target_os = "linux", not(any(target_os = "espidf", target_os = "horizon"))) => {
-            // Ferrocene addition: `fchmod` with `flags=AT_SYMLINK_NOFOLLOW` does not work on Ubuntu
-            // 20.04; support was added somewhere between this and 24.04
-            // Fall back to open + fchmod to support older distros.
-            use crate::fs::OpenOptions;
-            use crate::fs::Permissions;
-            use crate::os::unix::ffi::OsStrExt;
-            use crate::os::unix::fs::OpenOptionsExt;
 
-            let mut options = OpenOptions::new();
-            options.read(true).custom_flags(libc::O_NOFOLLOW);
-
-            let bytes = p.to_bytes();
-            let os_str = OsStr::from_bytes(bytes);
-
-            match options.open(Path::new(os_str)) {
-                Ok(file) => {
-                    file.set_permissions(Permissions::from_inner(perm))
-                },
-                Err(e) => {
-                    if e.kind() == crate::io::ErrorKind::FilesystemLoop {
-                        // This means the requested file was a symlink
-                        // Remap to Unsupported to match expected behaviour on other platforms
-                        Err(io::Error::from_raw_os_error(libc::ENOTSUP))
-                    } else {
-                        // Return other errors as-is
-                        Err(e)
-                    }
-                }
-            }
+        all(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "android"), not(any(target_os = "espidf", target_os = "horizon"))) => {
+            cvt_r(|| unsafe {
+                libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
+            })
+            .map(|_| ())
         },
         _ => {
+            // These platforms do not have `AT_SYMLINK_NOFOLLOW` but support fchmodat,
+            // so no flag is set for fchmodat.
             cvt_r(|| unsafe {
                 libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, 0)
             })

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2074,7 +2074,8 @@ pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
         target_os = "netbsd",
         target_os = "dragonfly",
         target_os = "android",
-        target_os = "qnx"
+        target_os = "nto",
+        target_os = "qnx",
     ))]
     {
         _res = cvt_r(|| unsafe {


### PR DESCRIPTION
Bring https://github.com/rust-lang/rust/pull/160170 over to ferrocene so I can run it under our CI