### PR TITLE
[869f2wya4] show covered regions for partially tested lines

### DIFF
--- a/ferrocene/tools/blanket/assets/html_report.css
+++ b/ferrocene/tools/blanket/assets/html_report.css
@@ -5,6 +5,7 @@
     --var-partial: #B3589A;
     --var-annotated: #BE8239;
     --var-ignored: gray;
+    --var-region-tested-bg: color-mix(in srgb, var(--var-tested) 35%, transparent);
     --var-untested-annotated: var(--var-untested);
     --var-partial-annotated: var(--var-partial);
     --var-annotated-text: none;
@@ -156,6 +157,11 @@ details.partial-annotation summary::after {
     padding-right: 0.5rem;
     color: white;
     background-color: var(--var-untested);
+}
+
+.functions .line-untested .region-tested {
+    background-color: var(--var-region-tested-bg);
+    border-radius: 2px;
 }
 
 .functions .line-ignored {

--- a/ferrocene/tools/blanket/assets/html_report.js
+++ b/ferrocene/tools/blanket/assets/html_report.js
@@ -82,8 +82,8 @@ function main() {
     }
     for (elem of document.querySelectorAll(".line")) {
         elem.addEventListener("click", async event => {
-            let filename = event.target.dataset.filename;
-            let linenum = event.target.dataset.linenum;
+            let filename = event.currentTarget.dataset.filename;
+            let linenum = event.currentTarget.dataset.linenum;
             await navigator.clipboard.writeText(`${filename}:${linenum}`);
         });
     }

--- a/ferrocene/tools/blanket/src/html_report.rs
+++ b/ferrocene/tools/blanket/src/html_report.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use maud::{DOCTYPE, PreEscaped};
 
-use crate::{Annotated, FunctionCoverage, FunctionCoverageStatus, LineCoverageStatus};
+use crate::{Annotated, ColumnRange, FunctionCoverage, FunctionCoverageStatus, LineCoverageStatus};
 
 const CSS: &str = include_str!("../assets/html_report.css");
 const JS: &str = include_str!("../assets/html_report.js");
@@ -217,7 +217,14 @@ fn generate_function(
                                     (line) "\n"
                                 },
                                 LineCoverageStatus::Untested => span class="line line-untested" data-filename=(filename) data-linenum=(linenum) {
-                                    (line) "\n"
+                                    @for (chunk, tested) in line_runs(line, function.regions.get(linenum)) {
+                                        @if tested {
+                                            span class="region-tested" { (chunk) }
+                                        } @else {
+                                            (chunk)
+                                        }
+                                    }
+                                    "\n"
                                 },
                                 LineCoverageStatus::Annotated => span class="line line-annotated" data-filename=(filename) data-linenum=(linenum) {
                                     (line) "\n"
@@ -233,4 +240,152 @@ fn generate_function(
         }
     );
     Ok(html)
+}
+
+fn line_runs(line: &str, regions: Option<&Vec<ColumnRange>>) -> Vec<(String, bool)> {
+    let len = line.len();
+    let Some(regions) = regions.filter(|regions| !regions.is_empty() && len > 0) else {
+        return vec![(line.to_string(), false)];
+    };
+
+    let mut tested = vec![false; len];
+
+    let mut by_specificity: Vec<&ColumnRange> = regions.iter().collect();
+    by_specificity.sort_by_key(|range| {
+        std::cmp::Reverse(range.end_col.unwrap_or(len).saturating_sub(range.start_col))
+    });
+
+    for range in by_specificity {
+        let start = floor_char_boundary(line, range.start_col.saturating_sub(1).min(len));
+        let end = ceil_char_boundary(line, range.end_col.unwrap_or(len).min(len)).max(start);
+        tested[start..end].fill(range.tested);
+    }
+
+    let mut offset = 0;
+    tested
+        .chunk_by(|a, b| a == b)
+        .map(|chunk| {
+            let start = offset;
+            offset += chunk.len();
+            (line[start..offset].to_string(), chunk[0])
+        })
+        .collect()
+}
+
+fn floor_char_boundary(line: &str, index: usize) -> usize {
+    (0..=index).rev().find(|&i| line.is_char_boundary(i)).unwrap_or(0)
+}
+
+fn ceil_char_boundary(line: &str, index: usize) -> usize {
+    (index..=line.len()).find(|&i| line.is_char_boundary(i)).unwrap_or(line.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn range(start_col: usize, end_col: Option<usize>, tested: bool) -> ColumnRange {
+        ColumnRange { start_col, end_col, tested }
+    }
+
+    #[test]
+    fn no_regions_is_one_untested_run() {
+        let runs = line_runs("    baz();", None);
+        assert_eq!(runs, vec![("    baz();".to_string(), false)]);
+    }
+
+    #[test]
+    fn single_region_covering_whole_line() {
+        let regions = vec![range(1, None, true)];
+        let runs = line_runs("    baz();", Some(&regions));
+        assert_eq!(runs, vec![("    baz();".to_string(), true)]);
+    }
+
+    #[test]
+    fn splits_covered_arm_from_uncovered_arm() {
+        // `if cond { covered() } else { uncovered() }`
+        let line = "if cond { covered() } else { uncovered() }";
+        let regions = vec![
+            range(1, Some(9), true),    // `if cond `
+            range(10, Some(21), true),  // `{ covered() }`
+            range(22, Some(27), true),  // ` else `
+            range(28, Some(42), false), // `{ uncovered() }`
+        ];
+        let runs = line_runs(line, Some(&regions));
+        assert_eq!(
+            runs,
+            vec![
+                ("if cond { covered() } else ".to_string(), true),
+                ("{ uncovered() }".to_string(), false),
+            ]
+        );
+    }
+
+    #[test]
+    fn narrower_region_overrides_broader_untested_one() {
+        // The whole line is nominally untested, but a nested, more specific region within it
+        // was hit (e.g. a branch condition that runs even though the statement as a whole
+        // never completes).
+        let line = "    a && b";
+        let regions = vec![
+            range(1, None, false),   // whole line, untested
+            range(5, Some(5), true), // `a`
+        ];
+        let runs = line_runs(line, Some(&regions));
+        assert_eq!(
+            runs,
+            vec![
+                ("    ".to_string(), false),
+                ("a".to_string(), true),
+                (" && b".to_string(), false),
+            ]
+        );
+    }
+
+    #[test]
+    fn out_of_range_columns_are_clamped_not_panicking() {
+        let regions = vec![range(1, Some(9999), true)];
+        let runs = line_runs("short", Some(&regions));
+        assert_eq!(runs, vec![("short".to_string(), true)]);
+    }
+
+    #[test]
+    fn generate_function_highlights_covered_fragment_of_untested_line() {
+        let dir = std::env::temp_dir().join(format!("blanket-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let relative_path = std::path::PathBuf::from("lib.rs");
+        std::fs::write(
+            dir.join(&relative_path),
+            "fn f(cond: bool) {\n    if cond { covered() } else { uncovered() }\n}\n",
+        )
+        .unwrap();
+
+        let mut regions = std::collections::BTreeMap::new();
+        regions.insert(
+            2,
+            vec![
+                range(5, Some(13), true),   // `if cond `
+                range(14, Some(25), true),  // `{ covered() }`
+                range(26, Some(31), true),  // ` else `
+                range(32, Some(46), false), // `{ uncovered() }`
+            ],
+        );
+
+        let lines = crate::LineCoverage {
+            lines: vec![
+                (1, LineCoverageStatus::Ignored),
+                (2, LineCoverageStatus::Untested),
+                (3, LineCoverageStatus::Ignored),
+            ],
+        };
+        let function =
+            FunctionCoverage::new("f".to_string(), relative_path, lines, regions, Annotated::Not);
+
+        let html = generate_function(&function, &dir).unwrap().into_string();
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert!(html.contains(r#"<span class="region-tested">if cond { covered() } else </span>"#));
+        assert!(html.contains("{ uncovered() }"));
+        assert!(!html.contains(r#"<span class="region-tested">{ uncovered() }</span>"#));
+    }
 }

--- a/ferrocene/tools/blanket/src/main.rs
+++ b/ferrocene/tools/blanket/src/main.rs
@@ -1,5 +1,6 @@
 // Derived from https://github.com/xd009642/llvm-profparser/blob/f12a20d33b371f62a3b63f3a19d2320c25aa48b9/src/bin/cov.rs
 
+use std::collections::BTreeMap;
 use std::fmt;
 use std::path::PathBuf;
 
@@ -80,6 +81,14 @@ struct LineCoverage {
     lines: Vec<(usize, LineCoverageStatus)>,
 }
 
+#[derive(Debug, Clone)]
+struct ColumnRange {
+    start_col: usize,
+    /// `None` means the region continues past the end of this line.
+    end_col: Option<usize>,
+    tested: bool,
+}
+
 #[derive(Debug, PartialEq, Eq, Hash)]
 enum FunctionCoverageStatus {
     FullyTested,
@@ -151,6 +160,8 @@ struct FunctionCoverage {
     source_name: String,
     relative_path: PathBuf,
     lines: LineCoverage,
+    // filled in only for partially covered lines
+    regions: BTreeMap<usize, Vec<ColumnRange>>,
     status: FunctionCoverageStatus,
     annotated: Annotated,
 }
@@ -160,10 +171,11 @@ impl FunctionCoverage {
         source_name: String,
         filename: PathBuf,
         lines: LineCoverage,
+        regions: BTreeMap<usize, Vec<ColumnRange>>,
         annotated: Annotated,
     ) -> Self {
         let status = FunctionCoverageStatus::new(&lines);
-        Self { source_name, relative_path: filename, lines, status, annotated }
+        Self { source_name, relative_path: filename, lines, regions, status, annotated }
     }
 }
 
@@ -237,7 +249,6 @@ fn get_coverage(
     };
 
     let source_lines = start_line..=end_line;
-    let source_name = source_name;
 
     // we didn't get any hits from the tool, so we don't know which lines shouldn't be
     // considered. report them all as considered and missing coverage.
@@ -253,25 +264,60 @@ fn get_coverage(
         // All lines require annotations as we didn't get any hits from the tool.
         let annotated = get_annotation_status(annotations, &mut no_coverage.lines);
 
-        return Ok(FunctionCoverage::new(source_name, filename, no_coverage, annotated));
+        return Ok(FunctionCoverage::new(
+            source_name,
+            filename,
+            no_coverage,
+            BTreeMap::new(),
+            annotated,
+        ));
     };
 
     let mut covered = vec![];
+    let mut regions = BTreeMap::new();
 
     for line in source_lines {
         // one more thing to do: within a function, some lines will always be uncovered (e.g. }
         // closing braces). so we do have to trust the coverage tool to report those accurately.
-        let status = match func_coverage.hits_for_line(line) {
-            None => LineCoverageStatus::Ignored,
-            Some(0) => LineCoverageStatus::Untested,
-            Some(_) => LineCoverageStatus::Tested,
+        let line_regions = column_ranges_for_line(func_coverage, line);
+        let status = if line_regions.is_empty() {
+            LineCoverageStatus::Ignored
+        } else if line_regions.iter().all(|range| range.tested) {
+            LineCoverageStatus::Tested
+        } else {
+            LineCoverageStatus::Untested
         };
+        // untested line has tested regions
+        if status == LineCoverageStatus::Untested && line_regions.iter().any(|range| range.tested) {
+            regions.insert(line, line_regions);
+        }
         covered.push((line, status));
     }
 
     let annotated = get_annotation_status(annotations, &mut covered);
 
-    Ok(FunctionCoverage::new(source_name, filename, LineCoverage { lines: covered }, annotated))
+    Ok(FunctionCoverage::new(
+        source_name,
+        filename,
+        LineCoverage { lines: covered },
+        regions,
+        annotated,
+    ))
+}
+
+fn column_ranges_for_line(func_coverage: &CoverageResult, line: usize) -> Vec<ColumnRange> {
+    let mut ranges: Vec<ColumnRange> = func_coverage
+        .hits
+        .iter()
+        .filter(|(loc, _)| loc.line_start <= line && loc.line_end >= line)
+        .map(|(loc, &count)| {
+            let start_col = if loc.line_start == line { loc.column_start } else { 1 };
+            let end_col = if loc.line_end == line { Some(loc.column_end) } else { None };
+            ColumnRange { start_col, end_col, tested: count > 0 }
+        })
+        .collect();
+    ranges.sort_by_key(|range| range.start_col);
+    ranges
 }
 
 impl ShowCommand {


### PR DESCRIPTION
For each line of code I gather regions that overlap this line. A region can be a small expression or a larger block of code spanning several lines: the exact logic of what to consider a region is dictated by LLVM. 

If some of these regions have hit count of 0 then I consider the corresponding part of the line as uncovered. A line that has both covered and uncovered perts is a partially covered line. For these lines I use background color to show the covered portions.

Local testing of this change with @Hoverbear helped us find a few common cases of partially covered lines. One of popular ones were `?` at ends of lines for formatting code. And another were `as` type conversions. The later turned out to be a bug in our coverage metrics aggregation logic, and the fix comes in a separate PR.

