### PR TITLE
Improve blanket performance on v8

### DIFF
--- a/ferrocene/tools/blanket/assets/html_report.js
+++ b/ferrocene/tools/blanket/assets/html_report.js
@@ -28,6 +28,7 @@ function main() {
     var annotatedIsTested = false;
 
     function onSearch() {
+        const matcher = new RegExp(currentQuery)
         var numLinesTested = 0;
         var numLinesUntested = 0;
 
@@ -35,10 +36,10 @@ function main() {
             var numFunctions = 0;
             for (details of section.querySelectorAll("details")) {
                 var summary = details.querySelector("summary");
-                if (summary.innerText.search(currentQuery) === -1) {
-                    details.style.display = "none";
+                if (!matcher.test(summary.textContent)) {
+                    details.hidden = true;
                 } else {
-                    details.style = "";
+                    details.hidden = false;
 
                     var testedLines = parseInt(summary.getAttribute("tested-lines"));
                     var untestedLines = parseInt(summary.getAttribute("untested-lines"));


### PR DESCRIPTION
Some users who like blanket (not [Linus](https://peanuts.fandom.com/wiki/Linus%27_security_blanket)) have reported performance issues previously when using the full coverage report.

This was only present in Chrome/v8, not Firefox.

It was, in fact, quite bad: 
<img width="901" height="564" alt="image" src="https://github.com/user-attachments/assets/40d17cf8-82be-44a1-8226-5da15a0b990f" />
<img width="875" height="305" alt="image" src="https://github.com/user-attachments/assets/0de2ed99-cb40-47d9-b5a6-b406a99e2a3b" />

This patch does some naive optimizations that lower the cost:
<img width="856" height="1040" alt="image" src="https://github.com/user-attachments/assets/adf4b6c5-3a59-4cbe-a6cc-7a1f3ae1ec13" />


I've tested this on:
* Firefox/Linux
* Chrome/Linux
* Edge/Windows
* Safari/Mac