### PR TITLE
[869ec9kc0] Do not try to generate coverage records for "always-const" instrinsics

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/query.rs
+++ b/compiler/rustc_mir_transform/src/coverage/query.rs
@@ -1,5 +1,6 @@
 use rustc_hir::attrs::CoverageAttrKind;
-use rustc_hir::find_attr;
+use rustc_hir::def::DefKind;
+use rustc_hir::{Constness, find_attr};
 use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::mir::coverage::{BasicCoverageBlock, CoverageIdsInfo, CoverageKind, MappingKind};
@@ -41,6 +42,21 @@ fn is_eligible_for_coverage(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
     if !tcx.coverage_attr_on(def_id) {
         trace!("InstrumentCoverage skipped for {def_id:?} (`#[coverage(off)]`)");
         return false;
+    }
+
+    // Ferrocene addition: Do not generate coverage records for "always-const" intrinsics
+    //
+    // An always-const intrinsic is one which should always resolve to a definite value at
+    // compile time, and so should never be called at runtime. This is enforced by a check in
+    // `compute_symbol_name` in `compiler/rustc_symbol_mangling/src/lib.rs`.
+    //
+    // Because these intrinsics are never used at runtime, `prepare_covfun_records_for_unused_functions`
+    // will detect them as unused functions and try to generate dummy coverage records, which will
+    // trip the above check. To avoid this, skip generating coverage for these intrinsics.
+    if let DefKind::Fn | DefKind::AssocFn = tcx.def_kind(def_id) {
+        if tcx.constness(def_id) == (Constness::Const { always: true }) {
+            return false;
+        }
     }
 
     true

--- a/compiler/rustc_symbol_mangling/src/lib.rs
+++ b/compiler/rustc_symbol_mangling/src/lib.rs
@@ -243,16 +243,7 @@ fn compute_symbol_name<'tcx>(
     let args = instance.args;
     let def_kind = tcx.def_kind(instance.def_id());
     if let DefKind::Fn | DefKind::AssocFn = def_kind {
-        // Ferrocene addition: The constness check here is to detect intrinsics like `needs_drop::<T>`
-        // which should always resolve to a constant at compile time and so should never reach codegen.
-        // However, when generating core coverage, we see the intrinsic as an unused function and try
-        // to generate dummy coverage data for it, which sets off this assertion.
-        //
-        // Temporarily disable the assertion when generating coverage data to resolve this
-        debug_assert!(
-            tcx.sess.instrument_coverage()
-                || tcx.constness(instance.def_id()) != hir::Constness::Const { always: true }
-        );
+        debug_assert!(tcx.constness(instance.def_id()) != hir::Constness::Const { always: true });
     }
 
     debug!("symbol_name(def_id={:?}, args={:?})", def_id, args);


### PR DESCRIPTION
These intrinsics should always be resolved at compile time, so should never exist at runtime. This means runtime coverage cannot possibly work for them. Trying to generate coverage data anyway trips a check which exists to make sure these intrinsics never reach codegen.

Previously we disabled the check when generating coverage; this patch instead disables coverage for these intrinsics, allowing the check to be reinstated.