### PR TITLE
[869eqbedu] Ensure that upstream pull automation always uses `pull.sh` from the target branch

### DIFF
--- a/ferrocene/tools/pull-upstream/automation.py
+++ b/ferrocene/tools/pull-upstream/automation.py
@@ -18,6 +18,9 @@
 # - `GITHUB_TOKEN`: API token with access to the repo contents, issues and RPs
 # - `GITHUB_REPOSITORY`: name of the GitHub repository to run this script on
 
+# Note: Regardless of the target branch, the automation will always run
+# the version of this script from the `main` branch.
+
 from automations_common import AutomatedPR, AutomationResult
 import generate_pr_body
 import os

--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: The Ferrocene Developers
 
+# Note: Regardless of the target branch, the automation will always run
+# the version of this script from the `main` branch.
+
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -17,6 +20,17 @@ X_HELP=src/etc/xhelp
 DIRECTORIES_CONTAINING_LOCKFILES=("" "src/bootstrap/")
 
 LOCAL_REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# Record where we were before we start checking out new things.
+# This is used to re-checkout the original versions of this script and its dependencies,
+# to avoid ending up in a state where we're running pull.sh from one branch but its
+# dependencies from a different branch.
+#
+# When run via Github Actions, this will always be the tip of the main branch; when
+# run locally for testing purposes, it will be whatever commit you had checked out.
+INITIAL_COMMIT=$(git rev-parse HEAD)
+INITIAL_BRANCH=$(git branch --show-current)
+if [ -z "$INITIAL_BRANCH" ]; then INITIAL_BRANCH=$INITIAL_COMMIT; fi
 
 # Set a default max of merges per PR to 30, if it was not overridden in the
 # environment.
@@ -191,7 +205,25 @@ else
     merge_message="pull new changes from upstream"
 fi
 
+# Switch to the target branch, but keep this script and its dependencies
+# pinned to the versions we started with
 git checkout "${current_commit}"
+
+git checkout "${INITIAL_COMMIT}" -- ferrocene/tools/pull-upstream/ ferrocene/tools/fix-merge/
+
+# Sync submodules to the target branch so that the next step doesn't commit a bunch
+# of unintended submodule changes
+git submodule update --recursive
+
+# Commit the updated scripts into the target branch if they're different
+# Note that `git commit` exits with status code 1 if nothing has changed, and we need to suppress
+# that to stop it breaking the script. This could be done with an `|| true` on the git commit line,
+# but that looks weird and unintuitive, so it's nicer to turn off the `-e` flag for a moment.
+set +e
+git commit --quiet -F- <<EOF
+sync pull-upstream and fix-merge scripts from ${INITIAL_BRANCH}
+EOF
+set -e
 
 # - Unset some env vars to make git ignore user configuration. For example, if
 #   mergiraf is set as the merge driver globally, git would attempt to use it

--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -97,7 +97,7 @@ if [[ $# -ge 2 ]]; then
 else
     current_commit="$(git rev-parse HEAD)"
     branch_name="$(git branch --show-current)"
-    if [ -n "$branch_name" ]; then branch_name=$current_commit; fi
+    if [ -z "$branch_name" ]; then branch_name=$current_commit; fi
 fi
 if [[ $# -ge 3 ]]; then
     upstream_commit="$3"


### PR DESCRIPTION
Since I split some of the merge conflict resolution from `pull.sh` out into a separate script, the upstream pulls into our release branches have been broken. This turned out to be caused by the following sequence of events:

* The pull-upstream automation starts on the main branch, and runs `ferrocene/tools/pull-upstream/pull.sh` from that branch.

* During execution of `pull.sh`, it switches the repository to the appropriate release branch

* We're still running the version of `pull.sh` from the main branch, which eventually tries to run `ferrocene/tools/fix-merge/fix-merge.sh`

* This file doesn't exist any more, so things break

Fix this by inserting a wrapper script in between `automation.py` and `pull.sh`, which checks out the target branch first so that we always run the version of `pull.sh` from the target branch.

Add warnings to all relevant scripts to be extremely careful when making changes which could break things in the future.