### PR TITLE
[869eqbedu] Upstream pull: Set up merge in a separate worktree

### DIFF
--- a/ferrocene/tools/fix-merge/fix-merge.sh
+++ b/ferrocene/tools/fix-merge/fix-merge.sh
@@ -43,10 +43,6 @@ else
     sed=sed
 fi
 
-# We do a `git submodule update` ahead of time to ensure the wrong
-# submodule commits are not accidentally added.
-git submodule update --recursive
-
 # The person handling the conflict should decide what to do if a file
 # has been deleted on either side of the merge, but doing a `git add .`
 # would mask the conflict (it would simply revert the deletion).

--- a/ferrocene/tools/pull-subtrees/pull.py
+++ b/ferrocene/tools/pull-subtrees/pull.py
@@ -491,6 +491,18 @@ local branch to GitHub and open a PR for it.
         return f"The automation failed to pull the latest changes from {self.repo_link} again."
 
 
+def update_submodules():
+    run(["git", "submodule", "update", "--recursive"])
+
+
+def is_git_worktree_dirty():
+    # The update-index command ensures diff-index doesn't spuriously fail.
+    # https://stackoverflow.com/questions/3878624#comment108071431_3879077
+    run(["git", "update-index", "--refresh"], check=False)
+    status = run(["git", "diff-index", "--quiet", "HEAD"], check=False).returncode
+    return status != 0
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -509,6 +521,17 @@ if __name__ == "__main__":
 
     config_file = Path(__file__).parent / "subtrees.yml"
     repo_root = retrieve_git_repo_root()
+
+    # Safety check to avoid messing with uncommitted changes.
+    # Submodules are updated before that, as submodules needing an update should
+    # not block merging changes from upstream.
+    update_submodules()
+    if is_git_worktree_dirty():
+        err("pull-subtrees: the current branch contains uncommitted changes!")
+        err(
+            "pull-subtrees: make sure all changes are committed before running this script."
+        )
+        exit(1)
 
     subtrees = parse_configuration(config_file)
     if args.automation_for_branch is not None:

--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -358,5 +358,33 @@ echo
 # and destroy the worktree
 RESULT_COMMIT=$(git rev-parse HEAD)
 cd "${SCRIPTDIR_ROOT}"
+
+# Upstream is slowly trying to migrate away from submodules in favor of subtrees. Whenever they do
+# that, in the same PR they remove the submodule and then create the subtree.
+#
+# This causes problems whenever the branch containing the subtree is checked out in a working
+# directory containing the submodule. Submodules "hide" from git's view the files they contain, and
+# when they are removed they stop hiding those, resulting in those files being untracked.
+#
+# When git tries to add the subtree files in the working directory, it will see the submodule files
+# as untracked, and exit with an error to avoid having to overwrite the files, crashing the script.
+#
+# To avoid the problem, *before* checking out the final merge commit, we `rm -rf` every directory
+# that is a submodule in the current branch but is not a submodule upstream. This correctly solves
+# the problem whenever upstream converts a submodule to a subtree. It also has the side effect of
+# removing the local contents of the submodules added in Ferrocene (not the submodules themselves),
+# but that doesn't cause any problem (the Ferrocene submodules are then re-fetched later).
+get_submodules() {
+    ref="$1"
+    git config --file <(git show "${ref}:.gitmodules") --get-regexp path | awk '{print($2)}'
+}
+new_submodules="$(get_submodules "${upstream_commit}")"
+for submodule in $(get_submodules "${current_commit}"); do
+    if ! grep --quiet "^${submodule}\$" <(echo "${new_submodules}"); then
+        echo "submodule ${submodule} is not present upstream, removing its contents"
+        rm -rf "${submodule}"
+    fi
+done
+
 git checkout "${RESULT_COMMIT}"
 git submodule update --recursive

--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -16,7 +16,12 @@ X_HELP=src/etc/xhelp
 # https://github.com/ferrocene/ferrocene/blob/d3f1e45/src/bootstrap/src/ferrocene/dist.rs#L119-L125
 DIRECTORIES_CONTAINING_LOCKFILES=("" "src/bootstrap/")
 
-LOCAL_REPO_ROOT=$(git rev-parse --show-toplevel)
+# During this script we maintain two copies of the Ferrocene repository:
+# 1) The one we start in. We are running *this script* and its dependencies from that directory,
+#    so we can't change branch or do anything which might mess with the script files without
+#    risking hard-to-understand breakages.
+# 2) A second worktree which we create to perform the merge in
+SCRIPTDIR_ROOT=$(git rev-parse --show-toplevel)
 
 # Set a default max of merges per PR to 30, if it was not overridden in the
 # environment.
@@ -73,7 +78,7 @@ fi
 upstream_branch="$1"
 
 # Move to the root of the repository to avoid the script from misbehaving.
-cd "${LOCAL_REPO_ROOT}"
+cd "${SCRIPTDIR_ROOT}"
 
 # Safety check to avoid messing with uncommitted changes.
 # Submodules are updated before that, as submodules needing an update should
@@ -133,7 +138,11 @@ if [[ "${upstream_commit}" = "FETCH_HEAD" ]]; then
         # return any difference between the two refs, resulting in an empty
         # ${upstream_commit}. To prevent the rest of the script from misbehaving,
         # we revert the commit back to FETCH_HEAD.
-        upstream_commit="FETCH_HEAD"
+        #
+        # Note: Later on we will switch to a separate worktree, which has its own FETCH_HEAD.
+        # So we can't literally set upstream_commit="FETCH_HEAD" here, we have to resolve it to a
+        # definite commit.
+        upstream_commit="${fetch_head}"
     elif [[ "${upstream_commit}" != "${fetch_head}" ]]; then
         partial_pull=yes
 
@@ -141,40 +150,21 @@ if [[ "${upstream_commit}" = "FETCH_HEAD" ]]; then
     fi
 fi
 
-# Upstream is slowly trying to migrate away from submodules in favor of subtrees. Whenever they do
-# that, in the same PR they remove the submodule and then create the subtree.
-#
-# This causes problems whenever the branch containing the subtree is checked out in a working
-# directory containing the submodule. Submodules "hide" from git's view the files they contain, and
-# when they are removed they stop hiding those, resulting in those files being untracked.
-#
-# When git tries to add the subtree files in the working directory, it will see the submodule files
-# as untracked, and exit with an error to avoid having to overwrite the files, crashing the script.
-#
-# To avoid the problem, this snippet below `rm -rf`s every directory that is a submodule in the
-# current branch but is not a submodule upstream. This correctly solves the problem whenever
-# upstream converts a submodule to a subtree. It also has the side effect of removing the local
-# contents of the submodules added in Ferrocene (not the submodules themselves), but that doesn't
-# cause any problem (the Ferrocene submodules are then re-fetched later).
-get_submodules() {
-    ref="$1"
-    git config --file <(git show "${ref}:.gitmodules") --get-regexp path | awk '{print($2)}'
-}
-new_submodules="$(get_submodules "${upstream_commit}")"
-for submodule in $(get_submodules "${current_commit}"); do
-    if ! grep --quiet "^${submodule}\$" <(echo "${new_submodules}"); then
-        echo "submodule ${submodule} is not present upstream, removing its contents"
-        rm -rf "${submodule}"
-    fi
-done
+# Set up the workdir
+# Note that a fresh worktree will not have any of its submodules initialized.
+# See https://stackoverflow.com/a/687052 for why we use `trap` here
+WORKDIR_ROOT=$(mktemp -d -t upstream-pull-workdir)
+git worktree add -b "${TEMP_BRANCH}" "${WORKDIR_ROOT}" "${upstream_commit}"
+trap "cd \"${SCRIPTDIR_ROOT}\" && git worktree remove --force \"${WORKDIR_ROOT}\" && git branch -D \"${TEMP_BRANCH}\"" EXIT
 
-git checkout -b "${TEMP_BRANCH}" "${upstream_commit}"
+# Operate on the workdir for the rest of the script
+cd ${WORKDIR_ROOT}
 
 # Delete all the files excluded from the pull. Those files are marked with the
 # `ferrocene-avoid-pulling-from-upstream` in `.gitattributes`.
 git checkout "${current_commit}" -- .gitattributes
 excluded_files | xargs git rm --quiet
-git checkout FETCH_HEAD -- .gitattributes
+git checkout "${upstream_commit}" -- .gitattributes
 
 git commit --quiet -F- <<EOF
 remove excluded files from upstream
@@ -284,7 +274,8 @@ then
     else
         automation_warning "There are merge conflicts in this PR. Attempting automatic resolution, but conflict markers may remain"
 
-        ${LOCAL_REPO_ROOT}/ferrocene/tools/fix-merge/fix-merge.sh ${branch_name}
+        # Run the fix-merge script from the *original* repository, which is still on the `main` branch
+        ${SCRIPTDIR_ROOT}/ferrocene/tools/fix-merge/fix-merge.sh ${branch_name}
     fi
 fi
 
@@ -357,10 +348,15 @@ else
     automation_warning "Couldn't regenerate the symbol report. Please run \`./x test ferrocene/doc/symbol-report.csv --bless\` after fixing the conflicts."
 fi
 
-git branch -D "${TEMP_BRANCH}"
-
 echo
 echo "You can generate the PR body manually by running:"
 echo
 echo "    ferrocene/tools/pull-upstream/generate_pr_body.py origin <base-branch> <current-branch>"
 echo
+
+# If successful, check out the merge result in the original directory before we finish this script
+# and destroy the worktree
+RESULT_COMMIT=$(git rev-parse HEAD)
+cd "${SCRIPTDIR_ROOT}"
+git checkout "${RESULT_COMMIT}"
+git submodule update --recursive

--- a/ferrocene/tools/pull-upstream/pull.sh
+++ b/ferrocene/tools/pull-upstream/pull.sh
@@ -97,7 +97,7 @@ if [[ $# -ge 2 ]]; then
 else
     current_commit="$(git rev-parse HEAD)"
     branch_name="$(git branch --show-current)"
-    if [ -n "$branch_name" ]; then branch_name=$current_commit; fi
+    if [ -z "$branch_name" ]; then branch_name=$current_commit; fi
 fi
 if [[ $# -ge 3 ]]; then
     upstream_commit="$3"


### PR DESCRIPTION
This allows us to run pull.sh and all of its dependencies from the main branch, without interference from the git shenanigans we need to do to build the merge commit for the upstream pull