### PR TITLE
[869ec9kc0] Sync logic to avoid generating coverage for compile-time-only functions with upstream

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/query.rs
+++ b/compiler/rustc_mir_transform/src/coverage/query.rs
@@ -1,6 +1,6 @@
 use rustc_hir::attrs::CoverageAttrKind;
 use rustc_hir::def::DefKind;
-use rustc_hir::{Constness, find_attr};
+use rustc_hir::{self as hir, find_attr};
 use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::mir::coverage::{BasicCoverageBlock, CoverageIdsInfo, CoverageKind, MappingKind};
@@ -29,8 +29,20 @@ fn is_eligible_for_coverage(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
     // expressions from coverage spans in enclosing MIR's, like we do for closures. (That might
     // be tricky if const expressions have no corresponding statements in the enclosing MIR.
     // Closures are carved out by their initial `Assign` statement.)
-    if !tcx.def_kind(def_id).is_fn_like() {
+    let def_kind = tcx.def_kind(def_id);
+    if !def_kind.is_fn_like() {
         trace!("InstrumentCoverage skipped for {def_id:?} (not an fn-like)");
+        return false;
+    }
+
+    // Comptime functions can't exist at runtime, so instrumenting them is useless.
+    // This also avoids an ICE when getting the symbol name for an unused-function record
+    // (due to <https://github.com/rust-lang/rust/pull/159777>).
+    // We check `def_kind` first to avoid any unexpected panics from merely asking for constness.
+    if matches!(def_kind, DefKind::Fn | DefKind::AssocFn)
+        && matches!(tcx.constness(def_id), hir::Constness::Const { always: true })
+    {
+        trace!("InstrumentCoverage skipped for {def_id:?} (comptime)");
         return false;
     }
 
@@ -42,21 +54,6 @@ fn is_eligible_for_coverage(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
     if !tcx.coverage_attr_on(def_id) {
         trace!("InstrumentCoverage skipped for {def_id:?} (`#[coverage(off)]`)");
         return false;
-    }
-
-    // Ferrocene addition: Do not generate coverage records for "always-const" intrinsics
-    //
-    // An always-const intrinsic is one which should always resolve to a definite value at
-    // compile time, and so should never be called at runtime. This is enforced by a check in
-    // `compute_symbol_name` in `compiler/rustc_symbol_mangling/src/lib.rs`.
-    //
-    // Because these intrinsics are never used at runtime, `prepare_covfun_records_for_unused_functions`
-    // will detect them as unused functions and try to generate dummy coverage records, which will
-    // trip the above check. To avoid this, skip generating coverage for these intrinsics.
-    if let DefKind::Fn | DefKind::AssocFn = tcx.def_kind(def_id) {
-        if tcx.constness(def_id) == (Constness::Const { always: true }) {
-            return false;
-        }
     }
 
     true

--- a/tests/coverage/comptime.cov-map
+++ b/tests/coverage/comptime.cov-map
@@ -1,0 +1,10 @@
+Function name: comptime::main
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 0b, 01, 00, 0a, 01, 00, 0c, 00, 0d]
+Number of files: 1
+- file 0 => $DIR/comptime.rs
+Number of expressions: 0
+Number of file 0 mappings: 2
+- Code(Counter(0)) at (prev + 11, 1) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 0, 12) to (start + 0, 13)
+Highest counter ID seen: c0
+

--- a/tests/coverage/comptime.coverage
+++ b/tests/coverage/comptime.coverage
@@ -1,0 +1,12 @@
+   LL|       |#![feature(rustc_attrs)]
+   LL|       |//@ edition: 2024
+   LL|       |
+   LL|       |// Check that instrumenting a crate with a comptime function doesn't ICE.
+   LL|       |// (The function itself doesn't need to be instrumented, and probably shouldn't be.)
+   LL|       |// Regression test for <https://github.com/rust-lang/rust/pull/161808>.
+   LL|       |
+   LL|       |#[rustc_comptime]
+   LL|       |fn comptime_fn() {}
+   LL|       |
+   LL|      1|fn main() {}
+

--- a/tests/coverage/comptime.rs
+++ b/tests/coverage/comptime.rs
@@ -1,0 +1,11 @@
+#![feature(rustc_attrs)]
+//@ edition: 2024
+
+// Check that instrumenting a crate with a comptime function doesn't ICE.
+// (The function itself doesn't need to be instrumented, and probably shouldn't be.)
+// Regression test for <https://github.com/rust-lang/rust/pull/161808>.
+
+#[rustc_comptime]
+fn comptime_fn() {}
+
+fn main() {}


### PR DESCRIPTION
In https://github.com/ferrocene/ferrocene/pull/2553 I marked compile-time-only functions as ineligible for coverage. I sent this upstream, and after a couple of further iterations it was merged as https://github.com/rust-lang/rust/pull/162354 .

Copy the final version of this logic back to Ferrocene.