### PR TITLE
Use monomorphized function names to track coverage

### DIFF
--- a/ferrocene/tools/Cargo.lock
+++ b/ferrocene/tools/Cargo.lock
@@ -164,21 +164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_cmd"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
-dependencies = [
- "anstyle",
- "bstr",
- "libc",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,17 +593,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "build_helper"
 version = "0.1.0"
 dependencies = [
@@ -874,12 +848,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,25 +936,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "env_filter",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,12 +950,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "evalexpr"
-version = "12.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae893d2d5e908b78f151ed89de3bfc272cdf6d368c7ed866942f98e24dea208a"
 
 [[package]]
 name = "fastrand"
@@ -1063,16 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "flip-link"
-version = "0.1.12"
-dependencies = [
- "assert_cmd",
- "env_logger",
- "evalexpr",
- "getrandom 0.2.16",
- "log",
- "object 0.35.0",
- "rstest",
-]
+version = "0.0.0"
 
 [[package]]
 name = "fnv"
@@ -1187,12 +1121,6 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
@@ -1422,10 +1350,9 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 [[package]]
 name = "llvm_profparser"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc5524f1aeb410f0f2a51accea00663055ea786d4d08c82a7c515cd528046f0"
 dependencies = [
  "anyhow",
+ "clap",
  "flate2",
  "indexmap 1.8.2",
  "leb128",
@@ -1435,6 +1362,7 @@ dependencies = [
  "rustc-hash",
  "thiserror",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1596,15 +1524,6 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
@@ -1727,33 +1646,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "predicates"
-version = "3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
-dependencies = [
- "anstyle",
- "difflib",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
-dependencies = [
- "predicates-core",
- "termtree",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,12 +1758,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,33 +1794,6 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rstest"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5316d2a1479eeef1ea21e7f9ddc67c191d497abc8fc3ba2467857abbb68330"
-dependencies = [
- "rstest_macros",
- "rustc_version",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04a9df72cc1f67020b0d63ad9bfe4a323e459ea7eb68e03bd9824db49f9a4c25"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn 2.0.108",
- "unicode-ident",
 ]
 
 [[package]]
@@ -2325,12 +2184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,15 +2480,6 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"

--- a/ferrocene/tools/blanket/Cargo.toml
+++ b/ferrocene/tools/blanket/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 [dependencies]
 anyhow = { version = "1.0.100", features = ["backtrace"] }
 build_helper = { path = "../../../src/build_helper", features = ["metrics"] }
-llvm_profparser = { version = "0.10.0", default-features = false }
+llvm_profparser = { path = "llvm-profparser", default-features = false }
 maud = { version = "0.27.0" }
 serde = { version = "1.0.226", features = ["derive"] }
 serde_json = "1.0.145"

--- a/ferrocene/tools/blanket/assets/html_report.css
+++ b/ferrocene/tools/blanket/assets/html_report.css
@@ -5,6 +5,7 @@
     --var-partial: #B3589A;
     --var-annotated: #BE8239;
     --var-ignored: gray;
+    --var-region-tested-bg: color-mix(in srgb, var(--var-tested) 35%, transparent);
     --var-untested-annotated: var(--var-untested);
     --var-partial-annotated: var(--var-partial);
     --var-annotated-text: none;
@@ -156,6 +157,11 @@ details.partial-annotation summary::after {
     padding-right: 0.5rem;
     color: white;
     background-color: var(--var-untested);
+}
+
+.functions .line-untested .region-tested {
+    background-color: var(--var-region-tested-bg);
+    border-radius: 2px;
 }
 
 .functions .line-ignored {

--- a/ferrocene/tools/blanket/assets/html_report.js
+++ b/ferrocene/tools/blanket/assets/html_report.js
@@ -82,8 +82,8 @@ function main() {
     }
     for (elem of document.querySelectorAll(".line")) {
         elem.addEventListener("click", async event => {
-            let filename = event.target.dataset.filename;
-            let linenum = event.target.dataset.linenum;
+            let filename = event.currentTarget.dataset.filename;
+            let linenum = event.currentTarget.dataset.linenum;
             await navigator.clipboard.writeText(`${filename}:${linenum}`);
         });
     }

--- a/ferrocene/tools/blanket/llvm-profparser/CHANGELOG.md
+++ b/ferrocene/tools/blanket/llvm-profparser/CHANGELOG.md
@@ -1,0 +1,133 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.10.0]
+### Changed
+- Load object files lazily to minimise memory usage
+
+## [0.9.2]
+### Fixed
+- Parsing of hash tables with the bitmap data field
+
+## [0.9.1]
+### Fixed
+- Fix expression evaluation for split regions.
+
+## [0.9.0]
+### Added
+- Basic MC/DC parsing in object files
+- llvm 21 into tests
+
+### Changed
+- Removed build script so there's no longer cfgs for the LLVM version compiled against
+
+### Fixed
+- Non-version number flags in version field weren't masked out when using version for indexed profile parsing of causing parse errors.
+
+## [0.8.3]
+### Changed
+- Saturating operations on expression adding/subtracting to avoid panics
+
+## [0.8.2]
+### Changed
+- More performance improvements this time changing search order to prefer deeper expression nodes first
+- Read object file sections without loading whole file into memory.
+
+## [0.8.1] 2025-05-06
+### Changed
+- Increased usage of memoization of hashes -> profiles to speedup report generation more
+
+## [0.8.0] 2025-05-03
+### Added
+- LLVM 20 into the test matrix
+
+### Changed
+- Big performance improvements! Removed some dumb code, made some normal code a bit better
+
+## [0.7.1] 2025-02-14
+### Changed
+- `InstrumentationProfile::is_empty` now takes into account the symbol table
+- Bump MSRV to 1.80.0
+- Remove invalid assertion from `HashTable`
+
+## [0.7.0] - 2024-08-05
+### Added
+- LLVM 19 support (ignores function entry coverage and some failing proftext files)
+
+## [0.6.0] - 2024-05-17
+### Added
+- Added the ability to filter out certain sections from the generated coverage reports
+
+### Changed
+- Now use some hashmap based caching to speedup record lookup during profile merge.
+
+## [0.5.0] - 2024-04-28
+### Changed
+- Now allow binaries to fail parsing for the mapping information (depdendent on function argument)
+
+## [0.4.0] - 2024-04-12
+### Added
+- LLVM 17 and 18 support (test fails still: `check_mapping_consistency` but tarpaulin tests all pass so nearly all working)
+
+### Changed
+- Removed another two redundant hash computations
+
+## [0.3.3] - 2023-04-04
+### Changed
+- Cache name hash calculation to avoid recomputing (perf)
+
+## [0.3.2] - 2023-03-29
+### Added
+- llvm-16 test files to ensure support doesn't break
+
+### Fixed
+- Fixed parsing of branch region counters
+
+## [0.3.1] - 2023-01-23
+### Added
+- Debug logging via tracing
+
+### Fixed
+- Build on 32 bit architectures
+
+## [0.3.0] - 2022-09-26
+### Added
+- `InstrumenationProfile::is_empty` to detect when there are no records
+- Fuzzing module for profile files
+
+### Changed
+- Added anyhow and use in place of `Result<T, Box<dyn Error>>`
+- Make error type for profiles `VerboseError`
+
+### Fixed
+- Handle merging of completely disjoint records - now profiles generated from multiple
+applications are accurately merged
+- Handle invalid Hash enum variant in `IndexedProfile`
+
+## [0.2.0] - 2022-09-11
+### Changed
+- Made instrumentation profile parsing failure message more serious
+- Made hit adding in report use `saturating_add` to prevent overflow
+
+### Fixed
+- Make counter value signed when tracking expressions to prevent underflow
+- Multiply max counters by counter size when comparing to counter delta
+- Fixed handling of profile instrumentation not tied to a counter with source location
+- Incorrect matching on hashes for instrumentation profile merging
+
+## [0.1.1] - 2022-06-26
+### Added
+- Detection of memory profiling
+
+### Fixed
+- Counter offsetting in raw profiles now implemented
+- Counter size for byte coverage now correct
+- Text profile now handles carriage returns
+
+## [0.1.0] - 2022-06-05
+### Added
+- Parsing of indexed, text and raw profiles (llvm version 11, 12, 13, 14)
+- Parsing of instrumented binary and generating line coverage reports

--- a/ferrocene/tools/blanket/llvm-profparser/Cargo.toml
+++ b/ferrocene/tools/blanket/llvm-profparser/Cargo.toml
@@ -1,0 +1,58 @@
+# Vendored copy of `llvm_profparser` 0.10.0 from crates.io.
+#
+# This file started as a copy of the upstream Cargo.toml.orig, with the `[[bench]]`
+# sections and dev-dependencies dropped since `benches/` and `tests/` aren't vendored.
+
+[package]
+name = "llvm_profparser"
+version = "0.10.0"
+authors = ["xd009642 <danielmckenna93@gmail.com>"]
+description = "Parsing and interpretation of llvm coverage profiles and generated data"
+repository = "https://github.com/xd009642/llvm-profparser"
+edition = "2018"
+readme = "README.md"
+license = "Apache-2.0"
+categories = ["encoding"]
+keywords = ["coverage", "llvm"]
+rust-version = "1.80.0"
+
+[features]
+default = ["cli", "__llvm_20"]
+cli = ["clap", "tracing-subscriber"]
+
+__llvm_11 = []
+__llvm_12 = []
+__llvm_13 = []
+__llvm_14 = []
+__llvm_15 = []
+__llvm_16 = []
+__llvm_17 = []
+__llvm_18 = []
+__llvm_19 = []
+__llvm_20 = []
+__llvm_21 = []
+
+[dependencies]
+anyhow = "1.0.65"
+flate2 = "1.0"
+indexmap = "~1.8"
+leb128 = "0.2.4"
+md5 = "0.8"
+nom = "7.0.0"
+object = "0.26.0"
+rustc-hash = "2.1"
+clap = { version = "4", features = ["derive"], optional = true }
+thiserror = "1.0.30"
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", optional = true }
+
+[[bin]]
+name = "profparser"
+required-features = ["cli"]
+
+[[bin]]
+name = "cov"
+required-features = ["cli"]
+
+[lints.rust]
+unexpected_cfgs = { level = "allow" }

--- a/ferrocene/tools/blanket/llvm-profparser/LICENSE
+++ b/ferrocene/tools/blanket/llvm-profparser/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/ferrocene/tools/blanket/llvm-profparser/README.md
+++ b/ferrocene/tools/blanket/llvm-profparser/README.md
@@ -1,0 +1,32 @@
+# llvm-profparser
+
+[![Build Status](https://github.com/xd009642/llvm-profparser/workflows/Build/badge.svg)](https://github.com/xd009642/llvm-profparser/actions)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Coverage Status](https://coveralls.io/repos/github/xd009642/llvm-profparser/badge.svg?branch=master)](https://coveralls.io/github/xd009642/llvm-profparser?branch=master)
+
+This is a reasonably complete to parse the llvm instrumentation profraw file
+format and avoid the need to install and use the llvm-profdata/llvm-cov
+binaries. It aims to be backwards compatible with as many llvm versions that
+could be used for coverage data in Rust projects and currently supports the
+following llvm versions: 11-21. Support for LLVM 11 is only partial.
+
+This parser supports the "instrumentation" profile format, but not the
+"sampling" or "memory access" profile format. For those, use `llvm-profdata`
+directly.
+
+**This project is not affilated with the llvm-project in anyway!** It is merely
+a parser for some of their file formats to aid interoperability in Rust.
+
+## Contributing
+
+All of the functionality required has been implemented, however there are areas
+to improve in handling unexpected or invalid files. To start finding issues
+there's a fuzz directory which will undoubtedly reveal some issues that can be
+fixed. Go into the fuzz directory for guides on how to run. 
+
+## License
+
+llvm\_profparser is currently licensed under the terms of the Apache License
+(Version 2.0). See LICENSE for details. Test data included from the llvm-project
+residing in `tests/data` retains the llvm license. See the llvm-project for 
+details. 

--- a/ferrocene/tools/blanket/llvm-profparser/src/bin/cov.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/bin/cov.rs
@@ -1,0 +1,96 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use llvm_profparser::*;
+use std::fs;
+use std::path::PathBuf;
+use tracing_subscriber::filter::filter_fn;
+use tracing_subscriber::{Layer, Registry};
+
+#[derive(Clone, Debug, Eq, PartialEq, Parser)]
+pub struct Opts {
+    #[command(subcommand)]
+    cmd: Command,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Subcommand)]
+pub enum Command {
+    Show {
+        #[command(flatten)]
+        show: ShowCommand,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Parser)]
+pub struct ShowCommand {
+    /// File with the profile data obtained after an instrumented run. This differs from llvm-cov
+    /// in that if multiple profiles are given it will do the equivalent of a llvm-profdata merge
+    /// on them.
+    #[structopt(long = "instr-profile")]
+    instr_profile: Vec<PathBuf>,
+    /// Coverage executable or object file
+    #[structopt(long = "object")]
+    objects: Vec<PathBuf>,
+    /// Pair of paths for a remapping to allow loading files after move. Comma separated in the
+    /// order `source,dest`
+    #[structopt(long = "path-equivalence")]
+    path_remapping: Option<PathRemapping>,
+    /// Turn on debug logging
+    #[structopt(long)]
+    debug: bool,
+}
+
+impl ShowCommand {
+    fn run(&self) -> Result<()> {
+        if self.debug {
+            let _ = enable_debug_logging();
+        }
+        let instr_prof = if self.instr_profile.len() == 1 {
+            parse(&self.instr_profile[0])?
+        } else if self.instr_profile.len() > 1 {
+            merge_profiles(&self.instr_profile)?
+        } else {
+            panic!("Must provide an instrumentation profile");
+        };
+        let mapping = CoverageMapping::new(&self.objects, &instr_prof, false)?;
+        let mut report = mapping.generate_report()?;
+        if let Some(remapping) = self.path_remapping.as_ref() {
+            report.apply_remapping(remapping);
+        }
+        for (path, result) in report.files.iter() {
+            // Read file to string
+            if let Ok(source) = fs::read_to_string(path) {
+                if report.files.len() > 1 {
+                    println!("{}", path.display());
+                }
+                for (line, source) in source.lines().enumerate() {
+                    print!("{: >5}|", line + 1);
+                    if let Some(hits) = result.hits_for_line(line + 1) {
+                        println!("{: >7}|{}", hits, source);
+                    } else {
+                        println!("       |{}", source);
+                    }
+                }
+                println!();
+            }
+        }
+        Ok(())
+    }
+}
+
+fn enable_debug_logging() -> anyhow::Result<()> {
+    let fmt = tracing_subscriber::fmt::Layer::default();
+    let subscriber = fmt
+        .with_filter(filter_fn(|metadata| {
+            metadata.target().contains("llvm_profparser")
+        }))
+        .with_subscriber(Registry::default());
+    tracing::subscriber::set_global_default(subscriber)?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    match opts.cmd {
+        Command::Show { show } => show.run(),
+    }
+}

--- a/ferrocene/tools/blanket/llvm-profparser/src/bin/profparser.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/bin/profparser.rs
@@ -1,0 +1,398 @@
+use anyhow::Result;
+use clap::Parser;
+use llvm_profparser::instrumentation_profile::summary::*;
+use llvm_profparser::instrumentation_profile::types::*;
+use llvm_profparser::*;
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::path::PathBuf;
+use tracing_subscriber::filter::filter_fn;
+use tracing_subscriber::{Layer, Registry};
+
+#[derive(Clone, Debug, Eq, PartialEq, Parser)]
+pub enum Command {
+    Show {
+        #[command(flatten)]
+        show: ShowCommand,
+    },
+    Merge {
+        #[command(flatten)]
+        merge: MergeCommand,
+    },
+    Overlap {
+        #[command(flatten)]
+        overlap: OverlapCommand,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Parser)]
+pub struct ShowCommand {
+    /// Input profraw file to show some information about
+    #[structopt(name = "<filename...>", long = "input", short = 'i')]
+    input: PathBuf,
+    /// Show counter values for shown functions
+    #[structopt(long = "counts")]
+    show_counts: bool,
+    /// Details for every function
+    #[structopt(long = "all-functions")]
+    all_functions: bool,
+    /// Show instr profile data in text dump format
+    #[structopt(long = "text")]
+    text: bool,
+    /// Show detailed profile summary
+    #[structopt(long = "show_detailed_summary")]
+    show_detailed_summary: bool,
+    /// Cutoff percentages (times 10000) for generating detailed summary
+    #[structopt(long = "detailed_summary_cutoffs")]
+    detailed_summary_cutoffs: Vec<usize>,
+    /// Show profile summary of a list of hot functions
+    #[structopt(long = "show_hot_fn_list")]
+    show_hot_fn_list: bool,
+    /// Show context sensitive counts
+    #[structopt(long = "showcs")]
+    showcs: bool,
+    /// Details for matching functions
+    #[structopt(long = "function")]
+    function: Option<String>,
+    /// Output file
+    #[structopt(long = "output", short = 'o')]
+    output: Option<String>,
+    /// Show the list of functions with the largest internal counts
+    #[structopt(long = "topn")]
+    topn: Option<usize>,
+    /// Set the count value cutoff. Functions with the maximum count less than
+    /// this value will not be printed out. (Default is 0)
+    #[structopt(long = "value_cutoff", default_value = "0")]
+    value_cutoff: u64,
+    /// Set the count value cutoff. Functions with the maximum count below the
+    /// cutoff value
+    #[structopt(long = "only_list_below")]
+    only_list_below: bool,
+    /// Show profile symbol list if it exists in the profile.
+    #[structopt(long = "show_profile_sym_list")]
+    show_profile_sym_list: bool,
+    /// Show the information of each section in the sample profile. The flag is
+    /// only usable when the sample profile is in extbinary format
+    #[structopt(long = "show_section_info_only")]
+    show_section_info_only: bool,
+    /// Turn on debug logging
+    #[structopt(long)]
+    debug: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Parser)]
+pub struct MergeCommand {
+    /// Input files to merge
+    #[structopt(name = "<filename...>", long = "input", short = 'i')]
+    input: Vec<PathBuf>,
+    /// Output file
+    #[structopt(long = "output", short = 'o')]
+    output: PathBuf,
+    /// List of weights and filenames in `<weight>,<filename>` format
+    #[structopt(long = "weighted-input", value_parser=try_parse_weighted)]
+    weighted_input: Vec<(u64, String)>,
+    /// Number of merge threads to use (will autodetect by default)
+    #[structopt(long = "num-threads", short = 'j')]
+    jobs: Option<usize>,
+    /// Turn on debug logging
+    #[structopt(long)]
+    debug: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Parser)]
+pub struct OverlapCommand {
+    #[structopt(name = "<base profile file>")]
+    base_file: PathBuf,
+    #[structopt(name = "<test profile file>")]
+    test_file: PathBuf,
+    #[structopt(long = "output", short = 'o')]
+    output: Option<PathBuf>,
+    /// For context sensitive counts
+    #[structopt(long = "cs")]
+    context_sensitive_counts: bool,
+    /// Function level overlap information for every function in test profile with max count value
+    /// greater than the parameter value
+    #[structopt(long = "value-cutoff")]
+    value_cutoff: Option<usize>,
+    /// Function level overlap information for matching functions
+    #[structopt(long = "function")]
+    function: Option<String>,
+    /// Generate a sparse profile
+    #[structopt(long = "sparse")]
+    sparse: bool,
+    /// Turn on debug logging
+    #[structopt(long)]
+    debug: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Parser)]
+pub struct Opts {
+    #[command(subcommand)]
+    cmd: Command,
+}
+
+impl Opts {
+    fn debug(&self) -> bool {
+        match &self.cmd {
+            &Command::Show { ref show } => show.debug,
+            &Command::Merge { ref merge } => merge.debug,
+            &Command::Overlap { ref overlap } => overlap.debug,
+        }
+    }
+}
+
+fn try_parse_weighted(input: &str) -> Result<(u64, String), String> {
+    if !input.contains(',') {
+        Ok((1, input.to_string()))
+    } else {
+        let parts = input.split(',').collect::<Vec<_>>();
+        if parts.len() != 2 {
+            Err("Unexpected weighting format, expected $weight,$name or just $name".to_string())
+        } else {
+            let weight = parts[0]
+                .parse()
+                .map_err(|e| format!("Invalid weight: {}", e))?;
+            if weight < 1 {
+                Err("Weight must be positive integer".to_string())
+            } else {
+                Ok((weight, parts[1].to_string()))
+            }
+        }
+    }
+}
+
+fn check_function(name: Option<&String>, pattern: Option<&String>) -> bool {
+    match pattern {
+        Some(pat) => name.map(|x| x.contains(pat)).unwrap_or(false),
+        None => false,
+    }
+}
+
+#[derive(Clone, Debug, Eq)]
+struct HotFn {
+    name: String,
+    count: u64,
+}
+
+impl PartialOrd for HotFn {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for HotFn {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Do the reverse here
+        other.count.cmp(&self.count)
+    }
+}
+
+impl PartialEq for HotFn {
+    fn eq(&self, other: &Self) -> bool {
+        self.count == other.count
+    }
+}
+
+impl ShowCommand {
+    pub fn run(&self) -> Result<()> {
+        let profile = parse(&self.input)?;
+        let mut summary = ProfileSummary::new();
+
+        let is_ir_instr = profile.is_ir_level_profile();
+        let mut hotties =
+            BinaryHeap::<HotFn>::with_capacity(self.topn.unwrap_or_default() as usize);
+        let mut shown_funcs = 0;
+        let mut below_cutoff_funcs = 0;
+        let topn = self.topn.unwrap_or_default();
+        for func in profile.records() {
+            if func.name.is_none() || func.hash.is_none() {
+                continue;
+            }
+            if is_ir_instr && func.has_cs_flag() != self.showcs {
+                continue;
+            }
+            let show =
+                self.all_functions || check_function(func.name.as_ref(), self.function.as_ref());
+
+            if show && self.text {
+                // TODO text format dump
+                continue;
+            }
+            summary.add_record(&func.record);
+
+            let (func_max, func_sum) = func.counts().iter().fold((0, 0u64), |acc, x| {
+                (*x.max(&acc.0), acc.1.saturating_add(*x))
+            });
+            if func_max < self.value_cutoff {
+                below_cutoff_funcs += 1;
+                if self.only_list_below {
+                    println!(
+                        "  {}: (Max = {} Sum = {})",
+                        func.name.as_ref().unwrap(),
+                        func_max,
+                        func_sum
+                    );
+                    continue;
+                }
+            } else if self.only_list_below {
+                continue;
+            }
+            if topn > 0 {
+                if hotties.len() == topn {
+                    let top = hotties.peek().unwrap();
+                    if top.count < func_max {
+                        hotties.pop();
+                        hotties.push(HotFn {
+                            name: func.name.as_ref().unwrap().to_string(),
+                            count: func_max,
+                        });
+                    }
+                } else {
+                    hotties.push(HotFn {
+                        name: func.name.as_ref().unwrap().to_string(),
+                        count: func_max,
+                    });
+                }
+            }
+            if show {
+                if shown_funcs == 0 {
+                    println!("Counters:");
+                }
+                shown_funcs += 1;
+                println!("  {}:", func.name.as_ref().unwrap());
+                println!("    Hash: {:#018x}", func.hash.unwrap());
+                println!("    Counters: {}", func.counts().len());
+                if !is_ir_instr {
+                    let counts = if func.counts().is_empty() {
+                        0
+                    } else {
+                        func.counts()[0]
+                    };
+                    println!("    Function count: {}", counts);
+                }
+                if self.show_counts {
+                    let start = if is_ir_instr { 0 } else { 1 };
+                    let counts = func
+                        .counts()
+                        .iter()
+                        .skip(start)
+                        .map(|x| x.to_string())
+                        .collect::<Vec<String>>()
+                        .join(", ");
+                    println!("    Block counts: [{}]", counts);
+                }
+            }
+        }
+        if profile.get_level() == InstrumentationLevel::Ir {
+            println!(
+                "Instrumentation level: {}  entry_first = {}",
+                profile.get_level(),
+                // NOTE: in llvm 11 this is always false
+                profile.is_entry_first() as usize
+            );
+        } else {
+            println!("Instrumentation level: {}", profile.get_level());
+        }
+        if self.all_functions || self.function.is_some() {
+            println!("Functions shown: {}", shown_funcs);
+        }
+        println!("Total functions: {}", summary.num_functions());
+        if self.value_cutoff > 0 {
+            println!(
+                "Number of functions with maximum count (< {} ): {}",
+                self.value_cutoff, below_cutoff_funcs
+            );
+            println!(
+                "Number of functions with maximum count (>= {}): {}",
+                self.value_cutoff,
+                summary.num_functions() - below_cutoff_funcs
+            );
+        }
+        println!("Maximum function count: {}", summary.max_function_count());
+        println!(
+            "Maximum internal block count: {}",
+            summary.max_internal_block_count()
+        );
+        if let Some(topn) = self.topn {
+            println!(
+                "Top {} functions with the largest internal block counts: ",
+                topn
+            );
+            let hotties = hotties.into_sorted_vec();
+            for f in hotties.iter() {
+                println!("  {}, max count = {}", f.name, f.count);
+            }
+        }
+
+        if self.show_detailed_summary {
+            println!("Total number of blocks: ?");
+            println!("Total count: ?");
+        }
+        Ok(())
+    }
+}
+
+impl MergeCommand {
+    fn run(&self) -> Result<()> {
+        assert!(
+            !self.input.is_empty(),
+            "No input files selected. See merge --help"
+        );
+        let profile = merge_profiles(&self.input)?;
+        // Now to write it out?
+        println!("{:#?}", profile);
+        Ok(())
+    }
+}
+
+fn enable_debug_logging() -> anyhow::Result<()> {
+    let fmt = tracing_subscriber::fmt::Layer::default();
+    let subscriber = fmt
+        .with_filter(filter_fn(|metadata| {
+            metadata.target().contains("llvm_profparser")
+        }))
+        .with_subscriber(Registry::default());
+    tracing::subscriber::set_global_default(subscriber)?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    if opts.debug() {
+        let _ = enable_debug_logging();
+    }
+    match opts.cmd {
+        Command::Show { show } => show.run(),
+        Command::Merge { merge } => merge.run(),
+        _ => {
+            panic!("Unsupported command");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn weight_arg_parsing() {
+        // Examples taken from LLVM docs
+        let foo_10 = "10,foo.profdata";
+        let bar_1 = "1,bar.profdata";
+
+        assert_eq!(
+            Ok((10, "foo.profdata".to_string())),
+            try_parse_weighted(foo_10)
+        );
+        assert_eq!(
+            Ok((1, "bar.profdata".to_string())),
+            try_parse_weighted(bar_1)
+        );
+        assert_eq!(
+            Ok((1, "foo.profdata".to_string())),
+            try_parse_weighted("foo.profdata")
+        );
+        assert!(try_parse_weighted("foo.profdata,1").is_err());
+        assert!(try_parse_weighted("1,1,foo.profdata").is_err());
+    }
+}

--- a/ferrocene/tools/blanket/llvm-profparser/src/coverage/coverage_mapping.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/coverage/coverage_mapping.rs
@@ -1,0 +1,631 @@
+use crate::coverage::reporting::*;
+use crate::coverage::*;
+use crate::instrumentation_profile::types::*;
+use crate::util::*;
+use anyhow::{bail, Result};
+use nom::error::Error as NomError;
+use object::{Endian, Endianness, Object, ObjectSection, ReadCache, ReadRef, Section};
+use std::convert::TryInto;
+use std::error::Error;
+use std::fmt;
+use std::fs;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+use tracing::{debug, error, trace, warn};
+
+/// Stores the instrumentation profile and information from the coverage mapping sections in the
+/// object files in order to construct a coverage report. Inspired, from the LLVM implementation
+/// with some differences/simplifications due to the fact this only hands instrumentation profiles
+/// for coverage.
+///
+/// So what the LLVM one has that this one doesn't yet:
+///
+/// 1. DenseMap<size_t, DenseSet<size_t>> RecordProvenance
+/// 2. std::vector<FunctionRecord> functions (this is probably taken straight from
+/// InstrumentationProfile
+/// 3. DenseMap<size_t, SmallVector<unsigned, 0>> FilenameHash2RecordIndices
+/// 4. Vec<Pair<String, u64>> FuncHashMismatches
+#[derive(Debug)]
+pub struct CoverageMapping<'a> {
+    profile: &'a InstrumentationProfile,
+    object_files: &'a [PathBuf],
+    allow_parsing_failures: bool,
+    version: u64,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum LlvmSection {
+    CoverageMap,
+    ProfileNames,
+    ProfileCounts,
+    ProfileData,
+    CoverageFunctions,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum SectionReadError {
+    EmptySection(LlvmSection),
+    MissingSection(LlvmSection),
+    InvalidPathList,
+}
+
+impl fmt::Display for SectionReadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptySection(s) => write!(f, "empty section: {:?}", s),
+            Self::MissingSection(s) => write!(f, "missing section: {:?}", s),
+            Self::InvalidPathList => write!(f, "unable to read path list"),
+        }
+    }
+}
+
+impl Error for SectionReadError {}
+
+pub fn read_object_file(object: &Path, version: u64) -> Result<CoverageMappingInfo> {
+    // I believe vnode sections added by llvm are unnecessary
+
+    let binary_data = ReadCache::new(BufReader::new(fs::File::open(object)?));
+    let object_file = object::File::parse(&binary_data)?;
+
+    let prof_counts = object_file
+        .section_by_name("__llvm_prf_cnts")
+        .or(object_file.section_by_name(".lprfc"))
+        .and_then(|x| parse_profile_counters(object_file.endianness(), &x).ok());
+
+    debug!("Parsed prf_cnts: {:?}", prof_counts);
+
+    let prof_data = object_file
+        .section_by_name("__llvm_prf_data")
+        .or(object_file.section_by_name(".lprfd"))
+        .and_then(|x| parse_profile_data(object_file.endianness(), &x).ok());
+
+    debug!("Parsed prf_data section: {:?}", prof_data);
+
+    let cov_fun = object_file
+        .section_by_name("__llvm_covfun")
+        .or(object_file.section_by_name(".lcovfun"))
+        .map(|x| parse_coverage_functions(object_file.endianness(), &x))
+        .ok_or(SectionReadError::MissingSection(
+            LlvmSection::CoverageFunctions,
+        ))??;
+
+    debug!("Parsed covfun section: {:?}", cov_fun);
+
+    let cov_map = object_file
+        .section_by_name("__llvm_covmap")
+        .or(object_file.section_by_name(".lcovmap"))
+        .map(|x| parse_coverage_mapping(object_file.endianness(), &x, version))
+        .ok_or(SectionReadError::MissingSection(LlvmSection::CoverageMap))??;
+
+    debug!("Parsed covmap section: {:?}", cov_map);
+
+    Ok(CoverageMappingInfo {
+        cov_map,
+        cov_fun,
+        prof_counts,
+        prof_data,
+    })
+}
+
+impl<'a> CoverageMapping<'a> {
+    pub fn new(
+        object_files: &'a [PathBuf],
+        profile: &'a InstrumentationProfile,
+        allow_parsing_failures: bool,
+    ) -> Result<Self> {
+        let version = match profile.version() {
+            Some(v) => v,
+            None => bail!("Invalid profile instrumentation, no version number provided"),
+        };
+
+        Ok(Self {
+            profile,
+            object_files,
+            allow_parsing_failures,
+            version,
+        })
+    }
+
+    /// All counters of type `CounterKind::ProfileInstrumentation` can be used in function regions
+    /// other than their own (particulary for functions which are only called from one location).
+    /// This gathers them all to use as a base list of counters.
+    pub(crate) fn get_simple_counters(&self, func: &FunctionRecordV3) -> FxHashMap<Counter, i64> {
+        let mut result = FxHashMap::default();
+        result.insert(Counter::default(), 0);
+        let record = self.profile.find_record_by_hash(func.header.name_hash);
+        if let Some(func_record) = record.as_ref() {
+            result.reserve(func_record.record.counts.len());
+            for (id, count) in func_record.record.counts.iter().enumerate() {
+                result.insert(Counter::instrumentation(id as u64), *count as i64);
+            }
+        }
+        result
+    }
+
+    pub fn generate_subreport<P>(&self, mut predicate: P) -> Result<CoverageReport>
+    where
+        P: FnMut(&[PathBuf]) -> bool,
+    {
+        let mut report = CoverageReport::default();
+        //let base_region_ids = info.get_simple_counters(self.profile);
+
+        for result in self.mapping_info_iter() {
+            let info = result?;
+            for func in &info.cov_fun {
+                let base_region_ids = self.get_simple_counters(func);
+                let paths = info.get_files_from_id(func.header.filenames_ref);
+                if paths.is_empty() || !predicate(&paths) {
+                    continue;
+                }
+
+                let mut region_ids = base_region_ids.clone();
+
+                for region in func.regions.iter().filter(|x| !x.count.is_expression()) {
+                    let count = region_ids.get(&region.count).copied().unwrap_or_default();
+                    let result = report
+                        .files
+                        .entry(paths[region.file_id].clone())
+                        .or_default();
+                    result.insert(region.loc.clone(), count as usize);
+                }
+
+                let mut pending_exprs = vec![];
+
+                for (expr_index, expr) in func.expressions.iter().enumerate().rev() {
+                    let lhs = region_ids.get(&expr.lhs);
+                    let rhs = region_ids.get(&expr.rhs);
+                    match (lhs, rhs) {
+                        (Some(lhs), Some(rhs)) => {
+                            let count: i64 = match expr.kind {
+                                ExprKind::Subtract => {
+                                    trace!("Subtracting counts: {} - {}", lhs, rhs);
+                                    // TODO these saturating ops need investigation. Potentially
+                                    // something is wrong.
+                                    lhs.saturating_sub(*rhs)
+                                }
+                                ExprKind::Add => {
+                                    trace!("Adding counts: {} + {}", lhs, rhs);
+                                    lhs.saturating_add(*rhs)
+                                }
+                            };
+
+                            let counter = Counter {
+                                kind: CounterType::Expression(expr.kind),
+                                id: expr_index as _,
+                            };
+
+                            region_ids.insert(counter, count);
+                            for expr_region in func.regions.iter().filter(|x| {
+                                x.count.is_expression() && x.count.id == expr_index as u64
+                            }) {
+                                let result = report
+                                    .files
+                                    .entry(paths[expr_region.file_id].clone())
+                                    .or_default();
+                                result.insert(expr_region.loc.clone(), count as _);
+                            }
+                        }
+                        _ => {
+                            let lhs_none = lhs.is_none();
+                            let rhs_none = rhs.is_none();
+                            // These counters have been optimised out, so just add then in as 0
+                            if lhs_none && expr.lhs.is_instrumentation() {
+                                region_ids.insert(expr.lhs, 0);
+                            }
+                            if rhs_none && expr.rhs.is_instrumentation() {
+                                region_ids.insert(expr.rhs, 0);
+                            }
+                            pending_exprs.push(Some((expr_index, expr)));
+                            continue;
+                        }
+                    }
+                }
+                let mut index = 0;
+                let mut cleared_expressions = 0;
+                let mut tries_left = pending_exprs.len() + 1;
+                while pending_exprs.len() != cleared_expressions {
+                    assert!(tries_left > 0);
+                    if index >= pending_exprs.len() {
+                        index = 0;
+                        tries_left -= 1;
+                    }
+                    let (expr_index, expr) = match pending_exprs[index].as_ref() {
+                        Some((idx, expr)) => (idx, expr),
+                        None => {
+                            index += 1;
+                            continue;
+                        }
+                    };
+                    let lhs = region_ids.get(&expr.lhs);
+                    let rhs = region_ids.get(&expr.rhs);
+                    match (lhs, rhs) {
+                        (Some(lhs), Some(rhs)) => {
+                            let count = match expr.kind {
+                                ExprKind::Subtract => lhs - rhs,
+                                ExprKind::Add => lhs + rhs,
+                            };
+
+                            let counter = Counter {
+                                kind: CounterType::Expression(expr.kind),
+                                id: *expr_index as _,
+                            };
+
+                            region_ids.insert(counter, count);
+                            for expr_region in func.regions.iter().filter(|x| {
+                                x.count.is_expression() && x.count.id == *expr_index as u64
+                            }) {
+                                let result = report
+                                    .files
+                                    .entry(paths[expr_region.file_id].clone())
+                                    .or_default();
+                                result.insert(expr_region.loc.clone(), count as _);
+                            }
+                            pending_exprs[index] = None;
+                            cleared_expressions += 1;
+                        }
+                        _ => {
+                            index += 1;
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(report)
+    }
+
+    pub fn generate_report(&self) -> Result<CoverageReport> {
+        self.generate_subreport(|_| true)
+    }
+
+    pub fn mapping_info_iter(&self) -> impl Iterator<Item = Result<CoverageMappingInfo>> + '_ {
+        self.object_files
+            .iter()
+            .map(move |object| (object, read_object_file(object, self.version)))
+            .skip_while(move |(object, result)| match result {
+                Err(ref e) if !self.allow_parsing_failures => {
+                    error!("{} couldn't be interpreted: {}", object.display(), e);
+                    true
+                }
+                _ => false,
+            })
+            .map(|(_, result)| result)
+    }
+}
+
+fn parse_coverage_mapping<'data, R: ReadRef<'data>>(
+    endian: Endianness,
+    section: &Section<'data, '_, R>,
+    version: u64,
+) -> Result<FxHashMap<u64, Vec<PathBuf>>, SectionReadError> {
+    if let Ok(mut data) = section.data() {
+        let mut result = FxHashMap::default();
+        while !data.is_empty() {
+            let data_len = data.len();
+            // Read the number of affixed function records (now just 0 as not in this header)
+            debug_assert_eq!(endian.read_i32_bytes(data[0..4].try_into().unwrap()), 0);
+            let filename_data_len = endian.read_i32_bytes(data[4..8].try_into().unwrap());
+            // Read the length of the affixed string that contains encoded coverage mapping data (now 0
+            // as not in this header)
+            debug_assert_eq!(endian.read_i32_bytes(data[8..12].try_into().unwrap()), 0);
+            let _format_version = endian.read_i32_bytes(data[12..16].try_into().unwrap());
+
+            let hash = md5::compute(&data[16..(filename_data_len as usize + 16)]);
+            let hash = endian.read_u64_bytes(hash.0[..8].try_into().unwrap());
+
+            //let bytes = &data[16..(16 + filename_data_len as usize)];
+            let bytes = &data[16..];
+            let (bytes, file_strings) = parse_path_list(bytes, version)
+                .map_err(|_: nom::Err<NomError<_>>| SectionReadError::InvalidPathList)?;
+            result.insert(hash, file_strings);
+            let read_len = data_len - bytes.len();
+            let padding = if !bytes.is_empty() && (read_len & 0x07) != 0 {
+                8 - (read_len & 0x07)
+            } else {
+                0
+            };
+            if padding > bytes.len() {
+                break;
+            }
+            data = &bytes[padding..];
+        }
+        Ok(result)
+    } else {
+        Err(SectionReadError::EmptySection(LlvmSection::CoverageMap))
+    }
+}
+
+// Strictly speaking, parsing __llvm_covfun ought to depend on the version number
+// observed in the __llvm_covmap headers.
+//
+// But in practice there haven’t been any non-additive changes to the covfun format
+// in a long time, which is why you can get away with parsing them independently,
+// at least for now.
+fn parse_coverage_functions<'data, R: ReadRef<'data>>(
+    endian: Endianness,
+    section: &Section<'data, '_, R>,
+) -> Result<Vec<FunctionRecordV3>, SectionReadError> {
+    debug!("Parsing coverage functions");
+    if let Ok(original_data) = section.data() {
+        let mut bytes = original_data;
+        let mut res = vec![];
+        let section_len = bytes.len();
+        while !bytes.is_empty() {
+            let name_hash = endian.read_u64_bytes(bytes[0..8].try_into().unwrap());
+            let data_len = endian.read_u32_bytes(bytes[8..12].try_into().unwrap());
+            let fn_hash = endian.read_u64_bytes(bytes[12..20].try_into().unwrap());
+            let filenames_ref = endian.read_u64_bytes(bytes[20..28].try_into().unwrap());
+            let header = FunctionRecordHeader {
+                name_hash,
+                data_len,
+                fn_hash,
+                filenames_ref,
+            };
+            let _start_len = bytes[28..].len();
+            bytes = &bytes[28..];
+
+            let (data, id_len) = parse_leb128::<NomError<_>>(bytes).unwrap();
+            bytes = data;
+            let mut filename_indices = vec![];
+            for _ in 0..id_len {
+                let (data, id) = parse_leb128::<NomError<_>>(bytes).unwrap(); // Issue
+                filename_indices.push(id);
+                bytes = data;
+            }
+
+            let (data, expr_len) = parse_leb128::<NomError<_>>(bytes).unwrap();
+            let expr_len = expr_len as usize;
+            bytes = data;
+            let mut exprs = vec![Expression::default(); expr_len];
+            for i in 0..expr_len {
+                let (data, lhs) = parse_leb128::<NomError<_>>(bytes).unwrap();
+                let (data, rhs) = parse_leb128::<NomError<_>>(data).unwrap();
+                let lhs = parse_counter(lhs, &mut exprs);
+                let rhs = parse_counter(rhs, &mut exprs);
+                exprs[i].lhs = lhs;
+                exprs[i].rhs = rhs;
+                bytes = data;
+            }
+
+            let (data, regions) =
+                parse_mapping_regions(bytes, &filename_indices, &mut exprs).unwrap();
+
+            res.push(FunctionRecordV3 {
+                header,
+                regions,
+                expressions: exprs,
+            });
+
+            // Todo set couners for expansion regions - counter of expansion region is the counter
+            // of the first region from the expanded file. This requires multiple passes to
+            // correctly propagate across all nested regions. N.B. I haven't seen any expansion
+            // regions in use so may not be an issue!
+
+            bytes = data;
+            let function_len = section_len - bytes.len(); // this should match header
+
+            let padding = if function_len < section_len && (function_len & 0x07) != 0 {
+                8 - (function_len & 0x07)
+            } else {
+                0
+            };
+
+            if padding > bytes.len() {
+                break;
+            }
+            // Now apply padding, and if hash is 0 move on as it's a dummy otherwise add to result
+            // And decide what end type will be
+            bytes = &bytes[padding..];
+        }
+        Ok(res)
+    } else {
+        error!("Can't read data for coverage function section");
+        Err(SectionReadError::EmptySection(
+            LlvmSection::CoverageFunctions,
+        ))
+    }
+}
+
+/// This code is ported from `RawCoverageMappingReader::readMappingRegionsSubArray`
+fn parse_mapping_regions<'a>(
+    mut bytes: &'a [u8],
+    file_indices: &[u64],
+    expressions: &mut Vec<Expression>,
+) -> IResult<&'a [u8], Vec<CounterMappingRegion>> {
+    let mut mapping = vec![];
+    for i in file_indices {
+        let (data, regions_len) = parse_leb128(bytes)?;
+        bytes = data;
+        let mut last_line = 0;
+        for _ in 0..regions_len {
+            let mut mcdc_params = None;
+
+            let mut false_count = Counter::default();
+            let mut kind = RegionKind::Code;
+            let (data, raw_header) = parse_leb128(bytes)?;
+            bytes = data;
+            let mut expanded_file_id = 0;
+            let mut counter = parse_counter(raw_header, expressions);
+            if counter.is_zero() {
+                if raw_header & Counter::ENCODING_EXPANSION_REGION_BIT > 0 {
+                    kind = RegionKind::Expansion;
+                    expanded_file_id = raw_header >> Counter::ENCODING_TAG_AND_EXP_REGION_BITS;
+                    if expanded_file_id >= file_indices.len() as u64 {
+                        panic!("expanded_file_id is invalid");
+                    }
+                } else {
+                    let shifted_counter = raw_header >> Counter::ENCODING_TAG_AND_EXP_REGION_BITS;
+                    match shifted_counter.try_into() {
+                        Ok(RegionKind::Code) | Ok(RegionKind::Skipped) => {}
+                        Ok(RegionKind::Branch) => {
+                            kind = RegionKind::Branch;
+                            let (data, c1) = parse_leb128(bytes)?;
+                            let (data, c2) = parse_leb128(data)?;
+
+                            counter = parse_counter(c1, expressions);
+                            false_count = parse_counter(c2, expressions);
+                            bytes = data;
+                        }
+                        Ok(RegionKind::MCDCBranch) => {
+                            kind = RegionKind::MCDCBranch;
+                            let (data, c1) = parse_leb128(bytes)?;
+                            let (data, c2) = parse_leb128(data)?;
+
+                            counter = parse_counter(c1, expressions);
+                            false_count = parse_counter(c2, expressions);
+
+                            let (data, id1) = parse_leb128(data)?;
+                            let (data, tid1) = parse_leb128(data)?;
+                            let (data, fid1) = parse_leb128(data)?;
+                            bytes = data;
+
+                            mcdc_params = Some(MCDCParams::Branch(BranchParameters {
+                                id: id1.try_into().unwrap(),
+                                false_cond: fid1.try_into().unwrap(),
+                                true_cond: tid1.try_into().unwrap(),
+                            }));
+                        }
+                        Ok(RegionKind::MCDCDecision) => {
+                            kind = RegionKind::MCDCDecision;
+                            let (data, bidx) = parse_leb128(data)?;
+                            let (data, nc) = parse_leb128(data)?;
+                            bytes = data;
+
+                            mcdc_params = Some(MCDCParams::Decision(DecisionParameters {
+                                bitmap_idx: bidx.try_into().unwrap(),
+                                num_conditions: nc.try_into().unwrap(),
+                            }));
+                        }
+                        e => panic!("Malformed: {:?}", e),
+                    }
+                }
+            }
+
+            let (data, delta_line) = parse_leb128(bytes)?;
+            let (data, column_start) = parse_leb128(data)?;
+            let (data, lines_len) = parse_leb128(data)?;
+            let (data, column_end) = parse_leb128(data)?;
+            bytes = data;
+
+            let (column_start, column_end) = if column_start == 0 && column_end == 0 {
+                (1usize, usize::MAX)
+            } else {
+                (column_start as usize, column_end as usize)
+            };
+
+            let line_start = last_line + delta_line as usize;
+            let line_end = line_start + lines_len as usize;
+            last_line = line_start;
+
+            // Add region working-out-stuff
+            mapping.push(CounterMappingRegion {
+                kind,
+                count: counter,
+                false_count,
+                file_id: *i as usize,
+                expanded_file_id: expanded_file_id as _,
+                loc: SourceLocation {
+                    line_start,
+                    line_end,
+                    column_start,
+                    column_end,
+                },
+                mcdc_params,
+            });
+        }
+    }
+    Ok((bytes, mapping))
+}
+
+fn parse_profile_data<'data, R: ReadRef<'data>>(
+    endian: Endianness,
+    section: &Section<'data, '_, R>,
+) -> Result<Vec<ProfileData>, SectionReadError> {
+    if let Ok(data) = section.data() {
+        let mut bytes = data;
+        let mut res = vec![];
+        while !bytes.is_empty() {
+            // bytes.len() >= 24 {
+            let name_md5 = endian.read_u64_bytes(bytes[..8].try_into().unwrap());
+            let structural_hash = endian.read_u64_bytes(bytes[8..16].try_into().unwrap());
+
+            let _counter_ptr = endian.read_u64_bytes(bytes[16..24].try_into().unwrap());
+            let counters_location = 24 + 16;
+            if bytes.len() <= counters_location {
+                bytes = &bytes[counters_location..];
+                let counters_len = endian.read_u32_bytes(bytes[..4].try_into().unwrap());
+                // TODO Might need to get the counter offset and get the list of counters from this?
+                // And potentially check against the maximum number of counters just to make sure that
+                // it's not being exceeded?
+                //
+                // Also counters_len >= 1 so this should be checked to make sure it's not malformed
+
+                bytes = &bytes[8..];
+
+                res.push(ProfileData {
+                    name_md5,
+                    structural_hash,
+                    counters_len,
+                });
+            } else {
+                bytes = &[];
+            }
+        }
+        if !bytes.is_empty() {
+            warn!("{} bytes left in profile data", bytes.len());
+        }
+        Ok(res)
+    } else {
+        Err(SectionReadError::EmptySection(LlvmSection::ProfileData))
+    }
+}
+
+fn parse_profile_counters<'data, R: ReadRef<'data>>(
+    endian: Endianness,
+    section: &Section<'data, '_, R>,
+) -> Result<Vec<u64>, SectionReadError> {
+    if let Ok(data) = section.data() {
+        let mut result = vec![];
+        for i in (0..data.len()).step_by(8) {
+            if data.len() < (i + 8) {
+                break;
+            }
+            result.push(endian.read_u64_bytes(data[i..(i + 8)].try_into().unwrap()));
+        }
+        Ok(result)
+    } else {
+        Err(SectionReadError::EmptySection(LlvmSection::ProfileCounts))
+    }
+}
+
+/// The equivalent llvm function is `RawCoverageMappingReader::decodeCounter`. This makes it
+/// stateless as I don't want to be maintaining an expression vector and clearing it and
+/// repopulating for every function record.
+fn parse_counter(input: u64, exprs: &mut Vec<Expression>) -> Counter {
+    let ty = (Counter::ENCODING_TAG_MASK & input) as u8;
+    let id = input >> 2; // For zero we don't actually care about this but we'll still do it
+    let kind = match ty {
+        0 => CounterType::Zero,
+        1 => CounterType::ProfileInstrumentation,
+        2 | 3 => {
+            let expr_kind = if ty == 2 {
+                ExprKind::Subtract
+            } else {
+                ExprKind::Add
+            };
+            let id = id as usize;
+            if exprs.len() <= id {
+                debug!(
+                    "Not enough expressions resizing {}->{}",
+                    exprs.len(),
+                    id + 1
+                );
+                exprs.resize(id + 1, Expression::default());
+            }
+            exprs[id].set_kind(expr_kind);
+            CounterType::Expression(expr_kind)
+        }
+        _ => unreachable!(),
+    };
+    Counter { kind, id }
+}

--- a/ferrocene/tools/blanket/llvm-profparser/src/coverage/coverage_mapping.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/coverage/coverage_mapping.rs
@@ -99,11 +99,21 @@ pub fn read_object_file(object: &Path, version: u64) -> Result<CoverageMappingIn
 
     debug!("Parsed covmap section: {:?}", cov_map);
 
+    let prof_names = object_file
+        .section_by_name("__llvm_prf_names")
+        .or(object_file.section_by_name(".lprfn"))
+        .map(|x| parse_profile_names(&x))
+        .transpose()?
+        .unwrap_or_default();
+
+    debug!("Parsed prf_names section: {} names", prof_names.len());
+
     Ok(CoverageMappingInfo {
         cov_map,
         cov_fun,
         prof_counts,
         prof_data,
+        prof_names,
     })
 }
 
@@ -158,6 +168,9 @@ impl<'a> CoverageMapping<'a> {
                     continue;
                 }
 
+                let function_name =
+                    info.prof_names.get(&func.header.name_hash).map(String::as_str).unwrap_or("");
+
                 let mut region_ids = base_region_ids.clone();
 
                 for region in func.regions.iter().filter(|x| !x.count.is_expression()) {
@@ -166,7 +179,7 @@ impl<'a> CoverageMapping<'a> {
                         .files
                         .entry(paths[region.file_id].clone())
                         .or_default();
-                    result.insert(region.loc.clone(), count as usize);
+                    result.insert(function_name, region.loc.clone(), count as usize);
                 }
 
                 let mut pending_exprs = vec![];
@@ -202,7 +215,7 @@ impl<'a> CoverageMapping<'a> {
                                     .files
                                     .entry(paths[expr_region.file_id].clone())
                                     .or_default();
-                                result.insert(expr_region.loc.clone(), count as _);
+                                result.insert(function_name, expr_region.loc.clone(), count as _);
                             }
                         }
                         _ => {
@@ -258,7 +271,7 @@ impl<'a> CoverageMapping<'a> {
                                     .files
                                     .entry(paths[expr_region.file_id].clone())
                                     .or_default();
-                                result.insert(expr_region.loc.clone(), count as _);
+                                result.insert(function_name, expr_region.loc.clone(), count as _);
                             }
                             pending_exprs[index] = None;
                             cleared_expressions += 1;
@@ -424,6 +437,30 @@ fn parse_coverage_functions<'data, R: ReadRef<'data>>(
             LlvmSection::CoverageFunctions,
         ))
     }
+}
+
+/// Parses `__llvm_prf_names`: a sequence of length-prefixed, optionally zlib-compressed chunks
+/// (see `parse_string_ref`), each containing one or more `\x01`-separated raw function names.
+/// Returns a map from each name's `compute_hash` to the name itself.
+fn parse_profile_names<'data, R: ReadRef<'data>>(
+    section: &Section<'data, '_, R>,
+) -> Result<FxHashMap<u64, String>, SectionReadError> {
+    let Ok(mut input) = section.data() else {
+        return Err(SectionReadError::EmptySection(LlvmSection::ProfileNames));
+    };
+    let mut result = FxHashMap::default();
+    while !input.is_empty() {
+        let Ok((rest, names)) = parse_string_ref::<NomError<_>>(input) else {
+            break;
+        };
+        for name in names.split(crate::instrumentation_profile::raw_profile::INSTR_PROF_NAME_SEP) {
+            if !name.is_empty() {
+                result.insert(compute_hash(name.as_bytes()), name.to_string());
+            }
+        }
+        input = rest;
+    }
+    Ok(result)
 }
 
 /// This code is ported from `RawCoverageMappingReader::readMappingRegionsSubArray`

--- a/ferrocene/tools/blanket/llvm-profparser/src/coverage/mod.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/coverage/mod.rs
@@ -1,0 +1,302 @@
+use nom::IResult;
+use rustc_hash::FxHashMap;
+use std::convert::TryFrom;
+use std::path::PathBuf;
+
+use crate::instrumentation_profile::types::MCDCParams;
+
+pub mod coverage_mapping;
+pub mod reporting;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CoverageMappingInfo {
+    pub cov_map: FxHashMap<u64, Vec<PathBuf>>,
+    pub cov_fun: Vec<FunctionRecordV3>,
+    pub prof_counts: Option<Vec<u64>>,
+    pub prof_data: Option<Vec<ProfileData>>,
+}
+
+impl CoverageMappingInfo {
+    /// Gets the files for a given ID converted to their absolute representation
+    pub fn get_files_from_id(&self, id: u64) -> Vec<PathBuf> {
+        let mut paths = vec![];
+        if let Some(v) = self.cov_map.get(&id) {
+            let mut last_absolute = None;
+            for path in v.iter() {
+                if path.is_absolute() {
+                    // Currently all examples I've checked have the base path as first arg and any
+                    // paths not in that directory are an absolute path. Now thread/local.rs in the
+                    // rust std is given an absolute path that doesn't exist on the system (I guess
+                    // it's compiled elsewhere). And also due to not having remapping info paths
+                    // may not be present. Meaning we can't use existence as a requirement to see
+                    // if it's a directory or not. And I'd rather not do name based heuristics so
+                    // just taking the first absolute path as the folder path and hoping LLVM keeps
+                    // to that convention
+                    if last_absolute.is_none() {
+                        last_absolute = Some(path.clone());
+                    }
+                    paths.push(path.clone());
+                } else {
+                    let base = last_absolute.clone().unwrap_or_default();
+                    paths.push(base.join(path))
+                }
+            }
+        }
+        paths
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct ProfileData {
+    pub name_md5: u64,
+    pub structural_hash: u64,
+    pub counters_len: u32,
+}
+
+/// This is the type of a counter expression. The equivalent type in llvm would be
+/// `CounterExpression::ExprKind` an inner enum.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub enum ExprKind {
+    /// Subtracts a counter from another
+    Subtract,
+    /// Adds a counter to another
+    Add,
+}
+
+/// Defines what type of region a counter maps to. The equivalent type in llvm would be
+/// `CounterMappingRegion::RegionKind`.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub enum RegionKind {
+    /// A Code Region associates some code with a counter
+    Code = 0,
+    /// An Expansion Region represents a file expansion region that associates a source range with
+    /// the expansion of a virtual source file, such as for a macro instantiation or include file
+    Expansion = 1,
+    /// A Skipped  Region represents a source range with code that was skipped by a preprocessor or
+    /// similar means
+    Skipped = 2,
+    /// A Gap Region is like a Code Region but its count is only set as the line execution count
+    /// when its the only region in the line
+    Gap = 3,
+    /// A Branch Region represents lead-level boolean expressions and is associated with two
+    /// counters, each representing the number of times the expression evaluates to true or false.
+    Branch = 4,
+    /// A DecisionRegion represents a top-level boolean expression and is
+    /// associated with a variable length bitmap index and condition number.
+    MCDCDecision = 5,
+    /// A Branch Region can be extended to include IDs to facilitate MC/DC.
+    MCDCBranch = 6,
+}
+
+impl TryFrom<u64> for RegionKind {
+    type Error = u64;
+
+    fn try_from(v: u64) -> Result<Self, Self::Error> {
+        match v {
+            0 => Ok(RegionKind::Code),
+            1 => Ok(RegionKind::Expansion),
+            2 => Ok(RegionKind::Skipped),
+            3 => Ok(RegionKind::Gap),
+            4 => Ok(RegionKind::Branch),
+            5 => Ok(RegionKind::MCDCDecision),
+            6 => Ok(RegionKind::MCDCBranch),
+            e => Err(e),
+        }
+    }
+}
+
+/// Represents the type of a counter. The equivalent type in llvm would be `Counter::CounterKind`.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum CounterType {
+    Zero,
+    ProfileInstrumentation,
+    Expression(ExprKind),
+}
+
+impl Default for CounterType {
+    fn default() -> Self {
+        Self::Zero
+    }
+}
+
+/// A `Counter` is an abstract value that describes how to compute the execution count for a region
+/// of code using the collected profile count data. The equivalent type in llvm would be `Counter`.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct Counter {
+    /// Type of the counter present
+    pub kind: CounterType,
+    /// A valid counter ID, if this counter isn't expected to have an ID then the ID must be zero.
+    pub id: u64,
+}
+
+impl Counter {
+    pub fn instrumentation(id: u64) -> Self {
+        Self {
+            kind: CounterType::ProfileInstrumentation,
+            id,
+        }
+    }
+
+    pub fn is_expression(&self) -> bool {
+        matches!(self.kind, CounterType::Expression(_))
+    }
+
+    pub fn is_instrumentation(&self) -> bool {
+        self.kind == CounterType::ProfileInstrumentation
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.kind == CounterType::Zero
+    }
+
+    /// Gets the kind of the expression
+    ///
+    /// # Panics
+    ///
+    /// Panics if not an kind of `CounterType::Expression`
+    pub fn get_expr_kind(&self) -> ExprKind {
+        match self.kind {
+            CounterType::Expression(e) => e,
+            _ => panic!("Counter is not an expression"),
+        }
+    }
+}
+
+/// A counter expression is a value that represents an arithmetic operation between two counters.
+/// The equivalent llvm type would be `CounterExpression`.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct Expression {
+    pub kind: ExprKind,
+    pub lhs: Counter,
+    pub rhs: Counter,
+}
+
+impl Default for Expression {
+    fn default() -> Self {
+        Expression::new(Counter::default(), Counter::default())
+    }
+}
+
+impl Expression {
+    pub fn new(lhs: Counter, rhs: Counter) -> Self {
+        Self {
+            kind: ExprKind::Subtract,
+            lhs,
+            rhs,
+        }
+    }
+
+    pub fn set_kind(&mut self, kind: ExprKind) {
+        self.kind = kind;
+    }
+}
+
+impl Counter {
+    const ENCODING_TAG_MASK: u64 = 3;
+    const ENCODING_TAG_AND_EXP_REGION_BITS: u64 = 3;
+    const ENCODING_EXPANSION_REGION_BIT: u64 = 4;
+}
+
+/// Associates a source code reader with a specific counter. The equivalent type in llvm would be
+/// `CounterMappingRegion`.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CounterMappingRegion {
+    pub kind: RegionKind,
+    /// Primary counter that is also used for true branches
+    pub count: Counter,
+    /// Secondary counter that is also used for false branches
+    pub false_count: Counter,
+    pub file_id: usize,
+    pub expanded_file_id: usize,
+    pub loc: SourceLocation,
+    pub mcdc_params: Option<MCDCParams>,
+}
+
+/// Refers to a location in the source code
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SourceLocation {
+    /// The start line of the coverage region
+    pub line_start: usize,
+    /// The start column of the coverage region
+    pub column_start: usize,
+    /// The last line of the coverage region (inclusive)
+    pub line_end: usize,
+    /// The last column of the coverage region (inclusive)
+    pub column_end: usize,
+}
+
+/// The execution count information starting at a point in a file. A sequence of execution counters
+/// for a file in a format hat's simple to iterate over for processing. The equivalent llvm type is
+/// `CoverageSegment`.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct CoverageSegment {
+    /// The line the segment begins
+    pub line: usize,
+    /// The column the segment begins
+    pub col: usize,
+    /// The execution count, or zero if not executed
+    pub count: usize,
+    /// When false the segment is not instrumented or skipped
+    pub has_count: bool,
+    /// whether this enters a new region or returns to a previous count
+    pub is_region_entry: usize,
+    /// Whether this enters a gap region
+    pub is_gap_region: usize,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct FunctionRecordHeader {
+    /// Truncated MD5 hash of the function name
+    pub name_hash: u64,
+    /// Length of the instrumentation data associated with the function
+    pub data_len: u32,
+    /// Function hash can be zero if the function isn't in the compiled binary - such as unused
+    /// generic functions
+    pub fn_hash: u64,
+    /// Hash reference of the file the function is defined in
+    pub filenames_ref: u64,
+}
+
+/// This type contains a header showing which function it refers to and then a list of regions in
+/// that function and a list of expressions. The expression IDs in the counter mapping region refer
+/// to indexes in the expressions list.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct FunctionRecordV3 {
+    pub header: FunctionRecordHeader,
+    pub regions: Vec<CounterMappingRegion>,
+    pub expressions: Vec<Expression>,
+}
+
+/// Coverage mapping information for a single function. The equivalent llvm type is
+/// `CoverageMappingRecord`.
+pub struct CoverageMappingRecord {
+    pub fn_name: String,
+    pub fn_hash: u64,
+    pub file_names: Vec<String>,
+    pub expressions: Vec<Expression>,
+    pub mapping_regions: Vec<CounterMappingRegion>,
+}
+
+/// Associates a source range with a specific counter. The equivalent llvm type is `CountedRegion`.
+pub struct CountedRegion {
+    pub execution_count: usize,
+    pub false_execution_count: usize,
+    pub folded: bool,
+    pub region: CounterMappingRegion,
+}
+
+/// This is the code coverage information for a single function. It is equivalent to
+/// `FunctionRecord` but has been renamed to avoid confusion with `FunctionRecordV3` etc
+pub struct FunctionCoverageRecord {
+    /// Raw function name
+    pub name: String,
+    /// This is a list to allow for macro expansions within a function where the macro is defined
+    /// in a different source file
+    pub filenames: Vec<String>,
+    /// regions in the function with their counts
+    pub counted_regions: Vec<CountedRegion>,
+    /// Branch regions with their counts
+    pub counted_branch_regions: Vec<CountedRegion>,
+    /// Number of times the function was executed
+    pub execution_count: usize,
+}

--- a/ferrocene/tools/blanket/llvm-profparser/src/coverage/mod.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/coverage/mod.rs
@@ -14,6 +14,8 @@ pub struct CoverageMappingInfo {
     pub cov_fun: Vec<FunctionRecordV3>,
     pub prof_counts: Option<Vec<u64>>,
     pub prof_data: Option<Vec<ProfileData>>,
+    /// LLVM function hash -> function linkage name
+    pub prof_names: FxHashMap<u64, String>,
 }
 
 impl CoverageMappingInfo {

--- a/ferrocene/tools/blanket/llvm-profparser/src/coverage/reporting.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/coverage/reporting.rs
@@ -1,0 +1,130 @@
+use crate::coverage::*;
+use std::collections::BTreeMap;
+use std::str::FromStr;
+use thiserror::Error;
+
+#[derive(Clone, Debug, Default)]
+pub struct CoverageReport {
+    pub files: BTreeMap<PathBuf, CoverageResult>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct CoverageResult {
+    pub hits: BTreeMap<SourceLocation, usize>,
+}
+
+impl CoverageReport {
+    pub fn apply_remapping(&mut self, remapping: &PathRemapping) {
+        let inputs = self.files.keys().cloned().collect::<Vec<_>>();
+        for path in &inputs {
+            if path.starts_with(&remapping.source) {
+                let end = path.strip_prefix(&remapping.source).unwrap();
+                let new_path = remapping.dest.join(end);
+                if let Some(values) = self.files.remove(path) {
+                    self.files.insert(new_path, values);
+                } else {
+                    unreachable!();
+                }
+            }
+        }
+    }
+}
+
+impl CoverageResult {
+    pub fn max_hits(&self) -> usize {
+        self.hits.values().max().copied().unwrap_or_default()
+    }
+
+    pub fn insert(&mut self, loc: SourceLocation, count: usize) {
+        self.hits
+            .entry(loc)
+            .and_modify(|x| *x = x.saturating_add(count))
+            .or_insert(count);
+    }
+
+    /// For line coverage just finds first region that mentions this line
+    pub fn hits_for_line(&self, line: usize) -> Option<usize> {
+        self.hits
+            .iter()
+            .find(|(k, _)| k.line_start <= line && k.line_end >= line)
+            .map(|(_, v)| *v)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Error)]
+pub enum RemappingParseError {
+    #[error("Path remapping is empty")]
+    EmptyRemapping,
+    #[error("Missing source path (remapping should be 'source,dest'")]
+    MissingSourcePath,
+    #[error("Missing destination path (remapping should be 'source,dest'")]
+    MissingDestinationPath,
+    #[error("Too many paths, two expected")]
+    TooManyPaths,
+}
+
+/// Map the paths in the coverage data to local source file paths. This allows
+/// you to generate the coverage data on one machine, and then use llvm-cov on a
+/// different machine where you have the same files on a different path.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct PathRemapping {
+    /// Path used on source machine
+    source: PathBuf,
+    /// Path used in destination machine
+    dest: PathBuf,
+}
+
+impl FromStr for PathRemapping {
+    type Err = RemappingParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let paths: Vec<&str> = s.split(',').collect();
+
+        if paths.is_empty() {
+            Err(Self::Err::EmptyRemapping)
+        } else if paths.len() > 2 {
+            Err(Self::Err::TooManyPaths)
+        } else if paths[0].is_empty() {
+            Err(Self::Err::MissingSourcePath)
+        } else if paths[1].is_empty() {
+            Err(Self::Err::MissingDestinationPath)
+        } else {
+            let source = PathBuf::from(paths[0]);
+            let dest = PathBuf::from(paths[1]);
+            Ok(Self { source, dest })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_remapping() {
+        let mut report = CoverageReport::default();
+
+        report
+            .files
+            .insert(PathBuf::from("/root/src/lib.rs"), CoverageResult::default());
+        report.files.insert(
+            PathBuf::from("/home/root/src/lib.rs"),
+            CoverageResult::default(),
+        );
+
+        let remapping = PathRemapping {
+            source: PathBuf::from("/root/src"),
+            dest: PathBuf::from("/home/me/src"),
+        };
+
+        report.apply_remapping(&remapping);
+
+        assert_eq!(report.files.len(), 2);
+        assert!(report
+            .files
+            .contains_key(&PathBuf::from("/home/me/src/lib.rs")));
+        assert!(report
+            .files
+            .contains_key(&PathBuf::from("/home/root/src/lib.rs")));
+    }
+}

--- a/ferrocene/tools/blanket/llvm-profparser/src/coverage/reporting.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/coverage/reporting.rs
@@ -11,6 +11,35 @@ pub struct CoverageReport {
 #[derive(Clone, Debug, Default)]
 pub struct CoverageResult {
     pub hits: BTreeMap<SourceLocation, usize>,
+    /// key is a compiled function name with crate-disambiguator hashes
+    /// stripped out
+    pub hits_by_function: BTreeMap<String, BTreeMap<SourceLocation, usize>>,
+}
+
+/// Strips crate-disambiguator hashes out of a v0-mangled name.
+/// Turns
+/// `_RNvMs6_NtCs7JbMdGCVdSh_4core3numm8abs_diff`
+/// into
+/// `_RNvMs6_NtC4core3numm8abs_diff`.
+///
+/// These hashes are different for each compilation run, and when running
+/// coverage tests Cargo reuses some previously built object files from prior
+/// compilations.
+pub fn strip_crate_hashes(name: &str) -> String {
+    let mut result = String::with_capacity(name.len());
+    let mut chars = name.chars().peekable();
+    while let Some(c) = chars.next() {
+        result.push(c);
+        if c == 'C' && chars.peek() == Some(&'s') {
+            chars.next(); // consume the 's'
+            for c2 in chars.by_ref() {
+                if c2 == '_' {
+                    break;
+                }
+            }
+        }
+    }
+    result
 }
 
 impl CoverageReport {
@@ -35,8 +64,14 @@ impl CoverageResult {
         self.hits.values().max().copied().unwrap_or_default()
     }
 
-    pub fn insert(&mut self, loc: SourceLocation, count: usize) {
+    pub fn insert(&mut self, function_linkage_name: &str, loc: SourceLocation, count: usize) {
         self.hits
+            .entry(loc.clone())
+            .and_modify(|x| *x = x.saturating_add(count))
+            .or_insert(count);
+        self.hits_by_function
+            .entry(strip_crate_hashes(function_linkage_name))
+            .or_default()
             .entry(loc)
             .and_modify(|x| *x = x.saturating_add(count))
             .or_insert(count);
@@ -99,6 +134,19 @@ impl FromStr for PathRemapping {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn strip_crate_hashes_normalizes_names_from_separate_compilations() {
+        // Two real mangled names for `core::num::<impl u32>::abs_diff`,
+        // taken from two separate compilations of `core`
+        let name1 = "_RNvMs6_NtCslH8vsGE0CQU_4core3numm8abs_diff";
+        let name2 = "_RNvMs6_NtCs7JbMdGCVdSh_4core3numm8abs_diff";
+
+        assert_eq!(
+            strip_crate_hashes(name1),
+            strip_crate_hashes(name2),
+        );
+    }
 
     #[test]
     fn report_remapping() {

--- a/ferrocene/tools/blanket/llvm-profparser/src/hash_table.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/hash_table.rs
@@ -1,0 +1,197 @@
+use crate::instrumentation_profile::{types::*, ParseResult};
+use indexmap::IndexMap;
+use nom::{
+    error::{ErrorKind, ParseError, VerboseError, VerboseErrorKind},
+    number::complete::*,
+};
+use std::borrow::Cow;
+use std::mem::size_of;
+use tracing::debug;
+
+#[derive(Copy, Clone, Debug)]
+struct KeyDataLen {
+    key_len: u64,
+    data_len: u64,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct HashTable(pub IndexMap<(u64, String), InstrProfRecord>);
+
+fn read_key_data_len(input: &[u8]) -> ParseResult<'_, KeyDataLen> {
+    let (bytes, key_len) = le_u64(input)?;
+    let (bytes, data_len) = le_u64(bytes)?;
+    let res = KeyDataLen { key_len, data_len };
+    Ok((bytes, res))
+}
+
+fn read_key(input: &[u8], key_len: usize) -> ParseResult<'_, Cow<'_, str>> {
+    if key_len > input.len() {
+        Err(nom::Err::Failure(VerboseError::from_error_kind(
+            &input[input.len()..],
+            ErrorKind::Eof,
+        )))
+    } else {
+        let res = String::from_utf8_lossy(&input[..key_len]);
+        Ok((&input[key_len..], res))
+    }
+}
+
+fn read_value(
+    version: u64,
+    mut input: &[u8],
+    data_len: usize,
+) -> ParseResult<'_, (u64, InstrProfRecord)> {
+    if data_len % 8 != 0 {
+        // Element is corrupted, it should be aligned
+        let errors = vec![(
+            input,
+            VerboseErrorKind::Context("table data length is not 8 byte aligned"),
+        )];
+        return Err(nom::Err::Failure(VerboseError { errors }));
+    }
+    if input.len() < data_len {
+        tracing::trace!("{} < {}", input.len(), data_len);
+        return Err(nom::Err::Failure(VerboseError::from_error_kind(
+            &input[input.len()..],
+            ErrorKind::Eof,
+        )));
+    }
+    let mut result = vec![];
+    let end_len = input.len() - data_len;
+
+    let expected_end = &input[data_len..];
+    let mut last_hash = 0;
+
+    while input.len() > end_len {
+        let mut counts = vec![];
+        let (bytes, hash) = le_u64(input)?;
+        last_hash = hash;
+        if bytes.len() <= end_len {
+            break;
+        }
+        // This is only available for versions > v1. But as rust won't be going backwards to legacy
+        // versions it's a safe assumption.
+        let (bytes, counts_len) = le_u64(bytes)?;
+        if bytes.len() <= end_len {
+            break;
+        }
+        input = bytes;
+        if size_of::<u64>().saturating_mul(counts_len as usize) > input.len() {
+            let errors = vec![(
+                input,
+                VerboseErrorKind::Context("hash_table value count length exceeds length of input"),
+            )];
+            return Err(nom::Err::Failure(VerboseError { errors }));
+        }
+        for _ in 0..counts_len {
+            let (bytes, count) = le_u64(input)?;
+            input = bytes;
+            counts.push(count);
+        }
+        result.push((hash, InstrProfRecord { counts, data: None }));
+        if input.len() <= end_len {
+            break;
+        }
+
+        if version > 10 {
+            let (bytes, bitmap_bytes) = le_u64(input)?;
+            input = bytes;
+            for _i in 0..bitmap_bytes {
+                let (bytes, _) = le_u64(input)?;
+                input = bytes;
+            }
+        }
+        // This should always be true
+        if version > 2 {
+            // If the version is > v2 then there can also be value profiling data so lets try and parse
+            // that now
+            let (bytes, total_size) = le_u32(input)?;
+            if bytes.len() <= end_len {
+                break;
+            }
+            let (bytes, num_value_kinds) = le_u32(bytes)?;
+            // Here it's just less than because we don't need to read anything else so if it's equal to
+            // we're good
+            if bytes.len() < end_len {
+                break;
+            }
+            input = bytes;
+            let value_prof_data = ValueProfData {
+                total_size,
+                num_value_kinds,
+            };
+            if value_prof_data.num_value_kinds > 0 && version > 2 {
+                // If we actually want to change data in future get result.last_mut() and change it
+                // there
+                break;
+            }
+        }
+    }
+    if result.is_empty() {
+        result.push((last_hash, InstrProfRecord::default()));
+    }
+    input = expected_end;
+    assert!(!result.is_empty());
+    Ok((input, result.remove(0)))
+}
+
+impl HashTable {
+    fn new() -> Self {
+        Self(IndexMap::new())
+    }
+
+    /// buckets is the data the hash table buckets start at - the start of the `HashTable` in memory.
+    /// hash. offset shows the offset from the base address to the start of the `HashTable` as this
+    /// will be used to correct any offsets
+    pub(crate) fn parse<'a>(
+        version: u64,
+        input: &'a [u8],
+        _offset: usize,
+        bucket_start: usize,
+    ) -> ParseResult<'a, Self> {
+        let (bytes, num_buckets) = le_u64(&input[bucket_start..])?;
+        debug!("Number of hashtable buckets: {}", num_buckets);
+        let (_bytes, mut num_entries) = le_u64(bytes)?;
+        debug!("Number of entries: {}", num_entries);
+
+        let mut payload = input;
+        let mut result = Self::new();
+        //TODO is this change right?
+        while num_entries > 0 {
+            let (bytes, entries) = result.parse_bucket(version, payload, num_entries)?;
+            payload = bytes;
+            num_entries = entries;
+        }
+        Ok((payload, result))
+    }
+
+    fn parse_bucket<'a>(
+        &mut self,
+        version: u64,
+        input: &'a [u8],
+        mut num_entries: u64,
+    ) -> ParseResult<'a, u64> {
+        let (bytes, num_items_in_bucket) = le_u16(input)?;
+        debug!(
+            "Number of items in bucket: {}, input remaining: {}",
+            num_items_in_bucket,
+            input.len()
+        );
+        let mut remaining = bytes;
+        for _i in 0..num_items_in_bucket {
+            let (bytes, _hash) = le_u64(remaining)?;
+            debug!("Hash(?): {}", _hash);
+            let (bytes, lens) = read_key_data_len(bytes)?;
+            let (bytes, key) = read_key(bytes, lens.key_len as usize)?;
+            debug!("lengths: {:?} and key: {}", lens, key);
+            let (bytes, (hash, value)) = read_value(version, bytes, lens.data_len as usize)?;
+            debug!("hash: {}, value: {:?}", hash, value);
+            self.0.insert((hash, key.to_string()), value);
+            assert!(num_entries > 0);
+            num_entries -= 1;
+
+            remaining = bytes;
+        }
+        Ok((remaining, num_entries))
+    }
+}

--- a/ferrocene/tools/blanket/llvm-profparser/src/instrumentation_profile/indexed_profile.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/instrumentation_profile/indexed_profile.rs
@@ -1,0 +1,280 @@
+use crate::hash_table::*;
+use crate::instrumentation_profile::*;
+use crate::summary::*;
+use anyhow::bail;
+use nom::{
+    error::{ContextError, ErrorKind, ParseError},
+    number::{complete::*, Endianness},
+};
+use rustc_hash::FxHashMap;
+use std::convert::TryFrom;
+use tracing::debug;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct IndexedInstrProf;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[repr(u64)]
+pub enum HashType {
+    Md5,
+}
+
+impl TryFrom<u64> for HashType {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Md5),
+            e => bail!("no variant matching {} found in `HashType`", e),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Header {
+    version: u64,
+    pub hash_type: HashType,
+    pub hash_offset: u64,
+    pub mem_prof_offset: Option<u64>,
+    pub binary_id_offset: Option<u64>,
+    pub vtable_offset: Option<u64>,
+    pub temporary_prof_traces_offset: Option<u64>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[repr(u64)]
+pub enum SummaryFieldKind {
+    TotalNumFunctions,
+    TotalNumBlocks,
+    MaxFunctionCount,
+    MaxBlockCount,
+    MaxInternalBlockCount,
+    TotalBlockCount,
+}
+
+impl TryFrom<u64> for SummaryFieldKind {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::TotalNumFunctions),
+            1 => Ok(Self::TotalNumBlocks),
+            2 => Ok(Self::MaxFunctionCount),
+            3 => Ok(Self::MaxBlockCount),
+            4 => Ok(Self::MaxInternalBlockCount),
+            5 => Ok(Self::TotalBlockCount),
+            e => bail!("no variant matching {} found in `SummaryFieldKind`", e),
+        }
+    }
+}
+
+impl Header {
+    pub fn version(&self) -> u64 {
+        self.version & !VARIANT_MASKS_ALL
+    }
+
+    pub fn is_csir_prof(&self) -> bool {
+        (self.version & VARIANT_MASK_CSIR_PROF) > 0
+    }
+
+    pub fn is_ir_prof(&self) -> bool {
+        (self.version & VARIANT_MASK_IR_PROF) > 0
+    }
+}
+
+fn parse_summary<'a>(
+    mut input: &'a [u8],
+    header: &Header,
+    use_cs: bool,
+) -> ParseResult<'a, Option<ProfileSummary>> {
+    if header.version() >= 4 {
+        let (bytes, n_fields) = le_u64(input)?;
+        let (bytes, n_entries) = le_u64(bytes)?;
+        debug!("n_fields: {} n_entries: {}", n_fields, n_entries);
+        input = bytes;
+        let mut fields = FxHashMap::default();
+        for i in 0..n_fields {
+            let (bytes, value) = le_u64(input)?;
+            input = bytes;
+            if let Ok(field) = SummaryFieldKind::try_from(i) {
+                fields.insert(field, value);
+            }
+        }
+        debug!("Parsed fields: {:?}", fields);
+        let mut detailed_summary = vec![];
+        for _ in 0..n_entries {
+            // Start getting the cutoffs
+            let (bytes, cutoff) = le_u64(input)?;
+            let (bytes, min_count) = le_u64(bytes)?;
+            let (bytes, num_counts) = le_u64(bytes)?;
+            debug!(
+                "Cutoff {} min_count {} num_counts {}",
+                cutoff, min_count, num_counts
+            );
+            input = bytes;
+            detailed_summary.push(ProfileSummaryEntry {
+                cutoff,
+                min_count,
+                num_counts,
+            });
+        }
+        let kind = if use_cs { Kind::CsInstr } else { Kind::Instr };
+        let total_count = fields
+            .get(&SummaryFieldKind::TotalBlockCount)
+            .copied()
+            .unwrap_or_default();
+        let max_count = fields
+            .get(&SummaryFieldKind::MaxBlockCount)
+            .copied()
+            .unwrap_or_default();
+        let max_internal_count = fields
+            .get(&SummaryFieldKind::MaxInternalBlockCount)
+            .copied()
+            .unwrap_or_default();
+        let max_function_count = fields
+            .get(&SummaryFieldKind::MaxFunctionCount)
+            .copied()
+            .unwrap_or_default();
+        let num_counts = fields
+            .get(&SummaryFieldKind::TotalNumBlocks)
+            .map(|x| *x as u32)
+            .unwrap_or_default();
+        let num_fns = fields
+            .get(&SummaryFieldKind::TotalNumFunctions)
+            .map(|x| *x as u32)
+            .unwrap_or_default();
+        let summary = ProfileSummary {
+            kind,
+            total_count,
+            max_count,
+            max_internal_count,
+            max_function_count,
+            num_counts,
+            num_fns,
+            partial: false,
+            partial_profile_ratio: 0.0,
+            detailed_summary,
+        };
+        Ok((input, Some(summary)))
+    } else {
+        Ok((input, None))
+    }
+}
+
+impl InstrProfReader for IndexedInstrProf {
+    type Header = Header;
+
+    fn parse_bytes(mut input: &[u8]) -> ParseResult<'_, InstrumentationProfile> {
+        let (bytes, header) = Self::parse_header(input)?;
+        debug!("Parsed header: {:?}", header);
+        let (bytes, summary) = parse_summary(bytes, &header, false)?;
+        debug!("Summary: {:?}", summary);
+        let (bytes, cs_summary) = if header.is_csir_prof() {
+            parse_summary(bytes, &header, true)?
+        } else {
+            (bytes, None)
+        };
+        debug!("cs_summary: {:?}", cs_summary);
+        let mut profile = InstrumentationProfile::new(
+            Some(header.version),
+            header.is_csir_prof(),
+            header.is_ir_prof(),
+            false,
+        );
+
+        let table_start = input.len() - bytes.len();
+        let (bytes, table) = HashTable::parse(
+            header.version,
+            bytes,
+            table_start,
+            header.hash_offset as usize - table_start,
+        )?;
+        debug!("Function hash table: {:?}", table);
+        input = bytes;
+        for ((hash, name), v) in &table.0 {
+            let name = name.to_string();
+            profile
+                .symtab
+                .add_func_name(name.clone(), Some(Endianness::Little));
+
+            let name_hash = compute_hash(&name);
+            let record = NamedInstrProfRecord {
+                name: Some(name),
+                name_hash: Some(name_hash),
+                hash: Some(*hash),
+                record: v.clone(),
+            };
+            debug!("Parsed record {:?}", record);
+            profile.push_record(record);
+        }
+        Ok((input, profile))
+    }
+
+    fn parse_header(input: &[u8]) -> ParseResult<'_, Self::Header> {
+        if Self::has_format(input) {
+            let (bytes, version) = le_u64(&input[8..])?;
+            let (bytes, _) = le_u64(bytes)?;
+            let (bytes, hash_type) = le_u64(bytes)?;
+            let hash_type = HashType::try_from(hash_type).map_err(|_e| {
+                let error = VerboseError::from_error_kind(bytes, ErrorKind::Satisfy);
+                nom::Err::Failure(VerboseError::add_context(
+                    bytes,
+                    "invalid enum variant for profile hash",
+                    error,
+                ))
+            })?;
+            let version_num = version & !VARIANT_MASKS_ALL;
+            let (bytes, hash_offset) = le_u64(bytes)?;
+            let (bytes, mem_prof_offset) = if version_num >= 8 {
+                let (bytes, offset) = le_u64(bytes)?;
+                (bytes, Some(offset))
+            } else {
+                (bytes, None)
+            };
+            let (bytes, binary_id_offset) = if version_num >= 9 {
+                let (bytes, offset) = le_u64(bytes)?;
+                (bytes, Some(offset))
+            } else {
+                (bytes, None)
+            };
+
+            let (bytes, vtable_offset) = if version_num >= 12 {
+                let (bytes, offset) = le_u64(bytes)?;
+                (bytes, Some(offset))
+            } else {
+                (bytes, None)
+            };
+
+            let (bytes, temporary_prof_traces_offset) = if version_num >= 10 {
+                let (bytes, offset) = le_u64(bytes)?;
+                (bytes, Some(offset))
+            } else {
+                (bytes, None)
+            };
+            Ok((
+                bytes,
+                Self::Header {
+                    version,
+                    hash_type,
+                    hash_offset,
+                    mem_prof_offset,
+                    binary_id_offset,
+                    vtable_offset,
+                    temporary_prof_traces_offset,
+                },
+            ))
+        } else {
+            todo!();
+        }
+    }
+
+    fn has_format(mut input: impl Read) -> bool {
+        const MAGIC: u64 = u64::from_le_bytes([0xff, 0x6c, 0x70, 0x72, 0x6f, 0x66, 0x69, 0x81]);
+        let mut buffer: [u8; 8] = [0; 8];
+        if input.read_exact(&mut buffer).is_ok() {
+            u64::from_le_bytes(buffer) == MAGIC
+        } else {
+            false
+        }
+    }
+}

--- a/ferrocene/tools/blanket/llvm-profparser/src/instrumentation_profile/mod.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/instrumentation_profile/mod.rs
@@ -1,0 +1,77 @@
+use crate::instrumentation_profile::indexed_profile::*;
+use crate::instrumentation_profile::raw_profile::*;
+use crate::instrumentation_profile::text_profile::*;
+use crate::instrumentation_profile::types::*;
+use nom::{error::VerboseError, Err, IResult};
+use std::fs::File;
+use std::io;
+use std::io::prelude::*;
+use std::path::Path;
+use tracing::trace;
+
+pub mod indexed_profile;
+pub mod raw_profile;
+pub mod summary;
+pub mod text_profile;
+pub mod types;
+
+pub type ParseResult<'a, T> = IResult<&'a [u8], T, VerboseError<&'a [u8]>>;
+
+pub const fn get_num_padding_bytes(len: u64) -> u8 {
+    7 & (8 - (len % 8) as u8)
+}
+
+pub fn parse(filename: impl AsRef<Path>) -> io::Result<InstrumentationProfile> {
+    let mut buffer = Vec::new();
+    let mut f = File::open(filename)?;
+    f.read_to_end(&mut buffer)?;
+    parse_bytes(buffer.as_slice())
+}
+
+pub fn parse_bytes(data: &[u8]) -> io::Result<InstrumentationProfile> {
+    let nom_res = if IndexedInstrProf::has_format(data) {
+        IndexedInstrProf::parse_bytes(data)
+    } else if RawInstrProf64::has_format(data) {
+        RawInstrProf64::parse_bytes(data)
+    } else if RawInstrProf32::has_format(data) {
+        RawInstrProf32::parse_bytes(data)
+    } else if TextInstrProf::has_format(data) {
+        TextInstrProf::parse_bytes(data)
+    } else {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "Unsupported instrumentation profile format",
+        ));
+    };
+    nom_res.map(|(_bytes, res)| res).map_err(|e| {
+        trace!("{}", e);
+        let verbose_error_message = |err: VerboseError<&[u8]>| {
+            err.errors
+                .iter()
+                .map(|(_, x)| format!("{:?}", x))
+                .collect::<Vec<String>>()
+                .join(" ")
+        };
+        let error_message = match e {
+            Err::Error(e) => format!("parser error: {}", verbose_error_message(e)),
+            Err::Failure(e) => format!("parser failure: {}", verbose_error_message(e)),
+            Err::Incomplete(_) => unreachable!("llvm_profparsers works on complete data"),
+        };
+        io::Error::new(io::ErrorKind::Other, error_message)
+    })
+}
+
+pub trait InstrProfReader {
+    type Header;
+    /// Parse the profile no lazy parsing here!
+    fn parse_bytes(input: &[u8]) -> ParseResult<'_, InstrumentationProfile>;
+    /// Parses a header
+    fn parse_header(input: &[u8]) -> ParseResult<'_, Self::Header>;
+    /// Detects that the bytes match the current reader format if it can't read the format it will
+    /// return false
+    fn has_format(input: impl Read) -> bool;
+}
+
+pub trait InstrProfWriter {
+    fn write(&self, profile: &InstrumentationProfile, writer: &mut impl Write) -> io::Result<()>;
+}

--- a/ferrocene/tools/blanket/llvm-profparser/src/instrumentation_profile/raw_profile.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/instrumentation_profile/raw_profile.rs
@@ -1,0 +1,552 @@
+use crate::instrumentation_profile::types::*;
+use crate::instrumentation_profile::*;
+use crate::util::parse_string_ref;
+use core::hash::Hash;
+use nom::bytes::complete::take;
+use nom::error::ParseError;
+use nom::lib::std::ops::RangeFrom;
+use nom::number::streaming::{u16 as nom_u16, u32 as nom_u32, u64 as nom_u64};
+use nom::number::Endianness;
+use nom::{
+    error::{ContextError, ErrorKind},
+    Err,
+};
+use nom::{InputIter, InputLength, Slice};
+use std::convert::TryInto;
+use std::fmt::{Debug, Display};
+use std::mem::size_of;
+use tracing::{debug, error, trace};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub enum RawProfileError {
+    Eof,
+    UnrecognizedFormat,
+    BadMagic(u64),
+    UnsupportedVersion(usize),
+    UnsupportedHashType,
+    TooLarge,
+    Truncated,
+    Malformed,
+    UnknownFunction,
+    HashMismatch,
+    CountMismatch,
+    CounterOverflow,
+    ValueSiteCountMismatch,
+    CompressFailed,
+    UncompressFailed,
+    EmptyRawProfile,
+}
+
+const INSTR_PROF_NAME_SEP: char = '\u{1}';
+
+pub type RawInstrProf32 = RawInstrProf<u32>;
+pub type RawInstrProf64 = RawInstrProf<u64>;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RawInstrProf<T>
+where
+    T: MemoryWidthExt,
+{
+    header: Header,
+    data: Vec<ProfileData<T>>,
+    records: Vec<InstrProfRecord>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Header {
+    endianness: Endianness,
+    pub version: u64,
+    pub binary_ids_len: u64,
+    pub data_len: u64,
+    pub padding_bytes_before_counters: u64,
+    pub counters_len: u64,
+    pub padding_bytes_after_counters: u64,
+    pub names_len: u64,
+    pub counters_delta: u64,
+    pub names_delta: u64,
+    pub value_kind_last: u64,
+    pub num_bitmap_bytes: u64,
+    pub padding_bytes_after_bitmap_bytes: u64,
+    pub bitmap_delta: u64,
+    pub num_vtables: u64,
+    pub vnames_size: u64,
+}
+
+impl Header {
+    #[inline(always)]
+    fn version(&self) -> u64 {
+        self.version & !VARIANT_MASKS_ALL
+    }
+
+    #[inline(always)]
+    fn has_byte_coverage(&self) -> bool {
+        (self.version & VARIANT_MASK_BYTE_COVERAGE) != 0
+    }
+
+    #[inline(always)]
+    fn ir_profile(&self) -> bool {
+        (self.version & VARIANT_MASK_IR_PROF) != 0
+    }
+
+    #[inline(always)]
+    fn csir_profile(&self) -> bool {
+        (self.version & VARIANT_MASK_CSIR_PROF) != 0
+    }
+
+    #[inline(always)]
+    fn function_entry_only(&self) -> bool {
+        (self.version & VARIANT_MASK_FUNCTION_ENTRY_ONLY) != 0
+    }
+
+    #[inline(always)]
+    fn memory_profile(&self) -> bool {
+        (self.version & VARIANT_MASK_MEMORY_PROFILE) != 0
+    }
+
+    #[inline(always)]
+    fn counter_size(&self) -> usize {
+        if self.has_byte_coverage() {
+            1
+        } else {
+            8
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct ProfileData<T> {
+    name_ref: u64,
+    func_hash: u64,
+    counter_ptr: T,
+    bitmap_ptr: Option<T>,
+    function_addr: T,
+    values_ptr_expr: T,
+    num_counters: u32,
+    /// This might just be two values?
+    num_value_sites: [u16; ValueKind::MemOpSize as usize + 1],
+    num_bitmap_bytes: u32,
+}
+
+impl<T> ProfileData<T> {
+    fn len(&self) -> usize {
+        16 + 4 + (2 * (ValueKind::MemOpSize as usize + 1)) + 3 * size_of::<T>()
+    }
+}
+
+impl Header {
+    pub fn max_counters_len(&self) -> i64 {
+        ((8 * self.counters_len) + self.padding_bytes_after_counters) as i64
+    }
+}
+
+/// Trait to represent memory widths. Currently just 32 or 64 bit. This implements Into<u64> so if
+/// we ever move beyond 64 bit systems this code will have to change to Into<u128> or whatever the
+/// next thing is.
+pub trait MemoryWidthExt:
+    Debug + Copy + Clone + Eq + PartialEq + Hash + Ord + PartialOrd + Display + Into<u64>
+{
+    const MAGIC: u64;
+
+    fn nom_parse_fn<I>(endianness: Endianness) -> fn(_: I) -> IResult<I, Self, VerboseError<I>>
+    where
+        I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength;
+}
+
+impl MemoryWidthExt for u32 {
+    const MAGIC: u64 = (255 << 56)
+        | ('l' as u64) << 48
+        | ('p' as u64) << 40
+        | ('r' as u64) << 32
+        | ('o' as u64) << 24
+        | ('f' as u64) << 16
+        | ('R' as u64) << 8
+        | 129;
+
+    fn nom_parse_fn<I>(endianness: Endianness) -> fn(_: I) -> IResult<I, Self, VerboseError<I>>
+    where
+        I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+    {
+        nom_u32(endianness)
+    }
+}
+impl MemoryWidthExt for u64 {
+    const MAGIC: u64 = (255 << 56)
+        | ('l' as u64) << 48
+        | ('p' as u64) << 40
+        | ('r' as u64) << 32
+        | ('o' as u64) << 24
+        | ('f' as u64) << 16
+        | ('r' as u64) << 8
+        | 129;
+
+    fn nom_parse_fn<I>(endianness: Endianness) -> fn(_: I) -> IResult<I, Self, VerboseError<I>>
+    where
+        I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+    {
+        nom_u64(endianness)
+    }
+}
+
+fn file_endianness<T>(magic: &[u8; 8]) -> Endianness
+where
+    T: MemoryWidthExt,
+{
+    // native endian and reversed endian
+    let provided = u64::from_le_bytes(*magic);
+    if provided == T::MAGIC {
+        Endianness::Little
+    } else if provided.swap_bytes() == T::MAGIC {
+        Endianness::Big
+    } else {
+        unreachable!("Invalid magic provided");
+    }
+}
+
+impl<T> RawInstrProf<T>
+where
+    T: MemoryWidthExt,
+{
+    fn read_raw_counts<'a>(
+        header: &Header,
+        data: &ProfileData<T>,
+        counter_offset: i64,
+        mut bytes: &'a [u8],
+    ) -> ParseResult<'a, InstrProfRecord> {
+        let max_counters = header.max_counters_len();
+        // From LLVM coverage mapping version 8 relative counter offsets are allowed which can be
+        // signed
+        // num 2 max 24 offset 7 counters len 3
+        trace!(
+            "Reading raw counts offset: {} max: {}. data {:?}",
+            counter_offset,
+            max_counters,
+            data
+        );
+        if data.num_counters == 0
+            || max_counters < 0
+            || counter_offset < 0
+            || counter_offset as u64 >= (header.counters_len * header.counter_size() as u64)
+            || data.num_counters as i64 > max_counters
+            || (header.version < 8 && counter_offset < 0)
+            || counter_offset > max_counters
+            || counter_offset + data.num_counters as i64 > max_counters
+        {
+            error!("consistency check for reading counts failed");
+            //Err(Err::Failure(Error::new(bytes, ErrorKind::Satisfy))) TODO
+            Err(Err::Failure(VerboseError::from_error_kind(
+                bytes,
+                ErrorKind::Satisfy,
+            )))
+        } else if counter_offset as usize > bytes.len() {
+            let pos = &bytes[bytes.len()..];
+            let inner = VerboseError::from_error_kind(pos, ErrorKind::Eof);
+            Err(Err::Failure(VerboseError::add_context(
+                pos,
+                "end of file reached before counters offset",
+                inner,
+            )))
+        } else {
+            let mut counts = Vec::<u64>::with_capacity(data.num_counters as usize);
+            bytes = &bytes[(counter_offset as usize)..];
+            for _ in 0..(data.num_counters as usize) {
+                let counter = if header.has_byte_coverage() {
+                    let counter = bytes[0];
+                    bytes = &bytes[1..];
+                    (counter == 0) as u64
+                } else {
+                    let (b, counter) = nom_u64(header.endianness)(bytes)?;
+                    bytes = b;
+                    counter
+                };
+                counts.push(counter);
+            }
+            let record = InstrProfRecord {
+                counts,
+                ..Default::default()
+            };
+            Ok((bytes, record))
+        }
+    }
+
+    fn read_value_profiling_data<'a>(
+        header: &Header,
+        data: &ProfileData<T>,
+        bytes: &'a [u8],
+        _record: &mut InstrProfRecord,
+    ) -> ParseResult<'a, ()> {
+        // record clear value data
+        if data.num_value_sites.iter().all(|x| *x == 0) {
+            // Okay so there's no value profiling data. So the next byte is actually a header
+            // wewww
+            Ok((bytes, ()))
+        } else {
+            let (_bytes, _total_size) = nom_u32(header.endianness)(bytes)?;
+            todo!()
+        }
+    }
+}
+
+impl<T> InstrProfReader for RawInstrProf<T>
+where
+    T: MemoryWidthExt,
+{
+    type Header = Header;
+
+    fn parse_bytes(mut input: &[u8]) -> ParseResult<'_, InstrumentationProfile> {
+        if !input.is_empty() {
+            let mut result = InstrumentationProfile::default();
+            let (bytes, header) = Self::parse_header(input)?;
+            // LLVM 11 and 12 are version 5. LLVM 13 is version 7
+            let version_num = header.version();
+            result.version = Some(version_num);
+            result.is_ir = header.ir_profile();
+            result.has_csir = header.csir_profile();
+            if version_num > 7 {
+                result.is_byte_coverage = header.has_byte_coverage();
+                result.fn_entry_only = header.function_entry_only();
+                result.memory_profiling = header.memory_profile();
+            }
+            if bytes.len() < header.binary_ids_len as usize {
+                return Err(nom::Err::Failure(VerboseError::from_error_kind(
+                    &bytes[bytes.len()..],
+                    ErrorKind::Eof,
+                )));
+            }
+            input = &bytes[(header.binary_ids_len as usize)..];
+            let mut data_section = vec![];
+            for _ in 0..header.data_len {
+                let (bytes, data) = ProfileData::<T>::parse(input, &header)?;
+                debug!("Parsed data section {:?}", data);
+                data_section.push(data);
+                if version_num > 8 {
+                    let (bytes, v) = take(4usize)(bytes)?; // TODO WHAT AM I MISSING HERE?
+                    debug!("Got those padding? bytes {:?}", v);
+                    input = bytes;
+                } else {
+                    input = bytes;
+                }
+            }
+            let bytes = match take(header.padding_bytes_before_counters as usize)(input) {
+                Ok((b, _)) => b,
+                Err(e) => {
+                    error!("Failed to skip padding bytes");
+                    return Err(e);
+                }
+            };
+            input = bytes;
+            let mut counters = vec![];
+            let mut counters_delta = header.counters_delta;
+
+            // Okay so the counters section looks a bit hairy. So as a brief explanation.
+            // 1. The base offset is from CountersStart pointer to entry of the record. Meaning
+            //    doing a nom type parsing we need to keep track of the total offset as counter
+            //    records can be offset in the middle of the counter list.
+            // 2. Also there may be some padding bytes before the last counter and end of counters
+            //    section. This needs to be applied as well as padding_bytes_after_counters for
+            //    total padding
+            let mut total_offset = 0;
+            let remaining_before_counters = input.len();
+            for data in &data_section {
+                let counters_offset = if header.version() == 8 {
+                    // Why oh why!?
+                    (data.counter_ptr.into() as i64 - counters_delta as i64) - total_offset
+                } else {
+                    0
+                };
+                let (bytes, record) = Self::read_raw_counts(&header, data, counters_offset, input)?;
+                debug!("Read counter record {:?}", record);
+                total_offset +=
+                    counters_offset + (record.counts.len() * header.counter_size()) as i64;
+                counters_delta -= data.len() as u64;
+                counters.push(record);
+                input = bytes;
+            }
+            let counters_end = header.padding_bytes_after_counters as usize
+                + (header.counters_len as usize * header.counter_size())
+                - (remaining_before_counters - input.len());
+            debug!("Applying padding bytes after counters");
+            let (bytes, _) = take(counters_end)(input)?;
+            input = bytes;
+            let end_length = input.len() - header.names_len as usize;
+            let mut symtab = Symtab::default();
+            while input.len() > end_length {
+                let (new_bytes, names) = parse_string_ref(input)?;
+                debug!(
+                    "Complete names string: '{}'. Read {} bytes",
+                    names,
+                    input.len() - new_bytes.len()
+                );
+                input = new_bytes;
+                for name in names.split(INSTR_PROF_NAME_SEP) {
+                    debug!("Symbol name parsed: '{}'", name);
+                    symtab.add_func_name(name.to_string(), Some(header.endianness));
+                }
+            }
+            let padding = get_num_padding_bytes(header.names_len);
+            let (bytes, _) = take(padding)(input)?;
+            input = bytes;
+            for (data, mut record) in data_section.iter().zip(counters.drain(..)) {
+                let (bytes, _) =
+                    Self::read_value_profiling_data(&header, data, input, &mut record)?;
+                input = bytes;
+                let name = symtab.names.get(&data.name_ref).cloned();
+                let (hash, name_hash) = if name.is_some() {
+                    // Previously this function calculated the function hash itself to be
+                    // ultra-defensive against the profraw format changing hash calculation method
+                    // so we try not to rely on reimplementing it. However, md5::compute was more
+                    // expensive than initially assumed and using the precomputed one reduces
+                    // runtime by 25% on benchmarks
+                    (Some(data.func_hash), Some(data.name_ref))
+                } else {
+                    (None, None)
+                };
+                debug!("Parsed record: {:?} {:?} {:?}", name, hash, record);
+
+                result.push_record(NamedInstrProfRecord {
+                    name,
+                    name_hash,
+                    hash,
+                    record,
+                });
+            }
+            result.symtab = symtab;
+            Ok((input, result))
+        } else {
+            // Okay return an error here
+            todo!()
+        }
+    }
+
+    fn parse_header(input: &[u8]) -> ParseResult<'_, Self::Header> {
+        if Self::has_format(input) {
+            let endianness = file_endianness::<T>(&input[..8].try_into().unwrap());
+            let (bytes, version) = nom_u64(endianness)(&input[8..])?;
+            debug!("Profraw version: {}", version & !VARIANT_MASKS_ALL);
+            let (bytes, binary_ids_len) = if (version & !VARIANT_MASKS_ALL) >= 7 {
+                nom_u64(endianness)(bytes)?
+            } else {
+                (bytes, 0)
+            };
+            let (bytes, data_len) = nom_u64(endianness)(bytes)?;
+            let (bytes, padding_bytes_before_counters) = nom_u64(endianness)(bytes)?;
+            let (bytes, counters_len) = nom_u64(endianness)(bytes)?;
+            let (bytes, padding_bytes_after_counters) = nom_u64(endianness)(bytes)?;
+
+            let (bytes, num_bitmap_bytes, padding_bytes_after_bitmap_bytes) =
+                if (version & !VARIANT_MASKS_ALL) >= 9 {
+                    let (bytes, num_bitmap_bytes) = nom_u64(endianness)(bytes)?;
+                    let (bytes, num_bitmap_padding_bytes) = nom_u64(endianness)(bytes)?;
+                    (bytes, num_bitmap_bytes, num_bitmap_padding_bytes)
+                } else {
+                    (bytes, 0, 0)
+                };
+
+            let (bytes, names_len) = nom_u64(endianness)(bytes)?;
+            let (bytes, counters_delta) = nom_u64(endianness)(bytes)?;
+
+            let (bytes, bitmap_delta) = if (version & !VARIANT_MASKS_ALL) >= 9 {
+                let (bytes, bitmap_delta) = nom_u64(endianness)(bytes)?;
+                (bytes, bitmap_delta)
+            } else {
+                (bytes, 0)
+            };
+
+            let (bytes, names_delta) = nom_u64(endianness)(bytes)?;
+
+            let (bytes, num_vtables, vnames_size) = if (version & !VARIANT_MASKS_ALL) >= 10 {
+                let (bytes, num_vtables) = nom_u64(endianness)(bytes)?;
+                let (bytes, vnames_len) = nom_u64(endianness)(bytes)?;
+                (bytes, num_vtables, vnames_len)
+            } else {
+                (bytes, 0, 0)
+            };
+
+            let (bytes, value_kind_last) = nom_u64(endianness)(bytes)?;
+
+            let result = Header {
+                endianness,
+                version,
+                binary_ids_len,
+                data_len,
+                padding_bytes_before_counters,
+                counters_len,
+                padding_bytes_after_counters,
+                names_len,
+                counters_delta,
+                names_delta,
+                value_kind_last,
+                num_bitmap_bytes,
+                padding_bytes_after_bitmap_bytes,
+                bitmap_delta,
+                num_vtables,
+                vnames_size,
+            };
+            debug!("Read header {:?}", result);
+            Ok((bytes, result))
+        } else {
+            //Err(Err::Failure(Error::new(input, ErrorKind::IsNot)))
+            Err(Err::Failure(VerboseError::from_error_kind(
+                input,
+                ErrorKind::IsNot,
+            )))
+        }
+    }
+
+    fn has_format(mut input: impl Read) -> bool {
+        let mut buffer: [u8; 8] = [0; 8];
+        if input.read_exact(&mut buffer).is_ok() {
+            let magic = u64::from_ne_bytes(buffer);
+            T::MAGIC == magic || T::MAGIC == magic.swap_bytes()
+        } else {
+            false
+        }
+    }
+}
+
+impl<T> ProfileData<T>
+where
+    T: MemoryWidthExt,
+{
+    fn parse<'a>(
+        bytes: &'a [u8],
+        header: &Header,
+    ) -> IResult<&'a [u8], Self, VerboseError<&'a [u8]>> {
+        let endianness = header.endianness;
+        let parse = T::nom_parse_fn(endianness);
+
+        let (bytes, name_ref) = nom_u64(endianness)(bytes)?;
+        let (bytes, func_hash) = nom_u64(endianness)(bytes)?;
+        let (bytes, counter_ptr) = parse(bytes)?;
+        let (bytes, bitmap_ptr) = if header.version() > 8 {
+            let (bytes, bitmap_ptr) = parse(bytes)?;
+            (bytes, Some(bitmap_ptr))
+        } else {
+            (bytes, None)
+        };
+        let (bytes, function_addr) = parse(bytes)?;
+        let (bytes, values_ptr_expr) = parse(bytes)?;
+        let (bytes, num_counters) = nom_u32(endianness)(bytes)?;
+        let (bytes, value_0) = nom_u16(endianness)(bytes)?;
+        let (bytes, value_1) = nom_u16(endianness)(bytes)?;
+        let (bytes, num_bitmap_bytes) = if header.version() > 8 {
+            nom_u32(endianness)(bytes)?
+        } else {
+            (bytes, 0)
+        };
+
+        Ok((
+            bytes,
+            Self {
+                name_ref,
+                func_hash,
+                counter_ptr,
+                bitmap_ptr,
+                function_addr,
+                values_ptr_expr,
+                num_counters,
+                num_value_sites: [value_0, value_1],
+                num_bitmap_bytes,
+            },
+        ))
+    }
+}

--- a/ferrocene/tools/blanket/llvm-profparser/src/instrumentation_profile/raw_profile.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/instrumentation_profile/raw_profile.rs
@@ -1,4 +1,3 @@
-use crate::instrumentation_profile::types::*;
 use crate::instrumentation_profile::*;
 use crate::util::parse_string_ref;
 use core::hash::Hash;
@@ -37,7 +36,7 @@ pub enum RawProfileError {
     EmptyRawProfile,
 }
 
-const INSTR_PROF_NAME_SEP: char = '\u{1}';
+pub(crate) const INSTR_PROF_NAME_SEP: char = '\u{1}';
 
 pub type RawInstrProf32 = RawInstrProf<u32>;
 pub type RawInstrProf64 = RawInstrProf<u64>;

--- a/ferrocene/tools/blanket/llvm-profparser/src/instrumentation_profile/summary.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/instrumentation_profile/summary.rs
@@ -1,0 +1,61 @@
+use crate::instrumentation_profile::types::*;
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Default)]
+pub struct ProfileSummary {
+    num_functions: usize,
+    total_count: u64,
+    max_count: u64,
+    max_function_count: u64,
+    max_internal_block_count: u64,
+    count_frequencies: BTreeMap<u64, usize>,
+}
+
+impl ProfileSummary {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_record(&mut self, record: &InstrProfRecord) {
+        if !record.counts.is_empty() {
+            self.num_functions += 1;
+            self.add_count(record.counts[0]);
+            if record.counts[0] > self.max_function_count {
+                self.max_function_count = record.counts[0];
+            }
+            self.add_internal_counts(&record.counts[1..]);
+        }
+    }
+
+    fn add_count(&mut self, count: u64) {
+        self.total_count = self.total_count.saturating_add(count);
+        if count > self.max_count {
+            self.max_count = count;
+        }
+        self.count_frequencies
+            .entry(count)
+            .and_modify(|x| *x += 1)
+            .or_insert(1);
+    }
+
+    fn add_internal_counts(&mut self, counts: &[u64]) {
+        for count in counts {
+            self.add_count(*count);
+            if *count > self.max_internal_block_count {
+                self.max_internal_block_count = *count;
+            }
+        }
+    }
+
+    pub fn num_functions(&self) -> usize {
+        self.num_functions
+    }
+
+    pub fn max_function_count(&self) -> u64 {
+        self.max_function_count
+    }
+
+    pub fn max_internal_block_count(&self) -> u64 {
+        self.max_internal_block_count
+    }
+}

--- a/ferrocene/tools/blanket/llvm-profparser/src/instrumentation_profile/text_profile.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/instrumentation_profile/text_profile.rs
@@ -1,0 +1,386 @@
+use crate::instrumentation_profile::types::*;
+use crate::instrumentation_profile::{InstrProfReader, ParseResult};
+use nom::branch::alt;
+use nom::bytes::complete::{tag, tag_no_case, take_until, take_while1};
+use nom::character::{
+    complete::{line_ending, one_of},
+    is_digit, is_hex_digit,
+};
+use nom::combinator::eof;
+use nom::error::{ErrorKind, ParseError, VerboseError};
+use nom::multi::*;
+use nom::sequence::*;
+use nom::*;
+use std::io::Read;
+
+const IR_TAG: &[u8] = b"ir";
+const FE_TAG: &[u8] = b"fe";
+const CSIR_TAG: &[u8] = b"csir";
+const ENTRY_TAG: &[u8] = b"entry_first";
+const NOT_ENTRY_TAG: &[u8] = b"not_entry_first";
+const EXTERNAL_SYMBOL: &[u8] = b"** External Symbol **";
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct TextInstrProf;
+
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct Header {
+    is_ir_level: bool,
+    has_csir: bool,
+    entry_first: bool,
+}
+
+fn check_tag(data: &[u8], tag: &[u8]) -> bool {
+    if let Ok(data) = std::str::from_utf8(data) {
+        let tag = std::str::from_utf8(tag).unwrap_or_default();
+        data == tag || data == tag.to_uppercase()
+    } else {
+        false
+    }
+}
+
+fn str_to_digit(bytes: &[u8]) -> u64 {
+    // As I'm only using this on lines nom identifies as just digits it won't fail
+    std::str::from_utf8(bytes)
+        .unwrap()
+        .parse()
+        .unwrap_or_default()
+}
+
+fn read_hexadecimal(input: &[u8]) -> ParseResult<'_, u64> {
+    preceded(alt((tag(b"0x"), tag(b"0X"))), take_while1(is_hex_digit))(input).map(|(b, v)| unsafe {
+        // We know this is okay because it's just the bytes that pass `is_hex_digit`
+        (
+            b,
+            u64::from_str_radix(std::str::from_utf8_unchecked(v), 16).unwrap(),
+        )
+    })
+}
+
+fn valid_name_char(character: u8) -> bool {
+    let c = character as char;
+    // Whitespace is allowed!
+    c.is_ascii() && c != '\n' && c != '\r'
+}
+
+fn strip_whitespace(s: &[u8]) -> ParseResult<'_, ()> {
+    one_of(&b" \n\r\t"[..])(s).map(|(b, _)| (b, ()))
+}
+
+fn strip_comments(s: &[u8]) -> ParseResult<'_, ()> {
+    delimited(
+        tag(b"#"),
+        alt((take_until("\r"), take_until("\n"))),
+        line_ending,
+    )(s)
+    .map(|(b, _)| (b, ()))
+}
+
+fn skip_to_content(s: &[u8]) -> ParseResult<'_, ()> {
+    many0(alt((strip_whitespace, strip_comments)))(s).map(|(b, _)| (b, ()))
+}
+
+fn match_header_tags(s: &[u8]) -> ParseResult<'_, &[u8]> {
+    alt((
+        tag_no_case(IR_TAG),
+        tag_no_case(FE_TAG),
+        tag_no_case(CSIR_TAG),
+        tag_no_case(ENTRY_TAG),
+        take_until("\r"),
+        take_until("\n"),
+    ))(s)
+}
+
+fn parse_header_tags(s: &[u8]) -> ParseResult<'_, Vec<&[u8]>> {
+    many0(delimited(tag(b":"), match_header_tags, line_ending))(s)
+}
+
+fn read_line(s: &[u8]) -> ParseResult<'_, &[u8]> {
+    tuple((take_while1(valid_name_char), line_ending))(s).map(|(b, (v, _))| (b, v))
+}
+
+fn read_decimal(s: &[u8]) -> ParseResult<'_, u64> {
+    tuple((take_while1(is_digit), alt((line_ending, eof))))(s).map(|(b, v)| (b, str_to_digit(v.0)))
+}
+
+fn read_digit(s: &[u8]) -> ParseResult<'_, u64> {
+    alt((read_decimal, read_hexadecimal))(s)
+}
+
+fn indirect_value_site(s: &[u8]) -> ParseResult<'_, (&[u8], u64)> {
+    tuple((take_until(":"), tag(":"), take_while1(is_digit)))(s)
+        .map(|(b, v)| (b, (v.0, str_to_digit(v.2))))
+}
+
+fn memop_value_site(s: &[u8]) -> ParseResult<'_, (u64, u64)> {
+    tuple((take_while1(is_digit), tag(":"), take_while1(is_digit)))(s)
+        .map(|(b, v)| (b, (str_to_digit(v.0), str_to_digit(v.2))))
+}
+
+fn read_value_profile_data(mut input: &[u8]) -> ParseResult<'_, Option<Box<ValueProfDataRecord>>> {
+    if let Ok((bytes, n_kinds)) = read_digit(input) {
+        let mut record = Box::<ValueProfDataRecord>::default();
+        // We have value profiling data!
+        if n_kinds == 0 || n_kinds > ValueKind::len() as u64 {
+            // TODO I am malformed
+            return Err(nom::Err::Failure(VerboseError::from_error_kind(
+                bytes,
+                ErrorKind::Satisfy,
+            )));
+        }
+        input = bytes;
+        for _i in 0..n_kinds {
+            let (bytes, _) = skip_to_content(input)?;
+            let (bytes2, kind) = read_digit(bytes)?;
+            let kind = match kind {
+                0 => ValueKind::IndirectCallTarget,
+                1 => ValueKind::MemOpSize,
+                _ => {
+                    return Err(nom::Err::Failure(VerboseError::from_error_kind(
+                        bytes,
+                        ErrorKind::OneOf,
+                    )));
+                }
+            };
+            let (bytes, _) = skip_to_content(bytes2)?;
+            let (bytes, n_sites) = match read_digit(bytes) {
+                Ok(s) => s,
+                Err(_) => {
+                    input = bytes;
+                    continue;
+                }
+            };
+            input = bytes;
+            for _j in 0..n_sites {
+                let (bytes, _) = skip_to_content(input)?;
+                let (bytes, n_val_data) = read_digit(bytes)?;
+                input = bytes;
+                let mut site_records = vec![];
+                for _k in 0..n_val_data {
+                    let (bytes, _) = skip_to_content(input)?;
+                    input = match kind {
+                        ValueKind::IndirectCallTarget => {
+                            let (bytes, (sym, count)) = indirect_value_site(bytes)?;
+                            let value = if sym == EXTERNAL_SYMBOL {
+                                0
+                            } else {
+                                compute_hash(sym)
+                            };
+                            site_records.push(InstrProfValueData { value, count });
+                            bytes
+                        }
+                        ValueKind::MemOpSize => {
+                            let (bytes, (value, count)) = memop_value_site(bytes)?;
+                            site_records.push(InstrProfValueData { value, count });
+                            bytes
+                        }
+                    };
+                }
+                match kind {
+                    ValueKind::IndirectCallTarget => record.indirect_callsites.push(site_records),
+                    ValueKind::MemOpSize => record.mem_op_sizes.push(site_records),
+                }
+            }
+        }
+        Ok((input, Some(record)))
+    } else {
+        Ok((input, None))
+    }
+}
+
+impl InstrProfReader for TextInstrProf {
+    type Header = Header;
+    fn parse_bytes(mut input: &[u8]) -> ParseResult<'_, InstrumentationProfile> {
+        let (bytes, header) = Self::parse_header(input)?;
+        let (bytes, _) = skip_to_content(bytes)?;
+        input = bytes;
+        let mut result = InstrumentationProfile::new(
+            None,
+            header.has_csir,
+            header.is_ir_level,
+            header.entry_first,
+        );
+        while !input.is_empty() {
+            // function name (demangled)
+            let (bytes, name) = read_line(input)?;
+            let (bytes, _) = skip_to_content(bytes)?;
+            // function hash
+            let (bytes, hash) = read_digit(bytes)?;
+            let (bytes, _) = skip_to_content(bytes)?;
+            // number of counters
+            let (bytes, num_counters) = read_digit(bytes)?;
+            let (bytes, _) = skip_to_content(bytes)?;
+            let mut counters = vec![];
+            // counter values
+            input = bytes;
+            for i in 0..num_counters {
+                let (bytes, counter) = read_digit(input)?;
+                counters.push(counter);
+                match skip_to_content(bytes) {
+                    Ok((bytes, _)) => {
+                        input = bytes;
+                    }
+                    Err(_) if i + 1 == num_counters => {
+                        input = &bytes[(bytes.len())..];
+                        break;
+                    }
+                    Err(e) => {
+                        Err(e)?;
+                    }
+                }
+            }
+            let (bytes, data) = read_value_profile_data(input)?;
+            let record = InstrProfRecord {
+                counts: counters,
+                data,
+            };
+            let name = std::str::from_utf8(name).map(|x| x.to_string()).ok();
+            result.push_record(NamedInstrProfRecord {
+                name: name.clone(),
+                name_hash: name.as_ref().map(compute_hash),
+                hash: Some(hash),
+                record,
+            });
+            if let Some(name) = name {
+                result.symtab.names.insert(hash, name);
+            }
+            input = match skip_to_content(bytes) {
+                Ok((bytes, _)) => bytes,
+                Err(_) => &bytes[(bytes.len())..],
+            };
+        }
+        Ok((bytes, result))
+    }
+
+    fn parse_header(input: &[u8]) -> ParseResult<'_, Self::Header> {
+        let (input, _) = skip_to_content(input)?;
+        let (bytes, names) = parse_header_tags(input)?;
+        let mut is_ir_level = false;
+        let mut has_csir = false;
+        let mut entry_first = false;
+        for name in &names {
+            if check_tag(name, IR_TAG) | check_tag(name, NOT_ENTRY_TAG) {
+                is_ir_level = true;
+            } else if check_tag(name, CSIR_TAG) {
+                has_csir = true;
+                is_ir_level = true;
+            } else if check_tag(name, ENTRY_TAG) {
+                entry_first = true;
+            } else if !check_tag(name, FE_TAG) {
+                return Err(Err::Failure(VerboseError::from_error_kind(
+                    bytes,
+                    ErrorKind::Tag,
+                )));
+            }
+        }
+        Ok((
+            bytes,
+            Header {
+                is_ir_level,
+                has_csir,
+                entry_first,
+            },
+        ))
+    }
+
+    fn has_format(mut input: impl Read) -> bool {
+        // looking at the code it looks like with file memory buffers in llvm it sets the buffer
+        // size to the size of the file meaning it checks all the characters
+        let mut s = String::new();
+        if input.read_to_string(&mut s).is_ok() {
+            s.is_ascii()
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_header() {
+        let csir_header = b"# CSIR flag\n:csir\n";
+        let (_, header) = TextInstrProf::parse_header(&csir_header[..]).unwrap();
+        assert!(header.is_ir_level);
+        assert!(header.has_csir);
+
+        let csir_header = b"# CSIR flag\n:CSIR\n";
+        let (_, header) = TextInstrProf::parse_header(&csir_header[..]).unwrap();
+        assert!(header.is_ir_level);
+        assert!(header.has_csir);
+
+        let ir_header = b"# IR flag\n\n:ir\n";
+        let (_, header) = TextInstrProf::parse_header(&ir_header[..]).unwrap();
+        assert!(header.is_ir_level);
+        assert!(!header.has_csir);
+
+        let ir_header = b"# IR flag\n\n:IR\n";
+        let (_, header) = TextInstrProf::parse_header(&ir_header[..]).unwrap();
+        assert!(header.is_ir_level);
+        assert!(!header.has_csir);
+
+        let fe_header = b"# FE flag\n\n:fe\n";
+        let (_, header) = TextInstrProf::parse_header(&fe_header[..]).unwrap();
+        assert!(!header.is_ir_level);
+        assert!(!header.has_csir);
+
+        let fe_header = b"# FE flag\n\n:FE\n";
+        let (_, header) = TextInstrProf::parse_header(&fe_header[..]).unwrap();
+        assert!(!header.is_ir_level);
+        assert!(!header.has_csir);
+
+        let no_header = b"# Straight to funcs\nfoobar";
+        let (_, header) = TextInstrProf::parse_header(&no_header[..]).unwrap();
+        assert!(!header.is_ir_level);
+        assert!(!header.has_csir);
+    }
+
+    #[test]
+    fn parse_multiline_header() {
+        let header = b":entry_first\n:ir\n#content";
+        let (_, header) = TextInstrProf::parse_header(&header[..]).unwrap();
+        assert!(header.is_ir_level);
+        assert!(header.entry_first);
+    }
+
+    #[test]
+    fn invalid_header() {
+        let bad_header = b"# CSIR flag\n:\n";
+        let header = TextInstrProf::parse_header(&bad_header[..]);
+        assert!(header.is_err(), "Valid header: {:?}", header);
+        let bad_header = b"# CSIR flag\n:CSI\n";
+        let header = TextInstrProf::parse_header(&bad_header[..]);
+        assert!(header.is_err(), "Valid header: {:?}", header);
+    }
+
+    #[test]
+    fn content_strip() {
+        let empty = b"\n";
+        let (bytes, _) = strip_whitespace(empty).unwrap();
+        assert_eq!(bytes.len(), 0);
+
+        let comment = b"# I am a comment\n";
+        let (bytes, _) = strip_comments(comment).unwrap();
+        assert_eq!(bytes.len(), 0);
+    }
+
+    #[test]
+    fn simple_hex_parse() {
+        let simple = "main\n0x0\n1\n100";
+        let (_buf, report) = TextInstrProf::parse_bytes(simple.as_bytes()).unwrap();
+
+        assert_eq!(report.get_level(), InstrumentationLevel::FrontEnd);
+        assert_eq!(report.records().len(), 1);
+        assert_eq!(report.symtab.len(), 1);
+        assert_eq!(report.symtab.names.get(&0).unwrap(), "main");
+
+        let rec = &report.records()[0];
+
+        assert_eq!(rec.name, Some("main".to_string()));
+        assert_eq!(rec.hash, Some(0));
+        assert_eq!(rec.record.counts, vec![100]);
+        assert_eq!(rec.record.data, None);
+    }
+}

--- a/ferrocene/tools/blanket/llvm-profparser/src/instrumentation_profile/types.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/instrumentation_profile/types.rs
@@ -1,0 +1,440 @@
+use nom::number::Endianness;
+use rustc_hash::FxHashMap;
+use std::cmp::Ordering;
+use std::convert::TryInto;
+use std::fmt;
+
+/// ~VARIANT_MASKS_ALL & Header.version is the version number
+pub(crate) const VARIANT_MASKS_ALL: u64 = 0xff00_0000_0000_0000;
+/// This is taken from `llvm/include/llvm/ProfileData/InstrProfileData.inc`
+pub(crate) const VARIANT_MASK_IR_PROF: u64 = 1u64 << 56;
+/// This is taken from `llvm/include/llvm/ProfileData/InstrProfileData.inc`
+pub(crate) const VARIANT_MASK_CSIR_PROF: u64 = 1u64 << 57;
+/// This is taken from `llvm/include/llvm/ProfileData/InstrProfileData.inc`
+pub(crate) const VARIANT_MASK_BYTE_COVERAGE: u64 = 1u64 << 60;
+/// This is taken from `llvm/include/llvm/ProfileData/InstrProfileData.inc`
+pub(crate) const VARIANT_MASK_FUNCTION_ENTRY_ONLY: u64 = 1u64 << 61;
+/// This is taken from `llvm/include/llvm/ProfileData/InstrProfileData.inc`
+pub(crate) const VARIANT_MASK_MEMORY_PROFILE: u64 = 1u64 << 62;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub enum ValueKind {
+    IndirectCallTarget = 0,
+    MemOpSize = 1,
+}
+
+impl ValueKind {
+    pub const fn len() -> usize {
+        2
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Symtab {
+    pub names: FxHashMap<u64, String>,
+}
+
+pub fn compute_hash(data: impl AsRef<[u8]>) -> u64 {
+    let hash = md5::compute(data).0[..8].try_into().unwrap_or_default();
+    u64::from_le_bytes(hash)
+}
+
+fn compute_be_hash(data: impl AsRef<[u8]>) -> u64 {
+    let hash = md5::compute(data).0[..8].try_into().unwrap_or_default();
+    u64::from_be_bytes(hash)
+}
+
+impl Symtab {
+    /// Number of symbols in the table
+    pub fn len(&self) -> usize {
+        self.names.len()
+    }
+
+    /// True if there are no symbols in the table
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Some formats such as the Raw profiles have configurable endianness. I think these may
+    /// require a matching endian hash. However, this doesn't seem to be represented in any of the
+    /// llvm test files so is largely a mystery. Computes a little endian hash unless specified
+    /// otherwise.
+    pub fn add_func_name(&mut self, name: String, endianness: Option<Endianness>) {
+        let hash = match endianness {
+            Some(Endianness::Big) => compute_be_hash(&name),
+            _ => compute_hash(&name),
+        };
+        self.names.insert(hash, name);
+    }
+
+    pub fn add_func_name_with_hash(&mut self, name: String, hash: u64) {
+        self.names.insert(hash, name);
+    }
+
+    pub fn contains(&self, hash: u64) -> bool {
+        self.names.contains_key(&hash)
+    }
+
+    pub fn get(&self, hash: u64) -> Option<&String> {
+        self.names.get(&hash)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&u64, &String)> {
+        self.names.iter()
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub enum InstrumentationLevel {
+    FrontEnd,
+    Ir,
+}
+
+impl fmt::Display for InstrumentationLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FrontEnd => write!(f, "Front-end"),
+            Self::Ir => write!(f, "IR"),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct InstrumentationProfile {
+    pub(crate) version: Option<u64>,
+    pub(crate) has_csir: bool,
+    pub(crate) is_ir: bool,
+    pub(crate) is_entry_first: bool,
+    pub(crate) is_byte_coverage: bool,
+    pub(crate) fn_entry_only: bool,
+    pub(crate) memory_profiling: bool,
+    records: Vec<NamedInstrProfRecord>,
+    record_name_lookup: FxHashMap<String, usize>,
+    pub symtab: Symtab,
+}
+
+impl InstrumentationProfile {
+    pub fn new(version: Option<u64>, has_csir: bool, is_ir: bool, is_entry_first: bool) -> Self {
+        Self {
+            version,
+            has_csir,
+            is_ir,
+            is_entry_first,
+            ..Default::default()
+        }
+    }
+
+    pub fn version(&self) -> Option<u64> {
+        self.version
+    }
+
+    pub fn version_unchecked(&self) -> u64 {
+        *self.version.as_ref().unwrap()
+    }
+
+    pub fn is_ir_level_profile(&self) -> bool {
+        self.is_ir
+    }
+
+    pub fn has_csir_level_profile(&self) -> bool {
+        self.has_csir
+    }
+
+    pub fn is_entry_first(&self) -> bool {
+        self.is_entry_first
+    }
+
+    pub fn has_memory_profile(&self) -> bool {
+        self.memory_profiling
+    }
+
+    pub fn get_level(&self) -> InstrumentationLevel {
+        if self.is_ir_level_profile() {
+            InstrumentationLevel::Ir
+        } else {
+            InstrumentationLevel::FrontEnd
+        }
+    }
+
+    pub fn records(&self) -> &[NamedInstrProfRecord] {
+        &self.records
+    }
+
+    pub fn push_record(&mut self, record: NamedInstrProfRecord) {
+        if let Some(name) = record.name.clone() {
+            self.record_name_lookup.insert(name, self.records.len());
+        }
+        self.records.push(record);
+    }
+
+    pub fn find_record_by_name(&self, name: &str) -> Option<&NamedInstrProfRecord> {
+        self.record_name_lookup.get(name).map(|x| &self.records[*x])
+    }
+
+    pub fn find_record_by_hash(&self, hash: u64) -> Option<&NamedInstrProfRecord> {
+        let name = self.symtab.get(hash)?;
+        self.find_record_by_name(name)
+    }
+
+    pub fn find_record_by_name_mut(&mut self, name: &str) -> Option<&mut NamedInstrProfRecord> {
+        if let Some(index) = self.record_name_lookup.get(name) {
+            Some(&mut self.records[*index])
+        } else {
+            None
+        }
+    }
+
+    /// Byte coverage switches things around to make `0` equivalent to coverage and !0 uncovered it
+    /// seems. This currently is not supported but also not output by any rust tools (to my
+    /// knowledge)
+    pub fn is_byte_coverage(&self) -> bool {
+        self.is_byte_coverage
+    }
+
+    pub fn fn_entry_only(&self) -> bool {
+        self.fn_entry_only
+    }
+
+    pub fn merge(&mut self, other: &Self) {
+        if self.version.is_none() && other.version.is_some() {
+            self.version = other.version;
+        }
+        for func in &other.records {
+            self.merge_record(func);
+        }
+    }
+
+    pub fn merge_record(&mut self, record: &NamedInstrProfRecord) {
+        if let Some(hash) = record.name_hash.as_ref() {
+            let added = if self.symtab.contains(*hash) {
+                // Find the record and merge things. 0 hashed records should have no counters in the
+                // code and otherwise we'll ignore the change that truncated md5 hashes can collide
+                if let Some(rec) = record
+                    .name
+                    .as_ref()
+                    .and_then(|x| self.find_record_by_name_mut(x))
+                {
+                    rec.record.merge(&record.record);
+                    true
+                } else {
+                    false
+                }
+            } else if let Some(alt_hash) = record.hash {
+                if self.symtab.contains(alt_hash) {
+                    if let Some(rec) = record
+                        .name
+                        .as_ref()
+                        .and_then(|x| self.find_record_by_name_mut(x))
+                    {
+                        rec.record.merge(&record.record);
+                        true
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+            if !added {
+                self.symtab.names.insert(*hash, record.name_unchecked());
+                self.push_record(record.clone());
+            }
+        }
+    }
+
+    /// Gets the instrumentation record for the give function
+    pub fn get_record(&self, name: &str) -> Option<&NamedInstrProfRecord> {
+        self.records
+            .iter()
+            .find(|x| x.name.as_deref() == Some(name))
+    }
+
+    /// Returns true if there are no instrumentation records associated with the profile
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty() && self.symtab.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct NamedInstrProfRecord {
+    pub name: Option<String>,
+    pub name_hash: Option<u64>,
+    pub hash: Option<u64>,
+    pub record: InstrProfRecord,
+}
+
+impl NamedInstrProfRecord {
+    /// This bit is reserved as the flag for the context sensitive profile record
+    const CS_FLAG_IN_FUNC_HASH: u64 = 60;
+
+    pub fn num_value_sites(&self, valuekind: ValueKind) -> usize {
+        use ValueKind::*;
+        let record_data = self.record.data.as_ref();
+        match valuekind {
+            IndirectCallTarget => record_data.map(|x| x.indirect_callsites.len()),
+            MemOpSize => record_data.map(|x| x.mem_op_sizes.len()),
+        }
+        .unwrap_or_default()
+    }
+
+    pub fn has_cs_flag(&self) -> bool {
+        let hash = self.hash.unwrap_or_default();
+        ((hash >> Self::CS_FLAG_IN_FUNC_HASH) & 1) != 0
+    }
+
+    pub fn set_cs_flag(&mut self) {
+        let x = self.hash.get_or_insert(0);
+        *x &= Self::CS_FLAG_IN_FUNC_HASH;
+    }
+
+    pub fn counts(&self) -> &[u64] {
+        &self.record.counts
+    }
+
+    pub fn hash_unchecked(&self) -> u64 {
+        self.hash.unwrap_or_default()
+    }
+
+    pub fn name_unchecked(&self) -> String {
+        self.name.clone().unwrap_or_default()
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct InstrProfRecord {
+    pub counts: Vec<u64>,
+    pub data: Option<Box<ValueProfDataRecord>>,
+}
+
+impl InstrProfRecord {
+    pub fn merge(&mut self, other: &Self) {
+        if self.counts.len() != other.counts.len() {
+            return;
+        }
+        for (own, other) in self.counts.iter_mut().zip(other.counts.iter()) {
+            let res = own.checked_add(*other);
+            *own = match res {
+                Some(s) => s,
+                None => u64::MAX, // TODO handle the warnings?
+            };
+        }
+        // TODO merge the data
+        if let Some((own, other)) = self.data.as_mut().zip(other.data.as_ref()) {
+            if own.indirect_callsites.len() == other.indirect_callsites.len() {
+                for (own, other) in own
+                    .indirect_callsites
+                    .iter_mut()
+                    .zip(other.indirect_callsites.iter())
+                {
+                    merge_site_records(own, other);
+                }
+            }
+            if own.mem_op_sizes.len() == other.mem_op_sizes.len() {
+                for (own, other) in own.mem_op_sizes.iter_mut().zip(other.mem_op_sizes.iter()) {
+                    merge_site_records(own, other);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct ValueProfDataRecord {
+    pub indirect_callsites: Vec<InstrProfValueSiteRecord>,
+    pub mem_op_sizes: Vec<InstrProfValueSiteRecord>,
+}
+
+type InstrProfValueSiteRecord = Vec<InstrProfValueData>;
+
+fn merge_site_records(dst: &mut InstrProfValueSiteRecord, src: &InstrProfValueSiteRecord) {
+    if dst.len() == src.len() {
+        dst.sort_unstable();
+        let mut other_vals = src.iter().map(|x| x.value).collect::<Vec<u64>>();
+        other_vals.sort_unstable();
+        let mut i = 0;
+        for j in src {
+            let current = dst
+                .iter_mut()
+                .enumerate()
+                .skip(i)
+                .find(|x| x.1.value >= j.value);
+
+            match current {
+                Some((index, element)) if element.value == j.value => {
+                    element.count = element.count.checked_add(j.count).unwrap_or(u64::MAX);
+                    dst.insert(index + 1, j.clone());
+                    i = index + 1;
+                }
+                Some((index, _)) => {
+                    dst.insert(index, j.clone());
+                    i = index + 1;
+                }
+                None => {
+                    i = dst.len();
+                    dst.push(j.clone());
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, Hash)]
+pub struct InstrProfValueData {
+    pub value: u64,
+    pub count: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValueProfData {
+    pub(crate) total_size: u32,
+    pub(crate) num_value_kinds: u32,
+}
+
+/// TODO This is currently unused but unsure on if it's used in llvm coverage. Every file I've
+/// tried has had the number of these set to zero.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValueProfRecord {
+    kind: u32,
+    num_value_sites: u32,
+    site_count: u8,
+}
+
+impl PartialOrd for InstrProfValueData {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for InstrProfValueData {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Do the reverse here
+        self.value.cmp(&other.value)
+    }
+}
+
+impl PartialEq for InstrProfValueData {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BranchParameters {
+    pub id: i16,
+    pub false_cond: i16,
+    pub true_cond: i16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DecisionParameters {
+    pub bitmap_idx: u32,
+    pub num_conditions: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MCDCParams {
+    Branch(BranchParameters),
+    Decision(DecisionParameters),
+}

--- a/ferrocene/tools/blanket/llvm-profparser/src/lib.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/lib.rs
@@ -1,0 +1,42 @@
+use crate::instrumentation_profile::types::InstrumentationProfile;
+use std::path::Path;
+
+pub mod coverage;
+mod hash_table;
+pub mod instrumentation_profile;
+pub mod summary;
+pub mod util;
+
+pub use crate::instrumentation_profile::{parse, parse_bytes};
+pub use coverage::coverage_mapping::CoverageMapping;
+pub use coverage::reporting::*;
+pub use coverage::*;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub enum ProfileFormat {
+    Binary,
+    CompactBinary,
+    ExtBinary,
+    Text,
+    Gcc,
+}
+
+pub fn merge_profiles<T>(files: &[T]) -> std::io::Result<InstrumentationProfile>
+where
+    T: AsRef<Path>,
+{
+    if files.is_empty() {
+        Ok(InstrumentationProfile::default())
+    } else {
+        let mut profiles = vec![];
+        for input in files {
+            let profile = parse(input)?;
+            profiles.push(profile);
+        }
+        let mut base = profiles.remove(0);
+        for profile in &profiles {
+            base.merge(profile);
+        }
+        Ok(base)
+    }
+}

--- a/ferrocene/tools/blanket/llvm-profparser/src/lib.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/lib.rs
@@ -7,6 +7,7 @@ pub mod instrumentation_profile;
 pub mod summary;
 pub mod util;
 
+pub use crate::instrumentation_profile::types::compute_hash;
 pub use crate::instrumentation_profile::{parse, parse_bytes};
 pub use coverage::coverage_mapping::CoverageMapping;
 pub use coverage::reporting::*;

--- a/ferrocene/tools/blanket/llvm-profparser/src/summary.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/summary.rs
@@ -1,0 +1,43 @@
+/// The amount to scale cutoffs by to go back to a more readable percentile
+pub const CUTOFF_SCALE: u64 = 10_000_000;
+
+/// These are the default cutoffs for profile summary entries. Without cutoffs specified manually
+/// llvm-profdata and associated tools will use these. These numbers represent percentiles of
+/// counts in the profile data scaled by 10_000_000 (divide by these scales to go back to
+/// percentiles)
+pub const DEFAULT_CUTOFFS: [u64; 16] = [
+    10000, 100000, 200000, 300000, 400000, 500000, 600000, 700000, 800000, 900000, 950000, 990000,
+    999000, 999900, 999990, 999999,
+];
+
+/// The type of the profile summary
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Kind {
+    /// Instrumentation profile
+    Instr,
+    /// Context Sensitive Instrumentation profile
+    CsInstr,
+    /// Sample based profile
+    Sample,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct ProfileSummaryEntry {
+    pub cutoff: u64,
+    pub min_count: u64,
+    pub num_counts: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct ProfileSummary {
+    pub kind: Kind,
+    pub total_count: u64,
+    pub max_count: u64,
+    pub max_internal_count: u64,
+    pub max_function_count: u64,
+    pub num_counts: u32,
+    pub num_fns: u32,
+    pub partial: bool,
+    pub partial_profile_ratio: f64,
+    pub detailed_summary: Vec<ProfileSummaryEntry>,
+}

--- a/ferrocene/tools/blanket/llvm-profparser/src/util.rs
+++ b/ferrocene/tools/blanket/llvm-profparser/src/util.rs
@@ -1,0 +1,167 @@
+use flate2::read::ZlibDecoder;
+use nom::{
+    error::{ContextError, ErrorKind, ParseError},
+    IResult,
+};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use tracing::debug;
+
+pub fn parse_leb128<'a, E>(mut input: &'a [u8]) -> IResult<&'a [u8], u64, E>
+where
+    E: ParseError<&'a [u8]> + ContextError<&'a [u8]>,
+{
+    let start = input;
+    let x = leb128::read::unsigned(&mut input).map_err(|e| {
+        use leb128::read::Error as LebError;
+        let kind = match e {
+            LebError::Overflow => ErrorKind::Satisfy,
+            // Here our Read impl is a slice so only one error possible
+            LebError::IoError(_) => ErrorKind::Eof,
+        };
+        nom::Err::Error(E::from_error_kind(start, kind))
+    })?;
+    Ok((input, x))
+}
+
+pub fn parse_string_ref<'a, E>(input: &'a [u8]) -> IResult<&'a [u8], String, E>
+where
+    E: ParseError<&'a [u8]> + ContextError<&'a [u8]>,
+{
+    let (input, uncompressed_size) = parse_leb128::<E>(input)?;
+    let (input, compressed_size) = parse_leb128::<E>(input)?;
+    if compressed_size != 0 {
+        if compressed_size as usize > input.len() {
+            debug!("Unexpected EOF parsing a string ref");
+            Err(nom::Err::Error(E::from_error_kind(input, ErrorKind::Eof)))
+        } else {
+            let compressed_size = compressed_size as usize;
+            let mut decoder = ZlibDecoder::new(&input[..compressed_size]);
+            let mut output = vec![];
+            if decoder.read_to_end(&mut output).is_ok() {
+                let name = String::from_utf8(output);
+                let name = name.unwrap();
+                Ok((&input[compressed_size..], name))
+            } else {
+                let inner = E::from_error_kind(input, ErrorKind::Satisfy);
+                Err(nom::Err::Failure(E::add_context(
+                    input,
+                    "invalid deflate stream",
+                    inner,
+                )))
+            }
+        }
+    } else {
+        let uncompressed_size = uncompressed_size as usize;
+        match String::from_utf8(input[..uncompressed_size].to_vec()) {
+            Ok(name) => Ok((&input[uncompressed_size..], name)),
+            Err(_e) => {
+                debug!("Invalid UTF-8 string");
+                let inner = E::from_error_kind(input, ErrorKind::Satisfy);
+                Err(nom::Err::Error(E::add_context(
+                    input,
+                    "invalid utf-8 string",
+                    inner,
+                )))
+            }
+        }
+    }
+}
+
+/// Parses a list of paths - this is currently only used in parsing the sections in an instrumented
+/// object file, and due to CWD joining is different to the other string parsing implemented
+pub fn parse_path_list<'a, E>(input: &'a [u8], version: u64) -> IResult<&'a [u8], Vec<PathBuf>, E>
+where
+    E: ParseError<&'a [u8]> + ContextError<&'a [u8]>,
+{
+    let (input, list_length) = parse_leb128::<E>(input)?;
+
+    if version < 3 {
+        // read_uncompressed
+        let (input, values) = parse_uncompressed_file_list(input, list_length, version)?;
+        Ok((input, values))
+    } else {
+        let (input, uncompressed_size) = parse_leb128::<E>(input)?;
+        let (input, compressed_size) = parse_leb128::<E>(input)?;
+
+        let compressed_size = compressed_size as usize;
+        let uncompressed_size = uncompressed_size as usize;
+
+        if compressed_size == 0 {
+            let (input, values) = parse_uncompressed_file_list::<E>(input, list_length, version)?;
+            Ok((input, values))
+        } else {
+            let mut decoder = ZlibDecoder::new(&input[..compressed_size]);
+            let mut output = Vec::with_capacity(uncompressed_size);
+            decoder.read_to_end(&mut output).unwrap();
+            // Use context error to
+            let values = parse_uncompressed_string_list::<()>(&output)
+                .map(|(_, v)| v.iter().map(PathBuf::from).collect())
+                .map_err(|_| nom::Err::Failure(E::from_error_kind(input, ErrorKind::Fail)))?;
+            Ok((&input[compressed_size..], values))
+        }
+    }
+}
+
+fn read_string<'a, E>(bytes: &'a [u8]) -> IResult<&'a [u8], String, E>
+where
+    E: ParseError<&'a [u8]> + ContextError<&'a [u8]>,
+{
+    let (bytes, len) = parse_leb128::<E>(bytes)?;
+    let len = len as usize;
+    let string = String::from_utf8_lossy(&bytes[..len]).to_string();
+    Ok((&bytes[len..], string))
+}
+
+fn parse_uncompressed_file_list<'a, E>(
+    mut input: &'a [u8],
+    list_length: u64,
+    version: u64,
+) -> IResult<&'a [u8], Vec<PathBuf>, E>
+where
+    E: ParseError<&'a [u8]> + ContextError<&'a [u8]>,
+{
+    let mut res = vec![];
+    if version < 5 {
+        for _ in 0..list_length {
+            let (bytes, string) = read_string(input)?;
+            res.push(PathBuf::from(string));
+            input = bytes;
+        }
+        Ok((input, res))
+    } else {
+        let (bytes, cwd) = read_string(input)?;
+        let cwd = Path::new(&cwd);
+        res.push(cwd.to_path_buf());
+        input = bytes;
+        for _ in 1..list_length {
+            let (bytes, path) = read_string(input)?;
+            input = bytes;
+            let tmp = Path::new(&path);
+            if tmp.is_absolute() {
+                res.push(tmp.to_path_buf());
+            } else {
+                // NB here the llvm code sometimes has the compilation dir available and joins
+                // paths onto that instead.
+                res.push(cwd.join(tmp));
+            }
+        }
+        Ok((input, res))
+    }
+}
+
+fn parse_uncompressed_string_list<'a, E>(mut input: &'a [u8]) -> IResult<&'a [u8], Vec<String>, E>
+where
+    E: ParseError<&'a [u8]> + ContextError<&'a [u8]>,
+{
+    let mut res = vec![];
+    while !input.is_empty() {
+        let (bytes, len) = parse_leb128::<E>(input)?;
+        let len = len as usize;
+        let string = String::from_utf8_lossy(&bytes[..len]).to_string();
+        res.push(string);
+
+        input = &bytes[len..];
+    }
+    Ok((input, res))
+}

--- a/ferrocene/tools/blanket/src/html_report.rs
+++ b/ferrocene/tools/blanket/src/html_report.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use maud::{DOCTYPE, PreEscaped};
 
-use crate::{Annotated, FunctionCoverage, FunctionCoverageStatus, LineCoverageStatus};
+use crate::{Annotated, ColumnRange, FunctionCoverage, FunctionCoverageStatus, LineCoverageStatus};
 
 const CSS: &str = include_str!("../assets/html_report.css");
 const JS: &str = include_str!("../assets/html_report.js");
@@ -217,7 +217,14 @@ fn generate_function(
                                     (line) "\n"
                                 },
                                 LineCoverageStatus::Untested => span class="line line-untested" data-filename=(filename) data-linenum=(linenum) {
-                                    (line) "\n"
+                                    @for (chunk, tested) in line_runs(line, function.regions.get(linenum)) {
+                                        @if tested {
+                                            span class="region-tested" { (chunk) }
+                                        } @else {
+                                            (chunk)
+                                        }
+                                    }
+                                    "\n"
                                 },
                                 LineCoverageStatus::Annotated => span class="line line-annotated" data-filename=(filename) data-linenum=(linenum) {
                                     (line) "\n"
@@ -233,4 +240,152 @@ fn generate_function(
         }
     );
     Ok(html)
+}
+
+fn line_runs(line: &str, regions: Option<&Vec<ColumnRange>>) -> Vec<(String, bool)> {
+    let len = line.len();
+    let Some(regions) = regions.filter(|regions| !regions.is_empty() && len > 0) else {
+        return vec![(line.to_string(), false)];
+    };
+
+    let mut tested = vec![false; len];
+
+    let mut by_specificity: Vec<&ColumnRange> = regions.iter().collect();
+    by_specificity.sort_by_key(|range| {
+        std::cmp::Reverse(range.end_col.unwrap_or(len).saturating_sub(range.start_col))
+    });
+
+    for range in by_specificity {
+        let start = floor_char_boundary(line, range.start_col.saturating_sub(1).min(len));
+        let end = ceil_char_boundary(line, range.end_col.unwrap_or(len).min(len)).max(start);
+        tested[start..end].fill(range.tested);
+    }
+
+    let mut offset = 0;
+    tested
+        .chunk_by(|a, b| a == b)
+        .map(|chunk| {
+            let start = offset;
+            offset += chunk.len();
+            (line[start..offset].to_string(), chunk[0])
+        })
+        .collect()
+}
+
+fn floor_char_boundary(line: &str, index: usize) -> usize {
+    (0..=index).rev().find(|&i| line.is_char_boundary(i)).unwrap_or(0)
+}
+
+fn ceil_char_boundary(line: &str, index: usize) -> usize {
+    (index..=line.len()).find(|&i| line.is_char_boundary(i)).unwrap_or(line.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn range(start_col: usize, end_col: Option<usize>, tested: bool) -> ColumnRange {
+        ColumnRange { start_col, end_col, tested }
+    }
+
+    #[test]
+    fn no_regions_is_one_untested_run() {
+        let runs = line_runs("    baz();", None);
+        assert_eq!(runs, vec![("    baz();".to_string(), false)]);
+    }
+
+    #[test]
+    fn single_region_covering_whole_line() {
+        let regions = vec![range(1, None, true)];
+        let runs = line_runs("    baz();", Some(&regions));
+        assert_eq!(runs, vec![("    baz();".to_string(), true)]);
+    }
+
+    #[test]
+    fn splits_covered_arm_from_uncovered_arm() {
+        // `if cond { covered() } else { uncovered() }`
+        let line = "if cond { covered() } else { uncovered() }";
+        let regions = vec![
+            range(1, Some(9), true),    // `if cond `
+            range(10, Some(21), true),  // `{ covered() }`
+            range(22, Some(27), true),  // ` else `
+            range(28, Some(42), false), // `{ uncovered() }`
+        ];
+        let runs = line_runs(line, Some(&regions));
+        assert_eq!(
+            runs,
+            vec![
+                ("if cond { covered() } else ".to_string(), true),
+                ("{ uncovered() }".to_string(), false),
+            ]
+        );
+    }
+
+    #[test]
+    fn narrower_region_overrides_broader_untested_one() {
+        // The whole line is nominally untested, but a nested, more specific region within it
+        // was hit (e.g. a branch condition that runs even though the statement as a whole
+        // never completes).
+        let line = "    a && b";
+        let regions = vec![
+            range(1, None, false),   // whole line, untested
+            range(5, Some(5), true), // `a`
+        ];
+        let runs = line_runs(line, Some(&regions));
+        assert_eq!(
+            runs,
+            vec![
+                ("    ".to_string(), false),
+                ("a".to_string(), true),
+                (" && b".to_string(), false),
+            ]
+        );
+    }
+
+    #[test]
+    fn out_of_range_columns_are_clamped_not_panicking() {
+        let regions = vec![range(1, Some(9999), true)];
+        let runs = line_runs("short", Some(&regions));
+        assert_eq!(runs, vec![("short".to_string(), true)]);
+    }
+
+    #[test]
+    fn generate_function_highlights_covered_fragment_of_untested_line() {
+        let dir = std::env::temp_dir().join(format!("blanket-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let relative_path = std::path::PathBuf::from("lib.rs");
+        std::fs::write(
+            dir.join(&relative_path),
+            "fn f(cond: bool) {\n    if cond { covered() } else { uncovered() }\n}\n",
+        )
+        .unwrap();
+
+        let mut regions = std::collections::BTreeMap::new();
+        regions.insert(
+            2,
+            vec![
+                range(5, Some(13), true),   // `if cond `
+                range(14, Some(25), true),  // `{ covered() }`
+                range(26, Some(31), true),  // ` else `
+                range(32, Some(46), false), // `{ uncovered() }`
+            ],
+        );
+
+        let lines = crate::LineCoverage {
+            lines: vec![
+                (1, LineCoverageStatus::Ignored),
+                (2, LineCoverageStatus::Untested),
+                (3, LineCoverageStatus::Ignored),
+            ],
+        };
+        let function =
+            FunctionCoverage::new("f".to_string(), relative_path, lines, regions, Annotated::Not);
+
+        let html = generate_function(&function, &dir).unwrap().into_string();
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert!(html.contains(r#"<span class="region-tested">if cond { covered() } else </span>"#));
+        assert!(html.contains("{ uncovered() }"));
+        assert!(!html.contains(r#"<span class="region-tested">{ uncovered() }</span>"#));
+    }
 }

--- a/ferrocene/tools/blanket/src/main.rs
+++ b/ferrocene/tools/blanket/src/main.rs
@@ -1,5 +1,6 @@
 // Derived from https://github.com/xd009642/llvm-profparser/blob/f12a20d33b371f62a3b63f3a19d2320c25aa48b9/src/bin/cov.rs
 
+use std::collections::BTreeMap;
 use std::fmt;
 use std::path::PathBuf;
 
@@ -80,6 +81,14 @@ struct LineCoverage {
     lines: Vec<(usize, LineCoverageStatus)>,
 }
 
+#[derive(Debug, Clone)]
+struct ColumnRange {
+    start_col: usize,
+    /// `None` means the region continues past the end of this line.
+    end_col: Option<usize>,
+    tested: bool,
+}
+
 #[derive(Debug, PartialEq, Eq, Hash)]
 enum FunctionCoverageStatus {
     FullyTested,
@@ -151,6 +160,8 @@ struct FunctionCoverage {
     source_name: String,
     relative_path: PathBuf,
     lines: LineCoverage,
+    // filled in only for partially covered lines
+    regions: BTreeMap<usize, Vec<ColumnRange>>,
     status: FunctionCoverageStatus,
     annotated: Annotated,
 }
@@ -160,10 +171,11 @@ impl FunctionCoverage {
         source_name: String,
         filename: PathBuf,
         lines: LineCoverage,
+        regions: BTreeMap<usize, Vec<ColumnRange>>,
         annotated: Annotated,
     ) -> Self {
         let status = FunctionCoverageStatus::new(&lines);
-        Self { source_name, relative_path: filename, lines, status, annotated }
+        Self { source_name, relative_path: filename, lines, regions, status, annotated }
     }
 }
 
@@ -237,7 +249,6 @@ fn get_coverage(
     };
 
     let source_lines = start_line..=end_line;
-    let source_name = source_name;
 
     // we didn't get any hits from the tool, so we don't know which lines shouldn't be
     // considered. report them all as considered and missing coverage.
@@ -253,25 +264,60 @@ fn get_coverage(
         // All lines require annotations as we didn't get any hits from the tool.
         let annotated = get_annotation_status(annotations, &mut no_coverage.lines);
 
-        return Ok(FunctionCoverage::new(source_name, filename, no_coverage, annotated));
+        return Ok(FunctionCoverage::new(
+            source_name,
+            filename,
+            no_coverage,
+            BTreeMap::new(),
+            annotated,
+        ));
     };
 
     let mut covered = vec![];
+    let mut regions = BTreeMap::new();
 
     for line in source_lines {
         // one more thing to do: within a function, some lines will always be uncovered (e.g. }
         // closing braces). so we do have to trust the coverage tool to report those accurately.
-        let status = match func_coverage.hits_for_line(line) {
-            None => LineCoverageStatus::Ignored,
-            Some(0) => LineCoverageStatus::Untested,
-            Some(_) => LineCoverageStatus::Tested,
+        let line_regions = column_ranges_for_line(func_coverage, line);
+        let status = if line_regions.is_empty() {
+            LineCoverageStatus::Ignored
+        } else if line_regions.iter().all(|range| range.tested) {
+            LineCoverageStatus::Tested
+        } else {
+            LineCoverageStatus::Untested
         };
+        // untested line has tested regions
+        if status == LineCoverageStatus::Untested && line_regions.iter().any(|range| range.tested) {
+            regions.insert(line, line_regions);
+        }
         covered.push((line, status));
     }
 
     let annotated = get_annotation_status(annotations, &mut covered);
 
-    Ok(FunctionCoverage::new(source_name, filename, LineCoverage { lines: covered }, annotated))
+    Ok(FunctionCoverage::new(
+        source_name,
+        filename,
+        LineCoverage { lines: covered },
+        regions,
+        annotated,
+    ))
+}
+
+fn column_ranges_for_line(func_coverage: &CoverageResult, line: usize) -> Vec<ColumnRange> {
+    let mut ranges: Vec<ColumnRange> = func_coverage
+        .hits
+        .iter()
+        .filter(|(loc, _)| loc.line_start <= line && loc.line_end >= line)
+        .map(|(loc, &count)| {
+            let start_col = if loc.line_start == line { loc.column_start } else { 1 };
+            let end_col = if loc.line_end == line { Some(loc.column_end) } else { None };
+            ColumnRange { start_col, end_col, tested: count > 0 }
+        })
+        .collect();
+    ranges.sort_by_key(|range| range.start_col);
+    ranges
 }
 
 impl ShowCommand {

--- a/ferrocene/tools/blanket/src/main.rs
+++ b/ferrocene/tools/blanket/src/main.rs
@@ -236,8 +236,11 @@ fn get_coverage(
     span: Span,
     ferrocene: &std::path::Path,
     source_name: String,
+    linkage_name: &str,
     annotations: Option<&mut Vec<Annotation>>,
 ) -> Result<FunctionCoverage> {
+    let normalized_name = llvm_profparser::strip_crate_hashes(linkage_name);
+
     let Span { filename, start_line, end_line } = span;
     let absolute_path = if filename.is_relative() {
         ferrocene
@@ -279,7 +282,7 @@ fn get_coverage(
     for line in source_lines {
         // one more thing to do: within a function, some lines will always be uncovered (e.g. }
         // closing braces). so we do have to trust the coverage tool to report those accurately.
-        let line_regions = column_ranges_for_line(func_coverage, line);
+        let line_regions = column_ranges_for_line(func_coverage, &normalized_name, line);
         let status = if line_regions.is_empty() {
             LineCoverageStatus::Ignored
         } else if line_regions.iter().all(|range| range.tested) {
@@ -305,9 +308,17 @@ fn get_coverage(
     ))
 }
 
-fn column_ranges_for_line(func_coverage: &CoverageResult, line: usize) -> Vec<ColumnRange> {
-    let mut ranges: Vec<ColumnRange> = func_coverage
-        .hits
+fn column_ranges_for_line(
+    func_coverage: &CoverageResult,
+    normalized_name: &str,
+    line: usize,
+) -> Vec<ColumnRange> {
+    let hits = match func_coverage.hits_by_function.get(normalized_name) {
+        Some(scoped) if !scoped.is_empty() => scoped,
+        _ => &func_coverage.hits,
+    };
+
+    let mut ranges: Vec<ColumnRange> = hits
         .iter()
         .filter(|(loc, _)| loc.line_start <= line && loc.line_end >= line)
         .map(|(loc, &count)| {

--- a/ferrocene/tools/blanket/src/rustc_driver.rs
+++ b/ferrocene/tools/blanket/src/rustc_driver.rs
@@ -26,7 +26,7 @@ pub fn coverage(cmd: &ShowCommand, report: &CoverageReport) -> Result<Vec<Functi
             )
         })
         .collect::<BTreeMap<_, _>>();
-    for Function { qualified_name, filename, start_line, end_line } in symbols {
+    for Function { qualified_name, filename, start_line, end_line, linkage_name } in symbols {
         let annotations = annotations.get_mut(&filename);
         let span = Span { filename: filename.into(), start_line, end_line };
         coverage.push(super::get_coverage(
@@ -34,6 +34,7 @@ pub fn coverage(cmd: &ShowCommand, report: &CoverageReport) -> Result<Vec<Functi
             span,
             &cmd.ferrocene,
             qualified_name,
+            &linkage_name,
             annotations,
         )?);
     }

--- a/ferrocene/tools/symbol-report/src/main.rs
+++ b/ferrocene/tools/symbol-report/src/main.rs
@@ -19,7 +19,7 @@ use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::{AttrId, Attribute, HirId};
 use rustc_interface::interface::Compiler;
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::{Instance, TyCtxt};
 use rustc_middle::ty::print::{
     with_no_trimmed_paths, with_no_visible_paths, with_resolve_crate_name,
 };
@@ -166,10 +166,30 @@ fn extract_all_functions<'tcx>(tcx: TyCtxt<'tcx>, mut vis: Vis<'tcx>) -> Vis<'tc
             start_line = start_line.min(span_start_line);
         }
 
-        vis.report.symbols.push(Function { qualified_name, filename, start_line, end_line });
+        let linkage_name = get_linkage_name(tcx, def);
+
+        vis.report.symbols.push(Function {
+            qualified_name,
+            filename,
+            start_line,
+            end_line,
+            linkage_name,
+        });
     }
 
     vis
+}
+
+/// Returns the mangled linkage (symbol) name for a compiled monomorphic item.
+/// For generic items returns an empty string.
+/// Later when a generic item is used by a dependent binary the compiler will
+/// produce a new monomorphized item with a new name.
+fn get_linkage_name(tcx: TyCtxt<'_>, def: LocalDefId) -> String {
+    if tcx.generics_of(def.to_def_id()).count() != 0 {
+        return String::new();
+    }
+    let instance = Instance::mono(tcx, def.to_def_id());
+    tcx.symbol_name(instance).name.to_string()
 }
 
 fn get_qualified_name(tcx: TyCtxt<'_>, def: LocalDefId) -> String {

--- a/src/build_helper/src/symbol_report.rs
+++ b/src/build_helper/src/symbol_report.rs
@@ -35,21 +35,24 @@ pub struct Function {
     pub filename: String,
     pub start_line: usize,
     pub end_line: usize,
+    pub linkage_name: String,
 }
 
 impl From<SerdeFunction> for Function {
-    fn from(SerdeFunction(qualified_name, filename, start_line, end_line): SerdeFunction) -> Self {
-        Self { qualified_name, filename, start_line, end_line }
+    fn from(
+        SerdeFunction(qualified_name, filename, start_line, end_line, linkage_name): SerdeFunction,
+    ) -> Self {
+        Self { qualified_name, filename, start_line, end_line, linkage_name }
     }
 }
 
 /// A single certified function, identified by its span
 #[derive(Clone, serde_derive::Deserialize, serde_derive::Serialize)]
 #[serde(from = "Function")]
-pub struct SerdeFunction(String, String, usize, usize);
+pub struct SerdeFunction(String, String, usize, usize, String);
 
 impl From<Function> for SerdeFunction {
     fn from(func: Function) -> Self {
-        Self(func.qualified_name, func.filename, func.start_line, func.end_line)
+        Self(func.qualified_name, func.filename, func.start_line, func.end_line, func.linkage_name)
     }
 }


### PR DESCRIPTION
When a macro is used to generate implementations of the same function for different types LLVM generates separate counters for different implementations. For example, in `core/src/num` a macro `uint_impl!` is used for generating versions of `abs_diff` function for `u8`, `u16`, etc. When the tests run for one of the types, say, `u8`, the counters for a corresponding compiled function `abs_diff` get updated.

However, since Blanket / `llvm_profparser::CoverageResult` tracked coverage by source line-column it does not disambiguate counters for different versions of the same function. When aggregating counters for a specific line or line fragment if an unrelated version of the function was not covered we would get 0 in one of the counters.

Also, while the source for all these versions is the same, when compiling LLVM can use different transformations for different paths. The resulting shape of functions can be different, and the borders of coverage regions don't always match!

To disambiguate counters correctly we need to track coverage over monomorphized versions of functions. I use their mangled names for them, referred as `linkage_name` in code. This gets slightly complicated because the mangled names of functions have randomized segments that get different values between compilation runs. When a tests binary is compiled, Cargo can decide to reuse a version of binary under test from a previous compilation run. For example, if we run `cargo build` followed by `cargo test` the later will reuse the results of the former. Unfortunately, metadata in prof files will have both versions of a mangle name present. For that reason I clean up random segments from mangled names to unify counters.

*Technically*, a truly generic function may not have exact implementations and monomorphized versions. In that case I keep the value for `linkage_name` as empty string. And in theory counters for these functions will still be merged. I'm not sure whether these kinds of functions are actually executable. My gut tells me that *at some point* there should be a monomorphized version of that function that gets called inside tests, and so far this has been the case.

blocked by https://github.com/ferrocene/ferrocene/pull/2546